### PR TITLE
Expose emitting API

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,8 +24,7 @@ install:
   - cd test
   - npm install -g elm@$ELM_VERSION elm-test@0.16.1-alpha2
   - npm install
+  - elm package install --yes
 
 script:
-  - elm package install --yes
-  - elm-test TestRunner.elm
   - npm test

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,10 @@ os:
 
 env:
   matrix:
-    - ELM_VERSION=0.16.0 TARGET_NODE_VERSION=node
-    - ELM_VERSION=0.16.0 TARGET_NODE_VERSION=0.12
+    - fast_finish: true
+    - env:
+      - ELM_VERSION=0.16.0 TARGET_NODE_VERSION=node
+      - ELM_VERSION=0.16.0 TARGET_NODE_VERSION=0.12
 
 before_install:
   - if [ ${TRAVIS_OS_NAME} == "osx" ];

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ os:
 
 env:
   matrix:
-    - fast_finish: true
     - ELM_VERSION=0.16.0 TARGET_NODE_VERSION=node
     - ELM_VERSION=0.16.0 TARGET_NODE_VERSION=0.12
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,8 @@ os:
 env:
   matrix:
     - fast_finish: true
-    - env:
-      - ELM_VERSION=0.16.0 TARGET_NODE_VERSION=node
-      - ELM_VERSION=0.16.0 TARGET_NODE_VERSION=0.12
+    - ELM_VERSION=0.16.0 TARGET_NODE_VERSION=node
+    - ELM_VERSION=0.16.0 TARGET_NODE_VERSION=0.12
 
 before_install:
   - if [ ${TRAVIS_OS_NAME} == "osx" ];

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,10 +18,9 @@ install:
   - cd test
   - npm install -g elm@%ELM_VERSION% elm-test@0.16.1-alpha2
   - npm install
+  - elm-package install --yes
 
 test_script:
-  - elm-package install --yes
-  - elm-test TestRunner.elm
   - npm test
 
 build: off

--- a/examples/src/HomepageStylesheet.elm
+++ b/examples/src/HomepageStylesheet.elm
@@ -1,36 +1,32 @@
-module HomepageStylesheet where
+module HomepageStylesheet (..) where
 
 import Css exposing (..)
 import SharedStyles exposing (..)
 
-port cssOutput : Css.CompilerOutput
-port cssOutput =
-    Css.outputToPort css
 
-css : Result String String
 css =
-    Css.prettyPrint <|
-        stylesheet { name = "homepage" }
-            $ header
-                ~ backgroundColor (rgb 90 90 90)
-                ~ boxSizing borderBox
-                ~ padding -80 px
-            $ nav
-                ~ display inlineBlock
-                ~ paddingBottom 12 px
-            . NavLink
-                ~ margin 12 px
-                ~ color (rgb 255 255 255)
-            # ReactiveLogo
-                ~ display inlineBlock
-                ~ marginLeft 150 px
-                ~ marginRight 80 px
-                ~ verticalAlign middle
-            # BuyTickets
-                ~ padding 16 px
-                ~ paddingLeft 24 px
-                ~ paddingRight 24 px
-                ~ marginLeft 50 px
-                ~ color (rgb 255 255 255)
-                ~ backgroundColor (rgb 27 217 130)
-                ~ verticalAlign middle
+    stylesheet { name = "homepage" }
+        $ header
+            ~ backgroundColor (rgb 90 90 90)
+            ~ boxSizing borderBox
+            ~ padding -80 px
+        $ nav
+            ~ display inlineBlock
+            ~ paddingBottom 12 px
+        . NavLink
+            ~ margin 12 px
+            ~ color (rgb 255 255 255)
+        # ReactiveLogo
+            ~ display inlineBlock
+            ~ marginLeft 150 px
+            ~ marginRight 80 px
+            ~ verticalAlign middle
+        # BuyTickets
+            ~ padding 16 px
+            ~ paddingLeft 24 px
+            ~ paddingRight 24 px
+            ~ marginLeft 50 px
+            ~ color (rgb 255 255 255)
+            ~ backgroundColor (rgb 27 217 130)
+            ~ verticalAlign middle
+

--- a/examples/src/HomepageStylesheet.elm
+++ b/examples/src/HomepageStylesheet.elm
@@ -1,4 +1,4 @@
-module HomepageStylesheet (..) where
+module HomepageStylesheet (css) where
 
 import Css exposing (..)
 import SharedStyles exposing (..)

