### PR TITLE
Added functionality to handle Result in node compiler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 elm-stuff
 node_modules
+output.css

--- a/examples/src/HomepageStylesheet.elm
+++ b/examples/src/HomepageStylesheet.elm
@@ -1,37 +1,36 @@
 module HomepageStylesheet where
 
-import Stylesheets exposing (..)
+import Css exposing (..)
 import SharedStyles exposing (..)
 
+port cssOutput : Css.CompilerOutput
+port cssOutput =
+    Css.outputToPort css
 
-port css : String
-port css =
-    Stylesheets.prettyPrint 4 <|
-        stylesheet
-            |%| header
-                |-| backgroundColor (rgb 90 90 90)
-                |-| boxSizing borderBox
-                |-| padding 12 px
-
-            |%| nav
-                |-| display inlineBlock
-                |-| paddingBottom 12 px
-
-            |.| NavLink
-                |-| margin 12 px
-                |-| color (rgb 255 255 255)
-
-            |#| ReactiveLogo
-                |-| display inlineBlock
-                |-| marginLeft 150 px
-                |-| marginRight 80 px
-                |-| verticalAlign middle
-
-            |#| BuyTickets
-                |-| padding 16 px
-                |-| paddingLeft 24 px
-                |-| paddingRight 24 px
-                |-| marginLeft 50 px
-                |-| color (rgb 255 255 255)
-                |-| backgroundColor (rgb 27 217 130)
-                |-| verticalAlign middle
+css : Result String String
+css =
+    Css.prettyPrint <|
+        stylesheet "homepage"
+            $ header
+                ~ backgroundColor (rgb 90 90 90)
+                ~ boxSizing borderBox
+                ~ padding -80 px
+            $ nav
+                ~ display inlineBlock
+                ~ paddingBottom 12 px
+            . NavLink
+                ~ margin 12 px
+                ~ color (rgb 255 255 255)
+            # ReactiveLogo
+                ~ display inlineBlock
+                ~ marginLeft 150 px
+                ~ marginRight 80 px
+                ~ verticalAlign middle
+            # BuyTickets
+                ~ padding 16 px
+                ~ paddingLeft 24 px
+                ~ paddingRight 24 px
+                ~ marginLeft 50 px
+                ~ color (rgb 255 255 255)
+                ~ backgroundColor (rgb 27 217 130)
+                ~ verticalAlign middle

--- a/index.js
+++ b/index.js
@@ -29,9 +29,15 @@ tmp.dir({unsafeCleanup: true}, function (err, tmpDirPath, cleanup) {
     fs.appendFileSync(emitterDest, "\nmodule.exports = Elm;");
 
     var Elm = require(emitterDest);
-    var compiledCss = Elm.worker(Elm[elmModuleName]).ports.css;
+    var result = Elm.worker(Elm[elmModuleName]).ports.cssOutput;
 
-    fs.writeFileSync(destCssFile, compiledCss);
+    if(result.success) {
+      fs.writeFileSync(destCssFile, result.content);
+    } else {
+      console.error("Compilation error: " + result.content, 1);
+      process.exit(1);
+    }
+
   }, function(exitCode) {
     console.error("Errored with exit code", exitCode);
 

--- a/src/Css.elm
+++ b/src/Css.elm
@@ -1,4 +1,4 @@
-module Css (Style, stylesheet, prettyPrint, ($), (#), (.), (@), (|$), (>$), (>>$), (+$), (~$), (>#), (>>#), (+#), (~#), (>.), (>>.), (+.), (~.), ($=), (~), (&::), (&:), (!), html, body, header, nav, div, span, img, nowrap, button, h1, h2, h3, h4, p, ol, input, verticalAlign, display, opacity, width, minWidth, height, minHeight, padding, paddingTop, paddingBottom, paddingRight, paddingLeft, margin, marginTop, marginBottom, marginRight, marginLeft, boxSizing, overflowX, overflowY, whiteSpace, backgroundColor, color, media, textShadow, outline, solid, transparent, rgb, rgba, hex, pct, em, px, borderBox, visible, block, inlineBlock, inline, none, auto, inherit, noWrap, top, middle, bottom, after, before, firstLetter, firstLine, selection, active, any, checked, dir, disabled, empty, enabled, first, firstChild, firstOfType, fullscreen, focus, hover, indeterminate, invalid, lang, lastChild, lastOfType, left, link, nthChild, nthLastChild, nthLastOfType, nthOfType, onlyChild, onlyOfType, optional, outOfRange, readWrite, required, right, root, scope, target, valid) where
+module Css (Style, stylesheet, prettyPrint, ($), (#), (.), (@), (|$), (>$), (>>$), (+$), (~$), (>#), (>>#), (+#), (~#), (>.), (>>.), (+.), (~.), ($=), (~), (&::), (&:), (!), html, body, header, nav, div, span, img, nowrap, button, h1, h2, h3, h4, p, ol, input, verticalAlign, display, opacity, width, minWidth, height, minHeight, padding, paddingTop, paddingBottom, paddingRight, paddingLeft, margin, marginTop, marginBottom, marginRight, marginLeft, boxSizing, overflowX, overflowY, whiteSpace, backgroundColor, color, media, textShadow, outline, solid, transparent, rgb, rgba, hex, pct, em, px, borderBox, visible, block, inlineBlock, inline, none, auto, inherit, noWrap, top, middle, bottom, after, before, firstLetter, firstLine, selection, active, any, checked, dir, disabled, empty, enabled, first, firstChild, firstOfType, fullscreen, focus, hover, indeterminate, invalid, lang, lastChild, lastOfType, left, link, nthChild, nthLastChild, nthLastOfType, nthOfType, onlyChild, onlyOfType, optional, outOfRange, readWrite, required, right, root, scope, target, valid, CompilerOutput, outputToPort) where
 {-| Functions for building stylesheets.
 
 # Style
@@ -24,6 +24,9 @@ module Css (Style, stylesheet, prettyPrint, ($), (#), (.), (@), (|$), (>$), (>>$
 
 # Pseudo-Elements
 @docs (&::), after, before, firstLetter, firstLine, selection
+
+# Compiler Output
+@docs (CompilerOutput, outputToPort)
 -}
 
 
@@ -1250,3 +1253,33 @@ updateLast update list =
 
         first :: rest ->
             first :: updateLast update rest
+
+
+{- Compiler Output -}
+
+{-| Record type for converting a Result to something consumable in Node
+-}
+type alias CompilerOutput =
+    { success: Bool
+    , content: String
+    }
+
+
+{-| Converts a Result emitted by prettyPrint to a CompilerOutput
+
+    port output =
+        outputToPort css
+
+    css =
+        prettyPrint <|
+            stylsheet "example"
+                $ body
+                    ~ margin 0 px
+-}
+outputToPort : Result String String -> CompilerOutput
+outputToPort result =
+    case result of
+        Ok styleString ->
+            CompilerOutput True styleString
+        Err message ->
+            CompilerOutput False message


### PR DESCRIPTION
I really like the approach you're taking here and wanted to help out :smile:
Even if you'd rather not accept the changes I would love any feedback if you have time. Thanks!

- Added a record type to represent the `Result` from `prettyPrint` in node
- Added a helper function to make that conversion
- Updated node compiler to exit with code 1 if the `Result` is `Err`
- Updated example elm file to use `Css` correctly