--- a/index.js
+++ b/index.js
@@ -1,5 +1,4 @@
 var fs = require("fs");
-var spawn = require("child_process").spawn;
 var tmp = require("tmp");
 var path = require("path");
 var templatesDir = path.join(__dirname, "templates");

--- a/index.js
+++ b/index.js
@@ -6,49 +6,43 @@ var compile = require("node-elm-compiler").compile;
 var emitterFilename = "emitter.js";
 
 
-// TODO: externalize all this and make it configurable
-var srcFile = "examples/src/HomepageStylesheet.elm";
-var elmModuleName = "HomepageStylesheet";
-var destCssFile = path.join(__dirname, "output.css")
-process.chdir("examples")
-// END TODO
-
-
-tmp.dir({unsafeCleanup: true}, function (err, tmpDirPath, cleanup) {
-  if (err) {
-    throw err;
-  }
-
-  var emitterDest = path.join(tmpDirPath, emitterFilename);
-
-  compileEmitter({
-    output: emitterDest
-  }, function() {
-    // Make the compiled emitter.js Node-friendly.
-    fs.appendFileSync(emitterDest, "\nmodule.exports = Elm;");
-
-    var Elm = require(emitterDest);
-    var result = Elm.worker(Elm[elmModuleName]).ports.cssOutput;
-
-    if(result.success) {
-      fs.writeFileSync(destCssFile, result.content + "\n");
-    } else {
-      console.error("Compilation error: " + result.content, 1);
-      process.exit(1);
+module.exports = function(srcFile, elmModuleName, destCssFile) {
+  tmp.dir({unsafeCleanup: true}, function (err, tmpDirPath, cleanup) {
+    if (err) {
+      throw err;
     }
-  }, function(exitCode) {
-    console.error("Errored with exit code", exitCode);
-    process.exit(exitCode);
-  });
-});
 
-function compileEmitter(options, onSuccess, onError) {
-  compile(path.join(__dirname, srcFile), options)
-    .on("close", function(exitCode) {
-      if (exitCode === 0) {
-        onSuccess()
+    var emitterDest = path.join(tmpDirPath, emitterFilename);
+
+    compileEmitter({
+      output: emitterDest
+    }, function() {
+      // Make the compiled emitter.js Node-friendly.
+      fs.appendFileSync(emitterDest, "\nmodule.exports = Elm;");
+
+      var Elm = require(emitterDest);
+      var result = Elm.worker(Elm[elmModuleName]).ports.cssOutput;
+
+      if(result.success) {
+        fs.writeFileSync(destCssFile, result.content + "\n");
       } else {
-        onError(exitCode);
+        console.error("Compilation error: " + result.content, 1);
+        process.exit(1);
       }
+    }, function(exitCode) {
+      console.error("Errored with exit code", exitCode);
+      process.exit(exitCode);
     });
+  });
+
+  function compileEmitter(options, onSuccess, onError) {
+    compile(path.join(__dirname, srcFile), options)
+      .on("close", function(exitCode) {
+        if (exitCode === 0) {
+          onSuccess()
+        } else {
+          onError(exitCode);
+        }
+      });
+  }
 }

--- a/index.js
+++ b/index.js
@@ -4,45 +4,109 @@ var path = require("path");
 var templatesDir = path.join(__dirname, "templates");
 var compile = require("node-elm-compiler").compile;
 var emitterFilename = "emitter.js";
+var cp = require("node-cp");
 
+// elmModuleName is optional, and is by default inferred based on the filename.
+module.exports = function(srcElmFile, destCssFile, elmModuleName) {
+  return new Promise(function(resolve, reject) {
+    var originalWorkingDir = process.cwd();
 
-module.exports = function(srcFile, elmModuleName, destCssFile) {
-  tmp.dir({unsafeCleanup: true}, function (err, tmpDirPath, cleanup) {
-    if (err) {
-      throw err;
-    }
-
-    var emitterDest = path.join(tmpDirPath, emitterFilename);
-
-    compileEmitter({
-      output: emitterDest
-    }, function() {
-      // Make the compiled emitter.js Node-friendly.
-      fs.appendFileSync(emitterDest, "\nmodule.exports = Elm;");
-
-      var Elm = require(emitterDest);
-      var result = Elm.worker(Elm[elmModuleName]).ports.cssOutput;
-
-      if(result.success) {
-        fs.writeFileSync(destCssFile, result.content + "\n");
-      } else {
-        console.error("Compilation error: " + result.content, 1);
-        process.exit(1);
+    tmp.dir(function (err, tmpDirPath) {
+      if (err) {
+        return reject(err);
       }
-    }, function(exitCode) {
-      console.error("Errored with exit code", exitCode);
-      process.exit(exitCode);
+
+      var tmpSrc = path.join(tmpDirPath, path.basename(srcElmFile));
+      var tmpDest = path.join(tmpDirPath, emitterFilename);
+
+      if (!elmModuleName) {
+        elmModuleName = path.basename(srcElmFile, ".elm");
+      }
+
+      process.chdir(tmpDirPath);
+
+      prepareAndEmit(srcElmFile, tmpSrc, tmpDest).then(function(result) {
+        process.chdir(originalWorkingDir);
+        resolve(result);
+      }).catch(function(err) {
+        process.chdir(originalWorkingDir);
+        reject(result);
+      });
     });
   });
+}
 
-  function compileEmitter(options, onSuccess, onError) {
-    compile(path.join(__dirname, srcFile), options)
-      .on("close", function(exitCode) {
-        if (exitCode === 0) {
-          onSuccess()
+function prepareAndEmit(srcElmFile, tmpSrc, tmpDest) {
+  return new Promise(function(resolve, reject) {
+    prepare(srcElmFile, tmpSrc, tmpDest).then(function() {
+      emit(tmpSrc, tmpDest).then(resolve).catch(reject);
+    }).catch(reject);
+  });
+}
+
+function prepare(srcElmFile, tmpSrc, tmpDest) {
+  return new Promise(function(resolve, reject) {
+    // Copy the contents of our source file into the temporary file.
+    cp(srcElmFile, tmpSrc, function(err) {
+      if (err) {
+        return reject(err);
+      }
+
+      // Append the ports boilerplate to the temporary file.
+      fs.appendFile(src, emitterPort, function(err, file) {
+        return err
+          ? reject(err)
+          : resolve(file);
+      });
+    });
+  });
+}
+
+function emit(src, dest) {
+  return new Promise(function(resolve, reject) {
+    // Compile the temporary file.
+    compileEmitter(src, {output: dest}).then(function() {
+      // Make the compiled emitter.js Node-friendly.
+      fs.appendFile(dest, "\nmodule.exports = Elm;", function() {
+        var Elm = require(dest);
+        var result = Elm.worker(Elm[elmModuleName]).ports[outputPortName];
+
+        if(result.success) {
+          fs.writeFile(destCssFile, result.content + "\n", function(err, file) {
+            return err ? reject(err) : resolve(file);
+          });
         } else {
-          onError(exitCode);
+          return reject("Compilation error: " + result.content);
         }
       });
-  }
+    }).catch(reject);
+  });
 }
+
+function compileEmitter(src, options) {
+  return new Promise(function(resolve, reject) {
+    compile(src, options)
+      .on("close", function(exitCode) {
+        if (exitCode === 0) {
+          resolve();
+        } else {
+          reject("Errored with exit code " + exitCode);
+        }
+      });
+  });
+}
+
+var outputPortName = "generatedElmCssOutputPort";
+var emitterPort =
+  [ "",
+    "port " + outputPortName + " : { success : Bool , content : String }",
+    "port " + outputPortName + " =",
+    "    (\\result ->",
+    "        case result of",
+    "            Ok styleString ->",
+    "                { success = True, content = styleString } ",
+    "            Err message ->",
+    "                { success = False, content = message }",
+    "    )",
+    ""
+  ].join("\n")

--- a/index.js
+++ b/index.js
@@ -3,7 +3,6 @@ var tmp = require("tmp");
 var path = require("path");
 var compile = require("node-elm-compiler").compile;
 var jsEmitterFilename = "emitter.js";
-var cp = require("node-cp");
 var replaceStream = require("replacestream");
 
 var templatesDir = path.join(__dirname, "templates", "emitter");

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "test"
   },
   "scripts": {
-    "test": "echo \"No npm tests yet!\" && exit 0"
+    "test": "cd test && elm-test TestRunner.elm"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "test"
   },
   "scripts": {
-    "test": "cd test && elm-test TestRunner.elm"
+    "test": "cd test && elm-test TestRunner.elm && mocha *.js"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "elm-stylesheets",
+  "name": "elm-css",
   "version": "0.1.0",
   "description": "Elm-based CSS Preprocessor",
   "main": "index.js",
@@ -11,7 +11,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/rtfeldman/elm-stylesheets.git"
+    "url": "git+https://github.com/rtfeldman/elm-css.git"
   },
   "keywords": [
     "elm",
@@ -23,11 +23,11 @@
   "author": "Richard Feldman <richard.t.feldman@gmail.com>",
   "license": "BSD-3-Clause",
   "bugs": {
-    "url": "https://github.com/rtfeldman/elm-stylesheets/issues"
+    "url": "https://github.com/rtfeldman/elm-css/issues"
   },
-  "homepage": "https://github.com/rtfeldman/elm-stylesheets#readme",
+  "homepage": "https://github.com/rtfeldman/elm-css#readme",
   "dependencies": {
-    "node-elm-compiler": "1.0.1",
+    "node-elm-compiler": "2.3.2",
     "tmp": "0.0.28"
   }
 }

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "tmp": "0.0.28"
   },
   "devDependencies": {
-    "chai": "3.4.1"
+    "chai": "3.4.1",
+    "mocha": "2.3.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -31,5 +31,8 @@
     "node-elm-compiler": "2.3.2",
     "replacestream": "4.0.0",
     "tmp": "0.0.28"
+  },
+  "devDependencies": {
+    "chai": "3.4.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   },
   "homepage": "https://github.com/rtfeldman/elm-css#readme",
   "dependencies": {
+    "node-cp": "0.1.1",
     "node-elm-compiler": "2.3.2",
     "tmp": "0.0.28"
   }

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   "dependencies": {
     "node-cp": "0.1.1",
     "node-elm-compiler": "2.3.2",
+    "replacestream": "4.0.0",
     "tmp": "0.0.28"
   }
 }

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
   },
   "homepage": "https://github.com/rtfeldman/elm-css#readme",
   "dependencies": {
-    "node-cp": "0.1.1",
     "node-elm-compiler": "2.3.2",
     "replacestream": "4.0.0",
     "tmp": "0.0.28"

--- a/src/Css.elm
+++ b/src/Css.elm
@@ -23,7 +23,7 @@ module Css (stylesheet, mixin, prettyPrint, (~=), ($), (#), (.), (@), (|$), (>$)
 # Values
 @docs (~), (!), solid, transparent, rgb, rgba, hex, borderBox, visible, block, inlineBlock, inline, none, auto, inherit, unset, initial, noWrap, top, middle, bottom
 
-# Units
+# Length
 @docs pct, px, em, pt, ex, ch, rem, vh, vw, vmin, vmax, mm, cm, inches, pc
 
 # Pseudo-Classes
@@ -198,7 +198,7 @@ print =
 
 
 
-{- Units -}
+{- Length -}
 
 
 propertyValueToString : (a -> String) -> PropertyValue a -> String
@@ -237,9 +237,9 @@ noneToString translate value =
             translate notNone
 
 
-unitsToString : Units -> String
+unitsToString : Length -> String
 unitsToString =
-    (\(ExplicitUnits str) -> str)
+    (\(ExplicitLength str) -> str)
         |> propertyValueToString
 
 
@@ -361,16 +361,16 @@ type alias Outline =
     PropertyValue ExplicitOutline
 
 
-type alias Units =
-    PropertyValue ExplicitUnits
+type alias Length =
+    PropertyValue ExplicitLength
 
 
 type alias VerticalAlign =
     PropertyValue ExplicitVerticalAlign
 
 
-type ExplicitUnits
-    = ExplicitUnits String
+type ExplicitLength
+    = ExplicitLength String
 
 
 type ExplicitBoxSizing
@@ -398,7 +398,7 @@ type ExplicitVerticalAlign
 
 
 type ExplicitOutline
-    = ExplicitOutline Float ExplicitUnits OutlineStyle OpacityStyle
+    = ExplicitOutline Float ExplicitLength OutlineStyle OpacityStyle
 
 
 type OutlineStyle
@@ -461,109 +461,109 @@ hex str =
 
 {-| [`pct`](https://developer.mozilla.org/en-US/docs/Web/CSS/length#pct) units.
 -}
-pct : Units
+pct : Length
 pct =
-    "%" |> ExplicitUnits |> NotInherit
+    "%" |> ExplicitLength |> NotInherit
 
 
 {-| [`em`](https://developer.mozilla.org/en-US/docs/Web/CSS/length#em) units.
 -}
-em : Units
+em : Length
 em =
-    "em" |> ExplicitUnits |> NotInherit
+    "em" |> ExplicitLength |> NotInherit
 
 
 {-| [`ex`](https://developer.mozilla.org/en-US/docs/Web/CSS/length#ex) units.
 -}
-ex : Units
+ex : Length
 ex =
-    "ex" |> ExplicitUnits |> NotInherit
+    "ex" |> ExplicitLength |> NotInherit
 
 
 {-| [`ch`](https://developer.mozilla.org/en-US/docs/Web/CSS/length#ch) units.
 -}
-ch : Units
+ch : Length
 ch =
-    "ch" |> ExplicitUnits |> NotInherit
+    "ch" |> ExplicitLength |> NotInherit
 
 
 {-| [`rem`](https://developer.mozilla.org/en-US/docs/Web/CSS/length#rem) units.
 -}
-rem : Units
+rem : Length
 rem =
-    "rem" |> ExplicitUnits |> NotInherit
+    "rem" |> ExplicitLength |> NotInherit
 
 
 {-| [`vh`](https://developer.mozilla.org/en-US/docs/Web/CSS/length#vh) units.
 -}
-vh : Units
+vh : Length
 vh =
-    "vh" |> ExplicitUnits |> NotInherit
+    "vh" |> ExplicitLength |> NotInherit
 
 
 {-| [`vw`](https://developer.mozilla.org/en-US/docs/Web/CSS/length#vw) units.
 -}
-vw : Units
+vw : Length
 vw =
-    "vw" |> ExplicitUnits |> NotInherit
+    "vw" |> ExplicitLength |> NotInherit
 
 
 {-| [`vmin`](https://developer.mozilla.org/en-US/docs/Web/CSS/length#vmin) units.
 -}
-vmin : Units
+vmin : Length
 vmin =
-    "vmin" |> ExplicitUnits |> NotInherit
+    "vmin" |> ExplicitLength |> NotInherit
 
 
 {-| [`vmax`](https://developer.mozilla.org/en-US/docs/Web/CSS/length#vmax) units.
 -}
-vmax : Units
+vmax : Length
 vmax =
-    "vmax" |> ExplicitUnits |> NotInherit
+    "vmax" |> ExplicitLength |> NotInherit
 
 
 {-| [`px`](https://developer.mozilla.org/en-US/docs/Web/CSS/length#px) units.
 -}
-px : Units
+px : Length
 px =
-    "px" |> ExplicitUnits |> NotInherit
+    "px" |> ExplicitLength |> NotInherit
 
 
 {-| [`mm`](https://developer.mozilla.org/en-US/docs/Web/CSS/length#mm) units.
 -}
-mm : Units
+mm : Length
 mm =
-    "mm" |> ExplicitUnits |> NotInherit
+    "mm" |> ExplicitLength |> NotInherit
 
 
 {-| [`cm`](https://developer.mozilla.org/en-US/docs/Web/CSS/length#cm) units.
 -}
-cm : Units
+cm : Length
 cm =
-    "cm" |> ExplicitUnits |> NotInherit
+    "cm" |> ExplicitLength |> NotInherit
 
 
 {-| [`in`](https://developer.mozilla.org/en-US/docs/Web/CSS/length#in) units.
 
 (This is `inches` instead of `in` because `in` is a reserved keyword in Elm.)
 -}
-inches : Units
+inches : Length
 inches =
-    "in" |> ExplicitUnits |> NotInherit
+    "in" |> ExplicitLength |> NotInherit
 
 
 {-| [`pt`](https://developer.mozilla.org/en-US/docs/Web/CSS/length#pt) units.
 -}
-pt : Units
+pt : Length
 pt =
-    "pt" |> ExplicitUnits |> NotInherit
+    "pt" |> ExplicitLength |> NotInherit
 
 
 {-| [`pc`](https://developer.mozilla.org/en-US/docs/Web/CSS/length#pc) units.
 -}
-pc : Units
+pc : Length
 pc =
-    "pc" |> ExplicitUnits |> NotInherit
+    "pc" |> ExplicitLength |> NotInherit
 
 
 {-| -}
@@ -699,85 +699,85 @@ opacity =
 
 
 {-| -}
-width : number -> Units -> ( String, String )
+width : number -> Length -> ( String, String )
 width =
     prop2 "width" numberToString unitsToString
 
 
 {-| -}
-minWidth : number -> Units -> ( String, String )
+minWidth : number -> Length -> ( String, String )
 minWidth =
     prop2 "min-width" numberToString unitsToString
 
 
 {-| -}
-height : number -> Units -> ( String, String )
+height : number -> Length -> ( String, String )
 height =
     prop2 "height" numberToString unitsToString
 
 
 {-| -}
-minHeight : number -> Units -> ( String, String )
+minHeight : number -> Length -> ( String, String )
 minHeight =
     prop2 "min-height" numberToString unitsToString
 
 
 {-| -}
-padding : number -> Units -> ( String, String )
+padding : number -> Length -> ( String, String )
 padding =
     prop2 "padding" numberToString unitsToString
 
 
 {-| -}
-paddingTop : number -> Units -> ( String, String )
+paddingTop : number -> Length -> ( String, String )
 paddingTop =
     prop2 "padding-top" numberToString unitsToString
 
 
 {-| -}
-paddingBottom : number -> Units -> ( String, String )
+paddingBottom : number -> Length -> ( String, String )
 paddingBottom =
     prop2 "padding-bottom" numberToString unitsToString
 
 
 {-| -}
-paddingRight : number -> Units -> ( String, String )
+paddingRight : number -> Length -> ( String, String )
 paddingRight =
     prop2 "padding-right" numberToString unitsToString
 
 
 {-| -}
-paddingLeft : number -> Units -> ( String, String )
+paddingLeft : number -> Length -> ( String, String )
 paddingLeft =
     prop2 "padding-left" numberToString unitsToString
 
 
 {-| -}
-margin : number -> Units -> ( String, String )
+margin : number -> Length -> ( String, String )
 margin =
     prop2 "margin" numberToString unitsToString
 
 
 {-| -}
-marginTop : number -> Units -> ( String, String )
+marginTop : number -> Length -> ( String, String )
 marginTop =
     prop2 "margin-top" numberToString unitsToString
 
 
 {-| -}
-marginBottom : number -> Units -> ( String, String )
+marginBottom : number -> Length -> ( String, String )
 marginBottom =
     prop2 "margin-bottom" numberToString unitsToString
 
 
 {-| -}
-marginRight : number -> Units -> ( String, String )
+marginRight : number -> Length -> ( String, String )
 marginRight =
     prop2 "margin-right" numberToString unitsToString
 
 
 {-| -}
-marginLeft : number -> Units -> ( String, String )
+marginLeft : number -> Length -> ( String, String )
 marginLeft =
     prop2 "margin-left" numberToString unitsToString
 
@@ -831,7 +831,7 @@ textShadow =
 
 
 {-| -}
-outline : Float -> Units -> OutlineStyle -> OpacityStyle -> ( String, String )
+outline : Float -> Length -> OutlineStyle -> OpacityStyle -> ( String, String )
 outline =
     prop4
         "outline"
@@ -1877,13 +1877,15 @@ updateLast update list =
             first :: updateLast update rest
 
 
+
 {- Compiler Output -}
+
 
 {-| Record type for converting a Result to something consumable in Node
 -}
 type alias CompilerOutput =
-    { success: Bool
-    , content: String
+    { success : Bool
+    , content : String
     }
 
 
@@ -1903,5 +1905,6 @@ outputToPort result =
     case result of
         Ok styleString ->
             CompilerOutput True styleString
+
         Err message ->
             CompilerOutput False message

--- a/src/Css.elm
+++ b/src/Css.elm
@@ -1875,36 +1875,3 @@ updateLast update list =
 
         first :: rest ->
             first :: updateLast update rest
-
-
-
-{- Compiler Output -}
-
-
-{-| Record type for converting a Result to something consumable in Node
--}
-type alias CompilerOutput =
-    { success : Bool
-    , content : String
-    }
-
-
-{-| Converts a Result emitted by prettyPrint to a CompilerOutput
-
-    port output =
-        outputToPort css
-
-    css =
-        prettyPrint <|
-            stylsheet "example"
-                $ body
-                    ~ margin 0 px
--}
-outputToPort : Result String String -> CompilerOutput
-outputToPort result =
-    case result of
-        Ok styleString ->
-            CompilerOutput True styleString
-
-        Err message ->
-            CompilerOutput False message

--- a/src/Css.elm
+++ b/src/Css.elm
@@ -1,4 +1,4 @@
-module Css (stylesheet, mixin, prettyPrint, (~=), ($), (#), (.), (@), (|$), (>$), (>>$), (+$), (~$), (>#), (>>#), (+#), (~#), (>.), (>>.), (+.), (~.), ($=), (~), (&::), (&:), (!), a, html, body, header, nav, div, span, img, nowrap, button, h1, h2, h3, h4, p, ol, input, verticalAlign, display, opacity, width, minWidth, height, minHeight, padding, paddingTop, paddingBottom, paddingRight, paddingLeft, margin, marginTop, marginBottom, marginRight, marginLeft, boxSizing, overflowX, overflowY, whiteSpace, backgroundColor, color, media, textShadow, outline, solid, transparent, rgb, rgba, hex, pct, px, em, pt, ex, ch, rem, vh, vw, vmin, vmax, mm, cm, inches, pc, borderBox, visible, block, inlineBlock, inline, none, auto, inherit, initial, unset, noWrap, top, middle, bottom, after, before, firstLetter, firstLine, selection, active, any, checked, dir, disabled, empty, enabled, first, firstChild, firstOfType, fullscreen, focus, hover, indeterminate, invalid, lang, lastChild, lastOfType, left, link, nthChild, nthLastChild, nthLastOfType, nthOfType, onlyChild, onlyOfType, optional, outOfRange, readWrite, required, right, root, scope, target, valid, CompilerOutput, outputToPort) where
+module Css (stylesheet, mixin, prettyPrint, (~=), ($), (#), (.), (@), (|$), (>$), (>>$), (+$), (~$), (>#), (>>#), (+#), (~#), (>.), (>>.), (+.), (~.), ($=), (~), (&::), (&:), (!), a, html, body, header, nav, div, span, img, nowrap, button, h1, h2, h3, h4, p, ol, input, verticalAlign, display, opacity, width, minWidth, height, minHeight, padding, paddingTop, paddingBottom, paddingRight, paddingLeft, margin, marginTop, marginBottom, marginRight, marginLeft, boxSizing, overflowX, overflowY, whiteSpace, backgroundColor, color, media, textShadow, outline, solid, transparent, rgb, rgba, hex, pct, px, em, pt, ex, ch, rem, vh, vw, vmin, vmax, mm, cm, inches, pc, borderBox, visible, block, inlineBlock, inline, none, auto, inherit, initial, unset, noWrap, top, middle, bottom, after, before, firstLetter, firstLine, selection, active, any, checked, dir, disabled, empty, enabled, first, firstChild, firstOfType, fullscreen, focus, hover, indeterminate, invalid, lang, lastChild, lastOfType, left, link, nthChild, nthLastChild, nthLastOfType, nthOfType, onlyChild, onlyOfType, optional, outOfRange, readWrite, required, right, root, scope, target, valid) where
 
 {-| Functions for building stylesheets.
 
@@ -31,9 +31,6 @@ module Css (stylesheet, mixin, prettyPrint, (~=), ($), (#), (.), (@), (|$), (>$)
 
 # Pseudo-Elements
 @docs (&::), after, before, firstLetter, firstLine, selection
-
-# Compiler Output
-@docs (CompilerOutput, outputToPort)
 -}
 
 import Css.Declaration as Declaration exposing (..)

--- a/src/Emitter.elm
+++ b/src/Emitter.elm
@@ -1,0 +1,39 @@
+module Emitter (..) where
+
+import Css exposing (..)
+import NameOfSourceModuleGoesHere as SourceModule
+
+
+port cssOutput : CompilerOutput
+port cssOutput =
+    SourceModule Css.prettyPrint SourceModule.css
+        |> outputToPort
+
+
+{-| Record type for converting a Result to something consumable in Node
+-}
+type alias CompilerOutput =
+    { success : Bool
+    , content : String
+    }
+
+
+{-| Converts a Result emitted by prettyPrint to a CompilerOutput
+
+    port output =
+        outputToPort css
+
+    css =
+        prettyPrint <|
+            stylsheet "example"
+                $ body
+                    ~ margin 0 px
+-}
+outputToPort : Result String String -> CompilerOutput
+outputToPort result =
+    case result of
+        Ok styleString ->
+            CompilerOutput True styleString
+
+        Err message ->
+            CompilerOutput False message

--- a/templates/emitter/Emitter.elm
+++ b/templates/emitter/Emitter.elm
@@ -6,7 +6,7 @@ import NameOfSourceModuleGoesHere as SourceModule
 
 port cssOutput : CompilerOutput
 port cssOutput =
-    SourceModule Css.prettyPrint SourceModule.css
+    Css.prettyPrint SourceModule.css
         |> outputToPort
 
 
@@ -21,13 +21,12 @@ type alias CompilerOutput =
 {-| Converts a Result emitted by prettyPrint to a CompilerOutput
 
     port output =
-        outputToPort css
+        outputToPort (prettyPrint css)
 
     css =
-        prettyPrint <|
-            stylsheet "example"
-                $ body
-                    ~ margin 0 px
+        stylsheet { name = "example" }
+            $ body
+                ~ margin 0 px
 -}
 outputToPort : Result String String -> CompilerOutput
 outputToPort result =

--- a/templates/emitter/elm-package.json
+++ b/templates/emitter/elm-package.json
@@ -1,0 +1,15 @@
+{
+    "version": "1.0.0",
+    "summary": "Emitter for elm-css",
+    "repository": "https://github.com/rtfeldman/elm-css.git",
+    "license": "BSD-3-Clause",
+    "source-directories": [
+        "$nameOfTargetSourceDirectoryGoesHere",
+        "."
+    ],
+    "exposed-modules": [],
+    "dependencies": {
+        "elm-lang/core": "3.0.0 <= v < 4.0.0"
+    },
+    "elm-version": "0.16.0 <= v < 0.17.0"
+}

--- a/test/emit.js
+++ b/test/emit.js
@@ -1,0 +1,29 @@
+var assert = require("chai").assert;
+var path = require("path");
+var emitter = require(path.join(__dirname, ".."));
+var fs = require("fs");
+
+var fixturesDir = path.join(__dirname, "fixtures");
+
+function prependFixturesDir(filename) {
+  return path.join(fixturesDir, filename);
+}
+
+describe("emitting", function() {
+  it("works with HomepageStylesheet.elm", function (done) {
+    // Use a timeout of 5 minutes because Travis on Linux can be SUPER slow.
+    this.timeout(300000);
+
+    var srcFile = path.join(__dirname, "..", "examples/src/HomepageStylesheet.elm");
+    var destCssFile = path.join(__dirname, "output.css")
+
+    emitter(srcFile, destCssFile).then(function() {
+      var expectedFile = path.join(fixturesDir, "homepage-compiled.css");
+      var expected = fs.readFileSync(expectedFile, {encoding: "utf8"});
+      var actual = fs.readFileSync(destCssFile, {encoding: "utf8"});
+
+      assert.strictEqual(expected, actual);
+      done();
+    }, assert.fail);
+  });
+});

--- a/test/emit.js
+++ b/test/emit.js
@@ -14,7 +14,7 @@ describe("emitting", function() {
     // Use a timeout of 5 minutes because Travis on Linux can be SUPER slow.
     this.timeout(300000);
 
-    var srcFile = path.join(__dirname, "..", "examples/src/HomepageStylesheet.elm");
+    var srcFile = path.join(__dirname, "..", "examples", "src", "HomepageStylesheet.elm");
     var destCssFile = path.join(__dirname, "output.css")
 
     emitter(srcFile, destCssFile).then(function() {

--- a/test/fixtures/homepage-compiled.css
+++ b/test/fixtures/homepage-compiled.css
@@ -1,0 +1,32 @@
+header {
+    background-color: rgb(90, 90, 90);
+    box-sizing: border-box;
+    padding: -80px;
+}
+
+nav {
+    display: inline-block;
+    padding-bottom: 12px;
+}
+
+.homepage_NavLink {
+    margin: 12px;
+    color: rgb(255, 255, 255);
+}
+
+#ReactiveLogo {
+    display: inline-block;
+    margin-left: 150px;
+    margin-right: 80px;
+    vertical-align: middle;
+}
+
+#BuyTickets {
+    padding: 16px;
+    padding-left: 24px;
+    padding-right: 24px;
+    margin-left: 50px;
+    color: rgb(255, 255, 255);
+    background-color: rgb(27, 217, 130);
+    vertical-align: middle;
+}


### PR DESCRIPTION
* Now you can do `var emit = require("elm-css")` to get a function which takes a source .elm file and a destination .css file and returns a promise which generates the latter from the former.
* Stylesheets can now expose just the return value of `stylesheet`, not a `Result String String`
* Css.elm no longer knows about `CompilerOutput`; that's all in `templates/` now, for use exclusively in the Node wrapper
* There's a basic test that asserts this all works for HomepageStylesheet