### PR TITLE
Revamp type hierarchy to use extensible records

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,7958 @@
+<!DOCTYPE HTML>
+<html><head><meta charset="UTF-8"><title>Css</title><style>html,head,body { padding:0; margin:0; }
+body { font-family: calibri, helvetica, arial, sans-serif; }</style><script type="text/javascript">var Elm = Elm || { Native: {} };Elm.Native.Basics = {};
+Elm.Native.Basics.make = function(localRuntime) {
+	localRuntime.Native = localRuntime.Native || {};
+	localRuntime.Native.Basics = localRuntime.Native.Basics || {};
+	if (localRuntime.Native.Basics.values)
+	{
+		return localRuntime.Native.Basics.values;
+	}
+
+	var Utils = Elm.Native.Utils.make(localRuntime);
+
+	function div(a, b)
+	{
+		return (a / b) | 0;
+	}
+	function rem(a, b)
+	{
+		return a % b;
+	}
+	function mod(a, b)
+	{
+		if (b === 0)
+		{
+			throw new Error('Cannot perform mod 0. Division by zero error.');
+		}
+		var r = a % b;
+		var m = a === 0 ? 0 : (b > 0 ? (a >= 0 ? r : r + b) : -mod(-a, -b));
+
+		return m === b ? 0 : m;
+	}
+	function logBase(base, n)
+	{
+		return Math.log(n) / Math.log(base);
+	}
+	function negate(n)
+	{
+		return -n;
+	}
+	function abs(n)
+	{
+		return n < 0 ? -n : n;
+	}
+
+	function min(a, b)
+	{
+		return Utils.cmp(a, b) < 0 ? a : b;
+	}
+	function max(a, b)
+	{
+		return Utils.cmp(a, b) > 0 ? a : b;
+	}
+	function clamp(lo, hi, n)
+	{
+		return Utils.cmp(n, lo) < 0 ? lo : Utils.cmp(n, hi) > 0 ? hi : n;
+	}
+
+	function xor(a, b)
+	{
+		return a !== b;
+	}
+	function not(b)
+	{
+		return !b;
+	}
+	function isInfinite(n)
+	{
+		return n === Infinity || n === -Infinity;
+	}
+
+	function truncate(n)
+	{
+		return n | 0;
+	}
+
+	function degrees(d)
+	{
+		return d * Math.PI / 180;
+	}
+	function turns(t)
+	{
+		return 2 * Math.PI * t;
+	}
+	function fromPolar(point)
+	{
+		var r = point._0;
+		var t = point._1;
+		return Utils.Tuple2(r * Math.cos(t), r * Math.sin(t));
+	}
+	function toPolar(point)
+	{
+		var x = point._0;
+		var y = point._1;
+		return Utils.Tuple2(Math.sqrt(x * x + y * y), Math.atan2(y, x));
+	}
+
+	return localRuntime.Native.Basics.values = {
+		div: F2(div),
+		rem: F2(rem),
+		mod: F2(mod),
+
+		pi: Math.PI,
+		e: Math.E,
+		cos: Math.cos,
+		sin: Math.sin,
+		tan: Math.tan,
+		acos: Math.acos,
+		asin: Math.asin,
+		atan: Math.atan,
+		atan2: F2(Math.atan2),
+
+		degrees: degrees,
+		turns: turns,
+		fromPolar: fromPolar,
+		toPolar: toPolar,
+
+		sqrt: Math.sqrt,
+		logBase: F2(logBase),
+		negate: negate,
+		abs: abs,
+		min: F2(min),
+		max: F2(max),
+		clamp: F3(clamp),
+		compare: Utils.compare,
+
+		xor: F2(xor),
+		not: not,
+
+		truncate: truncate,
+		ceiling: Math.ceil,
+		floor: Math.floor,
+		round: Math.round,
+		toFloat: function(x) { return x; },
+		isNaN: isNaN,
+		isInfinite: isInfinite
+	};
+};
+Elm.Native.Port = {};
+
+Elm.Native.Port.make = function(localRuntime) {
+	localRuntime.Native = localRuntime.Native || {};
+	localRuntime.Native.Port = localRuntime.Native.Port || {};
+	if (localRuntime.Native.Port.values)
+	{
+		return localRuntime.Native.Port.values;
+	}
+
+	var NS;
+
+	// INBOUND
+
+	function inbound(name, type, converter)
+	{
+		if (!localRuntime.argsTracker[name])
+		{
+			throw new Error(
+				'Port Error:\n' +
+				'No argument was given for the port named \'' + name + '\' with type:\n\n' +
+				'    ' + type.split('\n').join('\n        ') + '\n\n' +
+				'You need to provide an initial value!\n\n' +
+				'Find out more about ports here <http://elm-lang.org/learn/Ports.elm>'
+			);
+		}
+		var arg = localRuntime.argsTracker[name];
+		arg.used = true;
+
+		return jsToElm(name, type, converter, arg.value);
+	}
+
+
+	function inboundSignal(name, type, converter)
+	{
+		var initialValue = inbound(name, type, converter);
+
+		if (!NS)
+		{
+			NS = Elm.Native.Signal.make(localRuntime);
+		}
+		var signal = NS.input('inbound-port-' + name, initialValue);
+
+		function send(jsValue)
+		{
+			var elmValue = jsToElm(name, type, converter, jsValue);
+			setTimeout(function() {
+				localRuntime.notify(signal.id, elmValue);
+			}, 0);
+		}
+
+		localRuntime.ports[name] = { send: send };
+
+		return signal;
+	}
+
+
+	function jsToElm(name, type, converter, value)
+	{
+		try
+		{
+			return converter(value);
+		}
+		catch(e)
+		{
+			throw new Error(
+				'Port Error:\n' +
+				'Regarding the port named \'' + name + '\' with type:\n\n' +
+				'    ' + type.split('\n').join('\n        ') + '\n\n' +
+				'You just sent the value:\n\n' +
+				'    ' + JSON.stringify(value) + '\n\n' +
+				'but it cannot be converted to the necessary type.\n' +
+				e.message
+			);
+		}
+	}
+
+
+	// OUTBOUND
+
+	function outbound(name, converter, elmValue)
+	{
+		localRuntime.ports[name] = converter(elmValue);
+	}
+
+
+	function outboundSignal(name, converter, signal)
+	{
+		var subscribers = [];
+
+		function subscribe(handler)
+		{
+			subscribers.push(handler);
+		}
+		function unsubscribe(handler)
+		{
+			subscribers.pop(subscribers.indexOf(handler));
+		}
+
+		function notify(elmValue)
+		{
+			var jsValue = converter(elmValue);
+			var len = subscribers.length;
+			for (var i = 0; i < len; ++i)
+			{
+				subscribers[i](jsValue);
+			}
+		}
+
+		if (!NS)
+		{
+			NS = Elm.Native.Signal.make(localRuntime);
+		}
+		NS.output('outbound-port-' + name, notify, signal);
+
+		localRuntime.ports[name] = {
+			subscribe: subscribe,
+			unsubscribe: unsubscribe
+		};
+
+		return signal;
+	}
+
+
+	return localRuntime.Native.Port.values = {
+		inbound: inbound,
+		outbound: outbound,
+		inboundSignal: inboundSignal,
+		outboundSignal: outboundSignal
+	};
+};
+if (!Elm.fullscreen) {
+	(function() {
+		'use strict';
+
+		var Display = {
+			FULLSCREEN: 0,
+			COMPONENT: 1,
+			NONE: 2
+		};
+
+		Elm.fullscreen = function(module, args)
+		{
+			var container = document.createElement('div');
+			document.body.appendChild(container);
+			return init(Display.FULLSCREEN, container, module, args || {});
+		};
+
+		Elm.embed = function(module, container, args)
+		{
+			var tag = container.tagName;
+			if (tag !== 'DIV')
+			{
+				throw new Error('Elm.node must be given a DIV, not a ' + tag + '.');
+			}
+			return init(Display.COMPONENT, container, module, args || {});
+		};
+
+		Elm.worker = function(module, args)
+		{
+			return init(Display.NONE, {}, module, args || {});
+		};
+
+		function init(display, container, module, args, moduleToReplace)
+		{
+			// defining state needed for an instance of the Elm RTS
+			var inputs = [];
+
+			/* OFFSET
+			 * Elm's time traveling debugger lets you pause time. This means
+			 * "now" may be shifted a bit into the past. By wrapping Date.now()
+			 * we can manage this.
+			 */
+			var timer = {
+				programStart: Date.now(),
+				now: function()
+				{
+					return Date.now();
+				}
+			};
+
+			var updateInProgress = false;
+			function notify(id, v)
+			{
+				if (updateInProgress)
+				{
+					throw new Error(
+						'The notify function has been called synchronously!\n' +
+						'This can lead to frames being dropped.\n' +
+						'Definitely report this to <https://github.com/elm-lang/Elm/issues>\n');
+				}
+				updateInProgress = true;
+				var timestep = timer.now();
+				for (var i = inputs.length; i--; )
+				{
+					inputs[i].notify(timestep, id, v);
+				}
+				updateInProgress = false;
+			}
+			function setTimeout(func, delay)
+			{
+				return window.setTimeout(func, delay);
+			}
+
+			var listeners = [];
+			function addListener(relevantInputs, domNode, eventName, func)
+			{
+				domNode.addEventListener(eventName, func);
+				var listener = {
+					relevantInputs: relevantInputs,
+					domNode: domNode,
+					eventName: eventName,
+					func: func
+				};
+				listeners.push(listener);
+			}
+
+			var argsTracker = {};
+			for (var name in args)
+			{
+				argsTracker[name] = {
+					value: args[name],
+					used: false
+				};
+			}
+
+			// create the actual RTS. Any impure modules will attach themselves to this
+			// object. This permits many Elm programs to be embedded per document.
+			var elm = {
+				notify: notify,
+				setTimeout: setTimeout,
+				node: container,
+				addListener: addListener,
+				inputs: inputs,
+				timer: timer,
+				argsTracker: argsTracker,
+				ports: {},
+
+				isFullscreen: function() { return display === Display.FULLSCREEN; },
+				isEmbed: function() { return display === Display.COMPONENT; },
+				isWorker: function() { return display === Display.NONE; }
+			};
+
+			function swap(newModule)
+			{
+				removeListeners(listeners);
+				var div = document.createElement('div');
+				var newElm = init(display, div, newModule, args, elm);
+				inputs = [];
+
+				return newElm;
+			}
+
+			function dispose()
+			{
+				removeListeners(listeners);
+				inputs = [];
+			}
+
+			var Module = {};
+			try
+			{
+				Module = module.make(elm);
+				checkInputs(elm);
+			}
+			catch (error)
+			{
+				if (typeof container.appendChild === "function")
+				{
+					container.appendChild(errorNode(error.message));
+				}
+				else
+				{
+					console.error(error.message);
+				}
+				throw error;
+			}
+
+			if (display !== Display.NONE)
+			{
+				var graphicsNode = initGraphics(elm, Module);
+			}
+
+			var rootNode = { kids: inputs };
+			trimDeadNodes(rootNode);
+			inputs = rootNode.kids;
+			filterListeners(inputs, listeners);
+
+			addReceivers(elm.ports);
+
+			if (typeof moduleToReplace !== 'undefined')
+			{
+				hotSwap(moduleToReplace, elm);
+
+				// rerender scene if graphics are enabled.
+				if (typeof graphicsNode !== 'undefined')
+				{
+					graphicsNode.notify(0, true, 0);
+				}
+			}
+
+			return {
+				swap: swap,
+				ports: elm.ports,
+				dispose: dispose
+			};
+		}
+
+		function checkInputs(elm)
+		{
+			var argsTracker = elm.argsTracker;
+			for (var name in argsTracker)
+			{
+				if (!argsTracker[name].used)
+				{
+					throw new Error(
+						"Port Error:\nYou provided an argument named '" + name +
+						"' but there is no corresponding port!\n\n" +
+						"Maybe add a port '" + name + "' to your Elm module?\n" +
+						"Maybe remove the '" + name + "' argument from your initialization code in JS?"
+					);
+				}
+			}
+		}
+
+		function errorNode(message)
+		{
+			var code = document.createElement('code');
+
+			var lines = message.split('\n');
+			code.appendChild(document.createTextNode(lines[0]));
+			code.appendChild(document.createElement('br'));
+			code.appendChild(document.createElement('br'));
+			for (var i = 1; i < lines.length; ++i)
+			{
+				code.appendChild(document.createTextNode('\u00A0 \u00A0 ' + lines[i].replace(/  /g, '\u00A0 ')));
+				code.appendChild(document.createElement('br'));
+			}
+			code.appendChild(document.createElement('br'));
+			code.appendChild(document.createTextNode('Open the developer console for more details.'));
+			return code;
+		}
+
+
+		//// FILTER SIGNALS ////
+
+		// TODO: move this code into the signal module and create a function
+		// Signal.initializeGraph that actually instantiates everything.
+
+		function filterListeners(inputs, listeners)
+		{
+			loop:
+			for (var i = listeners.length; i--; )
+			{
+				var listener = listeners[i];
+				for (var j = inputs.length; j--; )
+				{
+					if (listener.relevantInputs.indexOf(inputs[j].id) >= 0)
+					{
+						continue loop;
+					}
+				}
+				listener.domNode.removeEventListener(listener.eventName, listener.func);
+			}
+		}
+
+		function removeListeners(listeners)
+		{
+			for (var i = listeners.length; i--; )
+			{
+				var listener = listeners[i];
+				listener.domNode.removeEventListener(listener.eventName, listener.func);
+			}
+		}
+
+		// add receivers for built-in ports if they are defined
+		function addReceivers(ports)
+		{
+			if ('title' in ports)
+			{
+				if (typeof ports.title === 'string')
+				{
+					document.title = ports.title;
+				}
+				else
+				{
+					ports.title.subscribe(function(v) { document.title = v; });
+				}
+			}
+			if ('redirect' in ports)
+			{
+				ports.redirect.subscribe(function(v) {
+					if (v.length > 0)
+					{
+						window.location = v;
+					}
+				});
+			}
+		}
+
+
+		// returns a boolean representing whether the node is alive or not.
+		function trimDeadNodes(node)
+		{
+			if (node.isOutput)
+			{
+				return true;
+			}
+
+			var liveKids = [];
+			for (var i = node.kids.length; i--; )
+			{
+				var kid = node.kids[i];
+				if (trimDeadNodes(kid))
+				{
+					liveKids.push(kid);
+				}
+			}
+			node.kids = liveKids;
+
+			return liveKids.length > 0;
+		}
+
+
+		////  RENDERING  ////
+
+		function initGraphics(elm, Module)
+		{
+			if (!('main' in Module))
+			{
+				throw new Error("'main' is missing! What do I display?!");
+			}
+
+			var signalGraph = Module.main;
+
+			// make sure the signal graph is actually a signal & extract the visual model
+			if (!('notify' in signalGraph))
+			{
+				signalGraph = Elm.Signal.make(elm).constant(signalGraph);
+			}
+			var initialScene = signalGraph.value;
+
+			// Figure out what the render functions should be
+			var render;
+			var update;
+			if (initialScene.props)
+			{
+				var Element = Elm.Native.Graphics.Element.make(elm);
+				render = Element.render;
+				update = Element.updateAndReplace;
+			}
+			else
+			{
+				var VirtualDom = Elm.Native.VirtualDom.make(elm);
+				render = VirtualDom.render;
+				update = VirtualDom.updateAndReplace;
+			}
+
+			// Add the initialScene to the DOM
+			var container = elm.node;
+			var node = render(initialScene);
+			while (container.firstChild)
+			{
+				container.removeChild(container.firstChild);
+			}
+			container.appendChild(node);
+
+			var _requestAnimationFrame =
+				typeof requestAnimationFrame !== 'undefined'
+					? requestAnimationFrame
+					: function(cb) { setTimeout(cb, 1000 / 60); }
+					;
+
+			// domUpdate is called whenever the main Signal changes.
+			//
+			// domUpdate and drawCallback implement a small state machine in order
+			// to schedule only 1 draw per animation frame. This enforces that
+			// once draw has been called, it will not be called again until the
+			// next frame.
+			//
+			// drawCallback is scheduled whenever
+			// 1. The state transitions from PENDING_REQUEST to EXTRA_REQUEST, or
+			// 2. The state transitions from NO_REQUEST to PENDING_REQUEST
+			//
+			// Invariants:
+			// 1. In the NO_REQUEST state, there is never a scheduled drawCallback.
+			// 2. In the PENDING_REQUEST and EXTRA_REQUEST states, there is always exactly 1
+			//    scheduled drawCallback.
+			var NO_REQUEST = 0;
+			var PENDING_REQUEST = 1;
+			var EXTRA_REQUEST = 2;
+			var state = NO_REQUEST;
+			var savedScene = initialScene;
+			var scheduledScene = initialScene;
+
+			function domUpdate(newScene)
+			{
+				scheduledScene = newScene;
+
+				switch (state)
+				{
+					case NO_REQUEST:
+						_requestAnimationFrame(drawCallback);
+						state = PENDING_REQUEST;
+						return;
+					case PENDING_REQUEST:
+						state = PENDING_REQUEST;
+						return;
+					case EXTRA_REQUEST:
+						state = PENDING_REQUEST;
+						return;
+				}
+			}
+
+			function drawCallback()
+			{
+				switch (state)
+				{
+					case NO_REQUEST:
+						// This state should not be possible. How can there be no
+						// request, yet somehow we are actively fulfilling a
+						// request?
+						throw new Error(
+							'Unexpected draw callback.\n' +
+							'Please report this to <https://github.com/elm-lang/core/issues>.'
+						);
+
+					case PENDING_REQUEST:
+						// At this point, we do not *know* that another frame is
+						// needed, but we make an extra request to rAF just in
+						// case. It's possible to drop a frame if rAF is called
+						// too late, so we just do it preemptively.
+						_requestAnimationFrame(drawCallback);
+						state = EXTRA_REQUEST;
+
+						// There's also stuff we definitely need to draw.
+						draw();
+						return;
+
+					case EXTRA_REQUEST:
+						// Turns out the extra request was not needed, so we will
+						// stop calling rAF. No reason to call it all the time if
+						// no one needs it.
+						state = NO_REQUEST;
+						return;
+				}
+			}
+
+			function draw()
+			{
+				update(elm.node.firstChild, savedScene, scheduledScene);
+				if (elm.Native.Window)
+				{
+					elm.Native.Window.values.resizeIfNeeded();
+				}
+				savedScene = scheduledScene;
+			}
+
+			var renderer = Elm.Native.Signal.make(elm).output('main', domUpdate, signalGraph);
+
+			// must check for resize after 'renderer' is created so
+			// that changes show up.
+			if (elm.Native.Window)
+			{
+				elm.Native.Window.values.resizeIfNeeded();
+			}
+
+			return renderer;
+		}
+
+		//// HOT SWAPPING ////
+
+		// Returns boolean indicating if the swap was successful.
+		// Requires that the two signal graphs have exactly the same
+		// structure.
+		function hotSwap(from, to)
+		{
+			function similar(nodeOld, nodeNew)
+			{
+				if (nodeOld.id !== nodeNew.id)
+				{
+					return false;
+				}
+				if (nodeOld.isOutput)
+				{
+					return nodeNew.isOutput;
+				}
+				return nodeOld.kids.length === nodeNew.kids.length;
+			}
+			function swap(nodeOld, nodeNew)
+			{
+				nodeNew.value = nodeOld.value;
+				return true;
+			}
+			var canSwap = depthFirstTraversals(similar, from.inputs, to.inputs);
+			if (canSwap)
+			{
+				depthFirstTraversals(swap, from.inputs, to.inputs);
+			}
+			from.node.parentNode.replaceChild(to.node, from.node);
+
+			return canSwap;
+		}
+
+		// Returns false if the node operation f ever fails.
+		function depthFirstTraversals(f, queueOld, queueNew)
+		{
+			if (queueOld.length !== queueNew.length)
+			{
+				return false;
+			}
+			queueOld = queueOld.slice(0);
+			queueNew = queueNew.slice(0);
+
+			var seen = [];
+			while (queueOld.length > 0 && queueNew.length > 0)
+			{
+				var nodeOld = queueOld.pop();
+				var nodeNew = queueNew.pop();
+				if (seen.indexOf(nodeOld.id) < 0)
+				{
+					if (!f(nodeOld, nodeNew))
+					{
+						return false;
+					}
+					queueOld = queueOld.concat(nodeOld.kids || []);
+					queueNew = queueNew.concat(nodeNew.kids || []);
+					seen.push(nodeOld.id);
+				}
+			}
+			return true;
+		}
+	}());
+
+	function F2(fun)
+	{
+		function wrapper(a) { return function(b) { return fun(a,b); }; }
+		wrapper.arity = 2;
+		wrapper.func = fun;
+		return wrapper;
+	}
+
+	function F3(fun)
+	{
+		function wrapper(a) {
+			return function(b) { return function(c) { return fun(a, b, c); }; };
+		}
+		wrapper.arity = 3;
+		wrapper.func = fun;
+		return wrapper;
+	}
+
+	function F4(fun)
+	{
+		function wrapper(a) { return function(b) { return function(c) {
+			return function(d) { return fun(a, b, c, d); }; }; };
+		}
+		wrapper.arity = 4;
+		wrapper.func = fun;
+		return wrapper;
+	}
+
+	function F5(fun)
+	{
+		function wrapper(a) { return function(b) { return function(c) {
+			return function(d) { return function(e) { return fun(a, b, c, d, e); }; }; }; };
+		}
+		wrapper.arity = 5;
+		wrapper.func = fun;
+		return wrapper;
+	}
+
+	function F6(fun)
+	{
+		function wrapper(a) { return function(b) { return function(c) {
+			return function(d) { return function(e) { return function(f) {
+			return fun(a, b, c, d, e, f); }; }; }; }; };
+		}
+		wrapper.arity = 6;
+		wrapper.func = fun;
+		return wrapper;
+	}
+
+	function F7(fun)
+	{
+		function wrapper(a) { return function(b) { return function(c) {
+			return function(d) { return function(e) { return function(f) {
+			return function(g) { return fun(a, b, c, d, e, f, g); }; }; }; }; }; };
+		}
+		wrapper.arity = 7;
+		wrapper.func = fun;
+		return wrapper;
+	}
+
+	function F8(fun)
+	{
+		function wrapper(a) { return function(b) { return function(c) {
+			return function(d) { return function(e) { return function(f) {
+			return function(g) { return function(h) {
+			return fun(a, b, c, d, e, f, g, h); }; }; }; }; }; }; };
+		}
+		wrapper.arity = 8;
+		wrapper.func = fun;
+		return wrapper;
+	}
+
+	function F9(fun)
+	{
+		function wrapper(a) { return function(b) { return function(c) {
+			return function(d) { return function(e) { return function(f) {
+			return function(g) { return function(h) { return function(i) {
+			return fun(a, b, c, d, e, f, g, h, i); }; }; }; }; }; }; }; };
+		}
+		wrapper.arity = 9;
+		wrapper.func = fun;
+		return wrapper;
+	}
+
+	function A2(fun, a, b)
+	{
+		return fun.arity === 2
+			? fun.func(a, b)
+			: fun(a)(b);
+	}
+	function A3(fun, a, b, c)
+	{
+		return fun.arity === 3
+			? fun.func(a, b, c)
+			: fun(a)(b)(c);
+	}
+	function A4(fun, a, b, c, d)
+	{
+		return fun.arity === 4
+			? fun.func(a, b, c, d)
+			: fun(a)(b)(c)(d);
+	}
+	function A5(fun, a, b, c, d, e)
+	{
+		return fun.arity === 5
+			? fun.func(a, b, c, d, e)
+			: fun(a)(b)(c)(d)(e);
+	}
+	function A6(fun, a, b, c, d, e, f)
+	{
+		return fun.arity === 6
+			? fun.func(a, b, c, d, e, f)
+			: fun(a)(b)(c)(d)(e)(f);
+	}
+	function A7(fun, a, b, c, d, e, f, g)
+	{
+		return fun.arity === 7
+			? fun.func(a, b, c, d, e, f, g)
+			: fun(a)(b)(c)(d)(e)(f)(g);
+	}
+	function A8(fun, a, b, c, d, e, f, g, h)
+	{
+		return fun.arity === 8
+			? fun.func(a, b, c, d, e, f, g, h)
+			: fun(a)(b)(c)(d)(e)(f)(g)(h);
+	}
+	function A9(fun, a, b, c, d, e, f, g, h, i)
+	{
+		return fun.arity === 9
+			? fun.func(a, b, c, d, e, f, g, h, i)
+			: fun(a)(b)(c)(d)(e)(f)(g)(h)(i);
+	}
+}
+Elm.Native = Elm.Native || {};
+Elm.Native.Utils = {};
+Elm.Native.Utils.make = function(localRuntime) {
+	localRuntime.Native = localRuntime.Native || {};
+	localRuntime.Native.Utils = localRuntime.Native.Utils || {};
+	if (localRuntime.Native.Utils.values)
+	{
+		return localRuntime.Native.Utils.values;
+	}
+
+
+	// COMPARISONS
+
+	function eq(l, r)
+	{
+		var stack = [{'x': l, 'y': r}];
+		while (stack.length > 0)
+		{
+			var front = stack.pop();
+			var x = front.x;
+			var y = front.y;
+			if (x === y)
+			{
+				continue;
+			}
+			if (typeof x === 'object')
+			{
+				var c = 0;
+				for (var i in x)
+				{
+					++c;
+					if (i in y)
+					{
+						if (i !== 'ctor')
+						{
+							stack.push({ 'x': x[i], 'y': y[i] });
+						}
+					}
+					else
+					{
+						return false;
+					}
+				}
+				if ('ctor' in x)
+				{
+					stack.push({'x': x.ctor, 'y': y.ctor});
+				}
+				if (c !== Object.keys(y).length)
+				{
+					return false;
+				}
+			}
+			else if (typeof x === 'function')
+			{
+				throw new Error('Equality error: general function equality is ' +
+								'undecidable, and therefore, unsupported');
+			}
+			else
+			{
+				return false;
+			}
+		}
+		return true;
+	}
+
+	// code in Generate/JavaScript.hs depends on the particular
+	// integer values assigned to LT, EQ, and GT
+	var LT = -1, EQ = 0, GT = 1, ord = ['LT', 'EQ', 'GT'];
+
+	function compare(x, y)
+	{
+		return {
+			ctor: ord[cmp(x, y) + 1]
+		};
+	}
+
+	function cmp(x, y) {
+		var ord;
+		if (typeof x !== 'object')
+		{
+			return x === y ? EQ : x < y ? LT : GT;
+		}
+		else if (x.isChar)
+		{
+			var a = x.toString();
+			var b = y.toString();
+			return a === b
+				? EQ
+				: a < b
+					? LT
+					: GT;
+		}
+		else if (x.ctor === '::' || x.ctor === '[]')
+		{
+			while (true)
+			{
+				if (x.ctor === '[]' && y.ctor === '[]')
+				{
+					return EQ;
+				}
+				if (x.ctor !== y.ctor)
+				{
+					return x.ctor === '[]' ? LT : GT;
+				}
+				ord = cmp(x._0, y._0);
+				if (ord !== EQ)
+				{
+					return ord;
+				}
+				x = x._1;
+				y = y._1;
+			}
+		}
+		else if (x.ctor.slice(0, 6) === '_Tuple')
+		{
+			var n = x.ctor.slice(6) - 0;
+			var err = 'cannot compare tuples with more than 6 elements.';
+			if (n === 0) return EQ;
+			if (n >= 1) { ord = cmp(x._0, y._0); if (ord !== EQ) return ord;
+			if (n >= 2) { ord = cmp(x._1, y._1); if (ord !== EQ) return ord;
+			if (n >= 3) { ord = cmp(x._2, y._2); if (ord !== EQ) return ord;
+			if (n >= 4) { ord = cmp(x._3, y._3); if (ord !== EQ) return ord;
+			if (n >= 5) { ord = cmp(x._4, y._4); if (ord !== EQ) return ord;
+			if (n >= 6) { ord = cmp(x._5, y._5); if (ord !== EQ) return ord;
+			if (n >= 7) throw new Error('Comparison error: ' + err); } } } } } }
+			return EQ;
+		}
+		else
+		{
+			throw new Error('Comparison error: comparison is only defined on ints, ' +
+							'floats, times, chars, strings, lists of comparable values, ' +
+							'and tuples of comparable values.');
+		}
+	}
+
+
+	// TUPLES
+
+	var Tuple0 = {
+		ctor: '_Tuple0'
+	};
+
+	function Tuple2(x, y)
+	{
+		return {
+			ctor: '_Tuple2',
+			_0: x,
+			_1: y
+		};
+	}
+
+
+	// LITERALS
+
+	function chr(c)
+	{
+		var x = new String(c);
+		x.isChar = true;
+		return x;
+	}
+
+	function txt(str)
+	{
+		var t = new String(str);
+		t.text = true;
+		return t;
+	}
+
+
+	// GUID
+
+	var count = 0;
+	function guid(_)
+	{
+		return count++;
+	}
+
+
+	// RECORDS
+
+	function update(oldRecord, updatedFields)
+	{
+		var newRecord = {};
+		for (var key in oldRecord)
+		{
+			var value = (key in updatedFields) ? updatedFields[key] : oldRecord[key];
+			newRecord[key] = value;
+		}
+		return newRecord;
+	}
+
+
+	// MOUSE COORDINATES
+
+	function getXY(e)
+	{
+		var posx = 0;
+		var posy = 0;
+		if (e.pageX || e.pageY)
+		{
+			posx = e.pageX;
+			posy = e.pageY;
+		}
+		else if (e.clientX || e.clientY)
+		{
+			posx = e.clientX + document.body.scrollLeft + document.documentElement.scrollLeft;
+			posy = e.clientY + document.body.scrollTop + document.documentElement.scrollTop;
+		}
+
+		if (localRuntime.isEmbed())
+		{
+			var rect = localRuntime.node.getBoundingClientRect();
+			var relx = rect.left + document.body.scrollLeft + document.documentElement.scrollLeft;
+			var rely = rect.top + document.body.scrollTop + document.documentElement.scrollTop;
+			// TODO: figure out if there is a way to avoid rounding here
+			posx = posx - Math.round(relx) - localRuntime.node.clientLeft;
+			posy = posy - Math.round(rely) - localRuntime.node.clientTop;
+		}
+		return Tuple2(posx, posy);
+	}
+
+
+	//// LIST STUFF ////
+
+	var Nil = { ctor: '[]' };
+
+	function Cons(hd, tl)
+	{
+		return {
+			ctor: '::',
+			_0: hd,
+			_1: tl
+		};
+	}
+
+	function list(arr)
+	{
+		var out = Nil;
+		for (var i = arr.length; i--; )
+		{
+			out = Cons(arr[i], out);
+		}
+		return out;
+	}
+
+	function range(lo, hi)
+	{
+		var list = Nil;
+		if (lo <= hi)
+		{
+			do
+			{
+				list = Cons(hi, list);
+			}
+			while (hi-- > lo);
+		}
+		return list;
+	}
+
+	function append(xs, ys)
+	{
+		// append Strings
+		if (typeof xs === 'string')
+		{
+			return xs + ys;
+		}
+
+		// append Text
+		if (xs.ctor.slice(0, 5) === 'Text:')
+		{
+			return {
+				ctor: 'Text:Append',
+				_0: xs,
+				_1: ys
+			};
+		}
+
+
+		// append Lists
+		if (xs.ctor === '[]')
+		{
+			return ys;
+		}
+		var root = Cons(xs._0, Nil);
+		var curr = root;
+		xs = xs._1;
+		while (xs.ctor !== '[]')
+		{
+			curr._1 = Cons(xs._0, Nil);
+			xs = xs._1;
+			curr = curr._1;
+		}
+		curr._1 = ys;
+		return root;
+	}
+
+
+	// CRASHES
+
+	function crash(moduleName, region)
+	{
+		return function(message) {
+			throw new Error(
+				'Ran into a `Debug.crash` in module `' + moduleName + '` ' + regionToString(region) + '\n'
+				+ 'The message provided by the code author is:\n\n    '
+				+ message
+			);
+		};
+	}
+
+	function crashCase(moduleName, region, value)
+	{
+		return function(message) {
+			throw new Error(
+				'Ran into a `Debug.crash` in module `' + moduleName + '`\n\n'
+				+ 'This was caused by the `case` expression ' + regionToString(region) + '.\n'
+				+ 'One of the branches ended with a crash and the following value got through:\n\n    ' + toString(value) + '\n\n'
+				+ 'The message provided by the code author is:\n\n    '
+				+ message
+			);
+		};
+	}
+
+	function regionToString(region)
+	{
+		if (region.start.line == region.end.line)
+		{
+			return 'on line ' + region.start.line;
+		}
+		return 'between lines ' + region.start.line + ' and ' + region.end.line;
+	}
+
+
+	// BAD PORTS
+
+	function badPort(expected, received)
+	{
+		throw new Error(
+			'Runtime error when sending values through a port.\n\n'
+			+ 'Expecting ' + expected + ' but was given ' + formatValue(received)
+		);
+	}
+
+	function formatValue(value)
+	{
+		// Explicity format undefined values as "undefined"
+		// because JSON.stringify(undefined) unhelpfully returns ""
+		return (value === undefined) ? "undefined" : JSON.stringify(value);
+	}
+
+
+	// TO STRING
+
+	var _Array;
+	var Dict;
+	var List;
+
+	var toString = function(v)
+	{
+		var type = typeof v;
+		if (type === 'function')
+		{
+			var name = v.func ? v.func.name : v.name;
+			return '<function' + (name === '' ? '' : ': ') + name + '>';
+		}
+		else if (type === 'boolean')
+		{
+			return v ? 'True' : 'False';
+		}
+		else if (type === 'number')
+		{
+			return v + '';
+		}
+		else if ((v instanceof String) && v.isChar)
+		{
+			return '\'' + addSlashes(v, true) + '\'';
+		}
+		else if (type === 'string')
+		{
+			return '"' + addSlashes(v, false) + '"';
+		}
+		else if (type === 'object' && 'ctor' in v)
+		{
+			if (v.ctor.substring(0, 6) === '_Tuple')
+			{
+				var output = [];
+				for (var k in v)
+				{
+					if (k === 'ctor') continue;
+					output.push(toString(v[k]));
+				}
+				return '(' + output.join(',') + ')';
+			}
+			else if (v.ctor === '_Array')
+			{
+				if (!_Array)
+				{
+					_Array = Elm.Array.make(localRuntime);
+				}
+				var list = _Array.toList(v);
+				return 'Array.fromList ' + toString(list);
+			}
+			else if (v.ctor === '::')
+			{
+				var output = '[' + toString(v._0);
+				v = v._1;
+				while (v.ctor === '::')
+				{
+					output += ',' + toString(v._0);
+					v = v._1;
+				}
+				return output + ']';
+			}
+			else if (v.ctor === '[]')
+			{
+				return '"[]';
+			}
+			else if (v.ctor === 'RBNode_elm_builtin' || v.ctor === 'RBEmpty_elm_builtin' || v.ctor === 'Set_elm_builtin')
+			{
+				if (!Dict)
+				{
+					Dict = Elm.Dict.make(localRuntime);
+				}
+				var list;
+				var name;
+				if (v.ctor === 'Set_elm_builtin')
+				{
+					if (!List)
+					{
+						List = Elm.List.make(localRuntime);
+					}
+					name = 'Set';
+					list = A2(List.map, function(x) {return x._0; }, Dict.toList(v._0));
+				}
+				else
+				{
+					name = 'Dict';
+					list = Dict.toList(v);
+				}
+				return name + '.fromList ' + toString(list);
+			}
+			else if (v.ctor.slice(0, 5) === 'Text:')
+			{
+				return '<text>';
+			}
+			else
+			{
+				var output = '';
+				for (var i in v)
+				{
+					if (i === 'ctor') continue;
+					var str = toString(v[i]);
+					var parenless = str[0] === '{' || str[0] === '<' || str.indexOf(' ') < 0;
+					output += ' ' + (parenless ? str : '(' + str + ')');
+				}
+				return v.ctor + output;
+			}
+		}
+		else if (type === 'object' && 'notify' in v && 'id' in v)
+		{
+			return '<Signal>';
+		}
+		else if (type === 'object' && probablyPublic(v))
+		{
+			var output = [];
+			for (var k in v)
+			{
+				output.push(k + ' = ' + toString(v[k]));
+			}
+			if (output.length === 0)
+			{
+				return '{}';
+			}
+			return '{ ' + output.join(', ') + ' }';
+		}
+		return '<internal structure>';
+	};
+
+	function addSlashes(str, isChar)
+	{
+		var s = str.replace(/\\/g, '\\\\')
+				  .replace(/\n/g, '\\n')
+				  .replace(/\t/g, '\\t')
+				  .replace(/\r/g, '\\r')
+				  .replace(/\v/g, '\\v')
+				  .replace(/\0/g, '\\0');
+		if (isChar)
+		{
+			return s.replace(/\'/g, '\\\'');
+		}
+		else
+		{
+			return s.replace(/\"/g, '\\"');
+		}
+	}
+
+	function probablyPublic(v)
+	{
+		var keys = Object.keys(v);
+		var len = keys.length;
+		if (len === 3
+			&& 'props' in v
+			&& 'element' in v)
+		{
+			return false;
+		}
+		else if (len === 5
+			&& 'horizontal' in v
+			&& 'vertical' in v
+			&& 'x' in v
+			&& 'y' in v)
+		{
+			return false;
+		}
+		else if (len === 7
+			&& 'theta' in v
+			&& 'scale' in v
+			&& 'x' in v
+			&& 'y' in v
+			&& 'alpha' in v
+			&& 'form' in v)
+		{
+			return false;
+		}
+		return true;
+	}
+
+
+	return localRuntime.Native.Utils.values = {
+		eq: eq,
+		cmp: cmp,
+		compare: F2(compare),
+		Tuple0: Tuple0,
+		Tuple2: Tuple2,
+		chr: chr,
+		txt: txt,
+		update: update,
+		guid: guid,
+		getXY: getXY,
+
+		Nil: Nil,
+		Cons: Cons,
+		list: list,
+		range: range,
+		append: F2(append),
+
+		crash: crash,
+		crashCase: crashCase,
+		badPort: badPort,
+
+		toString: toString
+	};
+};
+Elm.Basics = Elm.Basics || {};
+Elm.Basics.make = function (_elm) {
+   "use strict";
+   _elm.Basics = _elm.Basics || {};
+   if (_elm.Basics.values) return _elm.Basics.values;
+   var _U = Elm.Native.Utils.make(_elm),
+   $Native$Basics = Elm.Native.Basics.make(_elm),
+   $Native$Utils = Elm.Native.Utils.make(_elm);
+   var _op = {};
+   var uncurry = F2(function (f,_p0) {
+      var _p1 = _p0;
+      return A2(f,_p1._0,_p1._1);
+   });
+   var curry = F3(function (f,a,b) {
+      return f({ctor: "_Tuple2",_0: a,_1: b});
+   });
+   var flip = F3(function (f,b,a) {    return A2(f,a,b);});
+   var snd = function (_p2) {    var _p3 = _p2;return _p3._1;};
+   var fst = function (_p4) {    var _p5 = _p4;return _p5._0;};
+   var always = F2(function (a,_p6) {    return a;});
+   var identity = function (x) {    return x;};
+   _op["<|"] = F2(function (f,x) {    return f(x);});
+   _op["|>"] = F2(function (x,f) {    return f(x);});
+   _op[">>"] = F3(function (f,g,x) {    return g(f(x));});
+   _op["<<"] = F3(function (g,f,x) {    return g(f(x));});
+   _op["++"] = $Native$Utils.append;
+   var toString = $Native$Utils.toString;
+   var isInfinite = $Native$Basics.isInfinite;
+   var isNaN = $Native$Basics.isNaN;
+   var toFloat = $Native$Basics.toFloat;
+   var ceiling = $Native$Basics.ceiling;
+   var floor = $Native$Basics.floor;
+   var truncate = $Native$Basics.truncate;
+   var round = $Native$Basics.round;
+   var not = $Native$Basics.not;
+   var xor = $Native$Basics.xor;
+   _op["||"] = $Native$Basics.or;
+   _op["&&"] = $Native$Basics.and;
+   var max = $Native$Basics.max;
+   var min = $Native$Basics.min;
+   var GT = {ctor: "GT"};
+   var EQ = {ctor: "EQ"};
+   var LT = {ctor: "LT"};
+   var compare = $Native$Basics.compare;
+   _op[">="] = $Native$Basics.ge;
+   _op["<="] = $Native$Basics.le;
+   _op[">"] = $Native$Basics.gt;
+   _op["<"] = $Native$Basics.lt;
+   _op["/="] = $Native$Basics.neq;
+   _op["=="] = $Native$Basics.eq;
+   var e = $Native$Basics.e;
+   var pi = $Native$Basics.pi;
+   var clamp = $Native$Basics.clamp;
+   var logBase = $Native$Basics.logBase;
+   var abs = $Native$Basics.abs;
+   var negate = $Native$Basics.negate;
+   var sqrt = $Native$Basics.sqrt;
+   var atan2 = $Native$Basics.atan2;
+   var atan = $Native$Basics.atan;
+   var asin = $Native$Basics.asin;
+   var acos = $Native$Basics.acos;
+   var tan = $Native$Basics.tan;
+   var sin = $Native$Basics.sin;
+   var cos = $Native$Basics.cos;
+   _op["^"] = $Native$Basics.exp;
+   _op["%"] = $Native$Basics.mod;
+   var rem = $Native$Basics.rem;
+   _op["//"] = $Native$Basics.div;
+   _op["/"] = $Native$Basics.floatDiv;
+   _op["*"] = $Native$Basics.mul;
+   _op["-"] = $Native$Basics.sub;
+   _op["+"] = $Native$Basics.add;
+   var toPolar = $Native$Basics.toPolar;
+   var fromPolar = $Native$Basics.fromPolar;
+   var turns = $Native$Basics.turns;
+   var degrees = $Native$Basics.degrees;
+   var radians = function (t) {    return t;};
+   return _elm.Basics.values = {_op: _op
+                               ,max: max
+                               ,min: min
+                               ,compare: compare
+                               ,not: not
+                               ,xor: xor
+                               ,rem: rem
+                               ,negate: negate
+                               ,abs: abs
+                               ,sqrt: sqrt
+                               ,clamp: clamp
+                               ,logBase: logBase
+                               ,e: e
+                               ,pi: pi
+                               ,cos: cos
+                               ,sin: sin
+                               ,tan: tan
+                               ,acos: acos
+                               ,asin: asin
+                               ,atan: atan
+                               ,atan2: atan2
+                               ,round: round
+                               ,floor: floor
+                               ,ceiling: ceiling
+                               ,truncate: truncate
+                               ,toFloat: toFloat
+                               ,degrees: degrees
+                               ,radians: radians
+                               ,turns: turns
+                               ,toPolar: toPolar
+                               ,fromPolar: fromPolar
+                               ,isNaN: isNaN
+                               ,isInfinite: isInfinite
+                               ,toString: toString
+                               ,fst: fst
+                               ,snd: snd
+                               ,identity: identity
+                               ,always: always
+                               ,flip: flip
+                               ,curry: curry
+                               ,uncurry: uncurry
+                               ,LT: LT
+                               ,EQ: EQ
+                               ,GT: GT};
+};Elm.Maybe = Elm.Maybe || {};
+Elm.Maybe.make = function (_elm) {
+   "use strict";
+   _elm.Maybe = _elm.Maybe || {};
+   if (_elm.Maybe.values) return _elm.Maybe.values;
+   var _U = Elm.Native.Utils.make(_elm);
+   var _op = {};
+   var withDefault = F2(function ($default,maybe) {
+      var _p0 = maybe;
+      if (_p0.ctor === "Just") {
+            return _p0._0;
+         } else {
+            return $default;
+         }
+   });
+   var Nothing = {ctor: "Nothing"};
+   var oneOf = function (maybes) {
+      oneOf: while (true) {
+         var _p1 = maybes;
+         if (_p1.ctor === "[]") {
+               return Nothing;
+            } else {
+               var _p3 = _p1._0;
+               var _p2 = _p3;
+               if (_p2.ctor === "Nothing") {
+                     var _v3 = _p1._1;
+                     maybes = _v3;
+                     continue oneOf;
+                  } else {
+                     return _p3;
+                  }
+            }
+      }
+   };
+   var andThen = F2(function (maybeValue,callback) {
+      var _p4 = maybeValue;
+      if (_p4.ctor === "Just") {
+            return callback(_p4._0);
+         } else {
+            return Nothing;
+         }
+   });
+   var Just = function (a) {    return {ctor: "Just",_0: a};};
+   var map = F2(function (f,maybe) {
+      var _p5 = maybe;
+      if (_p5.ctor === "Just") {
+            return Just(f(_p5._0));
+         } else {
+            return Nothing;
+         }
+   });
+   var map2 = F3(function (func,ma,mb) {
+      var _p6 = {ctor: "_Tuple2",_0: ma,_1: mb};
+      if (_p6.ctor === "_Tuple2" && _p6._0.ctor === "Just" && _p6._1.ctor === "Just")
+      {
+            return Just(A2(func,_p6._0._0,_p6._1._0));
+         } else {
+            return Nothing;
+         }
+   });
+   var map3 = F4(function (func,ma,mb,mc) {
+      var _p7 = {ctor: "_Tuple3",_0: ma,_1: mb,_2: mc};
+      if (_p7.ctor === "_Tuple3" && _p7._0.ctor === "Just" && _p7._1.ctor === "Just" && _p7._2.ctor === "Just")
+      {
+            return Just(A3(func,_p7._0._0,_p7._1._0,_p7._2._0));
+         } else {
+            return Nothing;
+         }
+   });
+   var map4 = F5(function (func,ma,mb,mc,md) {
+      var _p8 = {ctor: "_Tuple4",_0: ma,_1: mb,_2: mc,_3: md};
+      if (_p8.ctor === "_Tuple4" && _p8._0.ctor === "Just" && _p8._1.ctor === "Just" && _p8._2.ctor === "Just" && _p8._3.ctor === "Just")
+      {
+            return Just(A4(func,
+            _p8._0._0,
+            _p8._1._0,
+            _p8._2._0,
+            _p8._3._0));
+         } else {
+            return Nothing;
+         }
+   });
+   var map5 = F6(function (func,ma,mb,mc,md,me) {
+      var _p9 = {ctor: "_Tuple5"
+                ,_0: ma
+                ,_1: mb
+                ,_2: mc
+                ,_3: md
+                ,_4: me};
+      if (_p9.ctor === "_Tuple5" && _p9._0.ctor === "Just" && _p9._1.ctor === "Just" && _p9._2.ctor === "Just" && _p9._3.ctor === "Just" && _p9._4.ctor === "Just")
+      {
+            return Just(A5(func,
+            _p9._0._0,
+            _p9._1._0,
+            _p9._2._0,
+            _p9._3._0,
+            _p9._4._0));
+         } else {
+            return Nothing;
+         }
+   });
+   return _elm.Maybe.values = {_op: _op
+                              ,andThen: andThen
+                              ,map: map
+                              ,map2: map2
+                              ,map3: map3
+                              ,map4: map4
+                              ,map5: map5
+                              ,withDefault: withDefault
+                              ,oneOf: oneOf
+                              ,Just: Just
+                              ,Nothing: Nothing};
+};Elm.Native.List = {};
+Elm.Native.List.make = function(localRuntime) {
+	localRuntime.Native = localRuntime.Native || {};
+	localRuntime.Native.List = localRuntime.Native.List || {};
+	if (localRuntime.Native.List.values)
+	{
+		return localRuntime.Native.List.values;
+	}
+	if ('values' in Elm.Native.List)
+	{
+		return localRuntime.Native.List.values = Elm.Native.List.values;
+	}
+
+	var Utils = Elm.Native.Utils.make(localRuntime);
+
+	var Nil = Utils.Nil;
+	var Cons = Utils.Cons;
+
+	var fromArray = Utils.list;
+
+	function toArray(xs)
+	{
+		var out = [];
+		while (xs.ctor !== '[]')
+		{
+			out.push(xs._0);
+			xs = xs._1;
+		}
+		return out;
+	}
+
+	// f defined similarly for both foldl and foldr (NB: different from Haskell)
+	// ie, foldl : (a -> b -> b) -> b -> [a] -> b
+	function foldl(f, b, xs)
+	{
+		var acc = b;
+		while (xs.ctor !== '[]')
+		{
+			acc = A2(f, xs._0, acc);
+			xs = xs._1;
+		}
+		return acc;
+	}
+
+	function foldr(f, b, xs)
+	{
+		var arr = toArray(xs);
+		var acc = b;
+		for (var i = arr.length; i--; )
+		{
+			acc = A2(f, arr[i], acc);
+		}
+		return acc;
+	}
+
+	function map2(f, xs, ys)
+	{
+		var arr = [];
+		while (xs.ctor !== '[]' && ys.ctor !== '[]')
+		{
+			arr.push(A2(f, xs._0, ys._0));
+			xs = xs._1;
+			ys = ys._1;
+		}
+		return fromArray(arr);
+	}
+
+	function map3(f, xs, ys, zs)
+	{
+		var arr = [];
+		while (xs.ctor !== '[]' && ys.ctor !== '[]' && zs.ctor !== '[]')
+		{
+			arr.push(A3(f, xs._0, ys._0, zs._0));
+			xs = xs._1;
+			ys = ys._1;
+			zs = zs._1;
+		}
+		return fromArray(arr);
+	}
+
+	function map4(f, ws, xs, ys, zs)
+	{
+		var arr = [];
+		while (   ws.ctor !== '[]'
+			   && xs.ctor !== '[]'
+			   && ys.ctor !== '[]'
+			   && zs.ctor !== '[]')
+		{
+			arr.push(A4(f, ws._0, xs._0, ys._0, zs._0));
+			ws = ws._1;
+			xs = xs._1;
+			ys = ys._1;
+			zs = zs._1;
+		}
+		return fromArray(arr);
+	}
+
+	function map5(f, vs, ws, xs, ys, zs)
+	{
+		var arr = [];
+		while (   vs.ctor !== '[]'
+			   && ws.ctor !== '[]'
+			   && xs.ctor !== '[]'
+			   && ys.ctor !== '[]'
+			   && zs.ctor !== '[]')
+		{
+			arr.push(A5(f, vs._0, ws._0, xs._0, ys._0, zs._0));
+			vs = vs._1;
+			ws = ws._1;
+			xs = xs._1;
+			ys = ys._1;
+			zs = zs._1;
+		}
+		return fromArray(arr);
+	}
+
+	function sortBy(f, xs)
+	{
+		return fromArray(toArray(xs).sort(function(a, b) {
+			return Utils.cmp(f(a), f(b));
+		}));
+	}
+
+	function sortWith(f, xs)
+	{
+		return fromArray(toArray(xs).sort(function(a, b) {
+			var ord = f(a)(b).ctor;
+			return ord === 'EQ' ? 0 : ord === 'LT' ? -1 : 1;
+		}));
+	}
+
+	function take(n, xs)
+	{
+		var arr = [];
+		while (xs.ctor !== '[]' && n > 0)
+		{
+			arr.push(xs._0);
+			xs = xs._1;
+			--n;
+		}
+		return fromArray(arr);
+	}
+
+
+	Elm.Native.List.values = {
+		Nil: Nil,
+		Cons: Cons,
+		cons: F2(Cons),
+		toArray: toArray,
+		fromArray: fromArray,
+
+		foldl: F3(foldl),
+		foldr: F3(foldr),
+
+		map2: F3(map2),
+		map3: F4(map3),
+		map4: F5(map4),
+		map5: F6(map5),
+		sortBy: F2(sortBy),
+		sortWith: F2(sortWith),
+		take: F2(take)
+	};
+	return localRuntime.Native.List.values = Elm.Native.List.values;
+};
+Elm.List = Elm.List || {};
+Elm.List.make = function (_elm) {
+   "use strict";
+   _elm.List = _elm.List || {};
+   if (_elm.List.values) return _elm.List.values;
+   var _U = Elm.Native.Utils.make(_elm),
+   $Basics = Elm.Basics.make(_elm),
+   $Maybe = Elm.Maybe.make(_elm),
+   $Native$List = Elm.Native.List.make(_elm);
+   var _op = {};
+   var sortWith = $Native$List.sortWith;
+   var sortBy = $Native$List.sortBy;
+   var sort = function (xs) {
+      return A2(sortBy,$Basics.identity,xs);
+   };
+   var drop = F2(function (n,list) {
+      drop: while (true) if (_U.cmp(n,0) < 1) return list; else {
+            var _p0 = list;
+            if (_p0.ctor === "[]") {
+                  return list;
+               } else {
+                  var _v1 = n - 1,_v2 = _p0._1;
+                  n = _v1;
+                  list = _v2;
+                  continue drop;
+               }
+         }
+   });
+   var take = $Native$List.take;
+   var map5 = $Native$List.map5;
+   var map4 = $Native$List.map4;
+   var map3 = $Native$List.map3;
+   var map2 = $Native$List.map2;
+   var any = F2(function (isOkay,list) {
+      any: while (true) {
+         var _p1 = list;
+         if (_p1.ctor === "[]") {
+               return false;
+            } else {
+               if (isOkay(_p1._0)) return true; else {
+                     var _v4 = isOkay,_v5 = _p1._1;
+                     isOkay = _v4;
+                     list = _v5;
+                     continue any;
+                  }
+            }
+      }
+   });
+   var all = F2(function (isOkay,list) {
+      return $Basics.not(A2(any,
+      function (_p2) {
+         return $Basics.not(isOkay(_p2));
+      },
+      list));
+   });
+   var foldr = $Native$List.foldr;
+   var foldl = $Native$List.foldl;
+   var length = function (xs) {
+      return A3(foldl,
+      F2(function (_p3,i) {    return i + 1;}),
+      0,
+      xs);
+   };
+   var sum = function (numbers) {
+      return A3(foldl,
+      F2(function (x,y) {    return x + y;}),
+      0,
+      numbers);
+   };
+   var product = function (numbers) {
+      return A3(foldl,
+      F2(function (x,y) {    return x * y;}),
+      1,
+      numbers);
+   };
+   var maximum = function (list) {
+      var _p4 = list;
+      if (_p4.ctor === "::") {
+            return $Maybe.Just(A3(foldl,$Basics.max,_p4._0,_p4._1));
+         } else {
+            return $Maybe.Nothing;
+         }
+   };
+   var minimum = function (list) {
+      var _p5 = list;
+      if (_p5.ctor === "::") {
+            return $Maybe.Just(A3(foldl,$Basics.min,_p5._0,_p5._1));
+         } else {
+            return $Maybe.Nothing;
+         }
+   };
+   var indexedMap = F2(function (f,xs) {
+      return A3(map2,f,_U.range(0,length(xs) - 1),xs);
+   });
+   var member = F2(function (x,xs) {
+      return A2(any,function (a) {    return _U.eq(a,x);},xs);
+   });
+   var isEmpty = function (xs) {
+      var _p6 = xs;
+      if (_p6.ctor === "[]") {
+            return true;
+         } else {
+            return false;
+         }
+   };
+   var tail = function (list) {
+      var _p7 = list;
+      if (_p7.ctor === "::") {
+            return $Maybe.Just(_p7._1);
+         } else {
+            return $Maybe.Nothing;
+         }
+   };
+   var head = function (list) {
+      var _p8 = list;
+      if (_p8.ctor === "::") {
+            return $Maybe.Just(_p8._0);
+         } else {
+            return $Maybe.Nothing;
+         }
+   };
+   _op["::"] = $Native$List.cons;
+   var map = F2(function (f,xs) {
+      return A3(foldr,
+      F2(function (x,acc) {    return A2(_op["::"],f(x),acc);}),
+      _U.list([]),
+      xs);
+   });
+   var filter = F2(function (pred,xs) {
+      var conditionalCons = F2(function (x,xs$) {
+         return pred(x) ? A2(_op["::"],x,xs$) : xs$;
+      });
+      return A3(foldr,conditionalCons,_U.list([]),xs);
+   });
+   var maybeCons = F3(function (f,mx,xs) {
+      var _p9 = f(mx);
+      if (_p9.ctor === "Just") {
+            return A2(_op["::"],_p9._0,xs);
+         } else {
+            return xs;
+         }
+   });
+   var filterMap = F2(function (f,xs) {
+      return A3(foldr,maybeCons(f),_U.list([]),xs);
+   });
+   var reverse = function (list) {
+      return A3(foldl,
+      F2(function (x,y) {    return A2(_op["::"],x,y);}),
+      _U.list([]),
+      list);
+   };
+   var scanl = F3(function (f,b,xs) {
+      var scan1 = F2(function (x,accAcc) {
+         var _p10 = accAcc;
+         if (_p10.ctor === "::") {
+               return A2(_op["::"],A2(f,x,_p10._0),accAcc);
+            } else {
+               return _U.list([]);
+            }
+      });
+      return reverse(A3(foldl,scan1,_U.list([b]),xs));
+   });
+   var append = F2(function (xs,ys) {
+      var _p11 = ys;
+      if (_p11.ctor === "[]") {
+            return xs;
+         } else {
+            return A3(foldr,
+            F2(function (x,y) {    return A2(_op["::"],x,y);}),
+            ys,
+            xs);
+         }
+   });
+   var concat = function (lists) {
+      return A3(foldr,append,_U.list([]),lists);
+   };
+   var concatMap = F2(function (f,list) {
+      return concat(A2(map,f,list));
+   });
+   var partition = F2(function (pred,list) {
+      var step = F2(function (x,_p12) {
+         var _p13 = _p12;
+         var _p15 = _p13._0;
+         var _p14 = _p13._1;
+         return pred(x) ? {ctor: "_Tuple2"
+                          ,_0: A2(_op["::"],x,_p15)
+                          ,_1: _p14} : {ctor: "_Tuple2"
+                                       ,_0: _p15
+                                       ,_1: A2(_op["::"],x,_p14)};
+      });
+      return A3(foldr,
+      step,
+      {ctor: "_Tuple2",_0: _U.list([]),_1: _U.list([])},
+      list);
+   });
+   var unzip = function (pairs) {
+      var step = F2(function (_p17,_p16) {
+         var _p18 = _p17;
+         var _p19 = _p16;
+         return {ctor: "_Tuple2"
+                ,_0: A2(_op["::"],_p18._0,_p19._0)
+                ,_1: A2(_op["::"],_p18._1,_p19._1)};
+      });
+      return A3(foldr,
+      step,
+      {ctor: "_Tuple2",_0: _U.list([]),_1: _U.list([])},
+      pairs);
+   };
+   var intersperse = F2(function (sep,xs) {
+      var _p20 = xs;
+      if (_p20.ctor === "[]") {
+            return _U.list([]);
+         } else {
+            var step = F2(function (x,rest) {
+               return A2(_op["::"],sep,A2(_op["::"],x,rest));
+            });
+            var spersed = A3(foldr,step,_U.list([]),_p20._1);
+            return A2(_op["::"],_p20._0,spersed);
+         }
+   });
+   var repeatHelp = F3(function (result,n,value) {
+      repeatHelp: while (true) if (_U.cmp(n,0) < 1) return result;
+      else {
+            var _v18 = A2(_op["::"],value,result),
+            _v19 = n - 1,
+            _v20 = value;
+            result = _v18;
+            n = _v19;
+            value = _v20;
+            continue repeatHelp;
+         }
+   });
+   var repeat = F2(function (n,value) {
+      return A3(repeatHelp,_U.list([]),n,value);
+   });
+   return _elm.List.values = {_op: _op
+                             ,isEmpty: isEmpty
+                             ,length: length
+                             ,reverse: reverse
+                             ,member: member
+                             ,head: head
+                             ,tail: tail
+                             ,filter: filter
+                             ,take: take
+                             ,drop: drop
+                             ,repeat: repeat
+                             ,append: append
+                             ,concat: concat
+                             ,intersperse: intersperse
+                             ,partition: partition
+                             ,unzip: unzip
+                             ,map: map
+                             ,map2: map2
+                             ,map3: map3
+                             ,map4: map4
+                             ,map5: map5
+                             ,filterMap: filterMap
+                             ,concatMap: concatMap
+                             ,indexedMap: indexedMap
+                             ,foldr: foldr
+                             ,foldl: foldl
+                             ,sum: sum
+                             ,product: product
+                             ,maximum: maximum
+                             ,minimum: minimum
+                             ,all: all
+                             ,any: any
+                             ,scanl: scanl
+                             ,sort: sort
+                             ,sortBy: sortBy
+                             ,sortWith: sortWith};
+};Elm.Native.Char = {};
+Elm.Native.Char.make = function(localRuntime) {
+	localRuntime.Native = localRuntime.Native || {};
+	localRuntime.Native.Char = localRuntime.Native.Char || {};
+	if (localRuntime.Native.Char.values)
+	{
+		return localRuntime.Native.Char.values;
+	}
+
+	var Utils = Elm.Native.Utils.make(localRuntime);
+
+	return localRuntime.Native.Char.values = {
+		fromCode: function(c) { return Utils.chr(String.fromCharCode(c)); },
+		toCode: function(c) { return c.charCodeAt(0); },
+		toUpper: function(c) { return Utils.chr(c.toUpperCase()); },
+		toLower: function(c) { return Utils.chr(c.toLowerCase()); },
+		toLocaleUpper: function(c) { return Utils.chr(c.toLocaleUpperCase()); },
+		toLocaleLower: function(c) { return Utils.chr(c.toLocaleLowerCase()); }
+	};
+};
+Elm.Char = Elm.Char || {};
+Elm.Char.make = function (_elm) {
+   "use strict";
+   _elm.Char = _elm.Char || {};
+   if (_elm.Char.values) return _elm.Char.values;
+   var _U = Elm.Native.Utils.make(_elm),
+   $Basics = Elm.Basics.make(_elm),
+   $Native$Char = Elm.Native.Char.make(_elm);
+   var _op = {};
+   var fromCode = $Native$Char.fromCode;
+   var toCode = $Native$Char.toCode;
+   var toLocaleLower = $Native$Char.toLocaleLower;
+   var toLocaleUpper = $Native$Char.toLocaleUpper;
+   var toLower = $Native$Char.toLower;
+   var toUpper = $Native$Char.toUpper;
+   var isBetween = F3(function (low,high,$char) {
+      var code = toCode($char);
+      return _U.cmp(code,toCode(low)) > -1 && _U.cmp(code,
+      toCode(high)) < 1;
+   });
+   var isUpper = A2(isBetween,_U.chr("A"),_U.chr("Z"));
+   var isLower = A2(isBetween,_U.chr("a"),_U.chr("z"));
+   var isDigit = A2(isBetween,_U.chr("0"),_U.chr("9"));
+   var isOctDigit = A2(isBetween,_U.chr("0"),_U.chr("7"));
+   var isHexDigit = function ($char) {
+      return isDigit($char) || (A3(isBetween,
+      _U.chr("a"),
+      _U.chr("f"),
+      $char) || A3(isBetween,_U.chr("A"),_U.chr("F"),$char));
+   };
+   return _elm.Char.values = {_op: _op
+                             ,isUpper: isUpper
+                             ,isLower: isLower
+                             ,isDigit: isDigit
+                             ,isOctDigit: isOctDigit
+                             ,isHexDigit: isHexDigit
+                             ,toUpper: toUpper
+                             ,toLower: toLower
+                             ,toLocaleUpper: toLocaleUpper
+                             ,toLocaleLower: toLocaleLower
+                             ,toCode: toCode
+                             ,fromCode: fromCode};
+};Elm.Native.Color = {};
+Elm.Native.Color.make = function(localRuntime) {
+	localRuntime.Native = localRuntime.Native || {};
+	localRuntime.Native.Color = localRuntime.Native.Color || {};
+	if (localRuntime.Native.Color.values)
+	{
+		return localRuntime.Native.Color.values;
+	}
+
+	function toCss(c)
+	{
+		var format = '';
+		var colors = '';
+		if (c.ctor === 'RGBA')
+		{
+			format = 'rgb';
+			colors = c._0 + ', ' + c._1 + ', ' + c._2;
+		}
+		else
+		{
+			format = 'hsl';
+			colors = (c._0 * 180 / Math.PI) + ', ' +
+					 (c._1 * 100) + '%, ' +
+					 (c._2 * 100) + '%';
+		}
+		if (c._3 === 1)
+		{
+			return format + '(' + colors + ')';
+		}
+		else
+		{
+			return format + 'a(' + colors + ', ' + c._3 + ')';
+		}
+	}
+
+	return localRuntime.Native.Color.values = {
+		toCss: toCss
+	};
+};
+Elm.Color = Elm.Color || {};
+Elm.Color.make = function (_elm) {
+   "use strict";
+   _elm.Color = _elm.Color || {};
+   if (_elm.Color.values) return _elm.Color.values;
+   var _U = Elm.Native.Utils.make(_elm),
+   $Basics = Elm.Basics.make(_elm);
+   var _op = {};
+   var Radial = F5(function (a,b,c,d,e) {
+      return {ctor: "Radial",_0: a,_1: b,_2: c,_3: d,_4: e};
+   });
+   var radial = Radial;
+   var Linear = F3(function (a,b,c) {
+      return {ctor: "Linear",_0: a,_1: b,_2: c};
+   });
+   var linear = Linear;
+   var fmod = F2(function (f,n) {
+      var integer = $Basics.floor(f);
+      return $Basics.toFloat(A2($Basics._op["%"],
+      integer,
+      n)) + f - $Basics.toFloat(integer);
+   });
+   var rgbToHsl = F3(function (red,green,blue) {
+      var b = $Basics.toFloat(blue) / 255;
+      var g = $Basics.toFloat(green) / 255;
+      var r = $Basics.toFloat(red) / 255;
+      var cMax = A2($Basics.max,A2($Basics.max,r,g),b);
+      var cMin = A2($Basics.min,A2($Basics.min,r,g),b);
+      var c = cMax - cMin;
+      var lightness = (cMax + cMin) / 2;
+      var saturation = _U.eq(lightness,
+      0) ? 0 : c / (1 - $Basics.abs(2 * lightness - 1));
+      var hue = $Basics.degrees(60) * (_U.eq(cMax,r) ? A2(fmod,
+      (g - b) / c,
+      6) : _U.eq(cMax,g) ? (b - r) / c + 2 : (r - g) / c + 4);
+      return {ctor: "_Tuple3",_0: hue,_1: saturation,_2: lightness};
+   });
+   var hslToRgb = F3(function (hue,saturation,lightness) {
+      var hue$ = hue / $Basics.degrees(60);
+      var chroma = (1 - $Basics.abs(2 * lightness - 1)) * saturation;
+      var x = chroma * (1 - $Basics.abs(A2(fmod,hue$,2) - 1));
+      var _p0 = _U.cmp(hue$,0) < 0 ? {ctor: "_Tuple3"
+                                     ,_0: 0
+                                     ,_1: 0
+                                     ,_2: 0} : _U.cmp(hue$,1) < 0 ? {ctor: "_Tuple3"
+                                                                    ,_0: chroma
+                                                                    ,_1: x
+                                                                    ,_2: 0} : _U.cmp(hue$,2) < 0 ? {ctor: "_Tuple3"
+                                                                                                   ,_0: x
+                                                                                                   ,_1: chroma
+                                                                                                   ,_2: 0} : _U.cmp(hue$,3) < 0 ? {ctor: "_Tuple3"
+                                                                                                                                  ,_0: 0
+                                                                                                                                  ,_1: chroma
+                                                                                                                                  ,_2: x} : _U.cmp(hue$,
+      4) < 0 ? {ctor: "_Tuple3",_0: 0,_1: x,_2: chroma} : _U.cmp(hue$,
+      5) < 0 ? {ctor: "_Tuple3",_0: x,_1: 0,_2: chroma} : _U.cmp(hue$,
+      6) < 0 ? {ctor: "_Tuple3"
+               ,_0: chroma
+               ,_1: 0
+               ,_2: x} : {ctor: "_Tuple3",_0: 0,_1: 0,_2: 0};
+      var r = _p0._0;
+      var g = _p0._1;
+      var b = _p0._2;
+      var m = lightness - chroma / 2;
+      return {ctor: "_Tuple3",_0: r + m,_1: g + m,_2: b + m};
+   });
+   var toRgb = function (color) {
+      var _p1 = color;
+      if (_p1.ctor === "RGBA") {
+            return {red: _p1._0
+                   ,green: _p1._1
+                   ,blue: _p1._2
+                   ,alpha: _p1._3};
+         } else {
+            var _p2 = A3(hslToRgb,_p1._0,_p1._1,_p1._2);
+            var r = _p2._0;
+            var g = _p2._1;
+            var b = _p2._2;
+            return {red: $Basics.round(255 * r)
+                   ,green: $Basics.round(255 * g)
+                   ,blue: $Basics.round(255 * b)
+                   ,alpha: _p1._3};
+         }
+   };
+   var toHsl = function (color) {
+      var _p3 = color;
+      if (_p3.ctor === "HSLA") {
+            return {hue: _p3._0
+                   ,saturation: _p3._1
+                   ,lightness: _p3._2
+                   ,alpha: _p3._3};
+         } else {
+            var _p4 = A3(rgbToHsl,_p3._0,_p3._1,_p3._2);
+            var h = _p4._0;
+            var s = _p4._1;
+            var l = _p4._2;
+            return {hue: h,saturation: s,lightness: l,alpha: _p3._3};
+         }
+   };
+   var HSLA = F4(function (a,b,c,d) {
+      return {ctor: "HSLA",_0: a,_1: b,_2: c,_3: d};
+   });
+   var hsla = F4(function (hue,saturation,lightness,alpha) {
+      return A4(HSLA,
+      hue - $Basics.turns($Basics.toFloat($Basics.floor(hue / (2 * $Basics.pi)))),
+      saturation,
+      lightness,
+      alpha);
+   });
+   var hsl = F3(function (hue,saturation,lightness) {
+      return A4(hsla,hue,saturation,lightness,1);
+   });
+   var complement = function (color) {
+      var _p5 = color;
+      if (_p5.ctor === "HSLA") {
+            return A4(hsla,
+            _p5._0 + $Basics.degrees(180),
+            _p5._1,
+            _p5._2,
+            _p5._3);
+         } else {
+            var _p6 = A3(rgbToHsl,_p5._0,_p5._1,_p5._2);
+            var h = _p6._0;
+            var s = _p6._1;
+            var l = _p6._2;
+            return A4(hsla,h + $Basics.degrees(180),s,l,_p5._3);
+         }
+   };
+   var grayscale = function (p) {    return A4(HSLA,0,0,1 - p,1);};
+   var greyscale = function (p) {    return A4(HSLA,0,0,1 - p,1);};
+   var RGBA = F4(function (a,b,c,d) {
+      return {ctor: "RGBA",_0: a,_1: b,_2: c,_3: d};
+   });
+   var rgba = RGBA;
+   var rgb = F3(function (r,g,b) {    return A4(RGBA,r,g,b,1);});
+   var lightRed = A4(RGBA,239,41,41,1);
+   var red = A4(RGBA,204,0,0,1);
+   var darkRed = A4(RGBA,164,0,0,1);
+   var lightOrange = A4(RGBA,252,175,62,1);
+   var orange = A4(RGBA,245,121,0,1);
+   var darkOrange = A4(RGBA,206,92,0,1);
+   var lightYellow = A4(RGBA,255,233,79,1);
+   var yellow = A4(RGBA,237,212,0,1);
+   var darkYellow = A4(RGBA,196,160,0,1);
+   var lightGreen = A4(RGBA,138,226,52,1);
+   var green = A4(RGBA,115,210,22,1);
+   var darkGreen = A4(RGBA,78,154,6,1);
+   var lightBlue = A4(RGBA,114,159,207,1);
+   var blue = A4(RGBA,52,101,164,1);
+   var darkBlue = A4(RGBA,32,74,135,1);
+   var lightPurple = A4(RGBA,173,127,168,1);
+   var purple = A4(RGBA,117,80,123,1);
+   var darkPurple = A4(RGBA,92,53,102,1);
+   var lightBrown = A4(RGBA,233,185,110,1);
+   var brown = A4(RGBA,193,125,17,1);
+   var darkBrown = A4(RGBA,143,89,2,1);
+   var black = A4(RGBA,0,0,0,1);
+   var white = A4(RGBA,255,255,255,1);
+   var lightGrey = A4(RGBA,238,238,236,1);
+   var grey = A4(RGBA,211,215,207,1);
+   var darkGrey = A4(RGBA,186,189,182,1);
+   var lightGray = A4(RGBA,238,238,236,1);
+   var gray = A4(RGBA,211,215,207,1);
+   var darkGray = A4(RGBA,186,189,182,1);
+   var lightCharcoal = A4(RGBA,136,138,133,1);
+   var charcoal = A4(RGBA,85,87,83,1);
+   var darkCharcoal = A4(RGBA,46,52,54,1);
+   return _elm.Color.values = {_op: _op
+                              ,rgb: rgb
+                              ,rgba: rgba
+                              ,hsl: hsl
+                              ,hsla: hsla
+                              ,greyscale: greyscale
+                              ,grayscale: grayscale
+                              ,complement: complement
+                              ,linear: linear
+                              ,radial: radial
+                              ,toRgb: toRgb
+                              ,toHsl: toHsl
+                              ,red: red
+                              ,orange: orange
+                              ,yellow: yellow
+                              ,green: green
+                              ,blue: blue
+                              ,purple: purple
+                              ,brown: brown
+                              ,lightRed: lightRed
+                              ,lightOrange: lightOrange
+                              ,lightYellow: lightYellow
+                              ,lightGreen: lightGreen
+                              ,lightBlue: lightBlue
+                              ,lightPurple: lightPurple
+                              ,lightBrown: lightBrown
+                              ,darkRed: darkRed
+                              ,darkOrange: darkOrange
+                              ,darkYellow: darkYellow
+                              ,darkGreen: darkGreen
+                              ,darkBlue: darkBlue
+                              ,darkPurple: darkPurple
+                              ,darkBrown: darkBrown
+                              ,white: white
+                              ,lightGrey: lightGrey
+                              ,grey: grey
+                              ,darkGrey: darkGrey
+                              ,lightCharcoal: lightCharcoal
+                              ,charcoal: charcoal
+                              ,darkCharcoal: darkCharcoal
+                              ,black: black
+                              ,lightGray: lightGray
+                              ,gray: gray
+                              ,darkGray: darkGray};
+};Elm.Native.Signal = {};
+
+Elm.Native.Signal.make = function(localRuntime) {
+	localRuntime.Native = localRuntime.Native || {};
+	localRuntime.Native.Signal = localRuntime.Native.Signal || {};
+	if (localRuntime.Native.Signal.values)
+	{
+		return localRuntime.Native.Signal.values;
+	}
+
+
+	var Task = Elm.Native.Task.make(localRuntime);
+	var Utils = Elm.Native.Utils.make(localRuntime);
+
+
+	function broadcastToKids(node, timestamp, update)
+	{
+		var kids = node.kids;
+		for (var i = kids.length; i--; )
+		{
+			kids[i].notify(timestamp, update, node.id);
+		}
+	}
+
+
+	// INPUT
+
+	function input(name, base)
+	{
+		var node = {
+			id: Utils.guid(),
+			name: 'input-' + name,
+			value: base,
+			parents: [],
+			kids: []
+		};
+
+		node.notify = function(timestamp, targetId, value) {
+			var update = targetId === node.id;
+			if (update)
+			{
+				node.value = value;
+			}
+			broadcastToKids(node, timestamp, update);
+			return update;
+		};
+
+		localRuntime.inputs.push(node);
+
+		return node;
+	}
+
+	function constant(value)
+	{
+		return input('constant', value);
+	}
+
+
+	// MAILBOX
+
+	function mailbox(base)
+	{
+		var signal = input('mailbox', base);
+
+		function send(value) {
+			return Task.asyncFunction(function(callback) {
+				localRuntime.setTimeout(function() {
+					localRuntime.notify(signal.id, value);
+				}, 0);
+				callback(Task.succeed(Utils.Tuple0));
+			});
+		}
+
+		return {
+			_: {},
+			signal: signal,
+			address: {
+				ctor: 'Address',
+				_0: send
+			}
+		};
+	}
+
+	function sendMessage(message)
+	{
+		Task.perform(message._0);
+	}
+
+
+	// OUTPUT
+
+	function output(name, handler, parent)
+	{
+		var node = {
+			id: Utils.guid(),
+			name: 'output-' + name,
+			parents: [parent],
+			isOutput: true
+		};
+
+		node.notify = function(timestamp, parentUpdate, parentID)
+		{
+			if (parentUpdate)
+			{
+				handler(parent.value);
+			}
+		};
+
+		parent.kids.push(node);
+
+		return node;
+	}
+
+
+	// MAP
+
+	function mapMany(refreshValue, args)
+	{
+		var node = {
+			id: Utils.guid(),
+			name: 'map' + args.length,
+			value: refreshValue(),
+			parents: args,
+			kids: []
+		};
+
+		var numberOfParents = args.length;
+		var count = 0;
+		var update = false;
+
+		node.notify = function(timestamp, parentUpdate, parentID)
+		{
+			++count;
+
+			update = update || parentUpdate;
+
+			if (count === numberOfParents)
+			{
+				if (update)
+				{
+					node.value = refreshValue();
+				}
+				broadcastToKids(node, timestamp, update);
+				update = false;
+				count = 0;
+			}
+		};
+
+		for (var i = numberOfParents; i--; )
+		{
+			args[i].kids.push(node);
+		}
+
+		return node;
+	}
+
+
+	function map(func, a)
+	{
+		function refreshValue()
+		{
+			return func(a.value);
+		}
+		return mapMany(refreshValue, [a]);
+	}
+
+
+	function map2(func, a, b)
+	{
+		function refreshValue()
+		{
+			return A2( func, a.value, b.value );
+		}
+		return mapMany(refreshValue, [a, b]);
+	}
+
+
+	function map3(func, a, b, c)
+	{
+		function refreshValue()
+		{
+			return A3( func, a.value, b.value, c.value );
+		}
+		return mapMany(refreshValue, [a, b, c]);
+	}
+
+
+	function map4(func, a, b, c, d)
+	{
+		function refreshValue()
+		{
+			return A4( func, a.value, b.value, c.value, d.value );
+		}
+		return mapMany(refreshValue, [a, b, c, d]);
+	}
+
+
+	function map5(func, a, b, c, d, e)
+	{
+		function refreshValue()
+		{
+			return A5( func, a.value, b.value, c.value, d.value, e.value );
+		}
+		return mapMany(refreshValue, [a, b, c, d, e]);
+	}
+
+
+	// FOLD
+
+	function foldp(update, state, signal)
+	{
+		var node = {
+			id: Utils.guid(),
+			name: 'foldp',
+			parents: [signal],
+			kids: [],
+			value: state
+		};
+
+		node.notify = function(timestamp, parentUpdate, parentID)
+		{
+			if (parentUpdate)
+			{
+				node.value = A2( update, signal.value, node.value );
+			}
+			broadcastToKids(node, timestamp, parentUpdate);
+		};
+
+		signal.kids.push(node);
+
+		return node;
+	}
+
+
+	// TIME
+
+	function timestamp(signal)
+	{
+		var node = {
+			id: Utils.guid(),
+			name: 'timestamp',
+			value: Utils.Tuple2(localRuntime.timer.programStart, signal.value),
+			parents: [signal],
+			kids: []
+		};
+
+		node.notify = function(timestamp, parentUpdate, parentID)
+		{
+			if (parentUpdate)
+			{
+				node.value = Utils.Tuple2(timestamp, signal.value);
+			}
+			broadcastToKids(node, timestamp, parentUpdate);
+		};
+
+		signal.kids.push(node);
+
+		return node;
+	}
+
+
+	function delay(time, signal)
+	{
+		var delayed = input('delay-input-' + time, signal.value);
+
+		function handler(value)
+		{
+			setTimeout(function() {
+				localRuntime.notify(delayed.id, value);
+			}, time);
+		}
+
+		output('delay-output-' + time, handler, signal);
+
+		return delayed;
+	}
+
+
+	// MERGING
+
+	function genericMerge(tieBreaker, leftStream, rightStream)
+	{
+		var node = {
+			id: Utils.guid(),
+			name: 'merge',
+			value: A2(tieBreaker, leftStream.value, rightStream.value),
+			parents: [leftStream, rightStream],
+			kids: []
+		};
+
+		var left = { touched: false, update: false, value: null };
+		var right = { touched: false, update: false, value: null };
+
+		node.notify = function(timestamp, parentUpdate, parentID)
+		{
+			if (parentID === leftStream.id)
+			{
+				left.touched = true;
+				left.update = parentUpdate;
+				left.value = leftStream.value;
+			}
+			if (parentID === rightStream.id)
+			{
+				right.touched = true;
+				right.update = parentUpdate;
+				right.value = rightStream.value;
+			}
+
+			if (left.touched && right.touched)
+			{
+				var update = false;
+				if (left.update && right.update)
+				{
+					node.value = A2(tieBreaker, left.value, right.value);
+					update = true;
+				}
+				else if (left.update)
+				{
+					node.value = left.value;
+					update = true;
+				}
+				else if (right.update)
+				{
+					node.value = right.value;
+					update = true;
+				}
+				left.touched = false;
+				right.touched = false;
+
+				broadcastToKids(node, timestamp, update);
+			}
+		};
+
+		leftStream.kids.push(node);
+		rightStream.kids.push(node);
+
+		return node;
+	}
+
+
+	// FILTERING
+
+	function filterMap(toMaybe, base, signal)
+	{
+		var maybe = toMaybe(signal.value);
+		var node = {
+			id: Utils.guid(),
+			name: 'filterMap',
+			value: maybe.ctor === 'Nothing' ? base : maybe._0,
+			parents: [signal],
+			kids: []
+		};
+
+		node.notify = function(timestamp, parentUpdate, parentID)
+		{
+			var update = false;
+			if (parentUpdate)
+			{
+				var maybe = toMaybe(signal.value);
+				if (maybe.ctor === 'Just')
+				{
+					update = true;
+					node.value = maybe._0;
+				}
+			}
+			broadcastToKids(node, timestamp, update);
+		};
+
+		signal.kids.push(node);
+
+		return node;
+	}
+
+
+	// SAMPLING
+
+	function sampleOn(ticker, signal)
+	{
+		var node = {
+			id: Utils.guid(),
+			name: 'sampleOn',
+			value: signal.value,
+			parents: [ticker, signal],
+			kids: []
+		};
+
+		var signalTouch = false;
+		var tickerTouch = false;
+		var tickerUpdate = false;
+
+		node.notify = function(timestamp, parentUpdate, parentID)
+		{
+			if (parentID === ticker.id)
+			{
+				tickerTouch = true;
+				tickerUpdate = parentUpdate;
+			}
+			if (parentID === signal.id)
+			{
+				signalTouch = true;
+			}
+
+			if (tickerTouch && signalTouch)
+			{
+				if (tickerUpdate)
+				{
+					node.value = signal.value;
+				}
+				tickerTouch = false;
+				signalTouch = false;
+
+				broadcastToKids(node, timestamp, tickerUpdate);
+			}
+		};
+
+		ticker.kids.push(node);
+		signal.kids.push(node);
+
+		return node;
+	}
+
+
+	// DROP REPEATS
+
+	function dropRepeats(signal)
+	{
+		var node = {
+			id: Utils.guid(),
+			name: 'dropRepeats',
+			value: signal.value,
+			parents: [signal],
+			kids: []
+		};
+
+		node.notify = function(timestamp, parentUpdate, parentID)
+		{
+			var update = false;
+			if (parentUpdate && !Utils.eq(node.value, signal.value))
+			{
+				node.value = signal.value;
+				update = true;
+			}
+			broadcastToKids(node, timestamp, update);
+		};
+
+		signal.kids.push(node);
+
+		return node;
+	}
+
+
+	return localRuntime.Native.Signal.values = {
+		input: input,
+		constant: constant,
+		mailbox: mailbox,
+		sendMessage: sendMessage,
+		output: output,
+		map: F2(map),
+		map2: F3(map2),
+		map3: F4(map3),
+		map4: F5(map4),
+		map5: F6(map5),
+		foldp: F3(foldp),
+		genericMerge: F3(genericMerge),
+		filterMap: F3(filterMap),
+		sampleOn: F2(sampleOn),
+		dropRepeats: dropRepeats,
+		timestamp: timestamp,
+		delay: F2(delay)
+	};
+};
+Elm.Native.Transform2D = {};
+Elm.Native.Transform2D.make = function(localRuntime) {
+	localRuntime.Native = localRuntime.Native || {};
+	localRuntime.Native.Transform2D = localRuntime.Native.Transform2D || {};
+	if (localRuntime.Native.Transform2D.values)
+	{
+		return localRuntime.Native.Transform2D.values;
+	}
+
+	var A;
+	if (typeof Float32Array === 'undefined')
+	{
+		A = function(arr)
+		{
+			this.length = arr.length;
+			this[0] = arr[0];
+			this[1] = arr[1];
+			this[2] = arr[2];
+			this[3] = arr[3];
+			this[4] = arr[4];
+			this[5] = arr[5];
+		};
+	}
+	else
+	{
+		A = Float32Array;
+	}
+
+	// layout of matrix in an array is
+	//
+	//   | m11 m12 dx |
+	//   | m21 m22 dy |
+	//   |  0   0   1 |
+	//
+	//  new A([ m11, m12, dx, m21, m22, dy ])
+
+	var identity = new A([1, 0, 0, 0, 1, 0]);
+	function matrix(m11, m12, m21, m22, dx, dy)
+	{
+		return new A([m11, m12, dx, m21, m22, dy]);
+	}
+
+	function rotation(t)
+	{
+		var c = Math.cos(t);
+		var s = Math.sin(t);
+		return new A([c, -s, 0, s, c, 0]);
+	}
+
+	function rotate(t, m)
+	{
+		var c = Math.cos(t);
+		var s = Math.sin(t);
+		var m11 = m[0], m12 = m[1], m21 = m[3], m22 = m[4];
+		return new A([m11 * c + m12 * s, -m11 * s + m12 * c, m[2],
+					  m21 * c + m22 * s, -m21 * s + m22 * c, m[5]]);
+	}
+	/*
+	function move(xy,m) {
+		var x = xy._0;
+		var y = xy._1;
+		var m11 = m[0], m12 = m[1], m21 = m[3], m22 = m[4];
+		return new A([m11, m12, m11*x + m12*y + m[2],
+					  m21, m22, m21*x + m22*y + m[5]]);
+	}
+	function scale(s,m) { return new A([m[0]*s, m[1]*s, m[2], m[3]*s, m[4]*s, m[5]]); }
+	function scaleX(x,m) { return new A([m[0]*x, m[1], m[2], m[3]*x, m[4], m[5]]); }
+	function scaleY(y,m) { return new A([m[0], m[1]*y, m[2], m[3], m[4]*y, m[5]]); }
+	function reflectX(m) { return new A([-m[0], m[1], m[2], -m[3], m[4], m[5]]); }
+	function reflectY(m) { return new A([m[0], -m[1], m[2], m[3], -m[4], m[5]]); }
+
+	function transform(m11, m21, m12, m22, mdx, mdy, n) {
+		var n11 = n[0], n12 = n[1], n21 = n[3], n22 = n[4], ndx = n[2], ndy = n[5];
+		return new A([m11*n11 + m12*n21,
+					  m11*n12 + m12*n22,
+					  m11*ndx + m12*ndy + mdx,
+					  m21*n11 + m22*n21,
+					  m21*n12 + m22*n22,
+					  m21*ndx + m22*ndy + mdy]);
+	}
+	*/
+	function multiply(m, n)
+	{
+		var m11 = m[0], m12 = m[1], m21 = m[3], m22 = m[4], mdx = m[2], mdy = m[5];
+		var n11 = n[0], n12 = n[1], n21 = n[3], n22 = n[4], ndx = n[2], ndy = n[5];
+		return new A([m11 * n11 + m12 * n21,
+					  m11 * n12 + m12 * n22,
+					  m11 * ndx + m12 * ndy + mdx,
+					  m21 * n11 + m22 * n21,
+					  m21 * n12 + m22 * n22,
+					  m21 * ndx + m22 * ndy + mdy]);
+	}
+
+	return localRuntime.Native.Transform2D.values = {
+		identity: identity,
+		matrix: F6(matrix),
+		rotation: rotation,
+		multiply: F2(multiply)
+		/*
+		transform: F7(transform),
+		rotate: F2(rotate),
+		move: F2(move),
+		scale: F2(scale),
+		scaleX: F2(scaleX),
+		scaleY: F2(scaleY),
+		reflectX: reflectX,
+		reflectY: reflectY
+		*/
+	};
+};
+Elm.Transform2D = Elm.Transform2D || {};
+Elm.Transform2D.make = function (_elm) {
+   "use strict";
+   _elm.Transform2D = _elm.Transform2D || {};
+   if (_elm.Transform2D.values) return _elm.Transform2D.values;
+   var _U = Elm.Native.Utils.make(_elm),
+   $Native$Transform2D = Elm.Native.Transform2D.make(_elm);
+   var _op = {};
+   var multiply = $Native$Transform2D.multiply;
+   var rotation = $Native$Transform2D.rotation;
+   var matrix = $Native$Transform2D.matrix;
+   var translation = F2(function (x,y) {
+      return A6(matrix,1,0,0,1,x,y);
+   });
+   var scale = function (s) {    return A6(matrix,s,0,0,s,0,0);};
+   var scaleX = function (x) {    return A6(matrix,x,0,0,1,0,0);};
+   var scaleY = function (y) {    return A6(matrix,1,0,0,y,0,0);};
+   var identity = $Native$Transform2D.identity;
+   var Transform2D = {ctor: "Transform2D"};
+   return _elm.Transform2D.values = {_op: _op
+                                    ,identity: identity
+                                    ,matrix: matrix
+                                    ,multiply: multiply
+                                    ,rotation: rotation
+                                    ,translation: translation
+                                    ,scale: scale
+                                    ,scaleX: scaleX
+                                    ,scaleY: scaleY};
+};
+// setup
+Elm.Native = Elm.Native || {};
+Elm.Native.Graphics = Elm.Native.Graphics || {};
+Elm.Native.Graphics.Collage = Elm.Native.Graphics.Collage || {};
+
+// definition
+Elm.Native.Graphics.Collage.make = function(localRuntime) {
+	'use strict';
+
+	// attempt to short-circuit
+	localRuntime.Native = localRuntime.Native || {};
+	localRuntime.Native.Graphics = localRuntime.Native.Graphics || {};
+	localRuntime.Native.Graphics.Collage = localRuntime.Native.Graphics.Collage || {};
+	if ('values' in localRuntime.Native.Graphics.Collage)
+	{
+		return localRuntime.Native.Graphics.Collage.values;
+	}
+
+	// okay, we cannot short-ciruit, so now we define everything
+	var Color = Elm.Native.Color.make(localRuntime);
+	var List = Elm.Native.List.make(localRuntime);
+	var NativeElement = Elm.Native.Graphics.Element.make(localRuntime);
+	var Transform = Elm.Transform2D.make(localRuntime);
+	var Utils = Elm.Native.Utils.make(localRuntime);
+
+	function setStrokeStyle(ctx, style)
+	{
+		ctx.lineWidth = style.width;
+
+		var cap = style.cap.ctor;
+		ctx.lineCap = cap === 'Flat'
+			? 'butt'
+			: cap === 'Round'
+				? 'round'
+				: 'square';
+
+		var join = style.join.ctor;
+		ctx.lineJoin = join === 'Smooth'
+			? 'round'
+			: join === 'Sharp'
+				? 'miter'
+				: 'bevel';
+
+		ctx.miterLimit = style.join._0 || 10;
+		ctx.strokeStyle = Color.toCss(style.color);
+	}
+
+	function setFillStyle(redo, ctx, style)
+	{
+		var sty = style.ctor;
+		ctx.fillStyle = sty === 'Solid'
+			? Color.toCss(style._0)
+			: sty === 'Texture'
+				? texture(redo, ctx, style._0)
+				: gradient(ctx, style._0);
+	}
+
+	function trace(ctx, path)
+	{
+		var points = List.toArray(path);
+		var i = points.length - 1;
+		if (i <= 0)
+		{
+			return;
+		}
+		ctx.moveTo(points[i]._0, points[i]._1);
+		while (i--)
+		{
+			ctx.lineTo(points[i]._0, points[i]._1);
+		}
+		if (path.closed)
+		{
+			i = points.length - 1;
+			ctx.lineTo(points[i]._0, points[i]._1);
+		}
+	}
+
+	function line(ctx, style, path)
+	{
+		if (style.dashing.ctor === '[]')
+		{
+			trace(ctx, path);
+		}
+		else
+		{
+			customLineHelp(ctx, style, path);
+		}
+		ctx.scale(1, -1);
+		ctx.stroke();
+	}
+
+	function customLineHelp(ctx, style, path)
+	{
+		var points = List.toArray(path);
+		if (path.closed)
+		{
+			points.push(points[0]);
+		}
+		var pattern = List.toArray(style.dashing);
+		var i = points.length - 1;
+		if (i <= 0)
+		{
+			return;
+		}
+		var x0 = points[i]._0, y0 = points[i]._1;
+		var x1 = 0, y1 = 0, dx = 0, dy = 0, remaining = 0;
+		var pindex = 0, plen = pattern.length;
+		var draw = true, segmentLength = pattern[0];
+		ctx.moveTo(x0, y0);
+		while (i--)
+		{
+			x1 = points[i]._0;
+			y1 = points[i]._1;
+			dx = x1 - x0;
+			dy = y1 - y0;
+			remaining = Math.sqrt(dx * dx + dy * dy);
+			while (segmentLength <= remaining)
+			{
+				x0 += dx * segmentLength / remaining;
+				y0 += dy * segmentLength / remaining;
+				ctx[draw ? 'lineTo' : 'moveTo'](x0, y0);
+				// update starting position
+				dx = x1 - x0;
+				dy = y1 - y0;
+				remaining = Math.sqrt(dx * dx + dy * dy);
+				// update pattern
+				draw = !draw;
+				pindex = (pindex + 1) % plen;
+				segmentLength = pattern[pindex];
+			}
+			if (remaining > 0)
+			{
+				ctx[draw ? 'lineTo' : 'moveTo'](x1, y1);
+				segmentLength -= remaining;
+			}
+			x0 = x1;
+			y0 = y1;
+		}
+	}
+
+	function drawLine(ctx, style, path)
+	{
+		setStrokeStyle(ctx, style);
+		return line(ctx, style, path);
+	}
+
+	function texture(redo, ctx, src)
+	{
+		var img = new Image();
+		img.src = src;
+		img.onload = redo;
+		return ctx.createPattern(img, 'repeat');
+	}
+
+	function gradient(ctx, grad)
+	{
+		var g;
+		var stops = [];
+		if (grad.ctor === 'Linear')
+		{
+			var p0 = grad._0, p1 = grad._1;
+			g = ctx.createLinearGradient(p0._0, -p0._1, p1._0, -p1._1);
+			stops = List.toArray(grad._2);
+		}
+		else
+		{
+			var p0 = grad._0, p2 = grad._2;
+			g = ctx.createRadialGradient(p0._0, -p0._1, grad._1, p2._0, -p2._1, grad._3);
+			stops = List.toArray(grad._4);
+		}
+		var len = stops.length;
+		for (var i = 0; i < len; ++i)
+		{
+			var stop = stops[i];
+			g.addColorStop(stop._0, Color.toCss(stop._1));
+		}
+		return g;
+	}
+
+	function drawShape(redo, ctx, style, path)
+	{
+		trace(ctx, path);
+		setFillStyle(redo, ctx, style);
+		ctx.scale(1, -1);
+		ctx.fill();
+	}
+
+
+	// TEXT RENDERING
+
+	function fillText(redo, ctx, text)
+	{
+		drawText(ctx, text, ctx.fillText);
+	}
+
+	function strokeText(redo, ctx, style, text)
+	{
+		setStrokeStyle(ctx, style);
+		// Use native canvas API for dashes only for text for now
+		// Degrades to non-dashed on IE 9 + 10
+		if (style.dashing.ctor !== '[]' && ctx.setLineDash)
+		{
+			var pattern = List.toArray(style.dashing);
+			ctx.setLineDash(pattern);
+		}
+		drawText(ctx, text, ctx.strokeText);
+	}
+
+	function drawText(ctx, text, canvasDrawFn)
+	{
+		var textChunks = chunkText(defaultContext, text);
+
+		var totalWidth = 0;
+		var maxHeight = 0;
+		var numChunks = textChunks.length;
+
+		ctx.scale(1,-1);
+
+		for (var i = numChunks; i--; )
+		{
+			var chunk = textChunks[i];
+			ctx.font = chunk.font;
+			var metrics = ctx.measureText(chunk.text);
+			chunk.width = metrics.width;
+			totalWidth += chunk.width;
+			if (chunk.height > maxHeight)
+			{
+				maxHeight = chunk.height;
+			}
+		}
+
+		var x = -totalWidth / 2.0;
+		for (var i = 0; i < numChunks; ++i)
+		{
+			var chunk = textChunks[i];
+			ctx.font = chunk.font;
+			ctx.fillStyle = chunk.color;
+			canvasDrawFn.call(ctx, chunk.text, x, maxHeight / 2);
+			x += chunk.width;
+		}
+	}
+
+	function toFont(props)
+	{
+		return [
+			props['font-style'],
+			props['font-variant'],
+			props['font-weight'],
+			props['font-size'],
+			props['font-family']
+		].join(' ');
+	}
+
+
+	// Convert the object returned by the text module
+	// into something we can use for styling canvas text
+	function chunkText(context, text)
+	{
+		var tag = text.ctor;
+		if (tag === 'Text:Append')
+		{
+			var leftChunks = chunkText(context, text._0);
+			var rightChunks = chunkText(context, text._1);
+			return leftChunks.concat(rightChunks);
+		}
+		if (tag === 'Text:Text')
+		{
+			return [{
+				text: text._0,
+				color: context.color,
+				height: context['font-size'].slice(0, -2) | 0,
+				font: toFont(context)
+			}];
+		}
+		if (tag === 'Text:Meta')
+		{
+			var newContext = freshContext(text._0, context);
+			return chunkText(newContext, text._1);
+		}
+	}
+
+	function freshContext(props, ctx)
+	{
+		return {
+			'font-style': props['font-style'] || ctx['font-style'],
+			'font-variant': props['font-variant'] || ctx['font-variant'],
+			'font-weight': props['font-weight'] || ctx['font-weight'],
+			'font-size': props['font-size'] || ctx['font-size'],
+			'font-family': props['font-family'] || ctx['font-family'],
+			'color': props['color'] || ctx['color']
+		};
+	}
+
+	var defaultContext = {
+		'font-style': 'normal',
+		'font-variant': 'normal',
+		'font-weight': 'normal',
+		'font-size': '12px',
+		'font-family': 'sans-serif',
+		'color': 'black'
+	};
+
+
+	// IMAGES
+
+	function drawImage(redo, ctx, form)
+	{
+		var img = new Image();
+		img.onload = redo;
+		img.src = form._3;
+		var w = form._0,
+			h = form._1,
+			pos = form._2,
+			srcX = pos._0,
+			srcY = pos._1,
+			srcW = w,
+			srcH = h,
+			destX = -w / 2,
+			destY = -h / 2,
+			destW = w,
+			destH = h;
+
+		ctx.scale(1, -1);
+		ctx.drawImage(img, srcX, srcY, srcW, srcH, destX, destY, destW, destH);
+	}
+
+	function renderForm(redo, ctx, form)
+	{
+		ctx.save();
+
+		var x = form.x,
+			y = form.y,
+			theta = form.theta,
+			scale = form.scale;
+
+		if (x !== 0 || y !== 0)
+		{
+			ctx.translate(x, y);
+		}
+		if (theta !== 0)
+		{
+			ctx.rotate(theta % (Math.PI * 2));
+		}
+		if (scale !== 1)
+		{
+			ctx.scale(scale, scale);
+		}
+		if (form.alpha !== 1)
+		{
+			ctx.globalAlpha = ctx.globalAlpha * form.alpha;
+		}
+
+		ctx.beginPath();
+		var f = form.form;
+		switch (f.ctor)
+		{
+			case 'FPath':
+				drawLine(ctx, f._0, f._1);
+				break;
+
+			case 'FImage':
+				drawImage(redo, ctx, f);
+				break;
+
+			case 'FShape':
+				if (f._0.ctor === 'Line')
+				{
+					f._1.closed = true;
+					drawLine(ctx, f._0._0, f._1);
+				}
+				else
+				{
+					drawShape(redo, ctx, f._0._0, f._1);
+				}
+				break;
+
+			case 'FText':
+				fillText(redo, ctx, f._0);
+				break;
+
+			case 'FOutlinedText':
+				strokeText(redo, ctx, f._0, f._1);
+				break;
+		}
+		ctx.restore();
+	}
+
+	function formToMatrix(form)
+	{
+	   var scale = form.scale;
+	   var matrix = A6( Transform.matrix, scale, 0, 0, scale, form.x, form.y );
+
+	   var theta = form.theta;
+	   if (theta !== 0)
+	   {
+		   matrix = A2( Transform.multiply, matrix, Transform.rotation(theta) );
+	   }
+
+	   return matrix;
+	}
+
+	function str(n)
+	{
+		if (n < 0.00001 && n > -0.00001)
+		{
+			return 0;
+		}
+		return n;
+	}
+
+	function makeTransform(w, h, form, matrices)
+	{
+		var props = form.form._0.props;
+		var m = A6( Transform.matrix, 1, 0, 0, -1,
+					(w - props.width ) / 2,
+					(h - props.height) / 2 );
+		var len = matrices.length;
+		for (var i = 0; i < len; ++i)
+		{
+			m = A2( Transform.multiply, m, matrices[i] );
+		}
+		m = A2( Transform.multiply, m, formToMatrix(form) );
+
+		return 'matrix(' +
+			str( m[0]) + ', ' + str( m[3]) + ', ' +
+			str(-m[1]) + ', ' + str(-m[4]) + ', ' +
+			str( m[2]) + ', ' + str( m[5]) + ')';
+	}
+
+	function stepperHelp(list)
+	{
+		var arr = List.toArray(list);
+		var i = 0;
+		function peekNext()
+		{
+			return i < arr.length ? arr[i].form.ctor : '';
+		}
+		// assumes that there is a next element
+		function next()
+		{
+			var out = arr[i];
+			++i;
+			return out;
+		}
+		return {
+			peekNext: peekNext,
+			next: next
+		};
+	}
+
+	function formStepper(forms)
+	{
+		var ps = [stepperHelp(forms)];
+		var matrices = [];
+		var alphas = [];
+		function peekNext()
+		{
+			var len = ps.length;
+			var formType = '';
+			for (var i = 0; i < len; ++i )
+			{
+				if (formType = ps[i].peekNext()) return formType;
+			}
+			return '';
+		}
+		// assumes that there is a next element
+		function next(ctx)
+		{
+			while (!ps[0].peekNext())
+			{
+				ps.shift();
+				matrices.pop();
+				alphas.shift();
+				if (ctx)
+				{
+					ctx.restore();
+				}
+			}
+			var out = ps[0].next();
+			var f = out.form;
+			if (f.ctor === 'FGroup')
+			{
+				ps.unshift(stepperHelp(f._1));
+				var m = A2(Transform.multiply, f._0, formToMatrix(out));
+				ctx.save();
+				ctx.transform(m[0], m[3], m[1], m[4], m[2], m[5]);
+				matrices.push(m);
+
+				var alpha = (alphas[0] || 1) * out.alpha;
+				alphas.unshift(alpha);
+				ctx.globalAlpha = alpha;
+			}
+			return out;
+		}
+		function transforms()
+		{
+			return matrices;
+		}
+		function alpha()
+		{
+			return alphas[0] || 1;
+		}
+		return {
+			peekNext: peekNext,
+			next: next,
+			transforms: transforms,
+			alpha: alpha
+		};
+	}
+
+	function makeCanvas(w, h)
+	{
+		var canvas = NativeElement.createNode('canvas');
+		canvas.style.width  = w + 'px';
+		canvas.style.height = h + 'px';
+		canvas.style.display = 'block';
+		canvas.style.position = 'absolute';
+		var ratio = window.devicePixelRatio || 1;
+		canvas.width  = w * ratio;
+		canvas.height = h * ratio;
+		return canvas;
+	}
+
+	function render(model)
+	{
+		var div = NativeElement.createNode('div');
+		div.style.overflow = 'hidden';
+		div.style.position = 'relative';
+		update(div, model, model);
+		return div;
+	}
+
+	function nodeStepper(w, h, div)
+	{
+		var kids = div.childNodes;
+		var i = 0;
+		var ratio = window.devicePixelRatio || 1;
+
+		function transform(transforms, ctx)
+		{
+			ctx.translate( w / 2 * ratio, h / 2 * ratio );
+			ctx.scale( ratio, -ratio );
+			var len = transforms.length;
+			for (var i = 0; i < len; ++i)
+			{
+				var m = transforms[i];
+				ctx.save();
+				ctx.transform(m[0], m[3], m[1], m[4], m[2], m[5]);
+			}
+			return ctx;
+		}
+		function nextContext(transforms)
+		{
+			while (i < kids.length)
+			{
+				var node = kids[i];
+				if (node.getContext)
+				{
+					node.width = w * ratio;
+					node.height = h * ratio;
+					node.style.width = w + 'px';
+					node.style.height = h + 'px';
+					++i;
+					return transform(transforms, node.getContext('2d'));
+				}
+				div.removeChild(node);
+			}
+			var canvas = makeCanvas(w, h);
+			div.appendChild(canvas);
+			// we have added a new node, so we must step our position
+			++i;
+			return transform(transforms, canvas.getContext('2d'));
+		}
+		function addElement(matrices, alpha, form)
+		{
+			var kid = kids[i];
+			var elem = form.form._0;
+
+			var node = (!kid || kid.getContext)
+				? NativeElement.render(elem)
+				: NativeElement.update(kid, kid.oldElement, elem);
+
+			node.style.position = 'absolute';
+			node.style.opacity = alpha * form.alpha * elem.props.opacity;
+			NativeElement.addTransform(node.style, makeTransform(w, h, form, matrices));
+			node.oldElement = elem;
+			++i;
+			if (!kid)
+			{
+				div.appendChild(node);
+			}
+			else
+			{
+				div.insertBefore(node, kid);
+			}
+		}
+		function clearRest()
+		{
+			while (i < kids.length)
+			{
+				div.removeChild(kids[i]);
+			}
+		}
+		return {
+			nextContext: nextContext,
+			addElement: addElement,
+			clearRest: clearRest
+		};
+	}
+
+
+	function update(div, _, model)
+	{
+		var w = model.w;
+		var h = model.h;
+
+		var forms = formStepper(model.forms);
+		var nodes = nodeStepper(w, h, div);
+		var ctx = null;
+		var formType = '';
+
+		while (formType = forms.peekNext())
+		{
+			// make sure we have context if we need it
+			if (ctx === null && formType !== 'FElement')
+			{
+				ctx = nodes.nextContext(forms.transforms());
+				ctx.globalAlpha = forms.alpha();
+			}
+
+			var form = forms.next(ctx);
+			// if it is FGroup, all updates are made within formStepper when next is called.
+			if (formType === 'FElement')
+			{
+				// update or insert an element, get a new context
+				nodes.addElement(forms.transforms(), forms.alpha(), form);
+				ctx = null;
+			}
+			else if (formType !== 'FGroup')
+			{
+				renderForm(function() { update(div, model, model); }, ctx, form);
+			}
+		}
+		nodes.clearRest();
+		return div;
+	}
+
+
+	function collage(w, h, forms)
+	{
+		return A3(NativeElement.newElement, w, h, {
+			ctor: 'Custom',
+			type: 'Collage',
+			render: render,
+			update: update,
+			model: {w: w, h: h, forms: forms}
+		});
+	}
+
+	return localRuntime.Native.Graphics.Collage.values = {
+		collage: F3(collage)
+	};
+};
+
+// setup
+Elm.Native = Elm.Native || {};
+Elm.Native.Graphics = Elm.Native.Graphics || {};
+Elm.Native.Graphics.Element = Elm.Native.Graphics.Element || {};
+
+// definition
+Elm.Native.Graphics.Element.make = function(localRuntime) {
+	'use strict';
+
+	// attempt to short-circuit
+	localRuntime.Native = localRuntime.Native || {};
+	localRuntime.Native.Graphics = localRuntime.Native.Graphics || {};
+	localRuntime.Native.Graphics.Element = localRuntime.Native.Graphics.Element || {};
+	if ('values' in localRuntime.Native.Graphics.Element)
+	{
+		return localRuntime.Native.Graphics.Element.values;
+	}
+
+	var Color = Elm.Native.Color.make(localRuntime);
+	var List = Elm.Native.List.make(localRuntime);
+	var Maybe = Elm.Maybe.make(localRuntime);
+	var Text = Elm.Native.Text.make(localRuntime);
+	var Utils = Elm.Native.Utils.make(localRuntime);
+
+
+	// CREATION
+
+	var createNode =
+		typeof document === 'undefined'
+			?
+				function(_)
+				{
+					return {
+						style: {},
+						appendChild: function() {}
+					};
+				}
+			:
+				function(elementType)
+				{
+					var node = document.createElement(elementType);
+					node.style.padding = '0';
+					node.style.margin = '0';
+					return node;
+				}
+			;
+
+
+	function newElement(width, height, elementPrim)
+	{
+		return {
+			_: {},
+			element: elementPrim,
+			props: {
+				_: {},
+				id: Utils.guid(),
+				width: width,
+				height: height,
+				opacity: 1,
+				color: Maybe.Nothing,
+				href: '',
+				tag: '',
+				hover: Utils.Tuple0,
+				click: Utils.Tuple0
+			}
+		};
+	}
+
+
+	// PROPERTIES
+
+	function setProps(elem, node)
+	{
+		var props = elem.props;
+
+		var element = elem.element;
+		var width = props.width - (element.adjustWidth || 0);
+		var height = props.height - (element.adjustHeight || 0);
+		node.style.width  = (width | 0) + 'px';
+		node.style.height = (height | 0) + 'px';
+
+		if (props.opacity !== 1)
+		{
+			node.style.opacity = props.opacity;
+		}
+
+		if (props.color.ctor === 'Just')
+		{
+			node.style.backgroundColor = Color.toCss(props.color._0);
+		}
+
+		if (props.tag !== '')
+		{
+			node.id = props.tag;
+		}
+
+		if (props.hover.ctor !== '_Tuple0')
+		{
+			addHover(node, props.hover);
+		}
+
+		if (props.click.ctor !== '_Tuple0')
+		{
+			addClick(node, props.click);
+		}
+
+		if (props.href !== '')
+		{
+			var anchor = createNode('a');
+			anchor.href = props.href;
+			anchor.style.display = 'block';
+			anchor.style.pointerEvents = 'auto';
+			anchor.appendChild(node);
+			node = anchor;
+		}
+
+		return node;
+	}
+
+	function addClick(e, handler)
+	{
+		e.style.pointerEvents = 'auto';
+		e.elm_click_handler = handler;
+		function trigger(ev)
+		{
+			e.elm_click_handler(Utils.Tuple0);
+			ev.stopPropagation();
+		}
+		e.elm_click_trigger = trigger;
+		e.addEventListener('click', trigger);
+	}
+
+	function removeClick(e, handler)
+	{
+		if (e.elm_click_trigger)
+		{
+			e.removeEventListener('click', e.elm_click_trigger);
+			e.elm_click_trigger = null;
+			e.elm_click_handler = null;
+		}
+	}
+
+	function addHover(e, handler)
+	{
+		e.style.pointerEvents = 'auto';
+		e.elm_hover_handler = handler;
+		e.elm_hover_count = 0;
+
+		function over(evt)
+		{
+			if (e.elm_hover_count++ > 0) return;
+			e.elm_hover_handler(true);
+			evt.stopPropagation();
+		}
+		function out(evt)
+		{
+			if (e.contains(evt.toElement || evt.relatedTarget)) return;
+			e.elm_hover_count = 0;
+			e.elm_hover_handler(false);
+			evt.stopPropagation();
+		}
+		e.elm_hover_over = over;
+		e.elm_hover_out = out;
+		e.addEventListener('mouseover', over);
+		e.addEventListener('mouseout', out);
+	}
+
+	function removeHover(e)
+	{
+		e.elm_hover_handler = null;
+		if (e.elm_hover_over)
+		{
+			e.removeEventListener('mouseover', e.elm_hover_over);
+			e.elm_hover_over = null;
+		}
+		if (e.elm_hover_out)
+		{
+			e.removeEventListener('mouseout', e.elm_hover_out);
+			e.elm_hover_out = null;
+		}
+	}
+
+
+	// IMAGES
+
+	function image(props, img)
+	{
+		switch (img._0.ctor)
+		{
+			case 'Plain':
+				return plainImage(img._3);
+
+			case 'Fitted':
+				return fittedImage(props.width, props.height, img._3);
+
+			case 'Cropped':
+				return croppedImage(img, props.width, props.height, img._3);
+
+			case 'Tiled':
+				return tiledImage(img._3);
+		}
+	}
+
+	function plainImage(src)
+	{
+		var img = createNode('img');
+		img.src = src;
+		img.name = src;
+		img.style.display = 'block';
+		return img;
+	}
+
+	function tiledImage(src)
+	{
+		var div = createNode('div');
+		div.style.backgroundImage = 'url(' + src + ')';
+		return div;
+	}
+
+	function fittedImage(w, h, src)
+	{
+		var div = createNode('div');
+		div.style.background = 'url(' + src + ') no-repeat center';
+		div.style.webkitBackgroundSize = 'cover';
+		div.style.MozBackgroundSize = 'cover';
+		div.style.OBackgroundSize = 'cover';
+		div.style.backgroundSize = 'cover';
+		return div;
+	}
+
+	function croppedImage(elem, w, h, src)
+	{
+		var pos = elem._0._0;
+		var e = createNode('div');
+		e.style.overflow = 'hidden';
+
+		var img = createNode('img');
+		img.onload = function() {
+			var sw = w / elem._1, sh = h / elem._2;
+			img.style.width = ((this.width * sw) | 0) + 'px';
+			img.style.height = ((this.height * sh) | 0) + 'px';
+			img.style.marginLeft = ((- pos._0 * sw) | 0) + 'px';
+			img.style.marginTop = ((- pos._1 * sh) | 0) + 'px';
+		};
+		img.src = src;
+		img.name = src;
+		e.appendChild(img);
+		return e;
+	}
+
+
+	// FLOW
+
+	function goOut(node)
+	{
+		node.style.position = 'absolute';
+		return node;
+	}
+	function goDown(node)
+	{
+		return node;
+	}
+	function goRight(node)
+	{
+		node.style.styleFloat = 'left';
+		node.style.cssFloat = 'left';
+		return node;
+	}
+
+	var directionTable = {
+		DUp: goDown,
+		DDown: goDown,
+		DLeft: goRight,
+		DRight: goRight,
+		DIn: goOut,
+		DOut: goOut
+	};
+	function needsReversal(dir)
+	{
+		return dir === 'DUp' || dir === 'DLeft' || dir === 'DIn';
+	}
+
+	function flow(dir, elist)
+	{
+		var array = List.toArray(elist);
+		var container = createNode('div');
+		var goDir = directionTable[dir];
+		if (goDir === goOut)
+		{
+			container.style.pointerEvents = 'none';
+		}
+		if (needsReversal(dir))
+		{
+			array.reverse();
+		}
+		var len = array.length;
+		for (var i = 0; i < len; ++i)
+		{
+			container.appendChild(goDir(render(array[i])));
+		}
+		return container;
+	}
+
+
+	// CONTAINER
+
+	function toPos(pos)
+	{
+		return pos.ctor === 'Absolute'
+			? pos._0 + 'px'
+			: (pos._0 * 100) + '%';
+	}
+
+	// must clear right, left, top, bottom, and transform
+	// before calling this function
+	function setPos(pos, elem, e)
+	{
+		var element = elem.element;
+		var props = elem.props;
+		var w = props.width + (element.adjustWidth ? element.adjustWidth : 0);
+		var h = props.height + (element.adjustHeight ? element.adjustHeight : 0);
+
+		e.style.position = 'absolute';
+		e.style.margin = 'auto';
+		var transform = '';
+
+		switch (pos.horizontal.ctor)
+		{
+			case 'P':
+				e.style.right = toPos(pos.x);
+				e.style.removeProperty('left');
+				break;
+
+			case 'Z':
+				transform = 'translateX(' + ((-w / 2) | 0) + 'px) ';
+
+			case 'N':
+				e.style.left = toPos(pos.x);
+				e.style.removeProperty('right');
+				break;
+		}
+		switch (pos.vertical.ctor)
+		{
+			case 'N':
+				e.style.bottom = toPos(pos.y);
+				e.style.removeProperty('top');
+				break;
+
+			case 'Z':
+				transform += 'translateY(' + ((-h / 2) | 0) + 'px)';
+
+			case 'P':
+				e.style.top = toPos(pos.y);
+				e.style.removeProperty('bottom');
+				break;
+		}
+		if (transform !== '')
+		{
+			addTransform(e.style, transform);
+		}
+		return e;
+	}
+
+	function addTransform(style, transform)
+	{
+		style.transform       = transform;
+		style.msTransform     = transform;
+		style.MozTransform    = transform;
+		style.webkitTransform = transform;
+		style.OTransform      = transform;
+	}
+
+	function container(pos, elem)
+	{
+		var e = render(elem);
+		setPos(pos, elem, e);
+		var div = createNode('div');
+		div.style.position = 'relative';
+		div.style.overflow = 'hidden';
+		div.appendChild(e);
+		return div;
+	}
+
+
+	function rawHtml(elem)
+	{
+		var html = elem.html;
+		var align = elem.align;
+
+		var div = createNode('div');
+		div.innerHTML = html;
+		div.style.visibility = 'hidden';
+		if (align)
+		{
+			div.style.textAlign = align;
+		}
+		div.style.visibility = 'visible';
+		div.style.pointerEvents = 'auto';
+		return div;
+	}
+
+
+	// RENDER
+
+	function render(elem)
+	{
+		return setProps(elem, makeElement(elem));
+	}
+	function makeElement(e)
+	{
+		var elem = e.element;
+		switch (elem.ctor)
+		{
+			case 'Image':
+				return image(e.props, elem);
+
+			case 'Flow':
+				return flow(elem._0.ctor, elem._1);
+
+			case 'Container':
+				return container(elem._0, elem._1);
+
+			case 'Spacer':
+				return createNode('div');
+
+			case 'RawHtml':
+				return rawHtml(elem);
+
+			case 'Custom':
+				return elem.render(elem.model);
+		}
+	}
+
+	function updateAndReplace(node, curr, next)
+	{
+		var newNode = update(node, curr, next);
+		if (newNode !== node)
+		{
+			node.parentNode.replaceChild(newNode, node);
+		}
+		return newNode;
+	}
+
+
+	// UPDATE
+
+	function update(node, curr, next)
+	{
+		var rootNode = node;
+		if (node.tagName === 'A')
+		{
+			node = node.firstChild;
+		}
+		if (curr.props.id === next.props.id)
+		{
+			updateProps(node, curr, next);
+			return rootNode;
+		}
+		if (curr.element.ctor !== next.element.ctor)
+		{
+			return render(next);
+		}
+		var nextE = next.element;
+		var currE = curr.element;
+		switch (nextE.ctor)
+		{
+			case 'Spacer':
+				updateProps(node, curr, next);
+				return rootNode;
+
+			case 'RawHtml':
+				if(currE.html.valueOf() !== nextE.html.valueOf())
+				{
+					node.innerHTML = nextE.html;
+				}
+				updateProps(node, curr, next);
+				return rootNode;
+
+			case 'Image':
+				if (nextE._0.ctor === 'Plain')
+				{
+					if (nextE._3 !== currE._3)
+					{
+						node.src = nextE._3;
+					}
+				}
+				else if (!Utils.eq(nextE, currE)
+					|| next.props.width !== curr.props.width
+					|| next.props.height !== curr.props.height)
+				{
+					return render(next);
+				}
+				updateProps(node, curr, next);
+				return rootNode;
+
+			case 'Flow':
+				var arr = List.toArray(nextE._1);
+				for (var i = arr.length; i--; )
+				{
+					arr[i] = arr[i].element.ctor;
+				}
+				if (nextE._0.ctor !== currE._0.ctor)
+				{
+					return render(next);
+				}
+				var nexts = List.toArray(nextE._1);
+				var kids = node.childNodes;
+				if (nexts.length !== kids.length)
+				{
+					return render(next);
+				}
+				var currs = List.toArray(currE._1);
+				var dir = nextE._0.ctor;
+				var goDir = directionTable[dir];
+				var toReverse = needsReversal(dir);
+				var len = kids.length;
+				for (var i = len; i--; )
+				{
+					var subNode = kids[toReverse ? len - i - 1 : i];
+					goDir(updateAndReplace(subNode, currs[i], nexts[i]));
+				}
+				updateProps(node, curr, next);
+				return rootNode;
+
+			case 'Container':
+				var subNode = node.firstChild;
+				var newSubNode = updateAndReplace(subNode, currE._1, nextE._1);
+				setPos(nextE._0, nextE._1, newSubNode);
+				updateProps(node, curr, next);
+				return rootNode;
+
+			case 'Custom':
+				if (currE.type === nextE.type)
+				{
+					var updatedNode = nextE.update(node, currE.model, nextE.model);
+					updateProps(updatedNode, curr, next);
+					return updatedNode;
+				}
+				return render(next);
+		}
+	}
+
+	function updateProps(node, curr, next)
+	{
+		var nextProps = next.props;
+		var currProps = curr.props;
+
+		var element = next.element;
+		var width = nextProps.width - (element.adjustWidth || 0);
+		var height = nextProps.height - (element.adjustHeight || 0);
+		if (width !== currProps.width)
+		{
+			node.style.width = (width | 0) + 'px';
+		}
+		if (height !== currProps.height)
+		{
+			node.style.height = (height | 0) + 'px';
+		}
+
+		if (nextProps.opacity !== currProps.opacity)
+		{
+			node.style.opacity = nextProps.opacity;
+		}
+
+		var nextColor = nextProps.color.ctor === 'Just'
+			? Color.toCss(nextProps.color._0)
+			: '';
+		if (node.style.backgroundColor !== nextColor)
+		{
+			node.style.backgroundColor = nextColor;
+		}
+
+		if (nextProps.tag !== currProps.tag)
+		{
+			node.id = nextProps.tag;
+		}
+
+		if (nextProps.href !== currProps.href)
+		{
+			if (currProps.href === '')
+			{
+				// add a surrounding href
+				var anchor = createNode('a');
+				anchor.href = nextProps.href;
+				anchor.style.display = 'block';
+				anchor.style.pointerEvents = 'auto';
+
+				node.parentNode.replaceChild(anchor, node);
+				anchor.appendChild(node);
+			}
+			else if (nextProps.href === '')
+			{
+				// remove the surrounding href
+				var anchor = node.parentNode;
+				anchor.parentNode.replaceChild(node, anchor);
+			}
+			else
+			{
+				// just update the link
+				node.parentNode.href = nextProps.href;
+			}
+		}
+
+		// update click and hover handlers
+		var removed = false;
+
+		// update hover handlers
+		if (currProps.hover.ctor === '_Tuple0')
+		{
+			if (nextProps.hover.ctor !== '_Tuple0')
+			{
+				addHover(node, nextProps.hover);
+			}
+		}
+		else
+		{
+			if (nextProps.hover.ctor === '_Tuple0')
+			{
+				removed = true;
+				removeHover(node);
+			}
+			else
+			{
+				node.elm_hover_handler = nextProps.hover;
+			}
+		}
+
+		// update click handlers
+		if (currProps.click.ctor === '_Tuple0')
+		{
+			if (nextProps.click.ctor !== '_Tuple0')
+			{
+				addClick(node, nextProps.click);
+			}
+		}
+		else
+		{
+			if (nextProps.click.ctor === '_Tuple0')
+			{
+				removed = true;
+				removeClick(node);
+			}
+			else
+			{
+				node.elm_click_handler = nextProps.click;
+			}
+		}
+
+		// stop capturing clicks if
+		if (removed
+			&& nextProps.hover.ctor === '_Tuple0'
+			&& nextProps.click.ctor === '_Tuple0')
+		{
+			node.style.pointerEvents = 'none';
+		}
+	}
+
+
+	// TEXT
+
+	function block(align)
+	{
+		return function(text)
+		{
+			var raw = {
+				ctor: 'RawHtml',
+				html: Text.renderHtml(text),
+				align: align
+			};
+			var pos = htmlHeight(0, raw);
+			return newElement(pos._0, pos._1, raw);
+		};
+	}
+
+	function markdown(text)
+	{
+		var raw = {
+			ctor: 'RawHtml',
+			html: text,
+			align: null
+		};
+		var pos = htmlHeight(0, raw);
+		return newElement(pos._0, pos._1, raw);
+	}
+
+	var htmlHeight =
+		typeof document !== 'undefined'
+			? realHtmlHeight
+			: function(a, b) { return Utils.Tuple2(0, 0); };
+
+	function realHtmlHeight(width, rawHtml)
+	{
+		// create dummy node
+		var temp = document.createElement('div');
+		temp.innerHTML = rawHtml.html;
+		if (width > 0)
+		{
+			temp.style.width = width + 'px';
+		}
+		temp.style.visibility = 'hidden';
+		temp.style.styleFloat = 'left';
+		temp.style.cssFloat = 'left';
+
+		document.body.appendChild(temp);
+
+		// get dimensions
+		var style = window.getComputedStyle(temp, null);
+		var w = Math.ceil(style.getPropertyValue('width').slice(0, -2) - 0);
+		var h = Math.ceil(style.getPropertyValue('height').slice(0, -2) - 0);
+		document.body.removeChild(temp);
+		return Utils.Tuple2(w, h);
+	}
+
+
+	return localRuntime.Native.Graphics.Element.values = {
+		render: render,
+		update: update,
+		updateAndReplace: updateAndReplace,
+
+		createNode: createNode,
+		newElement: F3(newElement),
+		addTransform: addTransform,
+		htmlHeight: F2(htmlHeight),
+		guid: Utils.guid,
+
+		block: block,
+		markdown: markdown
+	};
+};
+Elm.Native.Text = {};
+Elm.Native.Text.make = function(localRuntime) {
+	localRuntime.Native = localRuntime.Native || {};
+	localRuntime.Native.Text = localRuntime.Native.Text || {};
+	if (localRuntime.Native.Text.values)
+	{
+		return localRuntime.Native.Text.values;
+	}
+
+	var toCss = Elm.Native.Color.make(localRuntime).toCss;
+	var List = Elm.Native.List.make(localRuntime);
+
+
+	// CONSTRUCTORS
+
+	function fromString(str)
+	{
+		return {
+			ctor: 'Text:Text',
+			_0: str
+		};
+	}
+
+	function append(a, b)
+	{
+		return {
+			ctor: 'Text:Append',
+			_0: a,
+			_1: b
+		};
+	}
+
+	function addMeta(field, value, text)
+	{
+		var newProps = {};
+		var newText = {
+			ctor: 'Text:Meta',
+			_0: newProps,
+			_1: text
+		};
+
+		if (text.ctor === 'Text:Meta')
+		{
+			newText._1 = text._1;
+			var props = text._0;
+			for (var i = metaKeys.length; i--; )
+			{
+				var key = metaKeys[i];
+				var val = props[key];
+				if (val)
+				{
+					newProps[key] = val;
+				}
+			}
+		}
+		newProps[field] = value;
+		return newText;
+	}
+
+	var metaKeys = [
+		'font-size',
+		'font-family',
+		'font-style',
+		'font-weight',
+		'href',
+		'text-decoration',
+		'color'
+	];
+
+
+	// conversions from Elm values to CSS
+
+	function toTypefaces(list)
+	{
+		var typefaces = List.toArray(list);
+		for (var i = typefaces.length; i--; )
+		{
+			var typeface = typefaces[i];
+			if (typeface.indexOf(' ') > -1)
+			{
+				typefaces[i] = "'" + typeface + "'";
+			}
+		}
+		return typefaces.join(',');
+	}
+
+	function toLine(line)
+	{
+		var ctor = line.ctor;
+		return ctor === 'Under'
+			? 'underline'
+			: ctor === 'Over'
+				? 'overline'
+				: 'line-through';
+	}
+
+	// setting styles of Text
+
+	function style(style, text)
+	{
+		var newText = addMeta('color', toCss(style.color), text);
+		var props = newText._0;
+
+		if (style.typeface.ctor !== '[]')
+		{
+			props['font-family'] = toTypefaces(style.typeface);
+		}
+		if (style.height.ctor !== 'Nothing')
+		{
+			props['font-size'] = style.height._0 + 'px';
+		}
+		if (style.bold)
+		{
+			props['font-weight'] = 'bold';
+		}
+		if (style.italic)
+		{
+			props['font-style'] = 'italic';
+		}
+		if (style.line.ctor !== 'Nothing')
+		{
+			props['text-decoration'] = toLine(style.line._0);
+		}
+		return newText;
+	}
+
+	function height(px, text)
+	{
+		return addMeta('font-size', px + 'px', text);
+	}
+
+	function typeface(names, text)
+	{
+		return addMeta('font-family', toTypefaces(names), text);
+	}
+
+	function monospace(text)
+	{
+		return addMeta('font-family', 'monospace', text);
+	}
+
+	function italic(text)
+	{
+		return addMeta('font-style', 'italic', text);
+	}
+
+	function bold(text)
+	{
+		return addMeta('font-weight', 'bold', text);
+	}
+
+	function link(href, text)
+	{
+		return addMeta('href', href, text);
+	}
+
+	function line(line, text)
+	{
+		return addMeta('text-decoration', toLine(line), text);
+	}
+
+	function color(color, text)
+	{
+		return addMeta('color', toCss(color), text);
+	}
+
+
+	// RENDER
+
+	function renderHtml(text)
+	{
+		var tag = text.ctor;
+		if (tag === 'Text:Append')
+		{
+			return renderHtml(text._0) + renderHtml(text._1);
+		}
+		if (tag === 'Text:Text')
+		{
+			return properEscape(text._0);
+		}
+		if (tag === 'Text:Meta')
+		{
+			return renderMeta(text._0, renderHtml(text._1));
+		}
+	}
+
+	function renderMeta(metas, string)
+	{
+		var href = metas.href;
+		if (href)
+		{
+			string = '<a href="' + href + '">' + string + '</a>';
+		}
+		var styles = '';
+		for (var key in metas)
+		{
+			if (key === 'href')
+			{
+				continue;
+			}
+			styles += key + ':' + metas[key] + ';';
+		}
+		if (styles)
+		{
+			string = '<span style="' + styles + '">' + string + '</span>';
+		}
+		return string;
+	}
+
+	function properEscape(str)
+	{
+		if (str.length === 0)
+		{
+			return str;
+		}
+		str = str //.replace(/&/g,  '&#38;')
+			.replace(/"/g,  '&#34;')
+			.replace(/'/g,  '&#39;')
+			.replace(/</g,  '&#60;')
+			.replace(/>/g,  '&#62;');
+		var arr = str.split('\n');
+		for (var i = arr.length; i--; )
+		{
+			arr[i] = makeSpaces(arr[i]);
+		}
+		return arr.join('<br/>');
+	}
+
+	function makeSpaces(s)
+	{
+		if (s.length === 0)
+		{
+			return s;
+		}
+		var arr = s.split('');
+		if (arr[0] === ' ')
+		{
+			arr[0] = '&nbsp;';
+		}
+		for (var i = arr.length; --i; )
+		{
+			if (arr[i][0] === ' ' && arr[i - 1] === ' ')
+			{
+				arr[i - 1] = arr[i - 1] + arr[i];
+				arr[i] = '';
+			}
+		}
+		for (var i = arr.length; i--; )
+		{
+			if (arr[i].length > 1 && arr[i][0] === ' ')
+			{
+				var spaces = arr[i].split('');
+				for (var j = spaces.length - 2; j >= 0; j -= 2)
+				{
+					spaces[j] = '&nbsp;';
+				}
+				arr[i] = spaces.join('');
+			}
+		}
+		arr = arr.join('');
+		if (arr[arr.length - 1] === ' ')
+		{
+			return arr.slice(0, -1) + '&nbsp;';
+		}
+		return arr;
+	}
+
+
+	return localRuntime.Native.Text.values = {
+		fromString: fromString,
+		append: F2(append),
+
+		height: F2(height),
+		italic: italic,
+		bold: bold,
+		line: F2(line),
+		monospace: monospace,
+		typeface: F2(typeface),
+		color: F2(color),
+		link: F2(link),
+		style: F2(style),
+
+		toTypefaces: toTypefaces,
+		toLine: toLine,
+		renderHtml: renderHtml
+	};
+};
+Elm.Text = Elm.Text || {};
+Elm.Text.make = function (_elm) {
+   "use strict";
+   _elm.Text = _elm.Text || {};
+   if (_elm.Text.values) return _elm.Text.values;
+   var _U = Elm.Native.Utils.make(_elm),
+   $Color = Elm.Color.make(_elm),
+   $List = Elm.List.make(_elm),
+   $Maybe = Elm.Maybe.make(_elm),
+   $Native$Text = Elm.Native.Text.make(_elm);
+   var _op = {};
+   var line = $Native$Text.line;
+   var italic = $Native$Text.italic;
+   var bold = $Native$Text.bold;
+   var color = $Native$Text.color;
+   var height = $Native$Text.height;
+   var link = $Native$Text.link;
+   var monospace = $Native$Text.monospace;
+   var typeface = $Native$Text.typeface;
+   var style = $Native$Text.style;
+   var append = $Native$Text.append;
+   var fromString = $Native$Text.fromString;
+   var empty = fromString("");
+   var concat = function (texts) {
+      return A3($List.foldr,append,empty,texts);
+   };
+   var join = F2(function (seperator,texts) {
+      return concat(A2($List.intersperse,seperator,texts));
+   });
+   var defaultStyle = {typeface: _U.list([])
+                      ,height: $Maybe.Nothing
+                      ,color: $Color.black
+                      ,bold: false
+                      ,italic: false
+                      ,line: $Maybe.Nothing};
+   var Style = F6(function (a,b,c,d,e,f) {
+      return {typeface: a
+             ,height: b
+             ,color: c
+             ,bold: d
+             ,italic: e
+             ,line: f};
+   });
+   var Through = {ctor: "Through"};
+   var Over = {ctor: "Over"};
+   var Under = {ctor: "Under"};
+   var Text = {ctor: "Text"};
+   return _elm.Text.values = {_op: _op
+                             ,fromString: fromString
+                             ,empty: empty
+                             ,append: append
+                             ,concat: concat
+                             ,join: join
+                             ,link: link
+                             ,style: style
+                             ,defaultStyle: defaultStyle
+                             ,typeface: typeface
+                             ,monospace: monospace
+                             ,height: height
+                             ,color: color
+                             ,bold: bold
+                             ,italic: italic
+                             ,line: line
+                             ,Style: Style
+                             ,Under: Under
+                             ,Over: Over
+                             ,Through: Through};
+};Elm.Graphics = Elm.Graphics || {};
+Elm.Graphics.Element = Elm.Graphics.Element || {};
+Elm.Graphics.Element.make = function (_elm) {
+   "use strict";
+   _elm.Graphics = _elm.Graphics || {};
+   _elm.Graphics.Element = _elm.Graphics.Element || {};
+   if (_elm.Graphics.Element.values)
+   return _elm.Graphics.Element.values;
+   var _U = Elm.Native.Utils.make(_elm),
+   $Basics = Elm.Basics.make(_elm),
+   $Color = Elm.Color.make(_elm),
+   $List = Elm.List.make(_elm),
+   $Maybe = Elm.Maybe.make(_elm),
+   $Native$Graphics$Element = Elm.Native.Graphics.Element.make(_elm),
+   $Text = Elm.Text.make(_elm);
+   var _op = {};
+   var DOut = {ctor: "DOut"};
+   var outward = DOut;
+   var DIn = {ctor: "DIn"};
+   var inward = DIn;
+   var DRight = {ctor: "DRight"};
+   var right = DRight;
+   var DLeft = {ctor: "DLeft"};
+   var left = DLeft;
+   var DDown = {ctor: "DDown"};
+   var down = DDown;
+   var DUp = {ctor: "DUp"};
+   var up = DUp;
+   var RawPosition = F4(function (a,b,c,d) {
+      return {horizontal: a,vertical: b,x: c,y: d};
+   });
+   var Position = function (a) {
+      return {ctor: "Position",_0: a};
+   };
+   var Relative = function (a) {
+      return {ctor: "Relative",_0: a};
+   };
+   var relative = Relative;
+   var Absolute = function (a) {
+      return {ctor: "Absolute",_0: a};
+   };
+   var absolute = Absolute;
+   var N = {ctor: "N"};
+   var bottomLeft = Position({horizontal: N
+                             ,vertical: N
+                             ,x: Absolute(0)
+                             ,y: Absolute(0)});
+   var bottomLeftAt = F2(function (x,y) {
+      return Position({horizontal: N,vertical: N,x: x,y: y});
+   });
+   var Z = {ctor: "Z"};
+   var middle = Position({horizontal: Z
+                         ,vertical: Z
+                         ,x: Relative(0.5)
+                         ,y: Relative(0.5)});
+   var midLeft = Position({horizontal: N
+                          ,vertical: Z
+                          ,x: Absolute(0)
+                          ,y: Relative(0.5)});
+   var midBottom = Position({horizontal: Z
+                            ,vertical: N
+                            ,x: Relative(0.5)
+                            ,y: Absolute(0)});
+   var middleAt = F2(function (x,y) {
+      return Position({horizontal: Z,vertical: Z,x: x,y: y});
+   });
+   var midLeftAt = F2(function (x,y) {
+      return Position({horizontal: N,vertical: Z,x: x,y: y});
+   });
+   var midBottomAt = F2(function (x,y) {
+      return Position({horizontal: Z,vertical: N,x: x,y: y});
+   });
+   var P = {ctor: "P"};
+   var topLeft = Position({horizontal: N
+                          ,vertical: P
+                          ,x: Absolute(0)
+                          ,y: Absolute(0)});
+   var topRight = Position({horizontal: P
+                           ,vertical: P
+                           ,x: Absolute(0)
+                           ,y: Absolute(0)});
+   var bottomRight = Position({horizontal: P
+                              ,vertical: N
+                              ,x: Absolute(0)
+                              ,y: Absolute(0)});
+   var midRight = Position({horizontal: P
+                           ,vertical: Z
+                           ,x: Absolute(0)
+                           ,y: Relative(0.5)});
+   var midTop = Position({horizontal: Z
+                         ,vertical: P
+                         ,x: Relative(0.5)
+                         ,y: Absolute(0)});
+   var topLeftAt = F2(function (x,y) {
+      return Position({horizontal: N,vertical: P,x: x,y: y});
+   });
+   var topRightAt = F2(function (x,y) {
+      return Position({horizontal: P,vertical: P,x: x,y: y});
+   });
+   var bottomRightAt = F2(function (x,y) {
+      return Position({horizontal: P,vertical: N,x: x,y: y});
+   });
+   var midRightAt = F2(function (x,y) {
+      return Position({horizontal: P,vertical: Z,x: x,y: y});
+   });
+   var midTopAt = F2(function (x,y) {
+      return Position({horizontal: Z,vertical: P,x: x,y: y});
+   });
+   var justified = $Native$Graphics$Element.block("justify");
+   var centered = $Native$Graphics$Element.block("center");
+   var rightAligned = $Native$Graphics$Element.block("right");
+   var leftAligned = $Native$Graphics$Element.block("left");
+   var show = function (value) {
+      return leftAligned($Text.monospace($Text.fromString($Basics.toString(value))));
+   };
+   var Tiled = {ctor: "Tiled"};
+   var Cropped = function (a) {
+      return {ctor: "Cropped",_0: a};
+   };
+   var Fitted = {ctor: "Fitted"};
+   var Plain = {ctor: "Plain"};
+   var Custom = {ctor: "Custom"};
+   var RawHtml = {ctor: "RawHtml"};
+   var Spacer = {ctor: "Spacer"};
+   var Flow = F2(function (a,b) {
+      return {ctor: "Flow",_0: a,_1: b};
+   });
+   var Container = F2(function (a,b) {
+      return {ctor: "Container",_0: a,_1: b};
+   });
+   var Image = F4(function (a,b,c,d) {
+      return {ctor: "Image",_0: a,_1: b,_2: c,_3: d};
+   });
+   var newElement = $Native$Graphics$Element.newElement;
+   var image = F3(function (w,h,src) {
+      return A3(newElement,w,h,A4(Image,Plain,w,h,src));
+   });
+   var fittedImage = F3(function (w,h,src) {
+      return A3(newElement,w,h,A4(Image,Fitted,w,h,src));
+   });
+   var croppedImage = F4(function (pos,w,h,src) {
+      return A3(newElement,w,h,A4(Image,Cropped(pos),w,h,src));
+   });
+   var tiledImage = F3(function (w,h,src) {
+      return A3(newElement,w,h,A4(Image,Tiled,w,h,src));
+   });
+   var container = F4(function (w,h,_p0,e) {
+      var _p1 = _p0;
+      return A3(newElement,w,h,A2(Container,_p1._0,e));
+   });
+   var spacer = F2(function (w,h) {
+      return A3(newElement,w,h,Spacer);
+   });
+   var link = F2(function (href,e) {
+      var p = e.props;
+      return {element: e.element,props: _U.update(p,{href: href})};
+   });
+   var tag = F2(function (name,e) {
+      var p = e.props;
+      return {element: e.element,props: _U.update(p,{tag: name})};
+   });
+   var color = F2(function (c,e) {
+      var p = e.props;
+      return {element: e.element
+             ,props: _U.update(p,{color: $Maybe.Just(c)})};
+   });
+   var opacity = F2(function (o,e) {
+      var p = e.props;
+      return {element: e.element,props: _U.update(p,{opacity: o})};
+   });
+   var height = F2(function (nh,e) {
+      var p = e.props;
+      var props = function () {
+         var _p2 = e.element;
+         if (_p2.ctor === "Image") {
+               return _U.update(p,
+               {width: $Basics.round($Basics.toFloat(_p2._1) / $Basics.toFloat(_p2._2) * $Basics.toFloat(nh))});
+            } else {
+               return p;
+            }
+      }();
+      return {element: e.element,props: _U.update(p,{height: nh})};
+   });
+   var width = F2(function (nw,e) {
+      var p = e.props;
+      var props = function () {
+         var _p3 = e.element;
+         switch (_p3.ctor)
+         {case "Image": return _U.update(p,
+              {height: $Basics.round($Basics.toFloat(_p3._2) / $Basics.toFloat(_p3._1) * $Basics.toFloat(nw))});
+            case "RawHtml": return _U.update(p,
+              {height: $Basics.snd(A2($Native$Graphics$Element.htmlHeight,
+              nw,
+              e.element))});
+            default: return p;}
+      }();
+      return {element: e.element,props: _U.update(props,{width: nw})};
+   });
+   var size = F3(function (w,h,e) {
+      return A2(height,h,A2(width,w,e));
+   });
+   var sizeOf = function (e) {
+      return {ctor: "_Tuple2"
+             ,_0: e.props.width
+             ,_1: e.props.height};
+   };
+   var heightOf = function (e) {    return e.props.height;};
+   var widthOf = function (e) {    return e.props.width;};
+   var above = F2(function (hi,lo) {
+      return A3(newElement,
+      A2($Basics.max,widthOf(hi),widthOf(lo)),
+      heightOf(hi) + heightOf(lo),
+      A2(Flow,DDown,_U.list([hi,lo])));
+   });
+   var below = F2(function (lo,hi) {
+      return A3(newElement,
+      A2($Basics.max,widthOf(hi),widthOf(lo)),
+      heightOf(hi) + heightOf(lo),
+      A2(Flow,DDown,_U.list([hi,lo])));
+   });
+   var beside = F2(function (lft,rht) {
+      return A3(newElement,
+      widthOf(lft) + widthOf(rht),
+      A2($Basics.max,heightOf(lft),heightOf(rht)),
+      A2(Flow,right,_U.list([lft,rht])));
+   });
+   var layers = function (es) {
+      var hs = A2($List.map,heightOf,es);
+      var ws = A2($List.map,widthOf,es);
+      return A3(newElement,
+      A2($Maybe.withDefault,0,$List.maximum(ws)),
+      A2($Maybe.withDefault,0,$List.maximum(hs)),
+      A2(Flow,DOut,es));
+   };
+   var empty = A2(spacer,0,0);
+   var flow = F2(function (dir,es) {
+      var newFlow = F2(function (w,h) {
+         return A3(newElement,w,h,A2(Flow,dir,es));
+      });
+      var maxOrZero = function (list) {
+         return A2($Maybe.withDefault,0,$List.maximum(list));
+      };
+      var hs = A2($List.map,heightOf,es);
+      var ws = A2($List.map,widthOf,es);
+      if (_U.eq(es,_U.list([]))) return empty; else {
+            var _p4 = dir;
+            switch (_p4.ctor)
+            {case "DUp": return A2(newFlow,maxOrZero(ws),$List.sum(hs));
+               case "DDown": return A2(newFlow,maxOrZero(ws),$List.sum(hs));
+               case "DLeft": return A2(newFlow,$List.sum(ws),maxOrZero(hs));
+               case "DRight": return A2(newFlow,$List.sum(ws),maxOrZero(hs));
+               case "DIn": return A2(newFlow,maxOrZero(ws),maxOrZero(hs));
+               default: return A2(newFlow,maxOrZero(ws),maxOrZero(hs));}
+         }
+   });
+   var Properties = F9(function (a,b,c,d,e,f,g,h,i) {
+      return {id: a
+             ,width: b
+             ,height: c
+             ,opacity: d
+             ,color: e
+             ,href: f
+             ,tag: g
+             ,hover: h
+             ,click: i};
+   });
+   var Element = F2(function (a,b) {
+      return {props: a,element: b};
+   });
+   return _elm.Graphics.Element.values = {_op: _op
+                                         ,image: image
+                                         ,fittedImage: fittedImage
+                                         ,croppedImage: croppedImage
+                                         ,tiledImage: tiledImage
+                                         ,leftAligned: leftAligned
+                                         ,rightAligned: rightAligned
+                                         ,centered: centered
+                                         ,justified: justified
+                                         ,show: show
+                                         ,width: width
+                                         ,height: height
+                                         ,size: size
+                                         ,color: color
+                                         ,opacity: opacity
+                                         ,link: link
+                                         ,tag: tag
+                                         ,widthOf: widthOf
+                                         ,heightOf: heightOf
+                                         ,sizeOf: sizeOf
+                                         ,flow: flow
+                                         ,up: up
+                                         ,down: down
+                                         ,left: left
+                                         ,right: right
+                                         ,inward: inward
+                                         ,outward: outward
+                                         ,layers: layers
+                                         ,above: above
+                                         ,below: below
+                                         ,beside: beside
+                                         ,empty: empty
+                                         ,spacer: spacer
+                                         ,container: container
+                                         ,middle: middle
+                                         ,midTop: midTop
+                                         ,midBottom: midBottom
+                                         ,midLeft: midLeft
+                                         ,midRight: midRight
+                                         ,topLeft: topLeft
+                                         ,topRight: topRight
+                                         ,bottomLeft: bottomLeft
+                                         ,bottomRight: bottomRight
+                                         ,absolute: absolute
+                                         ,relative: relative
+                                         ,middleAt: middleAt
+                                         ,midTopAt: midTopAt
+                                         ,midBottomAt: midBottomAt
+                                         ,midLeftAt: midLeftAt
+                                         ,midRightAt: midRightAt
+                                         ,topLeftAt: topLeftAt
+                                         ,topRightAt: topRightAt
+                                         ,bottomLeftAt: bottomLeftAt
+                                         ,bottomRightAt: bottomRightAt
+                                         ,Element: Element};
+};Elm.Graphics = Elm.Graphics || {};
+Elm.Graphics.Collage = Elm.Graphics.Collage || {};
+Elm.Graphics.Collage.make = function (_elm) {
+   "use strict";
+   _elm.Graphics = _elm.Graphics || {};
+   _elm.Graphics.Collage = _elm.Graphics.Collage || {};
+   if (_elm.Graphics.Collage.values)
+   return _elm.Graphics.Collage.values;
+   var _U = Elm.Native.Utils.make(_elm),
+   $Basics = Elm.Basics.make(_elm),
+   $Color = Elm.Color.make(_elm),
+   $Graphics$Element = Elm.Graphics.Element.make(_elm),
+   $List = Elm.List.make(_elm),
+   $Native$Graphics$Collage = Elm.Native.Graphics.Collage.make(_elm),
+   $Text = Elm.Text.make(_elm),
+   $Transform2D = Elm.Transform2D.make(_elm);
+   var _op = {};
+   var Shape = function (a) {    return {ctor: "Shape",_0: a};};
+   var polygon = function (points) {    return Shape(points);};
+   var rect = F2(function (w,h) {
+      var hh = h / 2;
+      var hw = w / 2;
+      return Shape(_U.list([{ctor: "_Tuple2",_0: 0 - hw,_1: 0 - hh}
+                           ,{ctor: "_Tuple2",_0: 0 - hw,_1: hh}
+                           ,{ctor: "_Tuple2",_0: hw,_1: hh}
+                           ,{ctor: "_Tuple2",_0: hw,_1: 0 - hh}]));
+   });
+   var square = function (n) {    return A2(rect,n,n);};
+   var oval = F2(function (w,h) {
+      var hh = h / 2;
+      var hw = w / 2;
+      var n = 50;
+      var t = 2 * $Basics.pi / n;
+      var f = function (i) {
+         return {ctor: "_Tuple2"
+                ,_0: hw * $Basics.cos(t * i)
+                ,_1: hh * $Basics.sin(t * i)};
+      };
+      return Shape(A2($List.map,f,_U.range(0,n - 1)));
+   });
+   var circle = function (r) {    return A2(oval,2 * r,2 * r);};
+   var ngon = F2(function (n,r) {
+      var m = $Basics.toFloat(n);
+      var t = 2 * $Basics.pi / m;
+      var f = function (i) {
+         return {ctor: "_Tuple2"
+                ,_0: r * $Basics.cos(t * i)
+                ,_1: r * $Basics.sin(t * i)};
+      };
+      return Shape(A2($List.map,f,_U.range(0,m - 1)));
+   });
+   var Path = function (a) {    return {ctor: "Path",_0: a};};
+   var path = function (ps) {    return Path(ps);};
+   var segment = F2(function (p1,p2) {
+      return Path(_U.list([p1,p2]));
+   });
+   var collage = $Native$Graphics$Collage.collage;
+   var alpha = F2(function (a,f) {
+      return _U.update(f,{alpha: a});
+   });
+   var rotate = F2(function (t,f) {
+      return _U.update(f,{theta: f.theta + t});
+   });
+   var scale = F2(function (s,f) {
+      return _U.update(f,{scale: f.scale * s});
+   });
+   var moveY = F2(function (y,f) {
+      return _U.update(f,{y: f.y + y});
+   });
+   var moveX = F2(function (x,f) {
+      return _U.update(f,{x: f.x + x});
+   });
+   var move = F2(function (_p0,f) {
+      var _p1 = _p0;
+      return _U.update(f,{x: f.x + _p1._0,y: f.y + _p1._1});
+   });
+   var form = function (f) {
+      return {theta: 0,scale: 1,x: 0,y: 0,alpha: 1,form: f};
+   };
+   var Fill = function (a) {    return {ctor: "Fill",_0: a};};
+   var Line = function (a) {    return {ctor: "Line",_0: a};};
+   var FGroup = F2(function (a,b) {
+      return {ctor: "FGroup",_0: a,_1: b};
+   });
+   var group = function (fs) {
+      return form(A2(FGroup,$Transform2D.identity,fs));
+   };
+   var groupTransform = F2(function (matrix,fs) {
+      return form(A2(FGroup,matrix,fs));
+   });
+   var FElement = function (a) {
+      return {ctor: "FElement",_0: a};
+   };
+   var toForm = function (e) {    return form(FElement(e));};
+   var FImage = F4(function (a,b,c,d) {
+      return {ctor: "FImage",_0: a,_1: b,_2: c,_3: d};
+   });
+   var sprite = F4(function (w,h,pos,src) {
+      return form(A4(FImage,w,h,pos,src));
+   });
+   var FText = function (a) {    return {ctor: "FText",_0: a};};
+   var text = function (t) {    return form(FText(t));};
+   var FOutlinedText = F2(function (a,b) {
+      return {ctor: "FOutlinedText",_0: a,_1: b};
+   });
+   var outlinedText = F2(function (ls,t) {
+      return form(A2(FOutlinedText,ls,t));
+   });
+   var FShape = F2(function (a,b) {
+      return {ctor: "FShape",_0: a,_1: b};
+   });
+   var fill = F2(function (style,_p2) {
+      var _p3 = _p2;
+      return form(A2(FShape,Fill(style),_p3._0));
+   });
+   var outlined = F2(function (style,_p4) {
+      var _p5 = _p4;
+      return form(A2(FShape,Line(style),_p5._0));
+   });
+   var FPath = F2(function (a,b) {
+      return {ctor: "FPath",_0: a,_1: b};
+   });
+   var traced = F2(function (style,_p6) {
+      var _p7 = _p6;
+      return form(A2(FPath,style,_p7._0));
+   });
+   var LineStyle = F6(function (a,b,c,d,e,f) {
+      return {color: a
+             ,width: b
+             ,cap: c
+             ,join: d
+             ,dashing: e
+             ,dashOffset: f};
+   });
+   var Clipped = {ctor: "Clipped"};
+   var Sharp = function (a) {    return {ctor: "Sharp",_0: a};};
+   var Smooth = {ctor: "Smooth"};
+   var Padded = {ctor: "Padded"};
+   var Round = {ctor: "Round"};
+   var Flat = {ctor: "Flat"};
+   var defaultLine = {color: $Color.black
+                     ,width: 1
+                     ,cap: Flat
+                     ,join: Sharp(10)
+                     ,dashing: _U.list([])
+                     ,dashOffset: 0};
+   var solid = function (clr) {
+      return _U.update(defaultLine,{color: clr});
+   };
+   var dashed = function (clr) {
+      return _U.update(defaultLine,
+      {color: clr,dashing: _U.list([8,4])});
+   };
+   var dotted = function (clr) {
+      return _U.update(defaultLine,
+      {color: clr,dashing: _U.list([3,3])});
+   };
+   var Grad = function (a) {    return {ctor: "Grad",_0: a};};
+   var gradient = F2(function (grad,shape) {
+      return A2(fill,Grad(grad),shape);
+   });
+   var Texture = function (a) {
+      return {ctor: "Texture",_0: a};
+   };
+   var textured = F2(function (src,shape) {
+      return A2(fill,Texture(src),shape);
+   });
+   var Solid = function (a) {    return {ctor: "Solid",_0: a};};
+   var filled = F2(function (color,shape) {
+      return A2(fill,Solid(color),shape);
+   });
+   var Form = F6(function (a,b,c,d,e,f) {
+      return {theta: a,scale: b,x: c,y: d,alpha: e,form: f};
+   });
+   return _elm.Graphics.Collage.values = {_op: _op
+                                         ,collage: collage
+                                         ,toForm: toForm
+                                         ,filled: filled
+                                         ,textured: textured
+                                         ,gradient: gradient
+                                         ,outlined: outlined
+                                         ,traced: traced
+                                         ,text: text
+                                         ,outlinedText: outlinedText
+                                         ,move: move
+                                         ,moveX: moveX
+                                         ,moveY: moveY
+                                         ,scale: scale
+                                         ,rotate: rotate
+                                         ,alpha: alpha
+                                         ,group: group
+                                         ,groupTransform: groupTransform
+                                         ,rect: rect
+                                         ,oval: oval
+                                         ,square: square
+                                         ,circle: circle
+                                         ,ngon: ngon
+                                         ,polygon: polygon
+                                         ,segment: segment
+                                         ,path: path
+                                         ,solid: solid
+                                         ,dashed: dashed
+                                         ,dotted: dotted
+                                         ,defaultLine: defaultLine
+                                         ,Form: Form
+                                         ,LineStyle: LineStyle
+                                         ,Flat: Flat
+                                         ,Round: Round
+                                         ,Padded: Padded
+                                         ,Smooth: Smooth
+                                         ,Sharp: Sharp
+                                         ,Clipped: Clipped};
+};Elm.Native.Debug = {};
+Elm.Native.Debug.make = function(localRuntime) {
+	localRuntime.Native = localRuntime.Native || {};
+	localRuntime.Native.Debug = localRuntime.Native.Debug || {};
+	if (localRuntime.Native.Debug.values)
+	{
+		return localRuntime.Native.Debug.values;
+	}
+
+	var toString = Elm.Native.Utils.make(localRuntime).toString;
+
+	function log(tag, value)
+	{
+		var msg = tag + ': ' + toString(value);
+		var process = process || {};
+		if (process.stdout)
+		{
+			process.stdout.write(msg);
+		}
+		else
+		{
+			console.log(msg);
+		}
+		return value;
+	}
+
+	function crash(message)
+	{
+		throw new Error(message);
+	}
+
+	function tracePath(tag, form)
+	{
+		if (localRuntime.debug)
+		{
+			return localRuntime.debug.trace(tag, form);
+		}
+		return form;
+	}
+
+	function watch(tag, value)
+	{
+		if (localRuntime.debug)
+		{
+			localRuntime.debug.watch(tag, value);
+		}
+		return value;
+	}
+
+	function watchSummary(tag, summarize, value)
+	{
+		if (localRuntime.debug)
+		{
+			localRuntime.debug.watch(tag, summarize(value));
+		}
+		return value;
+	}
+
+	return localRuntime.Native.Debug.values = {
+		crash: crash,
+		tracePath: F2(tracePath),
+		log: F2(log),
+		watch: F2(watch),
+		watchSummary: F3(watchSummary)
+	};
+};
+Elm.Debug = Elm.Debug || {};
+Elm.Debug.make = function (_elm) {
+   "use strict";
+   _elm.Debug = _elm.Debug || {};
+   if (_elm.Debug.values) return _elm.Debug.values;
+   var _U = Elm.Native.Utils.make(_elm),
+   $Graphics$Collage = Elm.Graphics.Collage.make(_elm),
+   $Native$Debug = Elm.Native.Debug.make(_elm);
+   var _op = {};
+   var trace = $Native$Debug.tracePath;
+   var watchSummary = $Native$Debug.watchSummary;
+   var watch = $Native$Debug.watch;
+   var crash = $Native$Debug.crash;
+   var log = $Native$Debug.log;
+   return _elm.Debug.values = {_op: _op
+                              ,log: log
+                              ,crash: crash
+                              ,watch: watch
+                              ,watchSummary: watchSummary
+                              ,trace: trace};
+};Elm.Native.Task = {};
+
+Elm.Native.Task.make = function(localRuntime) {
+	localRuntime.Native = localRuntime.Native || {};
+	localRuntime.Native.Task = localRuntime.Native.Task || {};
+	if (localRuntime.Native.Task.values)
+	{
+		return localRuntime.Native.Task.values;
+	}
+
+	var Result = Elm.Result.make(localRuntime);
+	var Signal;
+	var Utils = Elm.Native.Utils.make(localRuntime);
+
+
+	// CONSTRUCTORS
+
+	function succeed(value)
+	{
+		return {
+			tag: 'Succeed',
+			value: value
+		};
+	}
+
+	function fail(error)
+	{
+		return {
+			tag: 'Fail',
+			value: error
+		};
+	}
+
+	function asyncFunction(func)
+	{
+		return {
+			tag: 'Async',
+			asyncFunction: func
+		};
+	}
+
+	function andThen(task, callback)
+	{
+		return {
+			tag: 'AndThen',
+			task: task,
+			callback: callback
+		};
+	}
+
+	function catch_(task, callback)
+	{
+		return {
+			tag: 'Catch',
+			task: task,
+			callback: callback
+		};
+	}
+
+
+	// RUNNER
+
+	function perform(task) {
+		runTask({ task: task }, function() {});
+	}
+
+	function performSignal(name, signal)
+	{
+		var workQueue = [];
+
+		function onComplete()
+		{
+			workQueue.shift();
+
+			if (workQueue.length > 0)
+			{
+				var task = workQueue[0];
+
+				setTimeout(function() {
+					runTask(task, onComplete);
+				}, 0);
+			}
+		}
+
+		function register(task)
+		{
+			var root = { task: task };
+			workQueue.push(root);
+			if (workQueue.length === 1)
+			{
+				runTask(root, onComplete);
+			}
+		}
+
+		if (!Signal)
+		{
+			Signal = Elm.Native.Signal.make(localRuntime);
+		}
+		Signal.output('perform-tasks-' + name, register, signal);
+
+		register(signal.value);
+
+		return signal;
+	}
+
+	function mark(status, task)
+	{
+		return { status: status, task: task };
+	}
+
+	function runTask(root, onComplete)
+	{
+		var result = mark('runnable', root.task);
+		while (result.status === 'runnable')
+		{
+			result = stepTask(onComplete, root, result.task);
+		}
+
+		if (result.status === 'done')
+		{
+			root.task = result.task;
+			onComplete();
+		}
+
+		if (result.status === 'blocked')
+		{
+			root.task = result.task;
+		}
+	}
+
+	function stepTask(onComplete, root, task)
+	{
+		var tag = task.tag;
+
+		if (tag === 'Succeed' || tag === 'Fail')
+		{
+			return mark('done', task);
+		}
+
+		if (tag === 'Async')
+		{
+			var placeHolder = {};
+			var couldBeSync = true;
+			var wasSync = false;
+
+			task.asyncFunction(function(result) {
+				placeHolder.tag = result.tag;
+				placeHolder.value = result.value;
+				if (couldBeSync)
+				{
+					wasSync = true;
+				}
+				else
+				{
+					runTask(root, onComplete);
+				}
+			});
+			couldBeSync = false;
+			return mark(wasSync ? 'done' : 'blocked', placeHolder);
+		}
+
+		if (tag === 'AndThen' || tag === 'Catch')
+		{
+			var result = mark('runnable', task.task);
+			while (result.status === 'runnable')
+			{
+				result = stepTask(onComplete, root, result.task);
+			}
+
+			if (result.status === 'done')
+			{
+				var activeTask = result.task;
+				var activeTag = activeTask.tag;
+
+				var succeedChain = activeTag === 'Succeed' && tag === 'AndThen';
+				var failChain = activeTag === 'Fail' && tag === 'Catch';
+
+				return (succeedChain || failChain)
+					? mark('runnable', task.callback(activeTask.value))
+					: mark('runnable', activeTask);
+			}
+			if (result.status === 'blocked')
+			{
+				return mark('blocked', {
+					tag: tag,
+					task: result.task,
+					callback: task.callback
+				});
+			}
+		}
+	}
+
+
+	// THREADS
+
+	function sleep(time) {
+		return asyncFunction(function(callback) {
+			setTimeout(function() {
+				callback(succeed(Utils.Tuple0));
+			}, time);
+		});
+	}
+
+	function spawn(task) {
+		return asyncFunction(function(callback) {
+			var id = setTimeout(function() {
+				perform(task);
+			}, 0);
+			callback(succeed(id));
+		});
+	}
+
+
+	return localRuntime.Native.Task.values = {
+		succeed: succeed,
+		fail: fail,
+		asyncFunction: asyncFunction,
+		andThen: F2(andThen),
+		catch_: F2(catch_),
+		perform: perform,
+		performSignal: performSignal,
+		spawn: spawn,
+		sleep: sleep
+	};
+};
+Elm.Result = Elm.Result || {};
+Elm.Result.make = function (_elm) {
+   "use strict";
+   _elm.Result = _elm.Result || {};
+   if (_elm.Result.values) return _elm.Result.values;
+   var _U = Elm.Native.Utils.make(_elm),
+   $Maybe = Elm.Maybe.make(_elm);
+   var _op = {};
+   var toMaybe = function (result) {
+      var _p0 = result;
+      if (_p0.ctor === "Ok") {
+            return $Maybe.Just(_p0._0);
+         } else {
+            return $Maybe.Nothing;
+         }
+   };
+   var withDefault = F2(function (def,result) {
+      var _p1 = result;
+      if (_p1.ctor === "Ok") {
+            return _p1._0;
+         } else {
+            return def;
+         }
+   });
+   var Err = function (a) {    return {ctor: "Err",_0: a};};
+   var andThen = F2(function (result,callback) {
+      var _p2 = result;
+      if (_p2.ctor === "Ok") {
+            return callback(_p2._0);
+         } else {
+            return Err(_p2._0);
+         }
+   });
+   var Ok = function (a) {    return {ctor: "Ok",_0: a};};
+   var map = F2(function (func,ra) {
+      var _p3 = ra;
+      if (_p3.ctor === "Ok") {
+            return Ok(func(_p3._0));
+         } else {
+            return Err(_p3._0);
+         }
+   });
+   var map2 = F3(function (func,ra,rb) {
+      var _p4 = {ctor: "_Tuple2",_0: ra,_1: rb};
+      if (_p4._0.ctor === "Ok") {
+            if (_p4._1.ctor === "Ok") {
+                  return Ok(A2(func,_p4._0._0,_p4._1._0));
+               } else {
+                  return Err(_p4._1._0);
+               }
+         } else {
+            return Err(_p4._0._0);
+         }
+   });
+   var map3 = F4(function (func,ra,rb,rc) {
+      var _p5 = {ctor: "_Tuple3",_0: ra,_1: rb,_2: rc};
+      if (_p5._0.ctor === "Ok") {
+            if (_p5._1.ctor === "Ok") {
+                  if (_p5._2.ctor === "Ok") {
+                        return Ok(A3(func,_p5._0._0,_p5._1._0,_p5._2._0));
+                     } else {
+                        return Err(_p5._2._0);
+                     }
+               } else {
+                  return Err(_p5._1._0);
+               }
+         } else {
+            return Err(_p5._0._0);
+         }
+   });
+   var map4 = F5(function (func,ra,rb,rc,rd) {
+      var _p6 = {ctor: "_Tuple4",_0: ra,_1: rb,_2: rc,_3: rd};
+      if (_p6._0.ctor === "Ok") {
+            if (_p6._1.ctor === "Ok") {
+                  if (_p6._2.ctor === "Ok") {
+                        if (_p6._3.ctor === "Ok") {
+                              return Ok(A4(func,_p6._0._0,_p6._1._0,_p6._2._0,_p6._3._0));
+                           } else {
+                              return Err(_p6._3._0);
+                           }
+                     } else {
+                        return Err(_p6._2._0);
+                     }
+               } else {
+                  return Err(_p6._1._0);
+               }
+         } else {
+            return Err(_p6._0._0);
+         }
+   });
+   var map5 = F6(function (func,ra,rb,rc,rd,re) {
+      var _p7 = {ctor: "_Tuple5"
+                ,_0: ra
+                ,_1: rb
+                ,_2: rc
+                ,_3: rd
+                ,_4: re};
+      if (_p7._0.ctor === "Ok") {
+            if (_p7._1.ctor === "Ok") {
+                  if (_p7._2.ctor === "Ok") {
+                        if (_p7._3.ctor === "Ok") {
+                              if (_p7._4.ctor === "Ok") {
+                                    return Ok(A5(func,
+                                    _p7._0._0,
+                                    _p7._1._0,
+                                    _p7._2._0,
+                                    _p7._3._0,
+                                    _p7._4._0));
+                                 } else {
+                                    return Err(_p7._4._0);
+                                 }
+                           } else {
+                              return Err(_p7._3._0);
+                           }
+                     } else {
+                        return Err(_p7._2._0);
+                     }
+               } else {
+                  return Err(_p7._1._0);
+               }
+         } else {
+            return Err(_p7._0._0);
+         }
+   });
+   var formatError = F2(function (f,result) {
+      var _p8 = result;
+      if (_p8.ctor === "Ok") {
+            return Ok(_p8._0);
+         } else {
+            return Err(f(_p8._0));
+         }
+   });
+   var fromMaybe = F2(function (err,maybe) {
+      var _p9 = maybe;
+      if (_p9.ctor === "Just") {
+            return Ok(_p9._0);
+         } else {
+            return Err(err);
+         }
+   });
+   return _elm.Result.values = {_op: _op
+                               ,withDefault: withDefault
+                               ,map: map
+                               ,map2: map2
+                               ,map3: map3
+                               ,map4: map4
+                               ,map5: map5
+                               ,andThen: andThen
+                               ,toMaybe: toMaybe
+                               ,fromMaybe: fromMaybe
+                               ,formatError: formatError
+                               ,Ok: Ok
+                               ,Err: Err};
+};Elm.Task = Elm.Task || {};
+Elm.Task.make = function (_elm) {
+   "use strict";
+   _elm.Task = _elm.Task || {};
+   if (_elm.Task.values) return _elm.Task.values;
+   var _U = Elm.Native.Utils.make(_elm),
+   $List = Elm.List.make(_elm),
+   $Maybe = Elm.Maybe.make(_elm),
+   $Native$Task = Elm.Native.Task.make(_elm),
+   $Result = Elm.Result.make(_elm);
+   var _op = {};
+   var sleep = $Native$Task.sleep;
+   var spawn = $Native$Task.spawn;
+   var ThreadID = function (a) {
+      return {ctor: "ThreadID",_0: a};
+   };
+   var onError = $Native$Task.catch_;
+   var andThen = $Native$Task.andThen;
+   var fail = $Native$Task.fail;
+   var mapError = F2(function (f,task) {
+      return A2(onError,
+      task,
+      function (err) {
+         return fail(f(err));
+      });
+   });
+   var succeed = $Native$Task.succeed;
+   var map = F2(function (func,taskA) {
+      return A2(andThen,
+      taskA,
+      function (a) {
+         return succeed(func(a));
+      });
+   });
+   var map2 = F3(function (func,taskA,taskB) {
+      return A2(andThen,
+      taskA,
+      function (a) {
+         return A2(andThen,
+         taskB,
+         function (b) {
+            return succeed(A2(func,a,b));
+         });
+      });
+   });
+   var map3 = F4(function (func,taskA,taskB,taskC) {
+      return A2(andThen,
+      taskA,
+      function (a) {
+         return A2(andThen,
+         taskB,
+         function (b) {
+            return A2(andThen,
+            taskC,
+            function (c) {
+               return succeed(A3(func,a,b,c));
+            });
+         });
+      });
+   });
+   var map4 = F5(function (func,taskA,taskB,taskC,taskD) {
+      return A2(andThen,
+      taskA,
+      function (a) {
+         return A2(andThen,
+         taskB,
+         function (b) {
+            return A2(andThen,
+            taskC,
+            function (c) {
+               return A2(andThen,
+               taskD,
+               function (d) {
+                  return succeed(A4(func,a,b,c,d));
+               });
+            });
+         });
+      });
+   });
+   var map5 = F6(function (func,taskA,taskB,taskC,taskD,taskE) {
+      return A2(andThen,
+      taskA,
+      function (a) {
+         return A2(andThen,
+         taskB,
+         function (b) {
+            return A2(andThen,
+            taskC,
+            function (c) {
+               return A2(andThen,
+               taskD,
+               function (d) {
+                  return A2(andThen,
+                  taskE,
+                  function (e) {
+                     return succeed(A5(func,a,b,c,d,e));
+                  });
+               });
+            });
+         });
+      });
+   });
+   var andMap = F2(function (taskFunc,taskValue) {
+      return A2(andThen,
+      taskFunc,
+      function (func) {
+         return A2(andThen,
+         taskValue,
+         function (value) {
+            return succeed(func(value));
+         });
+      });
+   });
+   var sequence = function (tasks) {
+      var _p0 = tasks;
+      if (_p0.ctor === "[]") {
+            return succeed(_U.list([]));
+         } else {
+            return A3(map2,
+            F2(function (x,y) {    return A2($List._op["::"],x,y);}),
+            _p0._0,
+            sequence(_p0._1));
+         }
+   };
+   var toMaybe = function (task) {
+      return A2(onError,
+      A2(map,$Maybe.Just,task),
+      function (_p1) {
+         return succeed($Maybe.Nothing);
+      });
+   };
+   var fromMaybe = F2(function ($default,maybe) {
+      var _p2 = maybe;
+      if (_p2.ctor === "Just") {
+            return succeed(_p2._0);
+         } else {
+            return fail($default);
+         }
+   });
+   var toResult = function (task) {
+      return A2(onError,
+      A2(map,$Result.Ok,task),
+      function (msg) {
+         return succeed($Result.Err(msg));
+      });
+   };
+   var fromResult = function (result) {
+      var _p3 = result;
+      if (_p3.ctor === "Ok") {
+            return succeed(_p3._0);
+         } else {
+            return fail(_p3._0);
+         }
+   };
+   var Task = {ctor: "Task"};
+   return _elm.Task.values = {_op: _op
+                             ,succeed: succeed
+                             ,fail: fail
+                             ,map: map
+                             ,map2: map2
+                             ,map3: map3
+                             ,map4: map4
+                             ,map5: map5
+                             ,andMap: andMap
+                             ,sequence: sequence
+                             ,andThen: andThen
+                             ,onError: onError
+                             ,mapError: mapError
+                             ,toMaybe: toMaybe
+                             ,fromMaybe: fromMaybe
+                             ,toResult: toResult
+                             ,fromResult: fromResult
+                             ,spawn: spawn
+                             ,sleep: sleep};
+};Elm.Signal = Elm.Signal || {};
+Elm.Signal.make = function (_elm) {
+   "use strict";
+   _elm.Signal = _elm.Signal || {};
+   if (_elm.Signal.values) return _elm.Signal.values;
+   var _U = Elm.Native.Utils.make(_elm),
+   $Basics = Elm.Basics.make(_elm),
+   $Debug = Elm.Debug.make(_elm),
+   $List = Elm.List.make(_elm),
+   $Maybe = Elm.Maybe.make(_elm),
+   $Native$Signal = Elm.Native.Signal.make(_elm),
+   $Task = Elm.Task.make(_elm);
+   var _op = {};
+   var send = F2(function (_p0,value) {
+      var _p1 = _p0;
+      return A2($Task.onError,
+      _p1._0(value),
+      function (_p2) {
+         return $Task.succeed({ctor: "_Tuple0"});
+      });
+   });
+   var Message = function (a) {
+      return {ctor: "Message",_0: a};
+   };
+   var message = F2(function (_p3,value) {
+      var _p4 = _p3;
+      return Message(_p4._0(value));
+   });
+   var mailbox = $Native$Signal.mailbox;
+   var Address = function (a) {
+      return {ctor: "Address",_0: a};
+   };
+   var forwardTo = F2(function (_p5,f) {
+      var _p6 = _p5;
+      return Address(function (x) {    return _p6._0(f(x));});
+   });
+   var Mailbox = F2(function (a,b) {
+      return {address: a,signal: b};
+   });
+   var sampleOn = $Native$Signal.sampleOn;
+   var dropRepeats = $Native$Signal.dropRepeats;
+   var filterMap = $Native$Signal.filterMap;
+   var filter = F3(function (isOk,base,signal) {
+      return A3(filterMap,
+      function (value) {
+         return isOk(value) ? $Maybe.Just(value) : $Maybe.Nothing;
+      },
+      base,
+      signal);
+   });
+   var merge = F2(function (left,right) {
+      return A3($Native$Signal.genericMerge,
+      $Basics.always,
+      left,
+      right);
+   });
+   var mergeMany = function (signalList) {
+      var _p7 = $List.reverse(signalList);
+      if (_p7.ctor === "[]") {
+            return _U.crashCase("Signal",
+            {start: {line: 184,column: 3},end: {line: 189,column: 40}},
+            _p7)("mergeMany was given an empty list!");
+         } else {
+            return A3($List.foldl,merge,_p7._0,_p7._1);
+         }
+   };
+   var foldp = $Native$Signal.foldp;
+   var map5 = $Native$Signal.map5;
+   var map4 = $Native$Signal.map4;
+   var map3 = $Native$Signal.map3;
+   var map2 = $Native$Signal.map2;
+   var map = $Native$Signal.map;
+   var constant = $Native$Signal.constant;
+   var Signal = {ctor: "Signal"};
+   return _elm.Signal.values = {_op: _op
+                               ,merge: merge
+                               ,mergeMany: mergeMany
+                               ,map: map
+                               ,map2: map2
+                               ,map3: map3
+                               ,map4: map4
+                               ,map5: map5
+                               ,constant: constant
+                               ,dropRepeats: dropRepeats
+                               ,filter: filter
+                               ,filterMap: filterMap
+                               ,sampleOn: sampleOn
+                               ,foldp: foldp
+                               ,mailbox: mailbox
+                               ,send: send
+                               ,message: message
+                               ,forwardTo: forwardTo
+                               ,Mailbox: Mailbox};
+};Elm.Native.String = {};
+
+Elm.Native.String.make = function(localRuntime) {
+	localRuntime.Native = localRuntime.Native || {};
+	localRuntime.Native.String = localRuntime.Native.String || {};
+	if (localRuntime.Native.String.values)
+	{
+		return localRuntime.Native.String.values;
+	}
+	if ('values' in Elm.Native.String)
+	{
+		return localRuntime.Native.String.values = Elm.Native.String.values;
+	}
+
+
+	var Char = Elm.Char.make(localRuntime);
+	var List = Elm.Native.List.make(localRuntime);
+	var Maybe = Elm.Maybe.make(localRuntime);
+	var Result = Elm.Result.make(localRuntime);
+	var Utils = Elm.Native.Utils.make(localRuntime);
+
+	function isEmpty(str)
+	{
+		return str.length === 0;
+	}
+	function cons(chr, str)
+	{
+		return chr + str;
+	}
+	function uncons(str)
+	{
+		var hd = str[0];
+		if (hd)
+		{
+			return Maybe.Just(Utils.Tuple2(Utils.chr(hd), str.slice(1)));
+		}
+		return Maybe.Nothing;
+	}
+	function append(a, b)
+	{
+		return a + b;
+	}
+	function concat(strs)
+	{
+		return List.toArray(strs).join('');
+	}
+	function length(str)
+	{
+		return str.length;
+	}
+	function map(f, str)
+	{
+		var out = str.split('');
+		for (var i = out.length; i--; )
+		{
+			out[i] = f(Utils.chr(out[i]));
+		}
+		return out.join('');
+	}
+	function filter(pred, str)
+	{
+		return str.split('').map(Utils.chr).filter(pred).join('');
+	}
+	function reverse(str)
+	{
+		return str.split('').reverse().join('');
+	}
+	function foldl(f, b, str)
+	{
+		var len = str.length;
+		for (var i = 0; i < len; ++i)
+		{
+			b = A2(f, Utils.chr(str[i]), b);
+		}
+		return b;
+	}
+	function foldr(f, b, str)
+	{
+		for (var i = str.length; i--; )
+		{
+			b = A2(f, Utils.chr(str[i]), b);
+		}
+		return b;
+	}
+	function split(sep, str)
+	{
+		return List.fromArray(str.split(sep));
+	}
+	function join(sep, strs)
+	{
+		return List.toArray(strs).join(sep);
+	}
+	function repeat(n, str)
+	{
+		var result = '';
+		while (n > 0)
+		{
+			if (n & 1)
+			{
+				result += str;
+			}
+			n >>= 1, str += str;
+		}
+		return result;
+	}
+	function slice(start, end, str)
+	{
+		return str.slice(start, end);
+	}
+	function left(n, str)
+	{
+		return n < 1 ? '' : str.slice(0, n);
+	}
+	function right(n, str)
+	{
+		return n < 1 ? '' : str.slice(-n);
+	}
+	function dropLeft(n, str)
+	{
+		return n < 1 ? str : str.slice(n);
+	}
+	function dropRight(n, str)
+	{
+		return n < 1 ? str : str.slice(0, -n);
+	}
+	function pad(n, chr, str)
+	{
+		var half = (n - str.length) / 2;
+		return repeat(Math.ceil(half), chr) + str + repeat(half | 0, chr);
+	}
+	function padRight(n, chr, str)
+	{
+		return str + repeat(n - str.length, chr);
+	}
+	function padLeft(n, chr, str)
+	{
+		return repeat(n - str.length, chr) + str;
+	}
+
+	function trim(str)
+	{
+		return str.trim();
+	}
+	function trimLeft(str)
+	{
+		return str.replace(/^\s+/, '');
+	}
+	function trimRight(str)
+	{
+		return str.replace(/\s+$/, '');
+	}
+
+	function words(str)
+	{
+		return List.fromArray(str.trim().split(/\s+/g));
+	}
+	function lines(str)
+	{
+		return List.fromArray(str.split(/\r\n|\r|\n/g));
+	}
+
+	function toUpper(str)
+	{
+		return str.toUpperCase();
+	}
+	function toLower(str)
+	{
+		return str.toLowerCase();
+	}
+
+	function any(pred, str)
+	{
+		for (var i = str.length; i--; )
+		{
+			if (pred(Utils.chr(str[i])))
+			{
+				return true;
+			}
+		}
+		return false;
+	}
+	function all(pred, str)
+	{
+		for (var i = str.length; i--; )
+		{
+			if (!pred(Utils.chr(str[i])))
+			{
+				return false;
+			}
+		}
+		return true;
+	}
+
+	function contains(sub, str)
+	{
+		return str.indexOf(sub) > -1;
+	}
+	function startsWith(sub, str)
+	{
+		return str.indexOf(sub) === 0;
+	}
+	function endsWith(sub, str)
+	{
+		return str.length >= sub.length &&
+			str.lastIndexOf(sub) === str.length - sub.length;
+	}
+	function indexes(sub, str)
+	{
+		var subLen = sub.length;
+		var i = 0;
+		var is = [];
+		while ((i = str.indexOf(sub, i)) > -1)
+		{
+			is.push(i);
+			i = i + subLen;
+		}
+		return List.fromArray(is);
+	}
+
+	function toInt(s)
+	{
+		var len = s.length;
+		if (len === 0)
+		{
+			return Result.Err("could not convert string '" + s + "' to an Int" );
+		}
+		var start = 0;
+		if (s[0] === '-')
+		{
+			if (len === 1)
+			{
+				return Result.Err("could not convert string '" + s + "' to an Int" );
+			}
+			start = 1;
+		}
+		for (var i = start; i < len; ++i)
+		{
+			if (!Char.isDigit(s[i]))
+			{
+				return Result.Err("could not convert string '" + s + "' to an Int" );
+			}
+		}
+		return Result.Ok(parseInt(s, 10));
+	}
+
+	function toFloat(s)
+	{
+		var len = s.length;
+		if (len === 0)
+		{
+			return Result.Err("could not convert string '" + s + "' to a Float" );
+		}
+		var start = 0;
+		if (s[0] === '-')
+		{
+			if (len === 1)
+			{
+				return Result.Err("could not convert string '" + s + "' to a Float" );
+			}
+			start = 1;
+		}
+		var dotCount = 0;
+		for (var i = start; i < len; ++i)
+		{
+			if (Char.isDigit(s[i]))
+			{
+				continue;
+			}
+			if (s[i] === '.')
+			{
+				dotCount += 1;
+				if (dotCount <= 1)
+				{
+					continue;
+				}
+			}
+			return Result.Err("could not convert string '" + s + "' to a Float" );
+		}
+		return Result.Ok(parseFloat(s));
+	}
+
+	function toList(str)
+	{
+		return List.fromArray(str.split('').map(Utils.chr));
+	}
+	function fromList(chars)
+	{
+		return List.toArray(chars).join('');
+	}
+
+	return Elm.Native.String.values = {
+		isEmpty: isEmpty,
+		cons: F2(cons),
+		uncons: uncons,
+		append: F2(append),
+		concat: concat,
+		length: length,
+		map: F2(map),
+		filter: F2(filter),
+		reverse: reverse,
+		foldl: F3(foldl),
+		foldr: F3(foldr),
+
+		split: F2(split),
+		join: F2(join),
+		repeat: F2(repeat),
+
+		slice: F3(slice),
+		left: F2(left),
+		right: F2(right),
+		dropLeft: F2(dropLeft),
+		dropRight: F2(dropRight),
+
+		pad: F3(pad),
+		padLeft: F3(padLeft),
+		padRight: F3(padRight),
+
+		trim: trim,
+		trimLeft: trimLeft,
+		trimRight: trimRight,
+
+		words: words,
+		lines: lines,
+
+		toUpper: toUpper,
+		toLower: toLower,
+
+		any: F2(any),
+		all: F2(all),
+
+		contains: F2(contains),
+		startsWith: F2(startsWith),
+		endsWith: F2(endsWith),
+		indexes: F2(indexes),
+
+		toInt: toInt,
+		toFloat: toFloat,
+		toList: toList,
+		fromList: fromList
+	};
+};
+Elm.String = Elm.String || {};
+Elm.String.make = function (_elm) {
+   "use strict";
+   _elm.String = _elm.String || {};
+   if (_elm.String.values) return _elm.String.values;
+   var _U = Elm.Native.Utils.make(_elm),
+   $Maybe = Elm.Maybe.make(_elm),
+   $Native$String = Elm.Native.String.make(_elm),
+   $Result = Elm.Result.make(_elm);
+   var _op = {};
+   var fromList = $Native$String.fromList;
+   var toList = $Native$String.toList;
+   var toFloat = $Native$String.toFloat;
+   var toInt = $Native$String.toInt;
+   var indices = $Native$String.indexes;
+   var indexes = $Native$String.indexes;
+   var endsWith = $Native$String.endsWith;
+   var startsWith = $Native$String.startsWith;
+   var contains = $Native$String.contains;
+   var all = $Native$String.all;
+   var any = $Native$String.any;
+   var toLower = $Native$String.toLower;
+   var toUpper = $Native$String.toUpper;
+   var lines = $Native$String.lines;
+   var words = $Native$String.words;
+   var trimRight = $Native$String.trimRight;
+   var trimLeft = $Native$String.trimLeft;
+   var trim = $Native$String.trim;
+   var padRight = $Native$String.padRight;
+   var padLeft = $Native$String.padLeft;
+   var pad = $Native$String.pad;
+   var dropRight = $Native$String.dropRight;
+   var dropLeft = $Native$String.dropLeft;
+   var right = $Native$String.right;
+   var left = $Native$String.left;
+   var slice = $Native$String.slice;
+   var repeat = $Native$String.repeat;
+   var join = $Native$String.join;
+   var split = $Native$String.split;
+   var foldr = $Native$String.foldr;
+   var foldl = $Native$String.foldl;
+   var reverse = $Native$String.reverse;
+   var filter = $Native$String.filter;
+   var map = $Native$String.map;
+   var length = $Native$String.length;
+   var concat = $Native$String.concat;
+   var append = $Native$String.append;
+   var uncons = $Native$String.uncons;
+   var cons = $Native$String.cons;
+   var fromChar = function ($char) {    return A2(cons,$char,"");};
+   var isEmpty = $Native$String.isEmpty;
+   return _elm.String.values = {_op: _op
+                               ,isEmpty: isEmpty
+                               ,length: length
+                               ,reverse: reverse
+                               ,repeat: repeat
+                               ,cons: cons
+                               ,uncons: uncons
+                               ,fromChar: fromChar
+                               ,append: append
+                               ,concat: concat
+                               ,split: split
+                               ,join: join
+                               ,words: words
+                               ,lines: lines
+                               ,slice: slice
+                               ,left: left
+                               ,right: right
+                               ,dropLeft: dropLeft
+                               ,dropRight: dropRight
+                               ,contains: contains
+                               ,startsWith: startsWith
+                               ,endsWith: endsWith
+                               ,indexes: indexes
+                               ,indices: indices
+                               ,toInt: toInt
+                               ,toFloat: toFloat
+                               ,toList: toList
+                               ,fromList: fromList
+                               ,toUpper: toUpper
+                               ,toLower: toLower
+                               ,pad: pad
+                               ,padLeft: padLeft
+                               ,padRight: padRight
+                               ,trim: trim
+                               ,trimLeft: trimLeft
+                               ,trimRight: trimRight
+                               ,map: map
+                               ,filter: filter
+                               ,foldl: foldl
+                               ,foldr: foldr
+                               ,any: any
+                               ,all: all};
+};Elm.Native.Regex = {};
+Elm.Native.Regex.make = function(localRuntime) {
+	localRuntime.Native = localRuntime.Native || {};
+	localRuntime.Native.Regex = localRuntime.Native.Regex || {};
+	if (localRuntime.Native.Regex.values)
+	{
+		return localRuntime.Native.Regex.values;
+	}
+	if ('values' in Elm.Native.Regex)
+	{
+		return localRuntime.Native.Regex.values = Elm.Native.Regex.values;
+	}
+
+	var List = Elm.Native.List.make(localRuntime);
+	var Maybe = Elm.Maybe.make(localRuntime);
+
+	function escape(str)
+	{
+		return str.replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&');
+	}
+	function caseInsensitive(re)
+	{
+		return new RegExp(re.source, 'gi');
+	}
+	function regex(raw)
+	{
+		return new RegExp(raw, 'g');
+	}
+
+	function contains(re, string)
+	{
+		return string.match(re) !== null;
+	}
+
+	function find(n, re, str)
+	{
+		n = n.ctor === 'All' ? Infinity : n._0;
+		var out = [];
+		var number = 0;
+		var string = str;
+		var lastIndex = re.lastIndex;
+		var prevLastIndex = -1;
+		var result;
+		while (number++ < n && (result = re.exec(string)))
+		{
+			if (prevLastIndex === re.lastIndex) break;
+			var i = result.length - 1;
+			var subs = new Array(i);
+			while (i > 0)
+			{
+				var submatch = result[i];
+				subs[--i] = submatch === undefined
+					? Maybe.Nothing
+					: Maybe.Just(submatch);
+			}
+			out.push({
+				_: {},
+				match: result[0],
+				submatches: List.fromArray(subs),
+				index: result.index,
+				number: number
+			});
+			prevLastIndex = re.lastIndex;
+		}
+		re.lastIndex = lastIndex;
+		return List.fromArray(out);
+	}
+
+	function replace(n, re, replacer, string)
+	{
+		n = n.ctor === 'All' ? Infinity : n._0;
+		var count = 0;
+		function jsReplacer(match)
+		{
+			if (count++ >= n)
+			{
+				return match;
+			}
+			var i = arguments.length - 3;
+			var submatches = new Array(i);
+			while (i > 0)
+			{
+				var submatch = arguments[i];
+				submatches[--i] = submatch === undefined
+					? Maybe.Nothing
+					: Maybe.Just(submatch);
+			}
+			return replacer({
+				_: {},
+				match: match,
+				submatches: List.fromArray(submatches),
+				index: arguments[i - 1],
+				number: count
+			});
+		}
+		return string.replace(re, jsReplacer);
+	}
+
+	function split(n, re, str)
+	{
+		n = n.ctor === 'All' ? Infinity : n._0;
+		if (n === Infinity)
+		{
+			return List.fromArray(str.split(re));
+		}
+		var string = str;
+		var result;
+		var out = [];
+		var start = re.lastIndex;
+		while (n--)
+		{
+			if (!(result = re.exec(string))) break;
+			out.push(string.slice(start, result.index));
+			start = re.lastIndex;
+		}
+		out.push(string.slice(start));
+		return List.fromArray(out);
+	}
+
+	return Elm.Native.Regex.values = {
+		regex: regex,
+		caseInsensitive: caseInsensitive,
+		escape: escape,
+
+		contains: F2(contains),
+		find: F3(find),
+		replace: F4(replace),
+		split: F3(split)
+	};
+};
+Elm.Regex = Elm.Regex || {};
+Elm.Regex.make = function (_elm) {
+   "use strict";
+   _elm.Regex = _elm.Regex || {};
+   if (_elm.Regex.values) return _elm.Regex.values;
+   var _U = Elm.Native.Utils.make(_elm),
+   $Maybe = Elm.Maybe.make(_elm),
+   $Native$Regex = Elm.Native.Regex.make(_elm);
+   var _op = {};
+   var split = $Native$Regex.split;
+   var replace = $Native$Regex.replace;
+   var find = $Native$Regex.find;
+   var AtMost = function (a) {    return {ctor: "AtMost",_0: a};};
+   var All = {ctor: "All"};
+   var Match = F4(function (a,b,c,d) {
+      return {match: a,submatches: b,index: c,number: d};
+   });
+   var contains = $Native$Regex.contains;
+   var caseInsensitive = $Native$Regex.caseInsensitive;
+   var regex = $Native$Regex.regex;
+   var escape = $Native$Regex.escape;
+   var Regex = {ctor: "Regex"};
+   return _elm.Regex.values = {_op: _op
+                              ,regex: regex
+                              ,escape: escape
+                              ,caseInsensitive: caseInsensitive
+                              ,contains: contains
+                              ,find: find
+                              ,replace: replace
+                              ,split: split
+                              ,Match: Match
+                              ,All: All
+                              ,AtMost: AtMost};
+};Elm.Css = Elm.Css || {};
+Elm.Css.Declaration = Elm.Css.Declaration || {};
+Elm.Css.Declaration.make = function (_elm) {
+   "use strict";
+   _elm.Css = _elm.Css || {};
+   _elm.Css.Declaration = _elm.Css.Declaration || {};
+   if (_elm.Css.Declaration.values) return _elm.Css.Declaration.values;
+   var _U = Elm.Native.Utils.make(_elm),
+   $Basics = Elm.Basics.make(_elm),
+   $Debug = Elm.Debug.make(_elm),
+   $List = Elm.List.make(_elm),
+   $Maybe = Elm.Maybe.make(_elm),
+   $Result = Elm.Result.make(_elm),
+   $Signal = Elm.Signal.make(_elm);
+   var _op = {};
+   var StandaloneAtRule = F2(function (a,b) {    return {ctor: "StandaloneAtRule",_0: a,_1: b};});
+   var ConditionalGroupRule = F2(function (a,b) {    return {ctor: "ConditionalGroupRule",_0: a,_1: b};});
+   var StyleBlock = F3(function (a,b,c) {    return {ctor: "StyleBlock",_0: a,_1: b,_2: c};});
+   var Property = F3(function (a,b,c) {    return {important: a,key: b,value: c};});
+   var PseudoElement = F2(function (a,b) {    return {ctor: "PseudoElement",_0: a,_1: b};});
+   var PseudoClass = F2(function (a,b) {    return {ctor: "PseudoClass",_0: a,_1: b};});
+   var Descendant = F2(function (a,b) {    return {ctor: "Descendant",_0: a,_1: b};});
+   var Child = F2(function (a,b) {    return {ctor: "Child",_0: a,_1: b};});
+   var GeneralSibling = F2(function (a,b) {    return {ctor: "GeneralSibling",_0: a,_1: b};});
+   var AdjacentSibling = F2(function (a,b) {    return {ctor: "AdjacentSibling",_0: a,_1: b};});
+   var MultiSelector = F2(function (a,b) {    return {ctor: "MultiSelector",_0: a,_1: b};});
+   var SingleSelector = function (a) {    return {ctor: "SingleSelector",_0: a};};
+   var CustomSelector = function (a) {    return {ctor: "CustomSelector",_0: a};};
+   var IdSelector = function (a) {    return {ctor: "IdSelector",_0: a};};
+   var ClassSelector = function (a) {    return {ctor: "ClassSelector",_0: a};};
+   var TypeSelector = function (a) {    return {ctor: "TypeSelector",_0: a};};
+   return _elm.Css.Declaration.values = {_op: _op
+                                        ,TypeSelector: TypeSelector
+                                        ,ClassSelector: ClassSelector
+                                        ,IdSelector: IdSelector
+                                        ,CustomSelector: CustomSelector
+                                        ,SingleSelector: SingleSelector
+                                        ,MultiSelector: MultiSelector
+                                        ,AdjacentSibling: AdjacentSibling
+                                        ,GeneralSibling: GeneralSibling
+                                        ,Child: Child
+                                        ,Descendant: Descendant
+                                        ,PseudoClass: PseudoClass
+                                        ,PseudoElement: PseudoElement
+                                        ,Property: Property
+                                        ,StyleBlock: StyleBlock
+                                        ,ConditionalGroupRule: ConditionalGroupRule
+                                        ,StandaloneAtRule: StandaloneAtRule};
+};Elm.Css = Elm.Css || {};
+Elm.Css.Elements = Elm.Css.Elements || {};
+Elm.Css.Elements.make = function (_elm) {
+   "use strict";
+   _elm.Css = _elm.Css || {};
+   _elm.Css.Elements = _elm.Css.Elements || {};
+   if (_elm.Css.Elements.values) return _elm.Css.Elements.values;
+   var _U = Elm.Native.Utils.make(_elm),
+   $Basics = Elm.Basics.make(_elm),
+   $Debug = Elm.Debug.make(_elm),
+   $List = Elm.List.make(_elm),
+   $Maybe = Elm.Maybe.make(_elm),
+   $Result = Elm.Result.make(_elm),
+   $Signal = Elm.Signal.make(_elm);
+   var _op = {};
+   var tagToString = function (_p0) {    var _p1 = _p0;return _p1._0;};
+   var Tag = function (a) {    return {ctor: "Tag",_0: a};};
+   var input = Tag("input");
+   var ol = Tag("ol");
+   var p = Tag("p");
+   var h4 = Tag("h4");
+   var h3 = Tag("h3");
+   var h2 = Tag("h2");
+   var h1 = Tag("h1");
+   var button = Tag("button");
+   var nowrap = Tag("nowrap");
+   var img = Tag("img");
+   var span = Tag("span");
+   var div = Tag("div");
+   var nav = Tag("nav");
+   var a = Tag("a");
+   var header = Tag("header");
+   var body = Tag("body");
+   var html = Tag("html");
+   return _elm.Css.Elements.values = {_op: _op
+                                     ,tagToString: tagToString
+                                     ,a: a
+                                     ,html: html
+                                     ,body: body
+                                     ,header: header
+                                     ,nav: nav
+                                     ,div: div
+                                     ,span: span
+                                     ,img: img
+                                     ,nowrap: nowrap
+                                     ,button: button
+                                     ,h1: h1
+                                     ,h2: h2
+                                     ,h3: h3
+                                     ,h4: h4
+                                     ,p: p
+                                     ,ol: ol
+                                     ,input: input};
+};Elm.Css = Elm.Css || {};
+Elm.Css.Util = Elm.Css.Util || {};
+Elm.Css.Util.make = function (_elm) {
+   "use strict";
+   _elm.Css = _elm.Css || {};
+   _elm.Css.Util = _elm.Css.Util || {};
+   if (_elm.Css.Util.values) return _elm.Css.Util.values;
+   var _U = Elm.Native.Utils.make(_elm),
+   $Basics = Elm.Basics.make(_elm),
+   $Debug = Elm.Debug.make(_elm),
+   $List = Elm.List.make(_elm),
+   $Maybe = Elm.Maybe.make(_elm),
+   $Regex = Elm.Regex.make(_elm),
+   $Result = Elm.Result.make(_elm),
+   $Signal = Elm.Signal.make(_elm),
+   $String = Elm.String.make(_elm);
+   var _op = {};
+   var toCssIdentifier = function (identifier) {
+      return A4($Regex.replace,
+      $Regex.All,
+      $Regex.regex("[^a-zA-Z0-9_-]"),
+      function (_p0) {
+         return "";
+      },
+      A4($Regex.replace,$Regex.All,$Regex.regex("\\s+"),function (_p1) {    return "-";},$String.trim($Basics.toString(identifier))));
+   };
+   var identifierToString = F2(function (name,identifier) {    return A2($Basics._op["++"],toCssIdentifier(name),toCssIdentifier(identifier));});
+   return _elm.Css.Util.values = {_op: _op,toCssIdentifier: toCssIdentifier,identifierToString: identifierToString};
+};Elm.Style = Elm.Style || {};
+Elm.Style.make = function (_elm) {
+   "use strict";
+   _elm.Style = _elm.Style || {};
+   if (_elm.Style.values) return _elm.Style.values;
+   var _U = Elm.Native.Utils.make(_elm),
+   $Basics = Elm.Basics.make(_elm),
+   $Css$Declaration = Elm.Css.Declaration.make(_elm),
+   $Debug = Elm.Debug.make(_elm),
+   $List = Elm.List.make(_elm),
+   $Maybe = Elm.Maybe.make(_elm),
+   $Result = Elm.Result.make(_elm),
+   $Signal = Elm.Signal.make(_elm);
+   var _op = {};
+   var InvalidStyle = function (a) {    return {ctor: "InvalidStyle",_0: a};};
+   var Mixin = function (a) {    return {ctor: "Mixin",_0: a};};
+   var NamespacedStyle = F2(function (a,b) {    return {ctor: "NamespacedStyle",_0: a,_1: b};});
+   return _elm.Style.values = {_op: _op,NamespacedStyle: NamespacedStyle,Mixin: Mixin,InvalidStyle: InvalidStyle};
+};Elm.Css = Elm.Css || {};
+Elm.Css.make = function (_elm) {
+   "use strict";
+   _elm.Css = _elm.Css || {};
+   if (_elm.Css.values) return _elm.Css.values;
+   var _U = Elm.Native.Utils.make(_elm),
+   $Basics = Elm.Basics.make(_elm),
+   $Css$Declaration = Elm.Css.Declaration.make(_elm),
+   $Css$Elements = Elm.Css.Elements.make(_elm),
+   $Css$Util = Elm.Css.Util.make(_elm),
+   $Debug = Elm.Debug.make(_elm),
+   $List = Elm.List.make(_elm),
+   $Maybe = Elm.Maybe.make(_elm),
+   $Result = Elm.Result.make(_elm),
+   $Signal = Elm.Signal.make(_elm),
+   $String = Elm.String.make(_elm),
+   $Style = Elm.Style.make(_elm);
+   var _op = {};
+   var valuesOrNone = function (list) {
+      return $List.isEmpty(list) ? {value: "none"} : {value: A2($String.join," ",A2($List.map,function (_) {    return _.value;},list))};
+   };
+   var numberToString = function (num) {    return $Basics.toString(num + 0);};
+   var updateLast = F2(function (update,list) {
+      var _p0 = list;
+      if (_p0.ctor === "[]") {
+            return list;
+         } else {
+            if (_p0._1.ctor === "[]") {
+                  return _U.list([update(_p0._0)]);
+               } else {
+                  return A2($List._op["::"],_p0._0,A2(updateLast,update,_p0._1));
+               }
+         }
+   });
+   var addSelector = F3(function (operatorName,newSelector,declarations) {
+      var _p1 = declarations;
+      if (_p1.ctor === "[]") {
+            return $Result.Err(A2($Basics._op["++"],operatorName," cannot be used as the first declaration."));
+         } else {
+            if (_p1._1.ctor === "[]") {
+                  var _p2 = _p1._0;
+                  switch (_p2.ctor)
+                  {case "StyleBlock": var newDeclaration = A3($Css$Declaration.StyleBlock,_p2._0,A2($Basics._op["++"],_p2._1,_U.list([newSelector])),_p2._2);
+                       return $Result.Ok(_U.list([newDeclaration]));
+                     case "ConditionalGroupRule": return $Result.Err(A2($Basics._op["++"],
+                       operatorName,
+                       " cannot modify a conditional group rule (such as an at-rule). See https://developer.mozilla.org/en-US/docs/Web/CSS/At-rule#Conditional_Group_Rules for more information on conditional group rules."));
+                     default: return $Result.Err(A2($Basics._op["++"],
+                       operatorName,
+                       " cannot modify an at-rule. See https://developer.mozilla.org/en-US/docs/Web/CSS/At-rule for more information on at-rules."));}
+               } else {
+                  var _p3 = A3(addSelector,operatorName,newSelector,_p1._1);
+                  if (_p3.ctor === "Ok") {
+                        return $Result.Ok(A2($List._op["::"],_p1._0,_p3._0));
+                     } else {
+                        return _p3;
+                     }
+               }
+         }
+   });
+   var extendLastSelector = F3(function (operatorName,update,declarations) {
+      var _p4 = declarations;
+      if (_p4.ctor === "[]") {
+            return $Result.Err(A2($Basics._op["++"],operatorName," cannot be used as the first declaration."));
+         } else {
+            if (_p4._1.ctor === "[]") {
+                  var _p6 = _p4._0;
+                  var _p5 = _p6;
+                  switch (_p5.ctor)
+                  {case "StyleBlock": var newDeclaration = A3($Css$Declaration.StyleBlock,update(_p5._0),A2($List.map,update,_p5._1),_U.list([]));
+                       var newDeclarations = $List.isEmpty(_p5._2) ? _U.list([newDeclaration]) : _U.list([_p6,newDeclaration]);
+                       return $Result.Ok(newDeclarations);
+                     case "ConditionalGroupRule": return $Result.Err(A2($Basics._op["++"],
+                       operatorName,
+                       " cannot modify a conditional group rule (such as an at-rule). See https://developer.mozilla.org/en-US/docs/Web/CSS/At-rule#Conditional_Group_Rules for more information on conditional group rules."));
+                     default: return $Result.Err(A2($Basics._op["++"],
+                       operatorName,
+                       " cannot modify an at-rule. See https://developer.mozilla.org/en-US/docs/Web/CSS/At-rule for more information on at-rules."));}
+               } else {
+                  var _p7 = A3(extendLastSelector,operatorName,update,_p4._1);
+                  if (_p7.ctor === "Ok") {
+                        return $Result.Ok(A2($List._op["::"],_p4._0,_p7._0));
+                     } else {
+                        return _p7;
+                     }
+               }
+         }
+   });
+   var addProperty = F2(function (property,declarations) {
+      var _p8 = declarations;
+      if (_p8.ctor === "[]") {
+            return $Result.Err("`~` cannot be used as the first declaration.");
+         } else {
+            if (_p8._1.ctor === "[]") {
+                  var _p9 = _p8._0;
+                  switch (_p9.ctor)
+                  {case "StyleBlock": var newDeclaration = A3($Css$Declaration.StyleBlock,_p9._0,_p9._1,A2($Basics._op["++"],_p9._2,_U.list([property])));
+                       return $Result.Ok(_U.list([newDeclaration]));
+                     case "ConditionalGroupRule":
+                     return $Result.Err("`~` cannot modify a conditional group rule (such as an at-rule). See https://developer.mozilla.org/en-US/docs/Web/CSS/At-rule#Conditional_Group_Rules for more information on conditional group rules.");
+                     default:
+                     return $Result.Err("`~` cannot modify an at-rule. See https://developer.mozilla.org/en-US/docs/Web/CSS/At-rule for more information on at-rules.");}
+               } else {
+                  var _p10 = A2(addProperty,property,_p8._1);
+                  if (_p10.ctor === "Ok") {
+                        return $Result.Ok(A2($List._op["::"],_p8._0,_p10._0));
+                     } else {
+                        return _p10;
+                     }
+               }
+         }
+   });
+   var updateLastProperty = F3(function (functionName,update,declarations) {
+      var _p11 = declarations;
+      if (_p11.ctor === "[]") {
+            return $Result.Err(A2($Basics._op["++"],"`",A2($Basics._op["++"],functionName,"` cannot update an empty list of declarations.")));
+         } else {
+            if (_p11._1.ctor === "[]") {
+                  var _p12 = _p11._0;
+                  switch (_p12.ctor)
+                  {case "StyleBlock": var newDeclaration = A3($Css$Declaration.StyleBlock,_p12._0,_p12._1,A2(updateLast,update,_p12._2));
+                       return $Result.Ok(_U.list([newDeclaration]));
+                     case "ConditionalGroupRule": return $Result.Err(A2($Basics._op["++"],
+                       "`",
+                       A2($Basics._op["++"],
+                       functionName,
+                       "` cannot modify a conditional group rule (such as an at-rule). See https://developer.mozilla.org/en-US/docs/Web/CSS/At-rule#Conditional_Group_Rules for more information on conditional group rules.")));
+                     default: return $Result.Err(A2($Basics._op["++"],
+                       "`",
+                       A2($Basics._op["++"],
+                       functionName,
+                       "` cannot modify an at-rule. See https://developer.mozilla.org/en-US/docs/Web/CSS/At-rule for more information on at-rules.")));}
+               } else {
+                  var _p13 = A3(updateLastProperty,functionName,update,_p11._1);
+                  if (_p13.ctor === "Ok") {
+                        return $Result.Ok(A2($List._op["::"],_p11._0,_p13._0));
+                     } else {
+                        return _p13;
+                     }
+               }
+         }
+   });
+   var selectorToBlock = function (selector) {    return A3($Css$Declaration.StyleBlock,$Css$Declaration.SingleSelector(selector),_U.list([]),_U.list([]));};
+   _op["|$"] = F2(function (style,tag) {
+      var _p14 = style;
+      switch (_p14.ctor)
+      {case "NamespacedStyle": var newSelector = $Css$Declaration.TypeSelector($Css$Elements.tagToString(tag));
+           var _p15 = A3(addSelector,"|$",$Css$Declaration.SingleSelector(newSelector),_p14._1);
+           if (_p15.ctor === "Ok") {
+                 return A2($Style.NamespacedStyle,_p14._0,_p15._0);
+              } else {
+                 return $Style.InvalidStyle(_p15._0);
+              }
+         case "Mixin": return $Style.Mixin(function (subject) {    return A2(_op["|$"],_p14._0(subject),tag);});
+         default: return style;}
+   });
+   var ExplicitPseudoClass = function (a) {    return {ctor: "ExplicitPseudoClass",_0: a};};
+   var pseudoClassToString = function (_p16) {    var _p17 = _p16;return _p17._0;};
+   var ExplicitPseudoElement = function (a) {    return {ctor: "ExplicitPseudoElement",_0: a};};
+   var pseudoElementToString = function (_p18) {    var _p19 = _p18;return _p19._0;};
+   var IntentionallyUnsupportedPleaseSeeDocs = {ctor: "IntentionallyUnsupportedPleaseSeeDocs"};
+   var thin = IntentionallyUnsupportedPleaseSeeDocs;
+   var medium = IntentionallyUnsupportedPleaseSeeDocs;
+   var thick = IntentionallyUnsupportedPleaseSeeDocs;
+   var blink = IntentionallyUnsupportedPleaseSeeDocs;
+   var selection = ExplicitPseudoElement("selection");
+   var firstLine = ExplicitPseudoElement("first-line");
+   var firstLetter = ExplicitPseudoElement("first-letter");
+   var before = ExplicitPseudoElement("before");
+   var after = ExplicitPseudoElement("after");
+   var valid = ExplicitPseudoClass("valid");
+   var target = ExplicitPseudoClass("target");
+   var scope = ExplicitPseudoClass("scope");
+   var root = ExplicitPseudoClass("root");
+   var required = ExplicitPseudoClass("required");
+   var readWrite = ExplicitPseudoClass("read-write");
+   var outOfRange = ExplicitPseudoClass("out-of-range");
+   var optional = ExplicitPseudoClass("optional");
+   var onlyOfType = ExplicitPseudoClass("only-of-type");
+   var onlyChild = ExplicitPseudoClass("only-child");
+   var nthOfType = function (str) {    return ExplicitPseudoClass(A2($Basics._op["++"],"nth-of-type(",A2($Basics._op["++"],str,")")));};
+   var nthLastOfType = function (str) {    return ExplicitPseudoClass(A2($Basics._op["++"],"nth-last-of-type(",A2($Basics._op["++"],str,")")));};
+   var nthLastChild = function (str) {    return ExplicitPseudoClass(A2($Basics._op["++"],"nth-last-child(",A2($Basics._op["++"],str,")")));};
+   var nthChild = function (str) {    return ExplicitPseudoClass(A2($Basics._op["++"],"nth-child(",A2($Basics._op["++"],str,")")));};
+   var link = ExplicitPseudoClass("link");
+   var lastOfType = ExplicitPseudoClass("last-of-type");
+   var lastChild = ExplicitPseudoClass("last-child");
+   var lang = function (str) {    return ExplicitPseudoClass(A2($Basics._op["++"],"lang(",A2($Basics._op["++"],str,")")));};
+   var invalid = ExplicitPseudoClass("invalid");
+   var indeterminate = ExplicitPseudoClass("indeterminate");
+   var hover = ExplicitPseudoClass("hover");
+   var focus = ExplicitPseudoClass("focus");
+   var fullscreen = ExplicitPseudoClass("fullscreen");
+   var firstOfType = ExplicitPseudoClass("first-of-type");
+   var firstChild = ExplicitPseudoClass("first-child");
+   var first = ExplicitPseudoClass("first");
+   var enabled = ExplicitPseudoClass("enabled");
+   var empty = ExplicitPseudoClass("empty");
+   var disabled = ExplicitPseudoClass("disabled");
+   var checked = ExplicitPseudoClass("checked");
+   var any = function (str) {    return ExplicitPseudoClass(A2($Basics._op["++"],"any(",A2($Basics._op["++"],str,")")));};
+   var active = ExplicitPseudoClass("active");
+   var directionalityToString = function (directionality) {    var _p20 = directionality;if (_p20.ctor === "Ltr") {    return "ltr";} else {    return "rtl";}};
+   var dir = function (directionality) {
+      return ExplicitPseudoClass(A2($Basics._op["++"],"dir(",A2($Basics._op["++"],directionalityToString(directionality),")")));
+   };
+   var Rtl = {ctor: "Rtl"};
+   var Ltr = {ctor: "Ltr"};
+   var extendLastMixinSelector = F3(function (operatorName,update,mixinStyles) {
+      var _p21 = mixinStyles;
+      if (_p21.ctor === "[]") {
+            return $Result.Err(A2($Basics._op["++"],operatorName," cannot be used as the first mixin style."));
+         } else {
+            if (_p21._0.ctor === "_Tuple2" && _p21._1.ctor === "[]") {
+                  return $Result.Ok(_U.list([{ctor: "_Tuple2",_0: A2($List.map,update,_p21._0._0),_1: _p21._0._1}]));
+               } else {
+                  var _p22 = A3(extendLastMixinSelector,operatorName,update,_p21._1);
+                  if (_p22.ctor === "Ok") {
+                        return $Result.Ok(A2($List._op["::"],_p21._0,_p22._0));
+                     } else {
+                        return _p22;
+                     }
+               }
+         }
+   });
+   var extendTypeSelector = F3(function (operatorName,update,style) {
+      var _p23 = style;
+      switch (_p23.ctor)
+      {case "NamespacedStyle": var _p25 = _p23._0;
+           var _p24 = A3(extendLastSelector,operatorName,update(_p25),_p23._1);
+           if (_p24.ctor === "Ok") {
+                 return A2($Style.NamespacedStyle,_p25,_p24._0);
+              } else {
+                 return $Style.InvalidStyle(_p24._0);
+              }
+         case "Mixin": return $Style.Mixin(function (subject) {    return A3(extendTypeSelector,operatorName,update,_p23._0(subject));});
+         default: return style;}
+   });
+   _op["&::"] = F2(function (style,pseudoElement) {
+      return A3(extendTypeSelector,"&::",function (_p26) {    return $Css$Declaration.PseudoElement(pseudoElementToString(pseudoElement));},style);
+   });
+   _op["&:"] = F2(function (style,pseudoClass) {
+      return A3(extendTypeSelector,"&:",function (_p27) {    return $Css$Declaration.PseudoClass(pseudoClassToString(pseudoClass));},style);
+   });
+   _op["~#"] = F2(function (style,id) {
+      return A3(extendTypeSelector,
+      "~#",
+      function (name) {
+         return $Css$Declaration.GeneralSibling($Css$Declaration.SingleSelector($Css$Declaration.IdSelector(A2($Css$Util.identifierToString,name,id))));
+      },
+      style);
+   });
+   _op["+#"] = F2(function (style,id) {
+      return A3(extendTypeSelector,
+      "+#",
+      function (name) {
+         return $Css$Declaration.AdjacentSibling($Css$Declaration.SingleSelector($Css$Declaration.IdSelector(A2($Css$Util.identifierToString,name,id))));
+      },
+      style);
+   });
+   _op[">>#"] = F2(function (style,id) {
+      return A3(extendTypeSelector,
+      ">>#",
+      function (name) {
+         return $Css$Declaration.Descendant($Css$Declaration.SingleSelector($Css$Declaration.IdSelector(A2($Css$Util.identifierToString,name,id))));
+      },
+      style);
+   });
+   _op[">#"] = F2(function (style,id) {
+      return A3(extendTypeSelector,
+      ">#",
+      function (name) {
+         return $Css$Declaration.Child($Css$Declaration.SingleSelector($Css$Declaration.IdSelector(A2($Css$Util.identifierToString,name,id))));
+      },
+      style);
+   });
+   _op["~."] = F2(function (style,$class) {
+      return A3(extendTypeSelector,
+      "~.",
+      function (name) {
+         return $Css$Declaration.GeneralSibling($Css$Declaration.SingleSelector($Css$Declaration.ClassSelector(A2($Css$Util.identifierToString,name,$class))));
+      },
+      style);
+   });
+   _op["+."] = F2(function (style,$class) {
+      return A3(extendTypeSelector,
+      "+.",
+      function (name) {
+         return $Css$Declaration.AdjacentSibling($Css$Declaration.SingleSelector($Css$Declaration.ClassSelector(A2($Css$Util.identifierToString,name,$class))));
+      },
+      style);
+   });
+   _op[">>."] = F2(function (style,$class) {
+      return A3(extendTypeSelector,
+      ">>.",
+      function (name) {
+         return $Css$Declaration.Descendant($Css$Declaration.SingleSelector($Css$Declaration.ClassSelector(A2($Css$Util.identifierToString,name,$class))));
+      },
+      style);
+   });
+   _op[">."] = F2(function (style,$class) {
+      return A3(extendTypeSelector,
+      ">.",
+      function (name) {
+         return $Css$Declaration.Child($Css$Declaration.SingleSelector($Css$Declaration.ClassSelector(A2($Css$Util.identifierToString,name,$class))));
+      },
+      style);
+   });
+   _op["~$"] = F2(function (style,tag) {
+      return A3(extendTypeSelector,
+      "~$",
+      function (_p28) {
+         return $Css$Declaration.GeneralSibling($Css$Declaration.SingleSelector($Css$Declaration.TypeSelector($Css$Elements.tagToString(tag))));
+      },
+      style);
+   });
+   _op["+$"] = F2(function (style,tag) {
+      return A3(extendTypeSelector,
+      "+$",
+      function (_p29) {
+         return $Css$Declaration.AdjacentSibling($Css$Declaration.SingleSelector($Css$Declaration.TypeSelector($Css$Elements.tagToString(tag))));
+      },
+      style);
+   });
+   _op[">>$"] = F2(function (style,tag) {
+      return A3(extendTypeSelector,
+      ">>$",
+      function (_p30) {
+         return $Css$Declaration.Descendant($Css$Declaration.SingleSelector($Css$Declaration.TypeSelector($Css$Elements.tagToString(tag))));
+      },
+      style);
+   });
+   _op[">$"] = F2(function (style,tag) {
+      return A3(extendTypeSelector,
+      ">$",
+      F2(function (_p31,parent) {
+         return A2($Css$Declaration.Child,parent,$Css$Declaration.SingleSelector($Css$Declaration.TypeSelector($Css$Elements.tagToString(tag))));
+      }),
+      style);
+   });
+   var resolveMixin = F2(function (newStyleFromDeclarations,style) {
+      var _p32 = style;
+      switch (_p32.ctor)
+      {case "NamespacedStyle": return A3(newStyleFromDeclarations,style,_p32._0,_p32._1);
+         case "Mixin": var newUpdate = function (subject) {
+              var _p33 = _p32._0(subject);
+              switch (_p33.ctor)
+              {case "NamespacedStyle": return A2(resolveMixin,newStyleFromDeclarations,_p33);
+                 case "Mixin": return $Style.Mixin(function (_p34) {    return newUpdate(_p33._0(_p34));});
+                 default: return _p33;}
+           };
+           return $Style.Mixin(newUpdate);
+         default: return style;}
+   });
+   var lastSelectorToMulti = F2(function (selector,otherSelectors) {
+      var _p35 = otherSelectors;
+      if (_p35.ctor === "[]") {
+            return _U.list([$Css$Declaration.SingleSelector(selector)]);
+         } else {
+            if (_p35._1.ctor === "[]") {
+                  return _U.list([A2($Css$Declaration.MultiSelector,_p35._0,selector)]);
+               } else {
+                  return A2($List._op["::"],_p35._0,A2(lastSelectorToMulti,selector,_p35._1));
+               }
+         }
+   });
+   var introduceSelector = F2(function (selector,declarations) {
+      var _p36 = declarations;
+      if (_p36.ctor === "[]") {
+            return _U.list([A3($Css$Declaration.StyleBlock,$Css$Declaration.SingleSelector(selector),_U.list([]),_U.list([]))]);
+         } else {
+            if (_p36._1.ctor === "[]") {
+                  if (_p36._0.ctor === "StyleBlock" && _p36._0._2.ctor === "[]") {
+                        var _p37 = A2(lastSelectorToMulti,selector,A2($List._op["::"],_p36._0._0,_p36._0._1));
+                        if (_p37.ctor === "[]") {
+                              return _U.list([A3($Css$Declaration.StyleBlock,$Css$Declaration.SingleSelector(selector),_U.list([]),_U.list([]))]);
+                           } else {
+                              return _U.list([A3($Css$Declaration.StyleBlock,_p37._0,_p37._1,_U.list([]))]);
+                           }
+                     } else {
+                        return A2($List._op["::"],
+                        _p36._0,
+                        _U.list([A3($Css$Declaration.StyleBlock,$Css$Declaration.SingleSelector(selector),_U.list([]),_U.list([]))]));
+                     }
+               } else {
+                  return A2($List._op["::"],_p36._0,A2(introduceSelector,selector,_p36._1));
+               }
+         }
+   });
+   _op["~"] = F2(function (style,mixinToApply) {
+      var _p38 = mixinToApply;
+      switch (_p38.ctor)
+      {case "Mixin": return _p38._0(style);
+         case "NamespacedStyle": return $Style.InvalidStyle(A2($Basics._op["++"],
+           "A stylesheet with namespace ",
+           A2($Basics._op["++"],$Basics.toString(_p38._0)," is not a valid property or mixin.")));
+         default: return style;}
+   });
+   _op["$="] = F2(function (style,selectorStr) {
+      var _p39 = style;
+      switch (_p39.ctor)
+      {case "NamespacedStyle": return A2($Style.NamespacedStyle,_p39._0,A2(introduceSelector,$Css$Declaration.CustomSelector(selectorStr),_p39._1));
+         case "Mixin": return $Style.Mixin(function (subject) {    return A2(_op["$="],_p39._0(subject),selectorStr);});
+         default: return style;}
+   });
+   _op["@"] = F2(function (style,rule) {
+      var _p40 = style;
+      switch (_p40.ctor)
+      {case "NamespacedStyle": return A2($Style.NamespacedStyle,
+           _p40._0,
+           A2($Basics._op["++"],_p40._1,_U.list([A2($Css$Declaration.ConditionalGroupRule,rule,_U.list([]))])));
+         case "Mixin": return $Style.InvalidStyle("@-rules are not allowed in mixins.");
+         default: return style;}
+   });
+   _op["."] = F2(function (style,$class) {
+      var _p41 = style;
+      switch (_p41.ctor)
+      {case "NamespacedStyle": var _p42 = _p41._0;
+           return A2($Style.NamespacedStyle,_p42,A2(introduceSelector,$Css$Declaration.ClassSelector(A2($Css$Util.identifierToString,_p42,$class)),_p41._1));
+         case "Mixin": return $Style.Mixin(function (subject) {    return A2(_op["."],_p41._0(subject),$class);});
+         default: return style;}
+   });
+   _op["#"] = F2(function (style,id) {
+      var _p43 = style;
+      switch (_p43.ctor)
+      {case "NamespacedStyle": var _p44 = _p43._0;
+           return A2($Style.NamespacedStyle,_p44,A2(introduceSelector,$Css$Declaration.IdSelector(A2($Css$Util.identifierToString,_p44,id)),_p43._1));
+         case "Mixin": return $Style.Mixin(function (subject) {    return A2(_op["#"],_p43._0(subject),id);});
+         default: return style;}
+   });
+   _op["$"] = F2(function (style,tag) {
+      var selector = $Css$Declaration.TypeSelector($Css$Elements.tagToString(tag));
+      var _p45 = style;
+      switch (_p45.ctor)
+      {case "NamespacedStyle": return A2($Style.NamespacedStyle,_p45._0,A2(introduceSelector,selector,_p45._1));
+         case "Mixin": return $Style.Mixin(function (subject) {    return A2(_op["$"],_p45._0(subject),tag);});
+         default: return style;}
+   });
+   var mixin = $Style.Mixin($Basics.identity);
+   var stylesheet = function (_p46) {    var _p47 = _p46;return A2($Style.NamespacedStyle,_p47.name,_U.list([]));};
+   var propertyMixin = function (propertyFromDeclarations) {
+      var newStyleFromDeclarations = F3(function (style,name,declarations) {
+         var property = A3(propertyFromDeclarations,style,name,declarations);
+         var _p48 = A2(addProperty,property,declarations);
+         if (_p48.ctor === "Ok") {
+               return A2($Style.NamespacedStyle,name,_p48._0);
+            } else {
+               return $Style.InvalidStyle(_p48._0);
+            }
+      });
+      return $Style.Mixin(resolveMixin(newStyleFromDeclarations));
+   };
+   var custom = F2(function (key,value) {    return propertyMixin(F3(function (_p51,_p50,_p49) {    return {key: key,value: value,important: false};}));});
+   var animationNames = function (identifiers) {
+      var propertyFromDeclarations = F3(function (style,name,declarations) {
+         var value = A2($String.join,", ",A2($List.map,$Css$Util.identifierToString(name),identifiers));
+         return {key: "animation-name",value: value,important: false};
+      });
+      return propertyMixin(propertyFromDeclarations);
+   };
+   var animationName = function (identifier) {    return animationNames(_U.list([identifier]));};
+   var media = function (value) {    return A2($Basics._op["++"],"media ",$Basics.toString(value));};
+   var prop4 = F5(function (key,argA,argB,argC,argD) {    return A2(custom,key,A2($String.join," ",_U.list([argA.value,argB.value,argC.value,argD.value])));});
+   var textShadow4 = prop4("text-shadow");
+   var padding4 = prop4("padding");
+   var margin4 = prop4("margin");
+   var borderImageOutset4 = prop4("border-image-outset");
+   var borderImageWidth4 = prop4("border-image-width");
+   var borderRadius4 = prop4("border-radius");
+   var borderColor4 = prop4("border-color");
+   var prop3 = F4(function (key,argA,argB,argC) {    return A2(custom,key,A2($String.join," ",_U.list([argA.value,argB.value,argC.value])));});
+   var textShadow3 = prop3("text-shadow");
+   var textIndent3 = prop3("text-indent");
+   var padding3 = prop3("padding");
+   var margin3 = prop3("margin");
+   var border3 = prop3("border");
+   var borderTop3 = prop3("border-top");
+   var borderBottom3 = prop3("border-bottom");
+   var borderLeft3 = prop3("border-left");
+   var borderRight3 = prop3("border-right");
+   var borderBlockStart3 = prop3("border-block-start");
+   var borderBlockEnd3 = prop3("border-block-end");
+   var borderInlineStart3 = prop3("border-block-start");
+   var borderInlineEnd3 = prop3("border-block-end");
+   var borderImageOutset3 = prop3("border-image-outset");
+   var borderImageWidth3 = prop3("border-image-width");
+   var borderRadius3 = prop3("border-radius");
+   var borderColor3 = prop3("border-color");
+   var textDecoration3 = prop3("text-decoration");
+   var textDecorations3 = function (_p52) {    return A2(prop3,"text-decoration",valuesOrNone(_p52));};
+   var prop2 = F3(function (key,argA,argB) {    return A2(custom,key,A2($String.join," ",_U.list([argA.value,argB.value])));});
+   var textShadow2 = prop2("text-shadow");
+   var textIndent2 = prop2("text-indent");
+   var padding2 = prop2("padding");
+   var margin2 = prop2("margin");
+   var border2 = prop2("border");
+   var borderTop2 = prop2("border-top");
+   var borderBottom2 = prop2("border-bottom");
+   var borderLeft2 = prop2("border-left");
+   var borderRight2 = prop2("border-right");
+   var borderBlockStart2 = prop2("border-block-start");
+   var borderBlockEnd2 = prop2("border-block-end");
+   var borderInlineStart2 = prop2("border-block-start");
+   var borderInlineEnd2 = prop2("border-block-end");
+   var borderImageOutset2 = prop2("border-image-outset");
+   var borderImageWidth2 = prop2("border-image-width");
+   var borderTopWidth2 = prop2("border-top-width");
+   var borderBottomLeftRadius2 = prop2("border-bottom-left-radius");
+   var borderBottomRightRadius2 = prop2("border-bottom-right-radius");
+   var borderTopLeftRadius2 = prop2("border-top-left-radius");
+   var borderTopRightRadius2 = prop2("border-top-right-radius");
+   var borderRadius2 = prop2("border-radius");
+   var borderSpacing2 = prop2("border-spacing");
+   var borderColor2 = prop2("border-color");
+   var textDecoration2 = prop2("text-decoration");
+   var textDecorations2 = function (_p53) {    return A2(prop2,"text-decoration",valuesOrNone(_p53));};
+   var prop1 = F2(function (key,arg) {    return A2(custom,key,arg.value);});
+   var textDecorationColor = prop1("text-decoration-color");
+   var textRendering = prop1("text-rendering");
+   var textOverflow = prop1("text-overflow");
+   var textShadow = prop1("text-shadow");
+   var textIndent = prop1("text-indent");
+   var textTransform = prop1("text-transform");
+   var display = prop1("display");
+   var opacity = function (num) {    return A2(prop1,"opacity",{value: numberToString(num)});};
+   var width = prop1("width");
+   var minWidth = prop1("min-width");
+   var height = prop1("height");
+   var minHeight = prop1("min-height");
+   var padding = prop1("padding");
+   var paddingBlockStart = prop1("padding-block-start");
+   var paddingBlockEnd = prop1("padding-block-end");
+   var paddingInlineStart = prop1("padding-inline-start");
+   var paddingInlineEnd = prop1("padding-inline-end");
+   var paddingTop = prop1("padding-top");
+   var paddingBottom = prop1("padding-bottom");
+   var paddingRight = prop1("padding-right");
+   var paddingLeft = prop1("padding-left");
+   var margin = prop1("margin");
+   var marginTop = prop1("margin-top");
+   var marginBottom = prop1("margin-bottom");
+   var marginRight = prop1("margin-right");
+   var marginLeft = prop1("margin-left");
+   var marginBlockStart = prop1("margin-block-start");
+   var marginBlockEnd = prop1("margin-block-end");
+   var marginInlineStart = prop1("margin-inline-start");
+   var marginInlineEnd = prop1("margin-inline-end");
+   var top = prop1("top");
+   var bottom = prop1("bottom");
+   var left = prop1("left");
+   var right = prop1("right");
+   var border = prop1("border");
+   var borderTop = prop1("border-top");
+   var borderBottom = prop1("border-bottom");
+   var borderLeft = prop1("border-left");
+   var borderRight = prop1("border-right");
+   var borderBlockStart = prop1("border-block-start");
+   var borderBlockEnd = prop1("border-block-end");
+   var borderInlineStart = prop1("border-block-start");
+   var borderInlineEnd = prop1("border-block-end");
+   var borderImageOutset = prop1("border-image-outset");
+   var borderImageWidth = prop1("border-image-width");
+   var borderBlockStartColor = prop1("border-block-start-color");
+   var borderBottomColor = prop1("border-bottom-color");
+   var borderInlineStartColor = prop1("border-inline-start-color");
+   var borderInlineEndColor = prop1("border-inline-end-color");
+   var borderLeftColor = prop1("border-left-color");
+   var borderRightColor = prop1("border-right-color");
+   var borderTopColor = prop1("border-top-color");
+   var borderBlockEndColor = prop1("border-block-end-color");
+   var borderBlockEndStyle = prop1("border-block-end-style");
+   var borderBlockStartStyle = prop1("border-block-start-style");
+   var borderInlineEndStyle = prop1("border-inline-end-style");
+   var borderBottomStyle = prop1("border-bottom-style");
+   var borderInlineStartStyle = prop1("border-inline-start-style");
+   var borderLeftStyle = prop1("border-left-style");
+   var borderRightStyle = prop1("border-right-style");
+   var borderTopStyle = prop1("border-top-style");
+   var borderStyle = prop1("border-style");
+   var borderBottomWidth = prop1("border-bottom-width");
+   var borderInlineEndWidth = prop1("border-inline-end-width");
+   var borderLeftWidth = prop1("border-left-width");
+   var borderRightWidth = prop1("border-right-width");
+   var borderTopWidth = prop1("border-top-width");
+   var borderBottomLeftRadius = prop1("border-bottom-left-radius");
+   var borderBottomRightRadius = prop1("border-bottom-right-radius");
+   var borderTopLeftRadius = prop1("border-top-left-radius");
+   var borderTopRightRadius = prop1("border-top-right-radius");
+   var borderRadius = prop1("border-radius");
+   var borderSpacing = prop1("border-spacing");
+   var borderColor = prop1("border-color");
+   var overflowX = prop1("overflow-x");
+   var overflowY = prop1("overflow-y");
+   var whiteSpace = prop1("white-space");
+   var backgroundColor = prop1("background-color");
+   var color = prop1("color");
+   var textDecoration = prop1("text-decoration");
+   var textDecorations = function (_p54) {    return A2(prop1,"text-decoration",valuesOrNone(_p54));};
+   var textDecorationLine = prop1("text-decoration-line");
+   var textDecorationLines = function (_p55) {    return A2(prop1,"text-decoration-line",valuesOrNone(_p55));};
+   var textDecorationStyle = prop1("text-decoration-style");
+   var position = prop1("position");
+   var textBottom = prop1("text-bottom");
+   var textTop = prop1("text-top");
+   var $super = prop1("super");
+   var sub = prop1("sub");
+   var baseline = prop1("baseline");
+   var middle = prop1("middle");
+   var transformStyle = prop1("transform-style");
+   var boxSizing = prop1("box-sizing");
+   var transformBox = prop1("transform-box");
+   var transforms = function (_p56) {    return A2(prop1,"transform",valuesOrNone(_p56));};
+   var transform = function (only) {    return transforms(_U.list([only]));};
+   var $true = prop1("true");
+   var matchParent = prop1("match-parent");
+   var end = prop1("end");
+   var start = prop1("start");
+   var justifyAll = prop1("justify-all");
+   var textJustify = prop1("text-justify");
+   var center = prop1("center");
+   var important = function (style) {
+      var _p57 = style;
+      switch (_p57.ctor)
+      {case "NamespacedStyle": return $Style.InvalidStyle(A2($Basics._op["++"],
+           "`important` must be given a property or mixin, not a stylesheet with namespace ",
+           $Css$Util.toCssIdentifier(_p57._0)));
+         case "Mixin": var update = function (property) {    return _U.update(property,{important: true});};
+           var newStyleFromDeclarations = F3(function (style,name,declarations) {
+              var _p58 = A3(updateLastProperty,"important",update,declarations);
+              if (_p58.ctor === "Ok") {
+                    return A2($Style.NamespacedStyle,name,_p58._0);
+                 } else {
+                    return $Style.InvalidStyle(_p58._0);
+                 }
+           });
+           return $Style.Mixin(function (_p59) {    return A2(resolveMixin,newStyleFromDeclarations,_p57._0(_p59));});
+         default: return style;}
+   };
+   var all = prop1("all");
+   var getLast = function (list) {
+      getLast: while (true) {
+         var _p60 = list;
+         if (_p60.ctor === "[]") {
+               return $Maybe.Nothing;
+            } else {
+               if (_p60._1.ctor === "[]") {
+                     return $Maybe.Just(_p60._0);
+                  } else {
+                     var _v38 = _p60._1;
+                     list = _v38;
+                     continue getLast;
+                  }
+            }
+      }
+   };
+   var getLastProperty = function (declarations) {
+      getLastProperty: while (true) {
+         var _p61 = declarations;
+         if (_p61.ctor === "[]") {
+               return $Maybe.Nothing;
+            } else {
+               if (_p61._0.ctor === "StyleBlock" && _p61._1.ctor === "[]") {
+                     return getLast(_p61._0._2);
+                  } else {
+                     var _v40 = _p61._1;
+                     declarations = _v40;
+                     continue getLastProperty;
+                  }
+            }
+      }
+   };
+   var lastPropertyKeyToString = function (style) {
+      var _p62 = style;
+      switch (_p62.ctor)
+      {case "NamespacedStyle": return A2($Maybe.withDefault,"",A2($Maybe.map,function (_) {    return _.key;},getLastProperty(_p62._1)));
+         case "Mixin": return $Basics.toString(_p62._0);
+         default: return "";}
+   };
+   var getOverloadedProperty = F3(function (functionName,key,style) {
+      var _p63 = style;
+      switch (_p63.ctor)
+      {case "NamespacedStyle": return $Style.InvalidStyle(A2($Basics._op["++"],
+           "`",
+           A2($Basics._op["++"],
+           functionName,
+           A2($Basics._op["++"],
+           "` must be given a property or mixin, not a stylesheet with name \"",
+           A2($Basics._op["++"],$Css$Util.toCssIdentifier(_p63._0),"\"")))));
+         case "Mixin": var newStyleFromDeclarations = F3(function (style,name,declarations) {
+              var value = A2($Maybe.withDefault,"",A2($Maybe.map,function (_) {    return _.key;},getLastProperty(declarations)));
+              var update = function (subject) {    return _U.update(subject,{key: key,value: value});};
+              var _p64 = A3(updateLastProperty,functionName,update,declarations);
+              if (_p64.ctor === "Ok") {
+                    return A2($Style.NamespacedStyle,name,_p64._0);
+                 } else {
+                    return $Style.InvalidStyle(_p64._0);
+                 }
+           });
+           return $Style.Mixin(function (_p65) {    return A2(resolveMixin,newStyleFromDeclarations,_p63._0(_p65));});
+         default: return _p63;}
+   });
+   var cssFunction = F2(function (funcName,args) {
+      return A2($Basics._op["++"],funcName,A2($Basics._op["++"],"(",A2($Basics._op["++"],A2($String.join,", ",args),")")));
+   });
+   var print = "print";
+   var screen = "screen";
+   var Compatible = {ctor: "Compatible"};
+   var transparent = {value: "transparent",color: Compatible};
+   var currentColor = {value: "currentColor",color: Compatible};
+   var visible = {value: "visible",overflow: Compatible};
+   var scroll = {value: "scroll",overflow: Compatible};
+   var hidden = {value: "hidden",overflow: Compatible,borderStyle: Compatible};
+   var initial = {value: "initial"
+                 ,overflow: Compatible
+                 ,none: Compatible
+                 ,textDecorationLine: Compatible
+                 ,boxSizing: Compatible
+                 ,display: Compatible
+                 ,all: Compatible};
+   var unset = _U.update(initial,{value: "unset"});
+   var inherit = _U.update(initial,{value: "inherit"});
+   var rgb = F3(function (r,g,b) {    return {value: A2(cssFunction,"rgb",A2($List.map,numberToString,_U.list([r,g,b]))),color: Compatible};});
+   var rgba = F4(function (r,g,b,a) {    return {value: A2(cssFunction,"rgba",A2($List.map,numberToString,_U.list([r,g,b,a]))),color: Compatible};});
+   var hex = function (str) {    return {value: A2($Basics._op["++"],"#",str),color: Compatible};};
+   var optimizeSpeed = {value: "optimizeSpeed",textRendering: Compatible};
+   var optimizeLegibility = {value: "optimizeLegibility",textRendering: Compatible};
+   var geometricPrecision = {value: "geometricPrecision",textRendering: Compatible};
+   var hanging = {value: "hanging",textIndent: Compatible};
+   var eachLine = {value: "each-line",textIndent: Compatible};
+   var capitalize = {value: "capitalize",textTransform: Compatible};
+   var uppercase = {value: "uppercase",textTransform: Compatible};
+   var lowercase = {value: "lowercase",textTransform: Compatible};
+   var fullWidth = {value: "full-width",textTransform: Compatible};
+   var ellipsis = {value: "ellipsis",textOverflow: Compatible};
+   var clip = {value: "clip",textOverflow: Compatible};
+   var wavy = {value: "wavy",textDecorationStyle: Compatible};
+   var dotted = {value: "dotted",borderStyle: Compatible,textDecorationStyle: Compatible};
+   var dashed = {value: "dashed",borderStyle: Compatible,textDecorationStyle: Compatible};
+   var solid = {value: "solid",borderStyle: Compatible,textDecorationStyle: Compatible};
+   var $double = {value: "double",borderStyle: Compatible,textDecorationStyle: Compatible};
+   var groove = {value: "groove",borderStyle: Compatible};
+   var ridge = {value: "ridge",borderStyle: Compatible};
+   var inset = {value: "inset",borderStyle: Compatible};
+   var outset = {value: "outset",borderStyle: Compatible};
+   var lengthConverter = F2(function (suffix,num) {
+      return {value: A2($Basics._op["++"],numberToString(num),suffix)
+             ,length: Compatible
+             ,lengthOrAuto: Compatible
+             ,lengthOrNumber: Compatible
+             ,textIndent: Compatible};
+   });
+   var pct = lengthConverter("%");
+   var em = lengthConverter("em");
+   var ex = lengthConverter("ex");
+   var ch = lengthConverter("ch");
+   var rem = lengthConverter("rem");
+   var vh = lengthConverter("vh");
+   var vw = lengthConverter("vw");
+   var vmin = lengthConverter("vmin");
+   var vmax = lengthConverter("vmax");
+   var px = lengthConverter("px");
+   var mm = lengthConverter("mm");
+   var cm = lengthConverter("cm");
+   var inches = lengthConverter("in");
+   var pt = lengthConverter("pt");
+   var pc = lengthConverter("pc");
+   var zero = {value: "0",length: Compatible,lengthOrNumber: Compatible,lengthOrAuto: Compatible,number: Compatible};
+   var textAlignLast = function (fn) {    return A3(getOverloadedProperty,"textAlignLast","text-align-last",fn(zero));};
+   var textAlign = function (fn) {    return A3(getOverloadedProperty,"textAlign","text-align",fn(zero));};
+   var verticalAlign = function (fn) {    return A3(getOverloadedProperty,"verticalAlign","vertical-align",fn(zero));};
+   var n = function (num) {    return {value: numberToString(num),lengthOrNumber: Compatible,number: Compatible};};
+   var angleConverter = F2(function (suffix,num) {    return {value: A2($Basics._op["++"],numberToString(num),suffix),angle: Compatible};});
+   var deg = angleConverter("deg");
+   var grad = angleConverter("grad");
+   var rad = angleConverter("rad");
+   var turn = angleConverter("turn");
+   var matrix = F6(function (a,b,c,d,tx,ty) {
+      return {value: A2(cssFunction,"matrix",A2($List.map,numberToString,_U.list([a,b,c,d,tx,ty]))),transform: Compatible};
+   });
+   var matrix3d = function (a1) {
+      return function (a2) {
+         return function (a3) {
+            return function (a4) {
+               return function (b1) {
+                  return function (b2) {
+                     return function (b3) {
+                        return function (b4) {
+                           return function (c1) {
+                              return function (c2) {
+                                 return function (c3) {
+                                    return function (c4) {
+                                       return function (d1) {
+                                          return function (d2) {
+                                             return function (d3) {
+                                                return function (d4) {
+                                                   return {value: A2(cssFunction,
+                                                          "matrix3d",
+                                                          A2($List.map,numberToString,_U.list([a1,a2,a3,a4,b1,b2,b3,b4,c1,c2,c3,c4,d1,d2,d3,d4])))
+                                                          ,transform: Compatible};
+                                                };
+                                             };
+                                          };
+                                       };
+                                    };
+                                 };
+                              };
+                           };
+                        };
+                     };
+                  };
+               };
+            };
+         };
+      };
+   };
+   var perspective = function (l) {    return {value: A2(cssFunction,"perspective",_U.list([numberToString(l)])),transform: Compatible};};
+   var rotate = function (_p66) {    var _p67 = _p66;return {value: A2(cssFunction,"rotate",_U.list([_p67.value])),transform: Compatible};};
+   var rotateX = function (_p68) {    var _p69 = _p68;return {value: A2(cssFunction,"rotateX",_U.list([_p69.value])),transform: Compatible};};
+   var rotateY = function (_p70) {    var _p71 = _p70;return {value: A2(cssFunction,"rotateY",_U.list([_p71.value])),transform: Compatible};};
+   var rotateZ = function (_p72) {    var _p73 = _p72;return {value: A2(cssFunction,"rotateZ",_U.list([_p73.value])),transform: Compatible};};
+   var rotate3d = F4(function (x,y,z,_p74) {
+      var _p75 = _p74;
+      var coordsAsStrings = A2($List.map,numberToString,_U.list([x,y,z]));
+      return {value: A2(cssFunction,"rotate3d",A2($Basics._op["++"],coordsAsStrings,_U.list([_p75.value]))),transform: Compatible};
+   });
+   var scale = function (x) {    return {value: A2(cssFunction,"scale",_U.list([numberToString(x)])),transform: Compatible};};
+   var scale2 = F2(function (x,y) {    return {value: A2(cssFunction,"scale",A2($List.map,numberToString,_U.list([x,y]))),transform: Compatible};});
+   var scaleX = function (x) {    return {value: A2(cssFunction,"scaleX",_U.list([numberToString(x)])),transform: Compatible};};
+   var scaleY = function (y) {    return {value: A2(cssFunction,"scaleY",_U.list([numberToString(y)])),transform: Compatible};};
+   var scale3d = F3(function (x,y,z) {    return {value: A2(cssFunction,"scale3d",A2($List.map,numberToString,_U.list([x,y,z]))),transform: Compatible};});
+   var skew = function (_p76) {    var _p77 = _p76;return {value: A2(cssFunction,"skew",_U.list([_p77.value])),transform: Compatible};};
+   var skew2 = F2(function (ax,ay) {    return {value: A2(cssFunction,"skew",_U.list([ax.value,ay.value])),transform: Compatible};});
+   var skewX = function (_p78) {    var _p79 = _p78;return {value: A2(cssFunction,"skewX",_U.list([_p79.value])),transform: Compatible};};
+   var skewY = function (_p80) {    var _p81 = _p80;return {value: A2(cssFunction,"skewY",_U.list([_p81.value])),transform: Compatible};};
+   var translate = function (_p82) {    var _p83 = _p82;return {value: A2(cssFunction,"translate",_U.list([_p83.value])),transform: Compatible};};
+   var translate2 = F2(function (tx,ty) {    return {value: A2(cssFunction,"translate",_U.list([tx.value,ty.value])),transform: Compatible};});
+   var translateX = function (_p84) {    var _p85 = _p84;return {value: A2(cssFunction,"translateX",_U.list([_p85.value])),transform: Compatible};};
+   var translateY = function (_p86) {    var _p87 = _p86;return {value: A2(cssFunction,"translateY",_U.list([_p87.value])),transform: Compatible};};
+   var translateZ = function (_p88) {    var _p89 = _p88;return {value: A2(cssFunction,"translateZ",_U.list([_p89.value])),transform: Compatible};};
+   var translate3d = F3(function (tx,ty,tz) {    return {value: A2(cssFunction,"translate3d",_U.list([tx.value,ty.value,tz.value])),transform: Compatible};});
+   var fillBox = {value: "fill-box",transformBox: Compatible};
+   var contentBox = {value: "content-box",boxSizing: Compatible};
+   var borderBox = {value: "border-box",boxSizing: Compatible};
+   var viewBox = {value: "view-box",transformBox: Compatible};
+   var preserve3d = {value: "preserve-3d",transformStyle: Compatible};
+   var flat = {value: "flat",transformStyle: Compatible};
+   var underline = {value: "underline",textDecorationLine: Compatible};
+   var overline = {value: "overline",textDecorationLine: Compatible};
+   var lineThrough = {value: "line-through",textDecorationLine: Compatible};
+   var block = {value: "block",display: Compatible};
+   var inlineBlock = {value: "inline-block",display: Compatible};
+   var inline = {value: "inline",display: Compatible};
+   var none = {value: "none",none: Compatible,textDecorationLine: Compatible,display: Compatible,transform: Compatible,borderStyle: Compatible};
+   var auto = {value: "auto",overflow: Compatible,textRendering: Compatible,lengthOrAuto: Compatible};
+   var noWrap = {value: "no-wrap",whiteSpace: Compatible};
+   var $static = {value: "static",position: Compatible};
+   var fixed = {value: "fixed",position: Compatible};
+   var sticky = {value: "sticky",position: Compatible};
+   var relative = {value: "relative",position: Compatible};
+   var absolute = {value: "absolute",position: Compatible};
+   return _elm.Css.values = {_op: _op
+                            ,stylesheet: stylesheet
+                            ,mixin: mixin
+                            ,all: all
+                            ,custom: custom
+                            ,important: important
+                            ,transformStyle: transformStyle
+                            ,transformBox: transformBox
+                            ,transform: transform
+                            ,transforms: transforms
+                            ,currentColor: currentColor
+                            ,underline: underline
+                            ,overline: overline
+                            ,lineThrough: lineThrough
+                            ,textDecoration: textDecoration
+                            ,textDecoration2: textDecoration2
+                            ,textDecoration3: textDecoration3
+                            ,textDecorations: textDecorations
+                            ,textDecorations2: textDecorations2
+                            ,textDecorations3: textDecorations3
+                            ,textDecorationLine: textDecorationLine
+                            ,textDecorationLines: textDecorationLines
+                            ,textDecorationStyle: textDecorationStyle
+                            ,capitalize: capitalize
+                            ,uppercase: uppercase
+                            ,lowercase: lowercase
+                            ,fullWidth: fullWidth
+                            ,hanging: hanging
+                            ,eachLine: eachLine
+                            ,textIndent: textIndent
+                            ,textIndent2: textIndent2
+                            ,textIndent3: textIndent3
+                            ,ellipsis: ellipsis
+                            ,clip: clip
+                            ,textOverflow: textOverflow
+                            ,textRendering: textRendering
+                            ,textTransform: textTransform
+                            ,textShadow: textShadow
+                            ,textShadow2: textShadow2
+                            ,textShadow3: textShadow3
+                            ,textShadow4: textShadow4
+                            ,textAlign: textAlign
+                            ,textAlignLast: textAlignLast
+                            ,left: left
+                            ,right: right
+                            ,center: center
+                            ,textJustify: textJustify
+                            ,justifyAll: justifyAll
+                            ,start: start
+                            ,end: end
+                            ,matchParent: matchParent
+                            ,$true: $true
+                            ,verticalAlign: verticalAlign
+                            ,display: display
+                            ,opacity: opacity
+                            ,width: width
+                            ,minWidth: minWidth
+                            ,height: height
+                            ,minHeight: minHeight
+                            ,padding: padding
+                            ,padding2: padding2
+                            ,padding3: padding3
+                            ,padding4: padding4
+                            ,paddingTop: paddingTop
+                            ,paddingBottom: paddingBottom
+                            ,paddingRight: paddingRight
+                            ,paddingLeft: paddingLeft
+                            ,paddingBlockStart: paddingBlockStart
+                            ,paddingBlockEnd: paddingBlockEnd
+                            ,paddingInlineStart: paddingInlineStart
+                            ,paddingInlineEnd: paddingInlineEnd
+                            ,margin: margin
+                            ,margin2: margin2
+                            ,margin3: margin3
+                            ,margin4: margin4
+                            ,marginTop: marginTop
+                            ,marginBottom: marginBottom
+                            ,marginRight: marginRight
+                            ,marginLeft: marginLeft
+                            ,marginBlockStart: marginBlockStart
+                            ,marginBlockEnd: marginBlockEnd
+                            ,marginInlineStart: marginInlineStart
+                            ,marginInlineEnd: marginInlineEnd
+                            ,boxSizing: boxSizing
+                            ,overflowX: overflowX
+                            ,overflowY: overflowY
+                            ,whiteSpace: whiteSpace
+                            ,backgroundColor: backgroundColor
+                            ,color: color
+                            ,media: media
+                            ,solid: solid
+                            ,transparent: transparent
+                            ,rgb: rgb
+                            ,rgba: rgba
+                            ,hex: hex
+                            ,zero: zero
+                            ,pct: pct
+                            ,px: px
+                            ,em: em
+                            ,pt: pt
+                            ,ex: ex
+                            ,ch: ch
+                            ,rem: rem
+                            ,vh: vh
+                            ,vw: vw
+                            ,vmin: vmin
+                            ,vmax: vmax
+                            ,mm: mm
+                            ,cm: cm
+                            ,inches: inches
+                            ,pc: pc
+                            ,n: n
+                            ,borderColor: borderColor
+                            ,borderColor2: borderColor2
+                            ,borderColor3: borderColor3
+                            ,borderColor4: borderColor4
+                            ,borderBottomLeftRadius: borderBottomLeftRadius
+                            ,borderBottomLeftRadius2: borderBottomLeftRadius2
+                            ,borderBottomRightRadius: borderBottomRightRadius
+                            ,borderBottomRightRadius2: borderBottomRightRadius2
+                            ,borderTopLeftRadius: borderTopLeftRadius
+                            ,borderTopLeftRadius2: borderTopLeftRadius2
+                            ,borderTopRightRadius: borderTopRightRadius
+                            ,borderTopRightRadius2: borderTopRightRadius2
+                            ,borderRadius: borderRadius
+                            ,borderRadius2: borderRadius2
+                            ,borderRadius3: borderRadius3
+                            ,borderRadius4: borderRadius4
+                            ,borderBottomWidth: borderBottomWidth
+                            ,borderInlineEndWidth: borderInlineEndWidth
+                            ,borderLeftWidth: borderLeftWidth
+                            ,borderRightWidth: borderRightWidth
+                            ,borderTopWidth: borderTopWidth
+                            ,borderBlockEndStyle: borderBlockEndStyle
+                            ,borderBlockStartStyle: borderBlockStartStyle
+                            ,borderInlineEndStyle: borderInlineEndStyle
+                            ,borderBottomStyle: borderBottomStyle
+                            ,borderInlineStartStyle: borderInlineStartStyle
+                            ,borderLeftStyle: borderLeftStyle
+                            ,borderRightStyle: borderRightStyle
+                            ,borderTopStyle: borderTopStyle
+                            ,borderStyle: borderStyle
+                            ,borderBlockStartColor: borderBlockStartColor
+                            ,borderBlockEndColor: borderBlockEndColor
+                            ,borderBottomColor: borderBottomColor
+                            ,borderInlineStartColor: borderInlineStartColor
+                            ,borderInlineEndColor: borderInlineEndColor
+                            ,borderLeftColor: borderLeftColor
+                            ,borderRightColor: borderRightColor
+                            ,borderTopColor: borderTopColor
+                            ,borderBox: borderBox
+                            ,border: border
+                            ,border2: border2
+                            ,border3: border3
+                            ,borderTop: borderTop
+                            ,borderTop2: borderTop2
+                            ,borderTop3: borderTop3
+                            ,borderBottom: borderBottom
+                            ,borderBottom2: borderBottom2
+                            ,borderBottom3: borderBottom3
+                            ,borderLeft: borderLeft
+                            ,borderLeft2: borderLeft2
+                            ,borderLeft3: borderLeft3
+                            ,borderRight: borderRight
+                            ,borderRight2: borderRight2
+                            ,borderRight3: borderRight3
+                            ,borderBlockEnd: borderBlockEnd
+                            ,borderBlockEnd2: borderBlockEnd2
+                            ,borderBlockEnd3: borderBlockEnd3
+                            ,borderBlockStart: borderBlockStart
+                            ,borderBlockStart2: borderBlockStart2
+                            ,borderBlockStart3: borderBlockStart3
+                            ,borderInlineEnd: borderInlineEnd
+                            ,borderInlineEnd2: borderInlineEnd2
+                            ,borderInlineEnd3: borderInlineEnd3
+                            ,borderInlineStart: borderInlineStart
+                            ,borderInlineStart2: borderInlineStart2
+                            ,borderInlineStart3: borderInlineStart3
+                            ,borderImageOutset: borderImageOutset
+                            ,borderImageOutset2: borderImageOutset2
+                            ,borderImageOutset3: borderImageOutset3
+                            ,borderImageOutset4: borderImageOutset4
+                            ,borderImageWidth: borderImageWidth
+                            ,borderImageWidth2: borderImageWidth2
+                            ,borderImageWidth3: borderImageWidth3
+                            ,borderImageWidth4: borderImageWidth4
+                            ,visible: visible
+                            ,block: block
+                            ,inlineBlock: inlineBlock
+                            ,inline: inline
+                            ,none: none
+                            ,auto: auto
+                            ,inherit: inherit
+                            ,initial: initial
+                            ,unset: unset
+                            ,noWrap: noWrap
+                            ,$static: $static
+                            ,fixed: fixed
+                            ,sticky: sticky
+                            ,relative: relative
+                            ,absolute: absolute
+                            ,position: position
+                            ,top: top
+                            ,bottom: bottom
+                            ,middle: middle
+                            ,baseline: baseline
+                            ,sub: sub
+                            ,$super: $super
+                            ,textTop: textTop
+                            ,textBottom: textBottom
+                            ,after: after
+                            ,before: before
+                            ,firstLetter: firstLetter
+                            ,firstLine: firstLine
+                            ,selection: selection
+                            ,active: active
+                            ,any: any
+                            ,checked: checked
+                            ,dir: dir
+                            ,disabled: disabled
+                            ,empty: empty
+                            ,enabled: enabled
+                            ,first: first
+                            ,firstChild: firstChild
+                            ,firstOfType: firstOfType
+                            ,fullscreen: fullscreen
+                            ,focus: focus
+                            ,hover: hover
+                            ,indeterminate: indeterminate
+                            ,invalid: invalid
+                            ,lang: lang
+                            ,lastChild: lastChild
+                            ,lastOfType: lastOfType
+                            ,link: link
+                            ,nthChild: nthChild
+                            ,nthLastChild: nthLastChild
+                            ,nthLastOfType: nthLastOfType
+                            ,nthOfType: nthOfType
+                            ,onlyChild: onlyChild
+                            ,onlyOfType: onlyOfType
+                            ,optional: optional
+                            ,outOfRange: outOfRange
+                            ,readWrite: readWrite
+                            ,required: required
+                            ,root: root
+                            ,scope: scope
+                            ,target: target
+                            ,valid: valid
+                            ,hidden: hidden
+                            ,dotted: dotted
+                            ,dashed: dashed
+                            ,$double: $double
+                            ,groove: groove
+                            ,ridge: ridge
+                            ,inset: inset
+                            ,outset: outset
+                            ,blink: blink
+                            ,thin: thin
+                            ,medium: medium
+                            ,thick: thick
+                            ,matrix: matrix
+                            ,matrix3d: matrix3d
+                            ,perspective: perspective
+                            ,rotate3d: rotate3d
+                            ,rotateX: rotateX
+                            ,rotateY: rotateY
+                            ,rotateZ: rotateZ
+                            ,scale: scale
+                            ,scale2: scale2
+                            ,scale3d: scale3d
+                            ,scaleX: scaleX
+                            ,scaleY: scaleY
+                            ,skew: skew
+                            ,skew2: skew2
+                            ,skewX: skewX
+                            ,skewY: skewY
+                            ,translate: translate
+                            ,translate2: translate2
+                            ,translate3d: translate3d
+                            ,translateX: translateX
+                            ,translateY: translateY
+                            ,translateZ: translateZ
+                            ,rotate: rotate
+                            ,fillBox: fillBox
+                            ,viewBox: viewBox
+                            ,flat: flat
+                            ,preserve3d: preserve3d
+                            ,deg: deg
+                            ,rad: rad
+                            ,grad: grad
+                            ,turn: turn};
+};</script></head><body><script type="text/javascript">Elm.fullscreen(Elm.Css)</script></body></html>

--- a/src/Css.elm
+++ b/src/Css.elm
@@ -1,4 +1,4 @@
-module Css (stylesheet, mixin, all, custom, important, ($), (#), (.), (@), (|$), (>$), (>>$), (+$), (~$), (>#), (>>#), (+#), (~#), (>.), (>>.), (+.), (~.), ($=), (~), (&::), (&:), transformStyle, transformBox, transform, transforms, currentColor, underline, overline, lineThrough, textDecoration, textDecoration2, textDecoration3, textDecorations, textDecorations2, textDecorations3, textDecorationLine, textDecorationLines, textDecorationStyle, capitalize, uppercase, lowercase, fullWidth, hanging, eachLine, textIndent, textIndent2, textIndent3, ellipsis, clip, textOverflow, textRendering, textTransform, textShadow, textShadow2, textShadow3, textShadow4, textAlign, textAlignLast, left, right, center, textJustify, justifyAll, start, end, matchParent, true, verticalAlign, display, opacity, width, minWidth, height, minHeight, padding, padding2, padding3, padding4, paddingTop, paddingBottom, paddingRight, paddingLeft, paddingBlockStart, paddingBlockEnd, paddingInlineStart, paddingInlineEnd, margin, margin2, margin3, margin4, marginTop, marginBottom, marginRight, marginLeft, marginBlockStart, marginBlockEnd, marginInlineStart, marginInlineEnd, boxSizing, overflowX, overflowY, whiteSpace, backgroundColor, color, media, outline, solid, transparent, rgb, rgba, hex, zero, pct, px, em, pt, ex, ch, rem, vh, vw, vmin, vmax, mm, cm, inches, pc, n, borderColor, borderColor2, borderColor3, borderColor4, borderBottomLeftRadius, borderBottomLeftRadius2, borderBottomRightRadius, borderBottomRightRadius2, borderTopLeftRadius, borderTopLeftRadius2, borderTopRightRadius, borderTopRightRadius2, borderRadius, borderRadius2, borderRadius3, borderRadius4, borderBottomWidth, borderInlineEndWidth, borderLeftWidth, borderRightWidth, borderTopWidth, borderBlockEndStyle, borderBlockStartStyle, borderInlineEndStyle, borderBottomStyle, borderInlineStartStyle, borderLeftStyle, borderRightStyle, borderTopStyle, borderStyle, borderBlockStartColor, borderBlockEndColor, borderBottomColor, borderInlineStartColor, borderInlineEndColor, borderLeftColor, borderRightColor, borderTopColor, borderBox, border, border2, border3, borderTop, borderTop2, borderTop3, borderBottom, borderBottom2, borderBottom3, borderLeft, borderLeft2, borderLeft3, borderRight, borderRight2, borderRight3, borderBlockEnd, borderBlockEnd2, borderBlockEnd3, borderBlockStart, borderBlockStart2, borderBlockStart3, borderInlineEnd, borderInlineEnd2, borderInlineEnd3, borderInlineStart, borderInlineStart2, borderInlineStart3, borderImageOutset, borderImageOutset2, borderImageOutset3, borderImageOutset4, borderImageWidth, borderImageWidth2, borderImageWidth3, borderImageWidth4, visible, block, inlineBlock, inline, none, auto, inherit, initial, unset, noWrap, static, fixed, sticky, relative, absolute, position, top, bottom, middle, baseline, sub, super, textTop, textBottom, after, before, firstLetter, firstLine, selection, active, any, checked, dir, disabled, empty, enabled, first, firstChild, firstOfType, fullscreen, focus, hover, indeterminate, invalid, lang, lastChild, lastOfType, link, nthChild, nthLastChild, nthLastOfType, nthOfType, onlyChild, onlyOfType, optional, outOfRange, readWrite, required, root, scope, target, valid, hidden, dotted, dashed, double, groove, ridge, inset, outset, blink, thin, medium, thick, matrix, matrix3d, perspective, rotate3d, rotateX, rotateY, rotateZ, scale, scale2, scale3d, scaleX, scaleY, skew, skew2, skewX, skewY, translate, translate2, translate3d, translateX, translateY, translateZ, rotate, fillBox, viewBox, flat, preserve3d, deg, rad, grad, turn) where
+module Css (stylesheet, mixin, all, custom, important, ($), (#), (.), (@), (|$), (>$), (>>$), (+$), (~$), (>#), (>>#), (+#), (~#), (>.), (>>.), (+.), (~.), ($=), (~), (&::), (&:), transformStyle, transformBox, transform, transforms, currentColor, underline, overline, lineThrough, textDecoration, textDecoration2, textDecoration3, textDecorations, textDecorations2, textDecorations3, textDecorationLine, textDecorationLines, textDecorationStyle, capitalize, uppercase, lowercase, fullWidth, hanging, eachLine, textIndent, textIndent2, textIndent3, ellipsis, clip, textOverflow, textRendering, textTransform, textShadow, textShadow2, textShadow3, textShadow4, textAlign, textAlignLast, left, right, center, textJustify, justifyAll, start, end, matchParent, true, verticalAlign, display, opacity, width, minWidth, height, minHeight, padding, padding2, padding3, padding4, paddingTop, paddingBottom, paddingRight, paddingLeft, paddingBlockStart, paddingBlockEnd, paddingInlineStart, paddingInlineEnd, margin, margin2, margin3, margin4, marginTop, marginBottom, marginRight, marginLeft, marginBlockStart, marginBlockEnd, marginInlineStart, marginInlineEnd, boxSizing, overflowX, overflowY, whiteSpace, backgroundColor, color, media, solid, transparent, rgb, rgba, hex, zero, pct, px, em, pt, ex, ch, rem, vh, vw, vmin, vmax, mm, cm, inches, pc, n, borderColor, borderColor2, borderColor3, borderColor4, borderBottomLeftRadius, borderBottomLeftRadius2, borderBottomRightRadius, borderBottomRightRadius2, borderTopLeftRadius, borderTopLeftRadius2, borderTopRightRadius, borderTopRightRadius2, borderRadius, borderRadius2, borderRadius3, borderRadius4, borderBottomWidth, borderInlineEndWidth, borderLeftWidth, borderRightWidth, borderTopWidth, borderBlockEndStyle, borderBlockStartStyle, borderInlineEndStyle, borderBottomStyle, borderInlineStartStyle, borderLeftStyle, borderRightStyle, borderTopStyle, borderStyle, borderBlockStartColor, borderBlockEndColor, borderBottomColor, borderInlineStartColor, borderInlineEndColor, borderLeftColor, borderRightColor, borderTopColor, borderBox, border, border2, border3, borderTop, borderTop2, borderTop3, borderBottom, borderBottom2, borderBottom3, borderLeft, borderLeft2, borderLeft3, borderRight, borderRight2, borderRight3, borderBlockEnd, borderBlockEnd2, borderBlockEnd3, borderBlockStart, borderBlockStart2, borderBlockStart3, borderInlineEnd, borderInlineEnd2, borderInlineEnd3, borderInlineStart, borderInlineStart2, borderInlineStart3, borderImageOutset, borderImageOutset2, borderImageOutset3, borderImageOutset4, borderImageWidth, borderImageWidth2, borderImageWidth3, borderImageWidth4, visible, block, inlineBlock, inline, none, auto, inherit, initial, unset, noWrap, static, fixed, sticky, relative, absolute, position, top, bottom, middle, baseline, sub, super, textTop, textBottom, after, before, firstLetter, firstLine, selection, active, any, checked, dir, disabled, empty, enabled, first, firstChild, firstOfType, fullscreen, focus, hover, indeterminate, invalid, lang, lastChild, lastOfType, link, nthChild, nthLastChild, nthLastOfType, nthOfType, onlyChild, onlyOfType, optional, outOfRange, readWrite, required, root, scope, target, valid, hidden, dotted, dashed, double, groove, ridge, inset, outset, blink, thin, medium, thick, matrix, matrix3d, perspective, rotate3d, rotateX, rotateY, rotateZ, scale, scale2, scale3d, scaleX, scaleY, skew, skew2, skewX, skewY, translate, translate2, translate3d, translateX, translateY, translateZ, rotate, fillBox, viewBox, flat, preserve3d, deg, rad, grad, turn) where
 
 {-| Functions for building stylesheets.
 
@@ -12,7 +12,7 @@ module Css (stylesheet, mixin, all, custom, important, ($), (#), (.), (@), (|$),
 @docs (|$), (>$), (>>$), (+$), (~$), (>#), (>>#), (+#), (~#), (>.), (>>.), (+.), (~.)
 
 # Attributes
-@docs transformStyle, transformBox, transform, transforms, currentColor, underline, overline, lineThrough, textDecoration, textDecoration2, textDecoration3, textDecorationLine, textDecorations, textDecorations2, textDecorations3, textDecorationLine, textDecorationLines, textDecorationStyle, capitalize, uppercase, lowercase, fullWidth, hanging, eachLine, textIndent, textIndent2, textIndent3, clip, ellipsis, textOverflow, textRendering, textTransform, textAlign, textAlignLast, left, right, center, textJustify, justifyAll, start, end, matchParent, true, verticalAlign, display, opacity, width, minWidth, height, minHeight, padding, padding2, padding3, padding4, paddingTop, paddingBottom, paddingRight, paddingLeft, paddingBlockStart, paddingBlockEnd, paddingInlineStart, paddingInlineEnd, margin, margin2, margin3, margin4, marginTop, marginBottom, marginRight, marginLeft, marginBlockStart, marginBlockEnd, marginInlineStart, marginInlineEnd, boxSizing, overflowX, overflowY, whiteSpace, backgroundColor, color, media, textShadow, textShadow2, textShadow3, textShadow4, outline
+@docs transformStyle, transformBox, transform, transforms, currentColor, underline, overline, lineThrough, textDecoration, textDecoration2, textDecoration3, textDecorationLine, textDecorations, textDecorations2, textDecorations3, textDecorationLine, textDecorationLines, textDecorationStyle, capitalize, uppercase, lowercase, fullWidth, hanging, eachLine, textIndent, textIndent2, textIndent3, clip, ellipsis, textOverflow, textRendering, textTransform, textAlign, textAlignLast, left, right, center, textJustify, justifyAll, start, end, matchParent, true, verticalAlign, display, opacity, width, minWidth, height, minHeight, padding, padding2, padding3, padding4, paddingTop, paddingBottom, paddingRight, paddingLeft, paddingBlockStart, paddingBlockEnd, paddingInlineStart, paddingInlineEnd, margin, margin2, margin3, margin4, marginTop, marginBottom, marginRight, marginLeft, marginBlockStart, marginBlockEnd, marginInlineStart, marginInlineEnd, boxSizing, overflowX, overflowY, whiteSpace, backgroundColor, color, media, textShadow, textShadow2, textShadow3, textShadow4
 
 # Values
 @docs all, important, custom, (~), solid, transparent, rgb, rgba, hex, borderColor, borderColor2, borderColor3, borderColor4, borderBottomLeftRadius, borderBottomLeftRadius2, borderBottomRightRadius, borderBottomRightRadius2, borderTopLeftRadius, borderTopLeftRadius2, borderTopRightRadius, borderTopRightRadius2, borderRadius, borderRadius2, borderRadius3, borderRadius4, borderBottomWidth, borderInlineEndWidth, borderLeftWidth, borderRightWidth, borderTopWidth, borderBlockEndStyle, borderBlockStartStyle, borderInlineEndStyle, borderBottomStyle, borderInlineStartStyle, borderLeftStyle, borderRightStyle, borderTopStyle, borderStyle, borderBlockStartColor, borderBlockEndColor, borderBottomColor, borderInlineStartColor, borderInlineEndColor, borderLeftColor, borderRightColor, borderTopColor, borderBox, border, border2, border3, borderTop, borderTop2, borderTop3, borderBottom, borderBottom2, borderBottom3, borderLeft, borderLeft2, borderLeft3, borderRight, borderRight2, borderRight3, borderBlockEnd, borderBlockEnd2, borderBlockEnd3, borderBlockStart, borderBlockStart2, borderBlockStart3, borderInlineEnd, borderInlineEnd2, borderInlineEnd3, borderInlineStart, borderInlineStart2, borderInlineStart3, borderImageOutset, borderImageOutset2, borderImageOutset3, borderImageOutset4, borderImageWidth, borderImageWidth2, borderImageWidth3, borderImageWidth4, visible, block, inlineBlock, inline, none, auto, inherit, unset, initial, noWrap, top, static, fixed, sticky, relative, absolute, position, bottom, middle, baseline, sub, super, textTop, textBottom, hidden, dotted, dashed, solid, double, groove, ridge, inset, outset, matrix, matrix3d, perspective, rotate3d, rotateX, rotateY, rotateZ, scale, scale2, scale3d, scaleX, scaleY, skew, skew2, skewX, skewY, translate, translate2, translate3d, translateX, translateY, translateZ, rotate, fillBox, viewBox, flat, preserve3d
@@ -45,6 +45,11 @@ import Style exposing (Style(..))
 import String
 
 
+type Compatible
+    = Compatible
+
+
+
 -- TODO these are just for @media - maybe improve type guarantees?
 
 
@@ -62,146 +67,12 @@ print =
 {- Length -}
 
 
-cssFunction : String -> (a -> String) -> List a -> String
-cssFunction funcName converter args =
-    args
-        |> List.map converter
-        |> String.join ", "
-        |> (++) (funcName ++ "(")
-        |> (flip (++)) ")"
-
-
-propertyValueToString : (a -> String) -> PropertyValue a -> String
-propertyValueToString translate value =
-    case value of
-        Inherit ->
-            "inherit"
-
-        Initial ->
-            "initial"
-
-        Unset ->
-            "unset"
-
-        ExplicitValue notInherit ->
-            translate notInherit
-
-
-autoToString : (a -> String) -> AutoOr a -> String
-autoToString translate value =
-    case value of
-        Auto ->
-            "auto"
-
-        NotAuto notAuto ->
-            translate notAuto
-
-
-noneToString : (a -> String) -> NoneOr a -> String
-noneToString translate value =
-    case value of
-        None ->
-            "none"
-
-        NotNone notNone ->
-            translate notNone
-
-
-absoluteNoneToString : None -> String
-absoluteNoneToString =
-    (\_ -> "")
-        |> noneToString
-        |> propertyValueToString
-
-
-lengthToString : Length -> String
-lengthToString =
-    (\(ExplicitLength str) -> str)
-        |> autoToString
-        |> propertyValueToString
-
-
-angleToString : Angle -> String
-angleToString =
-    (\(ExplicitAngle str) -> str)
-        |> propertyValueToString
-
-
-transformListToString : List Transform -> String
-transformListToString list =
-    case list of
-        [] ->
-            "none"
-
-        _ ->
-            list
-                |> List.map (\(Transform str) -> str)
-                |> String.join " "
-
-
-lengthOrNumberToString : LengthOrNumber -> String
-lengthOrNumberToString =
-    lengthToString
-
-
-borderStyleToString : BorderStyle -> String
-borderStyleToString =
-    (\(ExplicitBorderStyle str) -> str)
-        |> noneToString
-        |> propertyValueToString
-
-
-textRenderingToString : TextRendering -> String
-textRenderingToString =
-    (\(ExplicitTextRendering str) -> str)
-        |> autoToString
-        |> propertyValueToString
-
-
-textTransformToString : TextTransform -> String
-textTransformToString =
-    (\(ExplicitTextTransform str) -> str)
-        |> noneToString
-        |> propertyValueToString
-
-
-textOverflowToString : TextOverflow -> String
-textOverflowToString =
-    (\(ExplicitTextOverflow str) -> str)
-        |> propertyValueToString
-
-
-textIndentToString : TextIndent -> String
-textIndentToString =
-    (\(ExplicitTextIndent str) -> str)
-        |> propertyValueToString
-
-
-boxSizingToString : BoxSizing -> String
-boxSizingToString =
-    (\(ExplicitBoxSizing str) -> str)
-        |> borderBoxToString
-        |> propertyValueToString
-
-
-overflowToString : Overflow -> String
-overflowToString =
-    (\(ExplicitOverflow str) -> str)
-        |> autoToString
-        |> propertyValueToString
-
-
-displayToString : Display -> String
-displayToString =
-    (\(ExplicitDisplay str) -> str)
-        |> noneToString
-        |> propertyValueToString
-
-
-positionToString : Position -> String
-positionToString =
-    (\(ExplicitPosition str) -> str)
-        |> propertyValueToString
+cssFunction : String -> List String -> String
+cssFunction funcName args =
+    funcName
+        ++ "("
+        ++ (String.join ", " args)
+        ++ ")"
 
 
 {-| Caution: trickery ahead!
@@ -297,189 +168,144 @@ getLast list =
             getLast rest
 
 
-whiteSpaceToString : WhiteSpace -> String
-whiteSpaceToString =
-    (\(ExplicitWhiteSpace str) -> str)
-        |> autoToString
-        |> propertyValueToString
+type alias Value compatible =
+    { compatible | value : String }
 
 
-textDecorationStyleToString : TextDecorationStyle -> String
-textDecorationStyleToString =
-    borderStyleToString
+type alias All compatible =
+    { compatible | value : String, all : Compatible }
 
 
-textDecorationLinesToString : List TextDecorationLine -> String
-textDecorationLinesToString list =
-    list
-        |> List.map textDecorationLineToString
-        |> String.join " "
+type alias Number compatible =
+    { compatible | value : String, number : Compatible }
 
 
-textDecorationLineToString : TextDecorationLine -> String
-textDecorationLineToString =
-    (\(ExplicitTextDecorationLine str) -> str)
-        |> noneToString
-        |> propertyValueToString
+type alias None compatible =
+    { compatible | value : String, none : Compatible }
 
 
-colorToString : Color -> String
-colorToString =
-    (\(ExplicitColor str) -> str)
-        |> transparentToString
-        |> autoToString
-        |> propertyValueToString
+{-| https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-line#Values
+-}
+type alias TextDecorationLine compatible =
+    { compatible | value : String, textDecorationLine : Compatible }
 
 
-numberToString : number -> String
-numberToString num =
-    toString (num + 0)
+{-| https://developer.mozilla.org/en-US/docs/Web/CSS/box-sizing#Values
+-}
+type alias BoxSizing compatible =
+    { compatible | value : String, boxSizing : Compatible }
 
 
-textShadowToString : TextShadow -> String
-textShadowToString =
-    explicitTextShadowToString
-        |> noneToString
-        |> propertyValueToString
+{-| https://developer.mozilla.org/en-US/docs/Web/CSS/overflow#Values
+-}
+type alias Overflow compatible =
+    { compatible | value : String, overflow : Compatible }
 
 
-explicitTextShadowToString : ExplicitTextShadow -> String
-explicitTextShadowToString value =
-    case value of
-        NoTextShadow ->
-            "TODO"
+{-| https://developer.mozilla.org/en-US/docs/Web/CSS/display#Values
+-}
+type alias Display compatible =
+    { compatible | value : String, display : Compatible }
 
 
-explicitOpacityStyleToString : ExplicitOpacityStyle -> String
-explicitOpacityStyleToString (ExplicitOpacityStyle str) =
-    str
+{-| https://developer.mozilla.org/en-US/docs/Web/CSS/white-space#Values
+-}
+type alias WhiteSpace compatible =
+    { compatible | value : String, whiteSpace : Compatible }
 
 
-transparentToString : (a -> String) -> TransparentOr a -> String
-transparentToString translate value =
-    case value of
-        Transparent ->
-            "transparent"
+{-| https://developer.mozilla.org/en-US/docs/Web/CSS/color#Values
+-}
+type alias Color compatible =
+    { compatible | value : String, color : Compatible }
 
-        NotTransparent notTransparent ->
-            translate notTransparent
 
+{-| https://developer.mozilla.org/en-US/docs/Web/CSS/length
+-}
+type alias Length compatible =
+    { compatible | value : String, length : Compatible }
 
-transformBoxToString : TransformBox -> String
-transformBoxToString =
-    (\(ExplicitTransformBox str) -> str)
-        |> borderBoxToString
-        |> propertyValueToString
 
+{-| https://developer.mozilla.org/en-US/docs/Web/CSS/length
+-}
+type alias LengthOrAuto compatible =
+    { compatible | value : String, lengthOrAuto : Compatible }
 
-transformStyleToString : TransformStyle -> String
-transformStyleToString =
-    (\(ExplicitTransformStyle str) -> str)
-        |> propertyValueToString
 
+{-| https://developer.mozilla.org/en-US/docs/Web/CSS/length
+-}
+type alias LengthOrNumber compatible =
+    { compatible | value : String, lengthOrNumber : Compatible }
 
-borderBoxToString : (a -> String) -> BorderBoxOr a -> String
-borderBoxToString translate value =
-    case value of
-        BorderBox ->
-            "border-box"
 
-        NotBorderBox notBorderBox ->
-            translate notBorderBox
+type alias ExplicitLength =
+    LengthOrAuto (LengthOrNumber (Length (TextIndent {})))
 
 
-opacityStyleToString : OpacityStyle -> String
-opacityStyleToString =
-    explicitOpacityStyleToString
-        |> transparentToString
-        |> propertyValueToString
+{-| https://developer.mozilla.org/en-US/docs/Web/CSS/transform#Values
+-}
+type alias Transform compatible =
+    { compatible | value : String, transform : Compatible }
 
 
-type PropertyValue a
-    = Inherit
-    | Unset
-    | Initial
-    | ExplicitValue a
+{-| https://developer.mozilla.org/en-US/docs/Web/CSS/angle
+-}
+type alias Angle compatible =
+    { compatible | value : String, angle : Compatible }
 
 
-type TransparentOr a
-    = Transparent
-    | NotTransparent a
+{-| https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-style#Values
+-}
+type alias TextDecorationStyle compatible =
+    { compatible | value : String, textDecorationStyle : Compatible }
 
 
-type AutoOr a
-    = Auto
-    | NotAuto a
+{-| https://developer.mozilla.org/en-US/docs/Web/CSS/position#Values
+-}
+type alias Position compatible =
+    { compatible | value : String, position : Compatible }
 
 
-type NoneOr a
-    = None
-    | NotNone a
+{-| https://developer.mozilla.org/en-US/docs/Web/CSS/border-style#Values
+-}
+type alias BorderStyle compatible =
+    { compatible | value : String, borderStyle : Compatible }
 
 
-type BorderBoxOr a
-    = BorderBox
-    | NotBorderBox a
+{-| https://developer.mozilla.org/en-US/docs/Web/CSS/transform-box#Values
+-}
+type alias TransformBox compatible =
+    { compatible | value : String, transformBox : Compatible }
 
 
-type UninhabitableType
-    = UninhabitableType UninhabitableType
+{-| https://developer.mozilla.org/en-US/docs/Web/CSS/transform-style#Values
+-}
+type alias TransformStyle compatible =
+    { compatible | value : String, transformStyle : Compatible }
 
 
-type alias None =
-    PropertyValue (NoneOr UninhabitableType)
+{-| https://developer.mozilla.org/en-US/docs/Web/CSS/text-indent#Values
+-}
+type alias TextIndent compatible =
+    { compatible | value : String, textIndent : Compatible }
 
 
-type alias TextDecorationLine =
-    PropertyValue (NoneOr ExplicitTextDecorationLine)
+{-| https://developer.mozilla.org/en-US/docs/Web/CSS/text-overflow#Values
+-}
+type alias TextOverflow compatible =
+    { compatible | value : String, textOverflow : Compatible }
 
 
-type alias BoxSizing =
-    PropertyValue (BorderBoxOr ExplicitBoxSizing)
+{-| https://developer.mozilla.org/en-US/docs/Web/CSS/text-transform#Values
+-}
+type alias TextTransform compatible =
+    { compatible | value : String, textTransform : Compatible }
 
 
-type alias Overflow =
-    PropertyValue (AutoOr ExplicitOverflow)
-
-
-type alias Display =
-    PropertyValue (NoneOr ExplicitDisplay)
-
-
-type alias WhiteSpace =
-    PropertyValue (AutoOr ExplicitWhiteSpace)
-
-
-type alias Color =
-    PropertyValue (AutoOr (TransparentOr ExplicitColor))
-
-
-type alias TextShadow =
-    PropertyValue (NoneOr ExplicitTextShadow)
-
-
-type alias Outline =
-    PropertyValue ExplicitOutline
-
-
-type alias OpacityStyle =
-    PropertyValue (TransparentOr ExplicitOpacityStyle)
-
-
-type alias LengthOrAuto =
-    PropertyValue (AutoOr ExplicitLength)
-
-
-type alias Length =
-    LengthOrAuto
-
-
-type Transform
-    = Transform String
-
-
-type alias Angle =
-    PropertyValue ExplicitAngle
+{-| https://developer.mozilla.org/en-US/docs/Web/CSS/text-rendering#Values
+-}
+type alias TextRendering compatible =
+    { compatible | value : String, textRendering : Compatible }
 
 
 
@@ -492,8 +318,8 @@ that it will return the desired String as its key, and use that as our value.
 -}
 
 
-type alias TextAlign namespace animation class id =
-    Length -> Property namespace animation class id
+type alias TextAlign namespace animation class id a =
+    Length a -> Property namespace animation class id
 
 
 
@@ -506,136 +332,12 @@ that it will return the desired String as its key, and use that as our value.
 -}
 
 
-type alias VerticalAlign namespace animation class id =
-    Length -> Property namespace animation class id
+type alias VerticalAlign namespace animation class id a =
+    Length a -> Property namespace animation class id
 
 
 type alias Property namespace animation class id =
     Style namespace animation class id
-
-
-{-| Although not many propeties accept either a length or a number,
-there's no way to type check them separately. Having a separate type
-alias is at least more self-documenting.
--}
-type alias LengthOrNumber =
-    Length
-
-
-type alias TextDecorationStyle =
-    BorderStyle
-
-
-type alias Position =
-    PropertyValue ExplicitPosition
-
-
-type alias BorderStyle =
-    PropertyValue (NoneOr ExplicitBorderStyle)
-
-
-type alias TransformBox =
-    PropertyValue (BorderBoxOr ExplicitTransformBox)
-
-
-type alias TransformStyle =
-    PropertyValue ExplicitTransformStyle
-
-
-type ExplicitTransformBox
-    = ExplicitTransformBox String
-
-
-type ExplicitTransformStyle
-    = ExplicitTransformStyle String
-
-
-type alias TextIndent =
-    PropertyValue ExplicitTextIndent
-
-
-type alias TextOverflow =
-    PropertyValue ExplicitTextOverflow
-
-
-type alias TextTransform =
-    PropertyValue (NoneOr ExplicitTextTransform)
-
-
-type alias TextRendering =
-    PropertyValue (AutoOr ExplicitTextRendering)
-
-
-type ExplicitTextIndent
-    = ExplicitTextIndent String
-
-
-type ExplicitTextOverflow
-    = ExplicitTextOverflow String
-
-
-type ExplicitTextRendering
-    = ExplicitTextRendering String
-
-
-type ExplicitTextTransform
-    = ExplicitTextTransform String
-
-
-type ExplicitPosition
-    = ExplicitPosition String
-
-
-type ExplicitTextDecorationLine
-    = ExplicitTextDecorationLine String
-
-
-type ExplicitLength
-    = ExplicitLength String
-
-
-type ExplicitBoxSizing
-    = ExplicitBoxSizing String
-
-
-type ExplicitOverflow
-    = ExplicitOverflow String
-
-
-type ExplicitDisplay
-    = ExplicitDisplay String
-
-
-type ExplicitWhiteSpace
-    = ExplicitWhiteSpace String
-
-
-type ExplicitColor
-    = ExplicitColor String
-
-
-type ExplicitBorderStyle
-    = ExplicitBorderStyle String
-
-
-type ExplicitVerticalAlign
-    = ExplicitVerticalAlign String
-
-
-type ExplicitOutline
-    = ExplicitOutline Float ExplicitLength BorderStyle OpacityStyle
-
-
-type ExplicitOpacityStyle
-    = ExplicitOpacityStyle String
-
-
-type ExplicitTextShadow
-    = NoTextShadow
-
-
-type ExplicitAngle
-    = ExplicitAngle String
 
 
 
@@ -644,9 +346,9 @@ type ExplicitAngle
 
 {-| An [`all`](https://developer.mozilla.org/en-US/docs/Web/CSS/all) property.
 -}
-all : PropertyValue String -> Property namespace animation class id
+all : All compatible -> Property namespace animation class id
 all =
-    prop1 "all" (propertyValueToString (\_ -> ""))
+    prop1 "all"
 
 
 {-| Transforms the given property by adding !important to the end of its
@@ -679,54 +381,135 @@ important style =
 
 {-| A [`transparent`](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value#transparent_keyword) color.
 -}
-transparent : OpacityStyle
+transparent : Color {}
 transparent =
-    Transparent |> ExplicitValue
+    { value = "transparent"
+    , color = Compatible
+    }
 
 
 {-| The [`currentColor`](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value#currentColor_keyword)
     value.
 -}
-currentColor : Color
+currentColor : Color {}
 currentColor =
-    ExplicitColor "currentColor"
-        |> NotTransparent
-        |> NotAuto
-        |> ExplicitValue
+    { value = "currentColor"
+    , color = Compatible
+    }
+
+
+{-| The `visible` value for the [`overflow`](https://developer.mozilla.org/en-US/docs/Web/CSS/overflow#Values) property.
+-}
+visible : Overflow {}
+visible =
+    { value = "visible"
+    , overflow = Compatible
+    }
+
+
+{-| The `scroll` [`overflow`](https://developer.mozilla.org/en-US/docs/Web/CSS/overflow#Values) value.
+-}
+scroll : Overflow {}
+scroll =
+    { value = "scroll"
+    , overflow = Compatible
+    }
+
+
+{-| `hidden` [`overflow`](https://developer.mozilla.org/en-US/docs/Web/CSS/overflow#Values) value.
+
+This can also represent a `hidden` [border style](https://developer.mozilla.org/en-US/docs/Web/CSS/border-style#Values).
+-}
+hidden : Overflow (BorderStyle {})
+hidden =
+    { value = "hidden"
+    , overflow = Compatible
+    , borderStyle = Compatible
+    }
+
+
+{-| The [`unset`](https://developer.mozilla.org/en-US/docs/Web/CSS/unset) value.
+Any CSS property can be set to this value.
+-}
+unset :
+    { all : Compatible
+    , boxSizing : Compatible
+    , display : Compatible
+    , none : Compatible
+    , overflow : Compatible
+    , textDecorationLine : Compatible
+    , value : String
+    }
+unset =
+    { initial | value = "unset" }
+
+
+{-| The [`inherit`](https://developer.mozilla.org/en-US/docs/Web/CSS/inherit) value.
+Any CSS property can be set to this value.
+-}
+inherit :
+    { all : Compatible
+    , boxSizing : Compatible
+    , display : Compatible
+    , none : Compatible
+    , overflow : Compatible
+    , textDecorationLine : Compatible
+    , value : String
+    }
+inherit =
+    { initial | value = "inherit" }
+
+
+{-| The [`initial`](https://developer.mozilla.org/en-US/docs/Web/CSS/initial) value.
+Any CSS property can be set to this value.
+-}
+initial :
+    { all : Compatible
+    , boxSizing : Compatible
+    , display : Compatible
+    , none : Compatible
+    , overflow : Compatible
+    , textDecorationLine : Compatible
+    , value : String
+    }
+initial =
+    { value = "initial"
+    , overflow = Compatible
+    , none = Compatible
+    , textDecorationLine = Compatible
+    , boxSizing = Compatible
+    , display = Compatible
+    , all = Compatible
+    }
 
 
 {-| [RGB color value](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value#rgb())
     in functional notation.
 -}
-rgb : number -> number -> number -> Color
+rgb : number -> number -> number -> Color {}
 rgb r g b =
-    cssFunction "rgb" numberToString [ r, g, b ]
-        |> ExplicitColor
-        |> NotTransparent
-        |> NotAuto
-        |> ExplicitValue
+    { value = cssFunction "rgb" (List.map numberToString [ r, g, b ])
+    , color = Compatible
+    }
 
 
 {-| [RGBA color value](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value#rgba()).
 -}
-rgba : number -> number -> number -> number -> Color
+rgba : number -> number -> number -> number -> Color {}
 rgba r g b a =
-    cssFunction "rgba" numberToString [ r, g, b, a ]
-        |> ExplicitColor
-        |> NotTransparent
-        |> NotAuto
-        |> ExplicitValue
+    { value = cssFunction "rgba" (List.map numberToString [ r, g, b, a ])
+    , color = Compatible
+    }
 
 
 {-| [RGB color value](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value#rgb())
     in hexadecimal notation.
 -}
-hex : String -> Color
+hex : String -> Color {}
 hex str =
-    ExplicitColor ("#" ++ str)
-        |> NotTransparent
-        |> NotAuto
-        |> ExplicitValue
+    { value = "#" ++ str
+    , color = Compatible
+    }
 
 
 
@@ -735,29 +518,29 @@ hex str =
 
 {-| `optimizeSpeed` [`text-rendering`](https://developer.mozilla.org/en-US/docs/Web/CSS/text-rendering#Values) value
 -}
-optimizeSpeed : TextRendering
+optimizeSpeed : TextRendering {}
 optimizeSpeed =
-    ExplicitTextRendering "optimizeSpeed"
-        |> NotAuto
-        |> ExplicitValue
+    { value = "optimizeSpeed"
+    , textRendering = Compatible
+    }
 
 
 {-| `optimizeLegibility` [`text-rendering`](https://developer.mozilla.org/en-US/docs/Web/CSS/text-rendering#Values) value
 -}
-optimizeLegibility : TextRendering
+optimizeLegibility : TextRendering {}
 optimizeLegibility =
-    ExplicitTextRendering "optimizeLegibility"
-        |> NotAuto
-        |> ExplicitValue
+    { value = "optimizeLegibility"
+    , textRendering = Compatible
+    }
 
 
 {-| `geometricPrecision` [`text-rendering`](https://developer.mozilla.org/en-US/docs/Web/CSS/text-rendering#Values) value
 -}
-geometricPrecision : TextRendering
+geometricPrecision : TextRendering {}
 geometricPrecision =
-    ExplicitTextRendering "geometricPrecision"
-        |> NotAuto
-        |> ExplicitValue
+    { value = "geometricPrecision"
+    , textRendering = Compatible
+    }
 
 
 
@@ -766,18 +549,20 @@ geometricPrecision =
 
 {-| `hanging` [`hanging`](https://developer.mozilla.org/en-US/docs/Web/CSS/hanging#Values) value
 -}
-hanging : TextIndent
+hanging : TextIndent {}
 hanging =
-    ExplicitTextIndent "hanging"
-        |> ExplicitValue
+    { value = "hanging"
+    , textIndent = Compatible
+    }
 
 
 {-| `each-line` [`text-indent`](https://developer.mozilla.org/en-US/docs/Web/CSS/text-indent#Values) value
 -}
-eachLine : TextIndent
+eachLine : TextIndent {}
 eachLine =
-    ExplicitTextIndent "each-line"
-        |> ExplicitValue
+    { value = "each-line"
+    , textIndent = Compatible
+    }
 
 
 
@@ -786,128 +571,145 @@ eachLine =
 
 {-| `capitalize` [`text-transform`](https://developer.mozilla.org/en-US/docs/Web/CSS/text-transform#Values) value
 -}
-capitalize : TextTransform
+capitalize : TextTransform {}
 capitalize =
-    ExplicitTextTransform "capitalize"
-        |> NotNone
-        |> ExplicitValue
+    { value = "capitalize"
+    , textTransform = Compatible
+    }
 
 
 {-| `uppercase` [`text-transform`](https://developer.mozilla.org/en-US/docs/Web/CSS/text-transform#Values) value
 -}
-uppercase : TextTransform
+uppercase : TextTransform {}
 uppercase =
-    ExplicitTextTransform "uppercase"
-        |> NotNone
-        |> ExplicitValue
+    { value = "uppercase"
+    , textTransform = Compatible
+    }
 
 
 {-| `lowercase` [`text-transform`](https://developer.mozilla.org/en-US/docs/Web/CSS/text-transform#Values) value
 -}
-lowercase : TextTransform
+lowercase : TextTransform {}
 lowercase =
-    ExplicitTextTransform "lowercase"
-        |> NotNone
-        |> ExplicitValue
+    { value = "lowercase"
+    , textTransform = Compatible
+    }
 
 
 {-| `full-width` [`text-transform`](https://developer.mozilla.org/en-US/docs/Web/CSS/text-transform#Values) value
 -}
-fullWidth : TextTransform
+fullWidth : TextTransform {}
 fullWidth =
-    ExplicitTextTransform "fullWidth"
-        |> NotNone
-        |> ExplicitValue
+    { value = "full-width"
+    , textTransform = Compatible
+    }
 
 
 {-| `ellipsis` [`text-overflow`](https://developer.mozilla.org/en-US/docs/Web/CSS/text-overflow#Values) value
 -}
-ellipsis : TextOverflow
+ellipsis : TextOverflow {}
 ellipsis =
-    ExplicitTextOverflow "ellipsis"
-        |> ExplicitValue
+    { value = "ellipsis"
+    , textOverflow = Compatible
+    }
 
 
 {-| `clip` [`text-overflow`](https://developer.mozilla.org/en-US/docs/Web/CSS/text-overflow#Values) value
 -}
-clip : TextOverflow
+clip : TextOverflow {}
 clip =
-    ExplicitTextOverflow "clip"
-        |> ExplicitValue
+    { value = "clip"
+    , textOverflow = Compatible
+    }
 
 
 
 {- BORDER STYLE -}
 
 
-{-| A `hidden` [border style](https://developer.mozilla.org/en-US/docs/Web/CSS/border-style#Values).
--}
-hidden : BorderStyle
-hidden =
-    "hidden" |> ExplicitBorderStyle |> NotNone |> ExplicitValue
-
-
 {-| A `wavy` [text decoration style](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-style#Values).
 -}
-wavy : TextDecorationStyle
+wavy : TextDecorationStyle {}
 wavy =
-    "wavy" |> ExplicitBorderStyle |> NotNone |> ExplicitValue
+    { value = "wavy"
+    , textDecorationStyle = Compatible
+    }
 
 
 {-| A `dotted` [border style](https://developer.mozilla.org/en-US/docs/Web/CSS/border-style#Values).
 -}
-dotted : BorderStyle
+dotted : BorderStyle (TextDecorationStyle {})
 dotted =
-    "dotted" |> ExplicitBorderStyle |> NotNone |> ExplicitValue
+    { value = "dotted"
+    , borderStyle = Compatible
+    , textDecorationStyle = Compatible
+    }
 
 
 {-| A `dashed` [border style](https://developer.mozilla.org/en-US/docs/Web/CSS/border-style#Values).
 -}
-dashed : BorderStyle
+dashed : BorderStyle (TextDecorationStyle {})
 dashed =
-    "dashed" |> ExplicitBorderStyle |> NotNone |> ExplicitValue
+    { value = "dashed"
+    , borderStyle = Compatible
+    , textDecorationStyle = Compatible
+    }
 
 
 {-| A `solid` [border style](https://developer.mozilla.org/en-US/docs/Web/CSS/border-style#Values).
 -}
-solid : BorderStyle
+solid : BorderStyle (TextDecorationStyle {})
 solid =
-    "solid" |> ExplicitBorderStyle |> NotNone |> ExplicitValue
+    { value = "solid"
+    , borderStyle = Compatible
+    , textDecorationStyle = Compatible
+    }
 
 
 {-| A `double` [border style](https://developer.mozilla.org/en-US/docs/Web/CSS/border-style#Values).
 -}
-double : BorderStyle
+double : BorderStyle (TextDecorationStyle {})
 double =
-    "double" |> ExplicitBorderStyle |> NotNone |> ExplicitValue
+    { value = "double"
+    , borderStyle = Compatible
+    , textDecorationStyle = Compatible
+    }
 
 
 {-| A `groove` [border style](https://developer.mozilla.org/en-US/docs/Web/CSS/border-style#Values).
 -}
-groove : BorderStyle
+groove : BorderStyle {}
 groove =
-    "groove" |> ExplicitBorderStyle |> NotNone |> ExplicitValue
+    { value = "groove"
+    , borderStyle = Compatible
+    }
 
 
 {-| A `ridge` [border style](https://developer.mozilla.org/en-US/docs/Web/CSS/border-style#Values).
 -}
-ridge : BorderStyle
+ridge : BorderStyle {}
 ridge =
-    "ridge" |> ExplicitBorderStyle |> NotNone |> ExplicitValue
+    { value = "ridge"
+    , borderStyle = Compatible
+    }
 
 
 {-| An `inset` [border style](https://developer.mozilla.org/en-US/docs/Web/CSS/border-style#Values).
 -}
-inset : BorderStyle
+inset : BorderStyle {}
 inset =
-    "inset" |> ExplicitBorderStyle |> NotNone |> ExplicitValue
+    { value = "inset"
+    , borderStyle = Compatible
+    }
 
 
 {-| An `outset` [border style](https://developer.mozilla.org/en-US/docs/Web/CSS/border-style#Values).
 -}
-outset : BorderStyle
+outset : BorderStyle {}
 outset =
-    "outset" |> ExplicitBorderStyle |> NotNone |> ExplicitValue
+    { value = "outset"
+    , borderStyle = Compatible
+    }
 
 
 
@@ -916,62 +718,65 @@ outset =
 
 {-| `center` [alignment](https://developer.mozilla.org/en-US/docs/Web/CSS/text-align).
 -}
-center : TextAlign namespace animation class id
+center : TextAlign namespace animation class id a
 center =
-    prop1 "center" lengthToString
+    prop1 "center"
 
 
 {-| `text-justify` [alignment](https://developer.mozilla.org/en-US/docs/Web/CSS/text-align).
 -}
-textJustify : TextAlign namespace animation class id
+textJustify : TextAlign namespace animation class id a
 textJustify =
-    prop1 "text-justify" lengthToString
+    prop1 "text-justify"
 
 
 {-| `justify-all` [alignment](https://developer.mozilla.org/en-US/docs/Web/CSS/text-align).
 -}
-justifyAll : TextAlign namespace animation class id
+justifyAll : TextAlign namespace animation class id a
 justifyAll =
-    prop1 "justify-all" lengthToString
+    prop1 "justify-all"
 
 
 {-| `start` [alignment](https://developer.mozilla.org/en-US/docs/Web/CSS/text-align).
 -}
-start : TextAlign namespace animation class id
+start : TextAlign namespace animation class id a
 start =
-    prop1 "start" lengthToString
+    prop1 "start"
 
 
 {-| `end` [alignment](https://developer.mozilla.org/en-US/docs/Web/CSS/text-align).
 -}
-end : TextAlign namespace animation class id
+end : TextAlign namespace animation class id a
 end =
-    prop1 "end" lengthToString
+    prop1 "end"
 
 
 {-| `match-parent` [alignment](https://developer.mozilla.org/en-US/docs/Web/CSS/text-align).
 -}
-matchParent : TextAlign namespace animation class id
+matchParent : TextAlign namespace animation class id a
 matchParent =
-    prop1 "match-parent" lengthToString
+    prop1 "match-parent"
 
 
 {-| `true` [alignment](https://developer.mozilla.org/en-US/docs/Web/CSS/text-align).
 -}
-true : TextAlign namespace animation class id
+true : TextAlign namespace animation class id a
 true =
-    prop1 "true" lengthToString
+    prop1 "true"
 
 
 
 {- LENGTHS -}
 
 
-lengthConverter : String -> number -> Length
+lengthConverter : String -> number -> ExplicitLength
 lengthConverter suffix num =
-    ExplicitLength ((numberToString num) ++ suffix)
-        |> NotAuto
-        |> ExplicitValue
+    { value = (numberToString num) ++ suffix
+    , length = Compatible
+    , lengthOrAuto = Compatible
+    , lengthOrNumber = Compatible
+    , textIndent = Compatible
+    }
 
 
 {-| Convenience length value that compiles to 0 with no units.
@@ -985,91 +790,96 @@ lengthConverter suffix num =
         padding: 0;
     }
 -}
-zero : Length
+zero : Length (LengthOrNumber (LengthOrAuto (Number {})))
 zero =
-    "0" |> ExplicitLength |> NotAuto |> ExplicitValue
+    { value = "0"
+    , length = Compatible
+    , lengthOrNumber = Compatible
+    , lengthOrAuto = Compatible
+    , number = Compatible
+    }
 
 
 {-| [`pct`](https://developer.mozilla.org/en-US/docs/Web/CSS/length#pct) units.
 -}
-pct : number -> Length
+pct : number -> ExplicitLength
 pct =
     lengthConverter "%"
 
 
 {-| [`em`](https://developer.mozilla.org/en-US/docs/Web/CSS/length#em) units.
 -}
-em : number -> Length
+em : number -> ExplicitLength
 em =
     lengthConverter "em"
 
 
 {-| [`ex`](https://developer.mozilla.org/en-US/docs/Web/CSS/length#ex) units.
 -}
-ex : number -> Length
+ex : number -> ExplicitLength
 ex =
     lengthConverter "ex"
 
 
 {-| [`ch`](https://developer.mozilla.org/en-US/docs/Web/CSS/length#ch) units.
 -}
-ch : number -> Length
+ch : number -> ExplicitLength
 ch =
     lengthConverter "ch"
 
 
 {-| [`rem`](https://developer.mozilla.org/en-US/docs/Web/CSS/length#rem) units.
 -}
-rem : number -> Length
+rem : number -> ExplicitLength
 rem =
     lengthConverter "rem"
 
 
 {-| [`vh`](https://developer.mozilla.org/en-US/docs/Web/CSS/length#vh) units.
 -}
-vh : number -> Length
+vh : number -> ExplicitLength
 vh =
     lengthConverter "vh"
 
 
 {-| [`vw`](https://developer.mozilla.org/en-US/docs/Web/CSS/length#vw) units.
 -}
-vw : number -> Length
+vw : number -> ExplicitLength
 vw =
     lengthConverter "vw"
 
 
 {-| [`vmin`](https://developer.mozilla.org/en-US/docs/Web/CSS/length#vmin) units.
 -}
-vmin : number -> Length
+vmin : number -> ExplicitLength
 vmin =
     lengthConverter "vmin"
 
 
 {-| [`vmax`](https://developer.mozilla.org/en-US/docs/Web/CSS/length#vmax) units.
 -}
-vmax : number -> Length
+vmax : number -> ExplicitLength
 vmax =
     lengthConverter "vmax"
 
 
 {-| [`px`](https://developer.mozilla.org/en-US/docs/Web/CSS/length#px) units.
 -}
-px : number -> Length
+px : number -> ExplicitLength
 px =
     lengthConverter "px"
 
 
 {-| [`mm`](https://developer.mozilla.org/en-US/docs/Web/CSS/length#mm) units.
 -}
-mm : number -> Length
+mm : number -> ExplicitLength
 mm =
     lengthConverter "mm"
 
 
 {-| [`cm`](https://developer.mozilla.org/en-US/docs/Web/CSS/length#cm) units.
 -}
-cm : number -> Length
+cm : number -> ExplicitLength
 cm =
     lengthConverter "cm"
 
@@ -1078,21 +888,21 @@ cm =
 
 (This is `inches` instead of `in` because `in` is a reserved keyword in Elm.)
 -}
-inches : number -> Length
+inches : number -> ExplicitLength
 inches =
     lengthConverter "in"
 
 
 {-| [`pt`](https://developer.mozilla.org/en-US/docs/Web/CSS/length#pt) units.
 -}
-pt : number -> Length
+pt : number -> ExplicitLength
 pt =
     lengthConverter "pt"
 
 
 {-| [`pc`](https://developer.mozilla.org/en-US/docs/Web/CSS/length#pc) units.
 -}
-pc : number -> Length
+pc : number -> ExplicitLength
 pc =
     lengthConverter "pc"
 
@@ -1100,46 +910,49 @@ pc =
 {-| A unitless number. Useful with properties like [`borderImageOutset`](#borderImageOutset)
 which accept either length units or unitless numbers for some properties.
 -}
-n : number -> LengthOrNumber
-n =
-    lengthConverter ""
+n : number -> LengthOrNumber (Number {})
+n num =
+    { value = numberToString num
+    , lengthOrNumber = Compatible
+    , number = Compatible
+    }
 
 
 
 {- ANGLES -}
 
 
-angleConverter : String -> number -> Angle
+angleConverter : String -> number -> Angle {}
 angleConverter suffix num =
-    ((numberToString num) ++ suffix)
-        |> ExplicitAngle
-        |> ExplicitValue
+    { value = (numberToString num) ++ suffix
+    , angle = Compatible
+    }
 
 
 {-| [`deg`](https://developer.mozilla.org/en-US/docs/Web/CSS/angle#deg) units.
 -}
-deg : number -> Angle
+deg : number -> Angle {}
 deg =
     angleConverter "deg"
 
 
 {-| [`grad`](https://developer.mozilla.org/en-US/docs/Web/CSS/angle#grad) units.
 -}
-grad : number -> Angle
+grad : number -> Angle {}
 grad =
     angleConverter "grad"
 
 
 {-| [`rad`](https://developer.mozilla.org/en-US/docs/Web/CSS/angle#rad) units.
 -}
-rad : number -> Angle
+rad : number -> Angle {}
 rad =
     angleConverter "rad"
 
 
 {-| [`turn`](https://developer.mozilla.org/en-US/docs/Web/CSS/angle#tr) units.
 -}
-turn : number -> Angle
+turn : number -> Angle {}
 turn =
     angleConverter "turn"
 
@@ -1152,83 +965,92 @@ turn =
 
     ~ transform (matrix 0.5 1 1.5 2 2.5 3)
 -}
-matrix : number -> number -> number -> number -> number -> number -> Transform
+matrix : number -> number -> number -> number -> number -> number -> Transform {}
 matrix a b c d tx ty =
-    cssFunction "matrix" numberToString [ a, b, c, d, tx, ty ] |> Transform
+    { value = cssFunction "matrix" (List.map numberToString [ a, b, c, d, tx, ty ])
+    , transform = Compatible
+    }
 
 
 {-| The [`matrix3d()`](https://developer.mozilla.org/en-US/docs/Web/CSS/transform-function#matrix3d()) transform-function.
 
     ~ transform (matrix3d 0.5 1 1.5 2 2.5 3 0.5 1 1.5 2 2.5 3 0.5 1 1.5 2 2.5 3 0.5 1 1.5 2 2.5 3)
 -}
-matrix3d : number -> number -> number -> number -> number -> number -> number -> number -> number -> number -> number -> number -> number -> number -> number -> number -> Transform
+matrix3d : number -> number -> number -> number -> number -> number -> number -> number -> number -> number -> number -> number -> number -> number -> number -> number -> Transform {}
 matrix3d a1 a2 a3 a4 b1 b2 b3 b4 c1 c2 c3 c4 d1 d2 d3 d4 =
-    cssFunction "matrix3d" numberToString [ a1, a2, a3, a4, b1, b2, b3, b4, c1, c2, c3, c4, d1, d2, d3, d4 ]
-        |> Transform
+    { value = cssFunction "matrix3d" (List.map numberToString [ a1, a2, a3, a4, b1, b2, b3, b4, c1, c2, c3, c4, d1, d2, d3, d4 ])
+    , transform = Compatible
+    }
 
 
 {-| The [`perspective()`](https://developer.mozilla.org/en-US/docs/Web/CSS/transform-function#perspective()) transform-function.
 
      transform (perspective 0.5)
 -}
-perspective : number -> Transform
+perspective : number -> Transform {}
 perspective l =
-    cssFunction "perspective" numberToString [ l ] |> Transform
+    { value = cssFunction "perspective" [ numberToString l ]
+    , transform = Compatible
+    }
 
 
 {-| The [`rotate`](https://developer.mozilla.org/en-US/docs/Web/CSS/transform-function#rotate()) transform-function.
 
      transform (rotate (deg 90))
 -}
-rotate : Angle -> Transform
-rotate a =
-    cssFunction "rotate" angleToString [ a ] |> Transform
+rotate : Angle compatible -> Transform {}
+rotate { value } =
+    { value = cssFunction "rotate" [ value ]
+    , transform = Compatible
+    }
 
 
 {-| The [`rotateX`](https://developer.mozilla.org/en-US/docs/Web/CSS/transform-function#rotateX()) transform-function.
 
      transform (rotateX (deg 90))
 -}
-rotateX : Angle -> Transform
-rotateX a =
-    cssFunction "rotateX" angleToString [ a ] |> Transform
+rotateX : Angle compatible -> Transform {}
+rotateX { value } =
+    { value = cssFunction "rotateX" [ value ]
+    , transform = Compatible
+    }
 
 
 {-| The [`rotateY`](https://developer.mozilla.org/en-US/docs/Web/CSS/transform-function#rotateY()) transform-function.
 
      transform (rotateY (deg 90))
 -}
-rotateY : Angle -> Transform
-rotateY a =
-    cssFunction "rotateY" angleToString [ a ] |> Transform
+rotateY : Angle compatible -> Transform {}
+rotateY { value } =
+    { value = cssFunction "rotateY" [ value ]
+    , transform = Compatible
+    }
 
 
 {-| The [`rotateZ`](https://developer.mozilla.org/en-US/docs/Web/CSS/transform-function#rotateZ()) transform-function.
 
      transform (rotateZ (deg 90))
 -}
-rotateZ : Angle -> Transform
-rotateZ a =
-    cssFunction "rotateZ" angleToString [ a ] |> Transform
+rotateZ : Angle compatible -> Transform {}
+rotateZ { value } =
+    { value = cssFunction "rotateZ" [ value ]
+    , transform = Compatible
+    }
 
 
 {-| The [`rotate3d`](https://developer.mozilla.org/en-US/docs/Web/CSS/transform-function#rotate3d()) transform-function.
 
      transform (rotate3d 1 1 1 (deg 90))
 -}
-rotate3d : number -> number -> number -> Angle -> Transform
-rotate3d x y z a =
+rotate3d : number -> number -> number -> Angle compatible -> Transform {}
+rotate3d x y z { value } =
     let
         coordsAsStrings =
             List.map numberToString [ x, y, z ]
-
-        angleAsString =
-            angleToString a
-
-        allValues =
-            coordsAsStrings ++ [ angleAsString ]
     in
-        cssFunction "rotate3d" identity allValues |> Transform
+        { value = cssFunction "rotate3d" (coordsAsStrings ++ [ value ])
+        , transform = Compatible
+        }
 
 
 {-| The [`scale`](https://developer.mozilla.org/en-US/docs/Web/CSS/transform-function#scale()) transform-function.
@@ -1236,9 +1058,11 @@ rotate3d x y z a =
      transform (scale 0.5)
      transform (scale2 0.5 0.7)
 -}
-scale : number -> Transform
+scale : number -> Transform {}
 scale x =
-    cssFunction "scale" numberToString [ x ] |> Transform
+    { value = cssFunction "scale" [ numberToString x ]
+    , transform = Compatible
+    }
 
 
 {-| The [`scale`](https://developer.mozilla.org/en-US/docs/Web/CSS/transform-function#scale()) transform-function.
@@ -1246,36 +1070,44 @@ scale x =
      transform (scale 0.5)
      transform (scale2 0.5 0.7)
 -}
-scale2 : number -> number -> Transform
+scale2 : number -> number -> Transform {}
 scale2 x y =
-    cssFunction "scale" numberToString [ x, y ] |> Transform
+    { value = cssFunction "scale" (List.map numberToString [ x, y ])
+    , transform = Compatible
+    }
 
 
 {-| The [`scaleX`](https://developer.mozilla.org/en-US/docs/Web/CSS/transform-function#scaleX()) transform-function.
 
      transform (scaleX 0.5)
 -}
-scaleX : number -> Transform
+scaleX : number -> Transform {}
 scaleX x =
-    cssFunction "scaleX" numberToString [ x ] |> Transform
+    { value = cssFunction "scaleX" [ numberToString x ]
+    , transform = Compatible
+    }
 
 
 {-| The [`scaleY`](https://developer.mozilla.org/en-US/docs/Web/CSS/transform-function#scaleY()) transform-function.
 
      transform (scaleY 0.5)
 -}
-scaleY : number -> Transform
+scaleY : number -> Transform {}
 scaleY y =
-    cssFunction "scaleY" numberToString [ y ] |> Transform
+    { value = cssFunction "scaleY" [ numberToString y ]
+    , transform = Compatible
+    }
 
 
 {-| The [`scale3d`](https://developer.mozilla.org/en-US/docs/Web/CSS/transform-function#scale3d()) transform-function.
 
      transform (scale3d 0.5 0.5 1)
 -}
-scale3d : number -> number -> number -> Transform
+scale3d : number -> number -> number -> Transform {}
 scale3d x y z =
-    cssFunction "scale3d" numberToString [ x, y, z ] |> Transform
+    { value = cssFunction "scale3d" (List.map numberToString [ x, y, z ])
+    , transform = Compatible
+    }
 
 
 {-| The [`skew`](https://developer.mozilla.org/en-US/docs/Web/CSS/transform-function#skew()) transform-function.
@@ -1283,9 +1115,11 @@ scale3d x y z =
      transform (skew (deg 90))
      transform (skew2 (deg 90) (deg 45))
 -}
-skew : Angle -> Transform
-skew ax =
-    cssFunction "skew" angleToString [ ax ] |> Transform
+skew : Angle compatible -> Transform {}
+skew { value } =
+    { value = cssFunction "skew" [ value ]
+    , transform = Compatible
+    }
 
 
 {-| The [`skew`](https://developer.mozilla.org/en-US/docs/Web/CSS/transform-function#skew()) transform-function.
@@ -1293,27 +1127,33 @@ skew ax =
      transform (skew (deg 90))
      transform (skew2 (deg 90) (deg 45))
 -}
-skew2 : Angle -> Angle -> Transform
+skew2 : Angle compatibleA -> Angle compatibleB -> Transform {}
 skew2 ax ay =
-    cssFunction "skew" angleToString [ ax, ay ] |> Transform
+    { value = cssFunction "skew" [ ax.value, ay.value ]
+    , transform = Compatible
+    }
 
 
 {-| The [`skewX`](https://developer.mozilla.org/en-US/docs/Web/CSS/transform-function#skewX()) transform-function.
 
      transform (skewX (deg 90))
 -}
-skewX : Angle -> Transform
-skewX a =
-    cssFunction "skewX" angleToString [ a ] |> Transform
+skewX : Angle compatible -> Transform {}
+skewX { value } =
+    { value = cssFunction "skewX" [ value ]
+    , transform = Compatible
+    }
 
 
 {-| The [`skewY`](https://developer.mozilla.org/en-US/docs/Web/CSS/transform-function#skewY()) transform-function.
 
     transform (skewY (deg 90))
 -}
-skewY : Angle -> Transform
-skewY a =
-    cssFunction "skewY" angleToString [ a ] |> Transform
+skewY : Angle compatible -> Transform {}
+skewY { value } =
+    { value = cssFunction "skewY" [ value ]
+    , transform = Compatible
+    }
 
 
 {-| The [`translate`](https://developer.mozilla.org/en-US/docs/Web/CSS/transform-function#translate()) transform-function.
@@ -1321,9 +1161,11 @@ skewY a =
     transform (translate (px 100))
     transform (translate2 (px 100) (pct -45))
 -}
-translate : Length -> Transform
-translate tx =
-    cssFunction "translate" lengthToString [ tx ] |> Transform
+translate : Length compatible -> Transform {}
+translate { value } =
+    { value = cssFunction "translate" [ value ]
+    , transform = Compatible
+    }
 
 
 {-| The [`translate`](https://developer.mozilla.org/en-US/docs/Web/CSS/transform-function#translate()) transform-function.
@@ -1331,45 +1173,55 @@ translate tx =
     transform (translate (px 100))
     transform (translate2 (px 100) (pct -45))
 -}
-translate2 : Length -> Length -> Transform
+translate2 : Length compatible -> Length compatible -> Transform {}
 translate2 tx ty =
-    cssFunction "translate" lengthToString [ tx, ty ] |> Transform
+    { value = cssFunction "translate" [ tx.value, ty.value ]
+    , transform = Compatible
+    }
 
 
 {-| The [`translateX`](https://developer.mozilla.org/en-US/docs/Web/CSS/transform-function#translateX()) transform-function.
 
     transform (translateX (px 100))
 -}
-translateX : Length -> Transform
-translateX t =
-    cssFunction "translateX" lengthToString [ t ] |> Transform
+translateX : Length compatible -> Transform {}
+translateX { value } =
+    { value = cssFunction "translateX" [ value ]
+    , transform = Compatible
+    }
 
 
 {-| The [`translateY`](https://developer.mozilla.org/en-US/docs/Web/CSS/transform-function#translateY()) transform-function.
 
     transform (translateY (px 100))
 -}
-translateY : Length -> Transform
-translateY t =
-    cssFunction "translateY" lengthToString [ t ] |> Transform
+translateY : Length compatible -> Transform {}
+translateY { value } =
+    { value = cssFunction "translateY" [ value ]
+    , transform = Compatible
+    }
 
 
 {-| The [`translateZ`](https://developer.mozilla.org/en-US/docs/Web/CSS/transform-function#translateZ()) transform-function.
 
     transform (translateZ (px 100))
 -}
-translateZ : Length -> Transform
-translateZ t =
-    cssFunction "translateZ" lengthToString [ t ] |> Transform
+translateZ : Length compatible -> Transform {}
+translateZ { value } =
+    { value = cssFunction "translateZ" [ value ]
+    , transform = Compatible
+    }
 
 
 {-| The [`translateX`](https://developer.mozilla.org/en-US/docs/Web/CSS/transform-function#translateX()) transform-function.
 
     transform (translate3d (px 100) (px 100) (px 100))
 -}
-translate3d : Length -> Length -> Length -> Transform
+translate3d : Length compatible -> Length compatible -> Length compatible -> Transform {}
 translate3d tx ty tz =
-    cssFunction "translate3d" lengthToString [ tx, ty, tz ] |> Transform
+    { value = cssFunction "translate3d" [ tx.value, ty.value, tz.value ]
+    , transform = Compatible
+    }
 
 
 {-| Sets [`transform`](https://developer.mozilla.org/en-US/docs/Web/CSS/transform)
@@ -1390,9 +1242,9 @@ populated list:
 
     ~ transforms [ perspective 1, scale2 1 1.4 ]
 -}
-transforms : List Transform -> Property namespace animation class id
+transforms : List (Transform compatible) -> Property namespace animation class id
 transforms =
-    prop1 "transform" transformListToString
+    prop1 "transform" << valuesOrNone
 
 
 {-| Sets [`transform`](https://developer.mozilla.org/en-US/docs/Web/CSS/transform)
@@ -1402,58 +1254,86 @@ property to `none`, use the `transforms` function with an empty list. See
 
     transform (scaleX 1.4)
 -}
-transform : Transform -> Property namespace animation class id
+transform : Transform compatible -> Property namespace animation class id
 transform only =
     transforms [ only ]
 
 
-{-|
--}
-borderBox : PropertyValue (BorderBoxOr a)
-borderBox =
-    BorderBox |> ExplicitValue
-
-
 {-| The `fill-box` value for the [`transform-box`](https://developer.mozilla.org/en-US/docs/Web/CSS/transform-box) property.
 -}
-fillBox : TransformBox
+fillBox : TransformBox {}
 fillBox =
-    "fill-box" |> ExplicitTransformBox |> NotBorderBox |> ExplicitValue
+    { value = "fill-box"
+    , transformBox = Compatible
+    }
+
+
+{-| The `content-box` value for the [`box-sizing`](https://developer.mozilla.org/en-US/docs/Web/CSS/box-sizing) property.
+-}
+contentBox : BoxSizing {}
+contentBox =
+    { value = "content-box"
+    , boxSizing = Compatible
+    }
+
+
+{-| The `border-box` value for the [`box-sizing`](https://developer.mozilla.org/en-US/docs/Web/CSS/box-sizing) property.
+-}
+borderBox : BoxSizing {}
+borderBox =
+    { value = "border-box"
+    , boxSizing = Compatible
+    }
 
 
 {-| The `view-box` value for the [`transform-box`](https://developer.mozilla.org/en-US/docs/Web/CSS/transform-box) property.
 -}
-viewBox : TransformBox
+viewBox : TransformBox {}
 viewBox =
-    "view-box" |> ExplicitTransformBox |> NotBorderBox |> ExplicitValue
+    { value = "view-box"
+    , transformBox = Compatible
+    }
 
 
 {-| The [`transform-box`](https://developer.mozilla.org/en-US/docs/Web/CSS/transform-box) property.
 -}
-transformBox : TransformBox -> Property namespace animation class id
+transformBox : TransformBox compatible -> Property namespace animation class id
 transformBox =
-    prop1 "transform-box" transformBoxToString
+    prop1 "transform-box"
+
+
+{-| Sets [`box-sizing`](https://developer.mozilla.org/en-US/docs/Web/CSS/box-sizing)
+
+    ~ boxSizing borderBox
+-}
+boxSizing : BoxSizing compatible -> Property namespace animation class id
+boxSizing =
+    prop1 "box-sizing"
 
 
 {-| The `preserve-3d` value for the [`transform-style`](https://developer.mozilla.org/en-US/docs/Web/CSS/transform-style) property.
 -}
-preserve3d : TransformStyle
+preserve3d : TransformStyle {}
 preserve3d =
-    "preserve-3d" |> ExplicitTransformStyle |> ExplicitValue
+    { value = "preserve-3d"
+    , transformStyle = Compatible
+    }
 
 
 {-| The `flat` value for the [`transform-style`](https://developer.mozilla.org/en-US/docs/Web/CSS/transform-style) property.
 -}
-flat : TransformStyle
+flat : TransformStyle {}
 flat =
-    "flat" |> ExplicitTransformStyle |> ExplicitValue
+    { value = "flat"
+    , transformStyle = Compatible
+    }
 
 
 {-| The [`transform-style`](https://developer.mozilla.org/en-US/docs/Web/CSS/transform-style) property.
 -}
-transformStyle : TransformStyle -> Property namespace animation class id
+transformStyle : TransformStyle compatible -> Property namespace animation class id
 transformStyle =
-    prop1 "transform-style" transformStyleToString
+    prop1 "transform-style"
 
 
 
@@ -1463,25 +1343,31 @@ transformStyle =
 {-| An [`underline`](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-line#Value)
 text decoration line.
 -}
-underline : TextDecorationLine
+underline : TextDecorationLine {}
 underline =
-    "underline" |> ExplicitTextDecorationLine |> NotNone |> ExplicitValue
+    { value = "underline"
+    , textDecorationLine = Compatible
+    }
 
 
 {-| An [`overline`](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-line#Value)
 text decoration line.
 -}
-overline : TextDecorationLine
+overline : TextDecorationLine {}
 overline =
-    "overline" |> ExplicitTextDecorationLine |> NotNone |> ExplicitValue
+    { value = "overline"
+    , textDecorationLine = Compatible
+    }
 
 
 {-| A [`line-through`](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-line#Value)
 text decoration line.
 -}
-lineThrough : TextDecorationLine
+lineThrough : TextDecorationLine {}
 lineThrough =
-    "line-through" |> ExplicitTextDecorationLine |> NotNone |> ExplicitValue
+    { value = "line-through"
+    , textDecorationLine = Compatible
+    }
 
 
 
@@ -1489,69 +1375,69 @@ lineThrough =
 
 
 {-| -}
-visible : Display
-visible =
-    "visible" |> ExplicitDisplay |> NotNone |> ExplicitValue
-
-
-{-| -}
-block : Display
+block : Display {}
 block =
-    "block" |> ExplicitDisplay |> NotNone |> ExplicitValue
+    { value = "block"
+    , display = Compatible
+    }
 
 
 {-| -}
-inlineBlock : Display
+inlineBlock : Display {}
 inlineBlock =
-    "inline-block" |> ExplicitDisplay |> NotNone |> ExplicitValue
+    { value = "inline-block"
+    , display = Compatible
+    }
 
 
 {-| -}
-inline : Display
+inline : Display {}
 inline =
-    "inline" |> ExplicitDisplay |> NotNone |> ExplicitValue
+    { value = "inline"
+    , display = Compatible
+    }
 
 
 {-| -}
-none : PropertyValue (NoneOr a)
+none :
+    { borderStyle : Compatible
+    , display : Compatible
+    , none : Compatible
+    , textDecorationLine : Compatible
+    , transform : Compatible
+    , value : String
+    }
 none =
-    None |> ExplicitValue
+    { value = "none"
+    , none = Compatible
+    , textDecorationLine = Compatible
+    , display = Compatible
+    , transform = Compatible
+    , borderStyle = Compatible
+    }
 
 
 {-| -}
-auto : PropertyValue (AutoOr a)
+auto :
+    { lengthOrAuto : Compatible
+    , overflow : Compatible
+    , textRendering : Compatible
+    , value : String
+    }
 auto =
-    Auto |> ExplicitValue
-
-
-{-| The [`inherit`](https://developer.mozilla.org/en-US/docs/Web/CSS/inherit) value.
-Any CSS property can be set to this value.
--}
-inherit : PropertyValue a
-inherit =
-    Inherit
-
-
-{-| The [`unset`](https://developer.mozilla.org/en-US/docs/Web/CSS/unset) value.
-Any CSS property can be set to this value.
--}
-unset : PropertyValue a
-unset =
-    Unset
-
-
-{-| The [`initial`](https://developer.mozilla.org/en-US/docs/Web/CSS/initial) value.
-Any CSS property can be set to this value.
--}
-initial : PropertyValue a
-initial =
-    Initial
+    { value = "auto"
+    , overflow = Compatible
+    , textRendering = Compatible
+    , lengthOrAuto = Compatible
+    }
 
 
 {-| -}
-noWrap : WhiteSpace
+noWrap : WhiteSpace {}
 noWrap =
-    "no-wrap" |> ExplicitWhiteSpace |> NotAuto |> ExplicitValue
+    { value = "no-wrap"
+    , whiteSpace = Compatible
+    }
 
 
 
@@ -1562,99 +1448,94 @@ noWrap =
 
     ~ verticalAlign middle
 -}
-middle : VerticalAlign namespace animation class id
+middle : VerticalAlign namespace animation class id a
 middle =
-    prop1 "middle" lengthToString
+    prop1 "middle"
 
 
 {-| The `middle` [`vertical-align`](https://developer.mozilla.org/en-US/docs/Web/CSS/vertical-align) value.
 
     ~ verticalAlign baseline
 -}
-baseline : VerticalAlign namespace animation class id
+baseline : VerticalAlign namespace animation class id a
 baseline =
-    prop1 "baseline" lengthToString
+    prop1 "baseline"
 
 
 {-| The `middle` [`vertical-align`](https://developer.mozilla.org/en-US/docs/Web/CSS/vertical-align) value.
 
     ~ verticalAlign sub
 -}
-sub : VerticalAlign namespace animation class id
+sub : VerticalAlign namespace animation class id a
 sub =
-    prop1 "sub" lengthToString
+    prop1 "sub"
 
 
 {-| The `middle` [`vertical-align`](https://developer.mozilla.org/en-US/docs/Web/CSS/vertical-align) value.
 
     ~ verticalAlign super
 -}
-super : VerticalAlign namespace animation class id
+super : VerticalAlign namespace animation class id a
 super =
-    prop1 "super" lengthToString
+    prop1 "super"
 
 
 {-| The `middle` [`vertical-align`](https://developer.mozilla.org/en-US/docs/Web/CSS/vertical-align) value.
 
     ~ verticalAlign textTop
 -}
-textTop : VerticalAlign namespace animation class id
+textTop : VerticalAlign namespace animation class id a
 textTop =
-    prop1 "text-top" lengthToString
+    prop1 "text-top"
 
 
 {-| The `middle` [`vertical-align`](https://developer.mozilla.org/en-US/docs/Web/CSS/vertical-align) value.
 
     ~ verticalAlign textBottom
 -}
-textBottom : VerticalAlign namespace animation class id
+textBottom : VerticalAlign namespace animation class id a
 textBottom =
-    prop1 "text-bottom" lengthToString
+    prop1 "text-bottom"
 
 
 {-| The [`position`](https://developer.mozilla.org/en-US/docs/Web/CSS/position) property.
 -}
-position : Position -> Property namespace animation class id
+position : Position compatible -> Property namespace animation class id
 position =
-    prop1 "position" positionToString
+    prop1 "position"
 
 
 
 {- Properties -}
 
 
-prop1 : String -> (a -> String) -> a -> Property namespace animation class id
-prop1 key translate value =
-    custom key (translate value)
+prop1 : String -> Value a -> Property namespace animation class id
+prop1 key arg =
+    custom key arg.value
 
 
-prop2 : String -> (a -> String) -> (b -> String) -> a -> b -> Property namespace animation class id
-prop2 key translateA translateB valueA valueB =
-    custom key (String.join " " [ translateA valueA, translateB valueB ])
+prop2 : String -> Value a -> Value b -> Property namespace animation class id
+prop2 key argA argB =
+    custom key (String.join " " [ argA.value, argB.value ])
 
 
-prop3 : String -> (a -> String) -> (b -> String) -> (c -> String) -> a -> b -> c -> Property namespace animation class id
-prop3 key translateA translateB translateC valueA valueB valueC =
-    custom key (String.join " " [ translateA valueA, translateB valueB, translateC valueC ])
+prop3 : String -> Value a -> Value b -> Value c -> Property namespace animation class id
+prop3 key argA argB argC =
+    custom key (String.join " " [ argA.value, argB.value, argC.value ])
 
 
-prop4 : String -> (a -> String) -> (b -> String) -> (c -> String) -> (d -> String) -> a -> b -> c -> d -> Property namespace animation class id
-prop4 key translateA translateB translateC translateD valueA valueB valueC valueD =
-    custom key (String.join " " [ translateA valueA, translateB valueB, translateC valueC, translateD valueD ])
-
-
-prop5 : String -> (a -> String) -> (b -> String) -> (c -> String) -> (d -> String) -> (e -> String) -> a -> b -> c -> d -> e -> Property namespace animation class id
-prop5 key translateA translateB translateC translateD translateE valueA valueB valueC valueD valueE =
-    custom key (String.join " " [ translateA valueA, translateB valueB, translateC valueC, translateD valueD, translateE valueE ])
+prop4 : String -> Value a -> Value b -> Value c -> Value d -> Property namespace animation class id
+prop4 key argA argB argC argD =
+    custom key (String.join " " [ argA.value, argB.value, argC.value, argD.value ])
 
 
 {-| Sets [`text-decoration-color`](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-color)
 
     textDecorationColor (rgb 12 11 10)
 -}
-textDecorationColor : Color -> Property namespace animation class id
+textDecorationColor : Color compatible -> Property namespace animation class id
 textDecorationColor =
-    prop1 "text-decoration-color" colorToString
+    prop1 "text-decoration-color"
 
 
 {-| Sets [`text-align-last`](https://developer.mozilla.org/en-US/docs/Web/CSS/text-align-last).
@@ -1667,23 +1548,23 @@ textDecorationColor =
 
     ~ ("text-align-last", "auto")
 -}
-textAlignLast : TextAlign namespace animation class id -> Property namespace animation class id
+textAlignLast : (Length (LengthOrNumber (LengthOrAuto (Number {}))) -> Style a b c d) -> Property a b c d
 textAlignLast fn =
     getOverloadedProperty "textAlignLast" "text-align-last" (fn zero)
 
 
 {-| Sets [`text-align`](https://developer.mozilla.org/en-US/docs/Web/CSS/text-align).
 -}
-textAlign : TextAlign namespace animation class id -> Property namespace animation class id
+textAlign : (Length (LengthOrNumber (LengthOrAuto (Number {}))) -> Style a b c d) -> Property a b c d
 textAlign fn =
     getOverloadedProperty "textAlign" "text-align" (fn zero)
 
 
 {-| Sets [`text-rendering`](https://developer.mozilla.org/en-US/docs/Web/CSS/text-rendering).
 -}
-textRendering : TextRendering -> Property namespace animation class id
+textRendering : TextRendering a -> Property namespace animation class id
 textRendering =
-    prop1 "text-rendering" textRenderingToString
+    prop1 "text-rendering"
 
 
 {-| Sets [`text-overflow`](https://developer.mozilla.org/en-US/docs/Web/CSS/text-overflow).
@@ -1694,9 +1575,9 @@ To set `text-overflow` to an arbitrary String, use [`custom`](#custom) like so:
 
     ~ custom "text-overflow" "my custom text-overflow value"
 -}
-textOverflow : TextOverflow -> Property namespace animation class id
+textOverflow : TextOverflow compatible -> Property namespace animation class id
 textOverflow =
-    prop1 "text-overflow" textOverflowToString
+    prop1 "text-overflow"
 
 
 {-| Sets [`text-shadow`](https://developer.mozilla.org/en-US/docs/Web/CSS/text-shadow).
@@ -1707,9 +1588,9 @@ textOverflow =
     ~ textShadow4 (px 1) (px 2) (px 3) (rgb 211 121 112)
 
 -}
-textShadow : None -> Property namespace animation class id
+textShadow : None compatible -> Property namespace animation class id
 textShadow =
-    prop1 "text-shadow" absoluteNoneToString
+    prop1 "text-shadow"
 
 
 {-| Sets [`text-shadow`](https://developer.mozilla.org/en-US/docs/Web/CSS/text-shadow).
@@ -1720,9 +1601,9 @@ textShadow =
     ~ textShadow4 (px 1) (px 2) (px 3) (rgb 211 121 112)
 
 -}
-textShadow2 : Length -> Length -> Property namespace animation class id
+textShadow2 : Length compatible -> Length compatible -> Property namespace animation class id
 textShadow2 =
-    prop2 "text-shadow" lengthToString lengthToString
+    prop2 "text-shadow"
 
 
 {-| Sets [`text-shadow`](https://developer.mozilla.org/en-US/docs/Web/CSS/text-shadow).
@@ -1733,9 +1614,9 @@ textShadow2 =
     ~ textShadow4 (px 1) (px 2) (px 3) (rgb 211 121 112)
 
 -}
-textShadow3 : Length -> Length -> Color -> Property namespace animation class id
+textShadow3 : Length compatible -> Length compatible -> Color compatible -> Property namespace animation class id
 textShadow3 =
-    prop3 "text-shadow" lengthToString lengthToString colorToString
+    prop3 "text-shadow"
 
 
 {-| Sets [`text-shadow`](https://developer.mozilla.org/en-US/docs/Web/CSS/text-shadow).
@@ -1746,9 +1627,9 @@ textShadow3 =
     ~ textShadow4 (px 1) (px 2) (px 3) (rgb 211 121 112)
 
 -}
-textShadow4 : Length -> Length -> Length -> Color -> Property namespace animation class id
+textShadow4 : Length compatible -> Length compatible -> Length compatible -> Color compatible -> Property namespace animation class id
 textShadow4 =
-    prop4 "text-shadow" lengthToString lengthToString lengthToString colorToString
+    prop4 "text-shadow"
 
 
 {-| Sets [`text-indent`](https://developer.mozilla.org/en-US/docs/Web/CSS/text-indent).
@@ -1757,9 +1638,9 @@ textShadow4 =
     ~ textIndent2 (px 40) hanging
     ~ textIndent3 (px 40) hanging eachLine
 -}
-textIndent : Length -> Property namespace animation class id
+textIndent : Length compatible -> Property namespace animation class id
 textIndent =
-    prop1 "text-indent" lengthToString
+    prop1 "text-indent"
 
 
 {-| Sets [`text-indent`](https://developer.mozilla.org/en-US/docs/Web/CSS/text-indent).
@@ -1768,9 +1649,9 @@ textIndent =
     ~ textIndent2 (px 40) hanging
     ~ textIndent3 (px 40) hanging eachLine
 -}
-textIndent2 : Length -> TextIndent -> Property namespace animation class id
+textIndent2 : Length compatible -> TextIndent compatible -> Property namespace animation class id
 textIndent2 =
-    prop2 "text-indent" lengthToString textIndentToString
+    prop2 "text-indent"
 
 
 {-| Sets [`text-indent`](https://developer.mozilla.org/en-US/docs/Web/CSS/text-indent).
@@ -1779,35 +1660,35 @@ textIndent2 =
     ~ textIndent2 (px 40) hanging
     ~ textIndent3 (px 40) hanging eachLine
 -}
-textIndent3 : Length -> TextIndent -> TextIndent -> Property namespace animation class id
+textIndent3 : Length compatible -> TextIndent compatible -> TextIndent compatible -> Property namespace animation class id
 textIndent3 =
-    prop3 "text-indent" lengthToString textIndentToString textIndentToString
+    prop3 "text-indent"
 
 
 {-| Sets [`text-transform`](https://developer.mozilla.org/en-US/docs/Web/CSS/text-transform).
 -}
-textTransform : TextTransform -> Property namespace animation class id
+textTransform : TextTransform compatible -> Property namespace animation class id
 textTransform =
-    prop1 "text-transform" textTransformToString
+    prop1 "text-transform"
 
 
 {-| Sets [`vertical-align`](https://developer.mozilla.org/en-US/docs/Web/CSS/vertical-align).
 -}
-verticalAlign : VerticalAlign namespace animation class id -> Property namespace animation class id
+verticalAlign : (Length (LengthOrNumber (LengthOrAuto (Number {}))) -> Style a b c d) -> Property a b c d
 verticalAlign fn =
     getOverloadedProperty "verticalAlign" "vertical-align" (fn zero)
 
 
 {-| -}
-display : Display -> Property namespace animation class id
+display : Display compatible -> Property namespace animation class id
 display =
-    prop1 "display" displayToString
+    prop1 "display"
 
 
 {-| -}
-opacity : OpacityStyle -> Property namespace animation class id
-opacity =
-    prop1 "opacity" toString
+opacity : number -> Property namespace animation class id
+opacity num =
+    prop1 "opacity" { value = numberToString num }
 
 
 {-| Sets [`width`](https://developer.mozilla.org/en-US/docs/Web/CSS/width)
@@ -1815,9 +1696,9 @@ opacity =
     ~ width (px 960)
 
 -}
-width : LengthOrAuto -> Property namespace animation class id
+width : LengthOrAuto compatible -> Property namespace animation class id
 width =
-    prop1 "width" lengthToString
+    prop1 "width"
 
 
 {-| Sets [`min-width`](https://developer.mozilla.org/en-US/docs/Web/CSS/min-width)
@@ -1825,9 +1706,9 @@ width =
     ~ minWidth (px 100)
 
 -}
-minWidth : LengthOrAuto -> Property namespace animation class id
+minWidth : LengthOrAuto compatible -> Property namespace animation class id
 minWidth =
-    prop1 "min-width" lengthToString
+    prop1 "min-width"
 
 
 {-| Sets [`height`](https://developer.mozilla.org/en-US/docs/Web/CSS/height)
@@ -1835,9 +1716,9 @@ minWidth =
     ~ height (px 800)
 
 -}
-height : LengthOrAuto -> Property namespace animation class id
+height : LengthOrAuto compatible -> Property namespace animation class id
 height =
-    prop1 "height" lengthToString
+    prop1 "height"
 
 
 {-| Sets [`min-height`](https://developer.mozilla.org/en-US/docs/Web/CSS/min-height)
@@ -1845,15 +1726,9 @@ height =
     ~ minHeight (px 100)
 
 -}
-minHeight : LengthOrAuto -> Property namespace animation class id
+minHeight : LengthOrAuto compatible -> Property namespace animation class id
 minHeight =
-    prop1 "min-height" lengthToString
-
-
-{-| -}
-boxSizing : BoxSizing -> Property namespace animation class id
-boxSizing =
-    prop1 "box-sizing" boxSizingToString
+    prop1 "min-height"
 
 
 
@@ -1867,9 +1742,9 @@ boxSizing =
     padding3 (px 10) (px 10) (px 10)
     padding4 (px 10) (px 10) (px 10) (px 10)
 -}
-padding : Length -> Property namespace animation class id
+padding : Length compatible -> Property namespace animation class id
 padding =
-    prop1 "padding" lengthToString
+    prop1 "padding"
 
 
 {-| Sets [`padding`](https://developer.mozilla.org/en-US/docs/Web/CSS/padding)
@@ -1879,9 +1754,9 @@ padding =
     padding3 (px 10) (px 10) (px 10)
     padding4 (px 10) (px 10) (px 10) (px 10)
 -}
-padding2 : Length -> Length -> Property namespace animation class id
+padding2 : Length compatible -> Length compatible -> Property namespace animation class id
 padding2 =
-    prop2 "padding" lengthToString lengthToString
+    prop2 "padding"
 
 
 {-| Sets [`padding`](https://developer.mozilla.org/en-US/docs/Web/CSS/padding)
@@ -1891,9 +1766,9 @@ padding2 =
     padding3 (px 10) (px 10) (px 10)
     padding4 (px 10) (px 10) (px 10) (px 10)
 -}
-padding3 : Length -> Length -> Length -> Property namespace animation class id
+padding3 : Length compatible -> Length compatible -> Length compatible -> Property namespace animation class id
 padding3 =
-    prop3 "padding" lengthToString lengthToString lengthToString
+    prop3 "padding"
 
 
 {-| Sets [`padding`](https://developer.mozilla.org/en-US/docs/Web/CSS/padding)
@@ -1903,81 +1778,81 @@ padding3 =
     padding3 (px 10) (px 10) (px 10)
     padding4 (px 10) (px 10) (px 10) (px 10)
 -}
-padding4 : Length -> Length -> Length -> Length -> Property namespace animation class id
+padding4 : Length compatible -> Length compatible -> Length compatible -> Length compatible -> Property namespace animation class id
 padding4 =
-    prop4 "padding" lengthToString lengthToString lengthToString lengthToString
+    prop4 "padding"
 
 
 {-| Sets [`padding-block-start`](https://developer.mozilla.org/en-US/docs/Web/CSS/padding-block-start)
 
     paddingBlockStart (px 10)
 -}
-paddingBlockStart : LengthOrAuto -> Property namespace animation class id
+paddingBlockStart : LengthOrAuto compatible -> Property namespace animation class id
 paddingBlockStart =
-    prop1 "padding-block-start" lengthToString
+    prop1 "padding-block-start"
 
 
 {-| Sets [`padding-block-end`](https://developer.mozilla.org/en-US/docs/Web/CSS/padding-block-end)
 
     paddingBlockEnd (px 10)
 -}
-paddingBlockEnd : LengthOrAuto -> Property namespace animation class id
+paddingBlockEnd : LengthOrAuto compatible -> Property namespace animation class id
 paddingBlockEnd =
-    prop1 "padding-block-end" lengthToString
+    prop1 "padding-block-end"
 
 
 {-| Sets [`padding-inline-start`](https://developer.mozilla.org/en-US/docs/Web/CSS/padding-inline-start)
 
     paddingInlineStart (px 10)
 -}
-paddingInlineStart : LengthOrAuto -> Property namespace animation class id
+paddingInlineStart : LengthOrAuto compatible -> Property namespace animation class id
 paddingInlineStart =
-    prop1 "padding-inline-start" lengthToString
+    prop1 "padding-inline-start"
 
 
 {-| Sets [`padding-inline-end`](https://developer.mozilla.org/en-US/docs/Web/CSS/padding-inline-end)
 
     paddingInlineEnd (px 10)
 -}
-paddingInlineEnd : LengthOrAuto -> Property namespace animation class id
+paddingInlineEnd : LengthOrAuto compatible -> Property namespace animation class id
 paddingInlineEnd =
-    prop1 "padding-inline-end" lengthToString
+    prop1 "padding-inline-end"
 
 
 {-| Sets [`padding-top`](https://developer.mozilla.org/en-US/docs/Web/CSS/padding-top)
 
     paddingTop (px 10)
 -}
-paddingTop : Length -> Property namespace animation class id
+paddingTop : Length compatible -> Property namespace animation class id
 paddingTop =
-    prop1 "padding-top" lengthToString
+    prop1 "padding-top"
 
 
 {-| Sets [`padding-bottom`](https://developer.mozilla.org/en-US/docs/Web/CSS/padding-bottom)
 
     paddingBottom (px 10)
 -}
-paddingBottom : Length -> Property namespace animation class id
+paddingBottom : Length compatible -> Property namespace animation class id
 paddingBottom =
-    prop1 "padding-bottom" lengthToString
+    prop1 "padding-bottom"
 
 
 {-| Sets [`padding-right`](https://developer.mozilla.org/en-US/docs/Web/CSS/padding-right)
 
     paddingRight (px 10)
 -}
-paddingRight : Length -> Property namespace animation class id
+paddingRight : Length compatible -> Property namespace animation class id
 paddingRight =
-    prop1 "padding-right" lengthToString
+    prop1 "padding-right"
 
 
 {-| Sets [`padding-left`](https://developer.mozilla.org/en-US/docs/Web/CSS/padding-left)
 
     paddingLeft (px 10)
 -}
-paddingLeft : Length -> Property namespace animation class id
+paddingLeft : Length compatible -> Property namespace animation class id
 paddingLeft =
-    prop1 "padding-left" lengthToString
+    prop1 "padding-left"
 
 
 
@@ -1991,9 +1866,9 @@ paddingLeft =
     margin3 (px 10) (px 10) (px 10)
     margin4 (px 10) (px 10) (px 10) (px 10)
 -}
-margin : LengthOrAuto -> Property namespace animation class id
+margin : LengthOrAuto compatible -> Property namespace animation class id
 margin =
-    prop1 "margin" lengthToString
+    prop1 "margin"
 
 
 {-| Sets [`margin`](https://developer.mozilla.org/en-US/docs/Web/CSS/margin)
@@ -2003,9 +1878,9 @@ margin =
     margin3 (px 10) (px 10) (px 10)
     margin4 (px 10) (px 10) (px 10) (px 10)
 -}
-margin2 : LengthOrAuto -> LengthOrAuto -> Property namespace animation class id
+margin2 : LengthOrAuto compatible -> LengthOrAuto compatible -> Property namespace animation class id
 margin2 =
-    prop2 "margin" lengthToString lengthToString
+    prop2 "margin"
 
 
 {-| Sets [`margin`](https://developer.mozilla.org/en-US/docs/Web/CSS/margin)
@@ -2015,9 +1890,9 @@ margin2 =
     margin3 (px 10) (px 10) (px 10)
     margin4 (px 10) (px 10) (px 10) (px 10)
 -}
-margin3 : LengthOrAuto -> LengthOrAuto -> LengthOrAuto -> Property namespace animation class id
+margin3 : LengthOrAuto compatible -> LengthOrAuto compatible -> LengthOrAuto compatible -> Property namespace animation class id
 margin3 =
-    prop3 "margin" lengthToString lengthToString lengthToString
+    prop3 "margin"
 
 
 {-| Sets [`margin`](https://developer.mozilla.org/en-US/docs/Web/CSS/margin)
@@ -2027,81 +1902,81 @@ margin3 =
     margin3 (px 10) (px 10) (px 10)
     margin4 (px 10) (px 10) (px 10) (px 10)
 -}
-margin4 : LengthOrAuto -> LengthOrAuto -> LengthOrAuto -> LengthOrAuto -> Property namespace animation class id
+margin4 : LengthOrAuto compatible -> LengthOrAuto compatible -> LengthOrAuto compatible -> LengthOrAuto compatible -> Property namespace animation class id
 margin4 =
-    prop4 "margin" lengthToString lengthToString lengthToString lengthToString
+    prop4 "margin"
 
 
 {-| Sets [`margin-top`](https://developer.mozilla.org/en-US/docs/Web/CSS/margin-top)
 
     marginTop (px 10)
 -}
-marginTop : LengthOrAuto -> Property namespace animation class id
+marginTop : LengthOrAuto compatible -> Property namespace animation class id
 marginTop =
-    prop1 "margin-top" lengthToString
+    prop1 "margin-top"
 
 
 {-| Sets [`margin-bottom`](https://developer.mozilla.org/en-US/docs/Web/CSS/margin-bottom)
 
     marginBottom (px 10)
 -}
-marginBottom : LengthOrAuto -> Property namespace animation class id
+marginBottom : LengthOrAuto compatible -> Property namespace animation class id
 marginBottom =
-    prop1 "margin-bottom" lengthToString
+    prop1 "margin-bottom"
 
 
 {-| Sets [`margin-right`](https://developer.mozilla.org/en-US/docs/Web/CSS/margin-right)
 
     marginRight (px 10)
 -}
-marginRight : LengthOrAuto -> Property namespace animation class id
+marginRight : LengthOrAuto compatible -> Property namespace animation class id
 marginRight =
-    prop1 "margin-right" lengthToString
+    prop1 "margin-right"
 
 
 {-| Sets [`margin-left`](https://developer.mozilla.org/en-US/docs/Web/CSS/margin-left)
 
     marginLeft (px 10)
 -}
-marginLeft : LengthOrAuto -> Property namespace animation class id
+marginLeft : LengthOrAuto compatible -> Property namespace animation class id
 marginLeft =
-    prop1 "margin-left" lengthToString
+    prop1 "margin-left"
 
 
 {-| Sets [`margin-block-start`](https://developer.mozilla.org/en-US/docs/Web/CSS/margin-block-start)
 
     marginBlockStart (px 10)
 -}
-marginBlockStart : LengthOrAuto -> Property namespace animation class id
+marginBlockStart : LengthOrAuto compatible -> Property namespace animation class id
 marginBlockStart =
-    prop1 "margin-block-start" lengthToString
+    prop1 "margin-block-start"
 
 
 {-| Sets [`margin-block-end`](https://developer.mozilla.org/en-US/docs/Web/CSS/margin-block-end)
 
     marginBlockEnd (px 10)
 -}
-marginBlockEnd : LengthOrAuto -> Property namespace animation class id
+marginBlockEnd : LengthOrAuto compatible -> Property namespace animation class id
 marginBlockEnd =
-    prop1 "margin-block-end" lengthToString
+    prop1 "margin-block-end"
 
 
 {-| Sets [`margin-inline-start`](https://developer.mozilla.org/en-US/docs/Web/CSS/margin-inline-start)
 
     marginInlineStart (px 10)
 -}
-marginInlineStart : LengthOrAuto -> Property namespace animation class id
+marginInlineStart : LengthOrAuto compatible -> Property namespace animation class id
 marginInlineStart =
-    prop1 "margin-inline-start" lengthToString
+    prop1 "margin-inline-start"
 
 
 {-| Sets [`margin-inline-end`](https://developer.mozilla.org/en-US/docs/Web/CSS/margin-inline-end)
 
     marginInlineEnd (px 10)
 -}
-marginInlineEnd : LengthOrAuto -> Property namespace animation class id
+marginInlineEnd : LengthOrAuto compatible -> Property namespace animation class id
 marginInlineEnd =
-    prop1 "margin-inline-end" lengthToString
+    prop1 "margin-inline-end"
 
 
 {-| The [`top`](https://developer.mozilla.org/en-US/docs/Web/CSS/top) property.
@@ -2113,9 +1988,9 @@ This can also be used as a `top` [vertical-align](https://developer.mozilla.org/
 
     ~ verticalAlign top
 -}
-top : LengthOrAuto -> Property namespace animation class id
+top : LengthOrAuto compatible -> Property namespace animation class id
 top =
-    prop1 "top" lengthToString
+    prop1 "top"
 
 
 {-| The [`bottom`](https://developer.mozilla.org/en-US/docs/Web/CSS/bottom) property.
@@ -2127,9 +2002,9 @@ This can also be used as a `bottom` [vertical-align](https://developer.mozilla.o
 
     ~ verticalAlign bottom
 -}
-bottom : LengthOrAuto -> Property namespace animation class id
+bottom : LengthOrAuto compatible -> Property namespace animation class id
 bottom =
-    prop1 "bottom" lengthToString
+    prop1 "bottom"
 
 
 {-| The [`left`](https://developer.mozilla.org/en-US/docs/Web/CSS/left) property.
@@ -2141,9 +2016,9 @@ This can also be used as a `left` [text alignment](https://developer.mozilla.org
 
     ~ textAlign left
 -}
-left : LengthOrAuto -> Property namespace animation class id
+left : LengthOrAuto compatible -> Property namespace animation class id
 left =
-    prop1 "left" lengthToString
+    prop1 "left"
 
 
 {-| Sets [`right`](https://developer.mozilla.org/en-US/docs/Web/CSS/right).
@@ -2155,9 +2030,9 @@ This can also be used as a `right` [alignment](https://developer.mozilla.org/en-
 
     ~ textAlign right
 -}
-right : LengthOrAuto -> Property namespace animation class id
+right : LengthOrAuto compatible -> Property namespace animation class id
 right =
-    prop1 "right" lengthToString
+    prop1 "right"
 
 
 
@@ -2168,45 +2043,55 @@ right =
 
     ~ position static
 -}
-static : Position
+static : Position {}
 static =
-    "static" |> ExplicitPosition |> ExplicitValue
+    { value = "static"
+    , position = Compatible
+    }
 
 
 {-| A `fixed` [`position`](https://developer.mozilla.org/en-US/docs/Web/CSS/position) value.
 
     ~ position fixed
 -}
-fixed : Position
+fixed : Position {}
 fixed =
-    "fixed" |> ExplicitPosition |> ExplicitValue
+    { value = "fixed"
+    , position = Compatible
+    }
 
 
 {-| A `sticky` [`position`](https://developer.mozilla.org/en-US/docs/Web/CSS/position) value.
 
     ~ position sticky
 -}
-sticky : Position
+sticky : Position {}
 sticky =
-    "sticky" |> ExplicitPosition |> ExplicitValue
+    { value = "sticky"
+    , position = Compatible
+    }
 
 
 {-| A `relative` [`position`](https://developer.mozilla.org/en-US/docs/Web/CSS/position) value.
 
     ~ position relative
 -}
-relative : Position
+relative : Position {}
 relative =
-    "relative" |> ExplicitPosition |> ExplicitValue
+    { value = "relative"
+    , position = Compatible
+    }
 
 
 {-| An `absolute` [`position`](https://developer.mozilla.org/en-US/docs/Web/CSS/position) value.
 
     ~ position absolute
 -}
-absolute : Position
+absolute : Position {}
 absolute =
-    "absolute" |> ExplicitPosition |> ExplicitValue
+    { value = "absolute"
+    , position = Compatible
+    }
 
 
 
@@ -2219,9 +2104,9 @@ absolute =
     border2 (px 10) dashed
     border3 (px 10) dashed (rgb 11 14 17)
 -}
-border : Length -> Property namespace animation class id
+border : Length compatible -> Property namespace animation class id
 border =
-    prop1 "border" lengthToString
+    prop1 "border"
 
 
 {-| Sets [`border`](https://developer.mozilla.org/en-US/docs/Web/CSS/border)
@@ -2231,9 +2116,9 @@ border =
     border3 (px 10) dashed (rgb 11 14 17)
 
 -}
-border2 : Length -> BorderStyle -> Property namespace animation class id
+border2 : Length compatibleA -> BorderStyle compatibleB -> Property namespace animation class id
 border2 =
-    prop2 "border" lengthToString borderStyleToString
+    prop2 "border"
 
 
 {-| Sets [`border`](https://developer.mozilla.org/en-US/docs/Web/CSS/border)
@@ -2242,9 +2127,9 @@ border2 =
     border2 (px 10) dashed
     border3 (px 10) dashed (rgb 11 14 17)
 -}
-border3 : Length -> BorderStyle -> Color -> Property namespace animation class id
+border3 : Length compatibleA -> BorderStyle compatibleB -> Color compatibleC -> Property namespace animation class id
 border3 =
-    prop3 "border" lengthToString borderStyleToString colorToString
+    prop3 "border"
 
 
 {-| Sets [`border-top`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-top)
@@ -2254,9 +2139,9 @@ border3 =
     borderTop3 (px 5) dashed (rgb 11 14 17)
 
 -}
-borderTop : Length -> Property namespace animation class id
+borderTop : Length compatible -> Property namespace animation class id
 borderTop =
-    prop1 "border-top" lengthToString
+    prop1 "border-top"
 
 
 {-| Sets [`border-top`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-top)
@@ -2266,9 +2151,9 @@ borderTop =
     borderTop3 (px 5) dashed (rgb 11 14 17)
 
 -}
-borderTop2 : Length -> BorderStyle -> Property namespace animation class id
+borderTop2 : Length compatibleA -> BorderStyle compatibleB -> Property namespace animation class id
 borderTop2 =
-    prop2 "border-top" lengthToString borderStyleToString
+    prop2 "border-top"
 
 
 {-| Sets [`border-top`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-top)
@@ -2278,9 +2163,9 @@ borderTop2 =
     borderTop3 (px 5) dashed (rgb 11 14 17)
 
 -}
-borderTop3 : Length -> BorderStyle -> Color -> Property namespace animation class id
+borderTop3 : Length compatibleA -> BorderStyle compatibleB -> Color compatibleC -> Property namespace animation class id
 borderTop3 =
-    prop3 "border-top" lengthToString borderStyleToString colorToString
+    prop3 "border-top"
 
 
 {-| Sets [`border-bottom`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-bottom)
@@ -2290,9 +2175,9 @@ borderTop3 =
     borderBottom3 (px 5) dashed (rgb 11 14 17)
 
 -}
-borderBottom : Length -> Property namespace animation class id
+borderBottom : Length compatible -> Property namespace animation class id
 borderBottom =
-    prop1 "border-bottom" lengthToString
+    prop1 "border-bottom"
 
 
 {-| Sets [`border-bottom`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-bottom)
@@ -2302,9 +2187,9 @@ borderBottom =
     borderBottom3 (px 5) dashed (rgb 11 14 17)
 
 -}
-borderBottom2 : Length -> BorderStyle -> Property namespace animation class id
+borderBottom2 : Length compatibleA -> BorderStyle compatibleB -> Property namespace animation class id
 borderBottom2 =
-    prop2 "border-bottom" lengthToString borderStyleToString
+    prop2 "border-bottom"
 
 
 {-| Sets [`border-bottom`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-bottom)
@@ -2314,9 +2199,9 @@ borderBottom2 =
     borderBottom3 (px 5) dashed (rgb 11 14 17)
 
 -}
-borderBottom3 : Length -> BorderStyle -> Color -> Property namespace animation class id
+borderBottom3 : Length compatibleA -> BorderStyle compatibleB -> Color compatibleC -> Property namespace animation class id
 borderBottom3 =
-    prop3 "border-bottom" lengthToString borderStyleToString colorToString
+    prop3 "border-bottom"
 
 
 {-| Sets [`border-left`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-left)
@@ -2326,9 +2211,9 @@ borderBottom3 =
     borderLeft3 (px 5) dashed (rgb 11 14 17)
 
 -}
-borderLeft : Length -> Property namespace animation class id
+borderLeft : Length compatible -> Property namespace animation class id
 borderLeft =
-    prop1 "border-left" lengthToString
+    prop1 "border-left"
 
 
 {-| Sets [`border-left`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-left)
@@ -2338,9 +2223,9 @@ borderLeft =
     borderLeft3 (px 5) dashed (rgb 11 14 17)
 
 -}
-borderLeft2 : Length -> BorderStyle -> Property namespace animation class id
+borderLeft2 : Length compatibleA -> BorderStyle compatibleB -> Property namespace animation class id
 borderLeft2 =
-    prop2 "border-left" lengthToString borderStyleToString
+    prop2 "border-left"
 
 
 {-| Sets [`border-left`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-left)
@@ -2350,9 +2235,9 @@ borderLeft2 =
     borderLeft3 (px 5) dashed (rgb 11 14 17)
 
 -}
-borderLeft3 : Length -> BorderStyle -> Color -> Property namespace animation class id
+borderLeft3 : Length compatibleA -> BorderStyle compatibleB -> Color compatibleC -> Property namespace animation class id
 borderLeft3 =
-    prop3 "border-left" lengthToString borderStyleToString colorToString
+    prop3 "border-left"
 
 
 {-| Sets [`border-right`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-right)
@@ -2362,9 +2247,9 @@ borderLeft3 =
     borderRight3 (px 5) dashed (rgb 11 14 17)
 
 -}
-borderRight : Length -> Property namespace animation class id
+borderRight : Length compatible -> Property namespace animation class id
 borderRight =
-    prop1 "border-right" lengthToString
+    prop1 "border-right"
 
 
 {-| Sets [`border-right`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-right)
@@ -2374,9 +2259,9 @@ borderRight =
     borderRight3 (px 5) dashed (rgb 11 14 17)
 
 -}
-borderRight2 : Length -> BorderStyle -> Property namespace animation class id
+borderRight2 : Length compatibleA -> BorderStyle compatibleB -> Property namespace animation class id
 borderRight2 =
-    prop2 "border-right" lengthToString borderStyleToString
+    prop2 "border-right"
 
 
 {-| Sets [`border-right`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-right)
@@ -2386,9 +2271,9 @@ borderRight2 =
     borderRight3 (px 5) dashed (rgb 11 14 17)
 
 -}
-borderRight3 : Length -> BorderStyle -> Color -> Property namespace animation class id
+borderRight3 : Length compatibleA -> BorderStyle compatibleB -> Color compatibleC -> Property namespace animation class id
 borderRight3 =
-    prop3 "border-right" lengthToString borderStyleToString colorToString
+    prop3 "border-right"
 
 
 {-| Sets [`border-block-start`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-block-start)
@@ -2398,9 +2283,9 @@ borderRight3 =
     borderBlockStart3 (px 5) dashed (rgb 11 14 17)
 
 -}
-borderBlockStart : Length -> Property namespace animation class id
+borderBlockStart : Length compatible -> Property namespace animation class id
 borderBlockStart =
-    prop1 "border-block-start" lengthToString
+    prop1 "border-block-start"
 
 
 {-| Sets [`border-block-start`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-block-start)
@@ -2410,9 +2295,9 @@ borderBlockStart =
     borderBlockStart3 (px 5) dashed (rgb 11 14 17)
 
 -}
-borderBlockStart2 : Length -> BorderStyle -> Property namespace animation class id
+borderBlockStart2 : Length compatibleA -> BorderStyle compatibleB -> Property namespace animation class id
 borderBlockStart2 =
-    prop2 "border-block-start" lengthToString borderStyleToString
+    prop2 "border-block-start"
 
 
 {-| Sets [`border-block-start`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-block-start)
@@ -2422,9 +2307,9 @@ borderBlockStart2 =
     borderBlockStart3 (px 5) dashed (rgb 11 14 17)
 
 -}
-borderBlockStart3 : Length -> BorderStyle -> Color -> Property namespace animation class id
+borderBlockStart3 : Length compatibleA -> BorderStyle compatibleB -> Color compatibleC -> Property namespace animation class id
 borderBlockStart3 =
-    prop3 "border-block-start" lengthToString borderStyleToString colorToString
+    prop3 "border-block-start"
 
 
 {-| Sets [`border-block-end`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-block-end)
@@ -2434,9 +2319,9 @@ borderBlockStart3 =
     borderBlockEnd3 (px 5) dashed (rgb 11 14 17)
 
 -}
-borderBlockEnd : Length -> Property namespace animation class id
+borderBlockEnd : Length compatible -> Property namespace animation class id
 borderBlockEnd =
-    prop1 "border-block-end" lengthToString
+    prop1 "border-block-end"
 
 
 {-| Sets [`border-block-end`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-block-end)
@@ -2446,9 +2331,9 @@ borderBlockEnd =
     borderBlockEnd3 (px 5) dashed (rgb 11 14 17)
 
 -}
-borderBlockEnd2 : Length -> BorderStyle -> Property namespace animation class id
+borderBlockEnd2 : Length compatibleA -> BorderStyle compatibleB -> Property namespace animation class id
 borderBlockEnd2 =
-    prop2 "border-block-end" lengthToString borderStyleToString
+    prop2 "border-block-end"
 
 
 {-| Sets [`border-block-end`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-block-end)
@@ -2458,9 +2343,9 @@ borderBlockEnd2 =
     borderBlockEnd3 (px 5) dashed (rgb 11 14 17)
 
 -}
-borderBlockEnd3 : Length -> BorderStyle -> Color -> Property namespace animation class id
+borderBlockEnd3 : Length compatibleA -> BorderStyle compatibleB -> Color compatibleC -> Property namespace animation class id
 borderBlockEnd3 =
-    prop3 "border-block-end" lengthToString borderStyleToString colorToString
+    prop3 "border-block-end"
 
 
 {-| Sets [`border-block-start`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-block-start)
@@ -2470,9 +2355,9 @@ borderBlockEnd3 =
     borderInlineStart3 (px 5) dashed (rgb 11 14 17)
 
 -}
-borderInlineStart : Length -> Property namespace animation class id
+borderInlineStart : Length compatible -> Property namespace animation class id
 borderInlineStart =
-    prop1 "border-block-start" lengthToString
+    prop1 "border-block-start"
 
 
 {-| Sets [`border-block-start`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-block-start)
@@ -2482,9 +2367,9 @@ borderInlineStart =
     borderInlineStart3 (px 5) dashed (rgb 11 14 17)
 
 -}
-borderInlineStart2 : Length -> BorderStyle -> Property namespace animation class id
+borderInlineStart2 : Length compatibleA -> BorderStyle compatibleB -> Property namespace animation class id
 borderInlineStart2 =
-    prop2 "border-block-start" lengthToString borderStyleToString
+    prop2 "border-block-start"
 
 
 {-| Sets [`border-block-start`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-block-start)
@@ -2494,9 +2379,9 @@ borderInlineStart2 =
     borderInlineStart3 (px 5) dashed (rgb 11 14 17)
 
 -}
-borderInlineStart3 : Length -> BorderStyle -> Color -> Property namespace animation class id
+borderInlineStart3 : Length compatibleA -> BorderStyle compatibleB -> Color compatibleC -> Property namespace animation class id
 borderInlineStart3 =
-    prop3 "border-block-start" lengthToString borderStyleToString colorToString
+    prop3 "border-block-start"
 
 
 {-| Sets [`border-block-end`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-block-end)
@@ -2506,9 +2391,9 @@ borderInlineStart3 =
     borderInlineEnd3 (px 5) dashed (rgb 11 14 17)
 
 -}
-borderInlineEnd : Length -> Property namespace animation class id
+borderInlineEnd : Length compatible -> Property namespace animation class id
 borderInlineEnd =
-    prop1 "border-block-end" lengthToString
+    prop1 "border-block-end"
 
 
 {-| Sets [`border-block-end`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-block-end)
@@ -2518,9 +2403,9 @@ borderInlineEnd =
     borderInlineEnd3 (px 5) dashed (rgb 11 14 17)
 
 -}
-borderInlineEnd2 : Length -> BorderStyle -> Property namespace animation class id
+borderInlineEnd2 : Length compatibleA -> BorderStyle compatibleB -> Property namespace animation class id
 borderInlineEnd2 =
-    prop2 "border-block-end" lengthToString borderStyleToString
+    prop2 "border-block-end"
 
 
 {-| Sets [`border-block-end`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-block-end)
@@ -2530,9 +2415,9 @@ borderInlineEnd2 =
     borderInlineEnd3 (px 5) dashed (rgb 11 14 17)
 
 -}
-borderInlineEnd3 : Length -> BorderStyle -> Color -> Property namespace animation class id
+borderInlineEnd3 : Length compatibleA -> BorderStyle compatibleB -> Color compatibleC -> Property namespace animation class id
 borderInlineEnd3 =
-    prop3 "border-block-end" lengthToString borderStyleToString colorToString
+    prop3 "border-block-end"
 
 
 {-| Sets [`border-image-outset`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-image-outset)
@@ -2543,9 +2428,9 @@ borderInlineEnd3 =
     borderImageOutset4 (n 2) (px 15) (n 14) (em 3)
 
 -}
-borderImageOutset : LengthOrNumber -> Property namespace animation class id
+borderImageOutset : LengthOrNumber compatible -> Property namespace animation class id
 borderImageOutset =
-    prop1 "border-image-outset" lengthOrNumberToString
+    prop1 "border-image-outset"
 
 
 {-| Sets [`border-image-outset`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-image-outset)
@@ -2556,9 +2441,9 @@ borderImageOutset =
     borderImageOutset4 (n 2) (px 15) (n 14) (em 3)
 
 -}
-borderImageOutset2 : LengthOrNumber -> LengthOrNumber -> Property namespace animation class id
+borderImageOutset2 : LengthOrNumber compatibleA -> LengthOrNumber compatibleB -> Property namespace animation class id
 borderImageOutset2 =
-    prop2 "border-image-outset" lengthOrNumberToString lengthOrNumberToString
+    prop2 "border-image-outset"
 
 
 {-| Sets [`border-image-outset`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-image-outset)
@@ -2569,9 +2454,9 @@ borderImageOutset2 =
     borderImageOutset4 (n 2) (px 15) (n 14) (em 3)
 
 -}
-borderImageOutset3 : LengthOrNumber -> LengthOrNumber -> LengthOrNumber -> Property namespace animation class id
+borderImageOutset3 : LengthOrNumber compatibleA -> LengthOrNumber compatibleB -> LengthOrNumber compatibleC -> Property namespace animation class id
 borderImageOutset3 =
-    prop3 "border-image-outset" lengthOrNumberToString lengthOrNumberToString lengthOrNumberToString
+    prop3 "border-image-outset"
 
 
 {-| Sets [`border-image-outset`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-image-outset)
@@ -2582,9 +2467,9 @@ borderImageOutset3 =
     borderImageOutset4 (n 2) (px 15) (n 14) (em 3)
 
 -}
-borderImageOutset4 : LengthOrNumber -> LengthOrNumber -> LengthOrNumber -> LengthOrNumber -> Property namespace animation class id
+borderImageOutset4 : LengthOrNumber compatibleA -> LengthOrNumber compatibleB -> LengthOrNumber compatibleC -> LengthOrNumber compatibleD -> Property namespace animation class id
 borderImageOutset4 =
-    prop4 "border-image-outset" lengthOrNumberToString lengthOrNumberToString lengthOrNumberToString lengthOrNumberToString
+    prop4 "border-image-outset"
 
 
 {-| Sets [`border-image-width`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-image-width)
@@ -2595,9 +2480,9 @@ borderImageOutset4 =
     borderImageWidth4 (n 3) (px 15) auto (n 2)
 
 -}
-borderImageWidth : LengthOrNumber -> Property namespace animation class id
+borderImageWidth : LengthOrNumber compatible -> Property namespace animation class id
 borderImageWidth =
-    prop1 "border-image-width" lengthOrNumberToString
+    prop1 "border-image-width"
 
 
 {-| Sets [`border-image-width`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-image-width)
@@ -2608,9 +2493,9 @@ borderImageWidth =
     borderImageWidth4 (n 3) (px 15) auto (n 2)
 
 -}
-borderImageWidth2 : LengthOrNumber -> LengthOrNumber -> Property namespace animation class id
+borderImageWidth2 : LengthOrNumber compatibleA -> LengthOrNumber compatibleB -> Property namespace animation class id
 borderImageWidth2 =
-    prop2 "border-image-width" lengthOrNumberToString lengthOrNumberToString
+    prop2 "border-image-width"
 
 
 {-| Sets [`border-image-width`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-image-width)
@@ -2621,9 +2506,9 @@ borderImageWidth2 =
     borderImageWidth4 (n 3) (px 15) auto (n 2)
 
 -}
-borderImageWidth3 : LengthOrNumber -> LengthOrNumber -> LengthOrNumber -> Property namespace animation class id
+borderImageWidth3 : LengthOrNumber compatibleA -> LengthOrNumber compatibleB -> LengthOrNumber compatibleC -> Property namespace animation class id
 borderImageWidth3 =
-    prop3 "border-image-width" lengthOrNumberToString lengthOrNumberToString lengthOrNumberToString
+    prop3 "border-image-width"
 
 
 {-| Sets [`border-image-width`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-image-width)
@@ -2634,198 +2519,198 @@ borderImageWidth3 =
     borderImageWidth4 (n 3) (px 15) auto (n 2)
 
 -}
-borderImageWidth4 : LengthOrNumber -> LengthOrNumber -> LengthOrNumber -> LengthOrNumber -> Property namespace animation class id
+borderImageWidth4 : LengthOrNumber compatibleA -> LengthOrNumber compatibleB -> LengthOrNumber compatibleC -> LengthOrNumber compatibleD -> Property namespace animation class id
 borderImageWidth4 =
-    prop4 "border-image-width" lengthOrNumberToString lengthOrNumberToString lengthOrNumberToString lengthOrNumberToString
+    prop4 "border-image-width"
 
 
 {-| Sets [`border-block-start-color`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-block-start-color)
 
     borderBlockStartColor (rgb 101 202 0)
 -}
-borderBlockStartColor : Color -> Property namespace animation class id
+borderBlockStartColor : Color compatible -> Property namespace animation class id
 borderBlockStartColor =
-    prop1 "border-block-start-color" colorToString
+    prop1 "border-block-start-color"
 
 
 {-| Sets [`border-bottom-color`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-bottom-color)
 
     borderBottomColor (rgb 101 202 0)
 -}
-borderBottomColor : Color -> Property namespace animation class id
+borderBottomColor : Color compatible -> Property namespace animation class id
 borderBottomColor =
-    prop1 "border-bottom-color" colorToString
+    prop1 "border-bottom-color"
 
 
 {-| Sets [`border-inline-start-color`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-inline-start-color)
 
     borderInlineStartColor (rgb 101 202 0)
 -}
-borderInlineStartColor : Color -> Property namespace animation class id
+borderInlineStartColor : Color compatible -> Property namespace animation class id
 borderInlineStartColor =
-    prop1 "border-inline-start-color" colorToString
+    prop1 "border-inline-start-color"
 
 
 {-| Sets [`border-inline-end-color`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-inline-end-color)
 
     borderInlineEndColor (rgb 101 202 0)
 -}
-borderInlineEndColor : Color -> Property namespace animation class id
+borderInlineEndColor : Color compatible -> Property namespace animation class id
 borderInlineEndColor =
-    prop1 "border-inline-end-color" colorToString
+    prop1 "border-inline-end-color"
 
 
 {-| Sets [`border-left-color`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-left-color)
 
     borderLeftColor (rgb 101 202 0)
 -}
-borderLeftColor : Color -> Property namespace animation class id
+borderLeftColor : Color compatible -> Property namespace animation class id
 borderLeftColor =
-    prop1 "border-left-color" colorToString
+    prop1 "border-left-color"
 
 
 {-| Sets [`border-right-color`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-right-color)
 
     borderRightColor (rgb 101 202 0)
 -}
-borderRightColor : Color -> Property namespace animation class id
+borderRightColor : Color compatible -> Property namespace animation class id
 borderRightColor =
-    prop1 "border-right-color" colorToString
+    prop1 "border-right-color"
 
 
 {-| Sets [`border-top-color`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-top-color)
 
     borderTopColor (rgb 101 202 0)
 -}
-borderTopColor : Color -> Property namespace animation class id
+borderTopColor : Color compatible -> Property namespace animation class id
 borderTopColor =
-    prop1 "border-top-color" colorToString
+    prop1 "border-top-color"
 
 
 {-| Sets [`border-block-end-color`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-block-end-color)
 
     borderBlockEndColor (rgb 101 202 0)
 -}
-borderBlockEndColor : Color -> Property namespace animation class id
+borderBlockEndColor : Color compatible -> Property namespace animation class id
 borderBlockEndColor =
-    prop1 "border-block-end-color" colorToString
+    prop1 "border-block-end-color"
 
 
 {-| Sets [`border-block-end-style`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-block-end-style)
 
     borderBlockEndStyle dashed
 -}
-borderBlockEndStyle : BorderStyle -> Property namespace animation class id
+borderBlockEndStyle : BorderStyle compatible -> Property namespace animation class id
 borderBlockEndStyle =
-    prop1 "border-block-end-style" borderStyleToString
+    prop1 "border-block-end-style"
 
 
 {-| Sets [`border-block-start-style`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-block-start-style)
 
     borderBlockStartStyle dashed
 -}
-borderBlockStartStyle : BorderStyle -> Property namespace animation class id
+borderBlockStartStyle : BorderStyle compatible -> Property namespace animation class id
 borderBlockStartStyle =
-    prop1 "border-block-start-style" borderStyleToString
+    prop1 "border-block-start-style"
 
 
 {-| Sets [`border-inline-end-style`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-inline-end-style)
 
     borderInlineEndStyle dashed
 -}
-borderInlineEndStyle : BorderStyle -> Property namespace animation class id
+borderInlineEndStyle : BorderStyle compatible -> Property namespace animation class id
 borderInlineEndStyle =
-    prop1 "border-inline-end-style" borderStyleToString
+    prop1 "border-inline-end-style"
 
 
 {-| Sets [`border-bottom-style`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-bottom-style)
 
     borderBottomStyle dashed
 -}
-borderBottomStyle : BorderStyle -> Property namespace animation class id
+borderBottomStyle : BorderStyle compatible -> Property namespace animation class id
 borderBottomStyle =
-    prop1 "border-bottom-style" borderStyleToString
+    prop1 "border-bottom-style"
 
 
 {-| Sets [`border-inline-start-style`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-inline-start-style)
 
     borderInlineStartStyle dashed
 -}
-borderInlineStartStyle : BorderStyle -> Property namespace animation class id
+borderInlineStartStyle : BorderStyle compatible -> Property namespace animation class id
 borderInlineStartStyle =
-    prop1 "border-inline-start-style" borderStyleToString
+    prop1 "border-inline-start-style"
 
 
 {-| Sets [`border-left-style`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-left-style)
 
     borderLeftStyle dashed
 -}
-borderLeftStyle : BorderStyle -> Property namespace animation class id
+borderLeftStyle : BorderStyle compatible -> Property namespace animation class id
 borderLeftStyle =
-    prop1 "border-left-style" borderStyleToString
+    prop1 "border-left-style"
 
 
 {-| Sets [`border-right-style`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-right-style)
 
     borderRightStyle dashed
 -}
-borderRightStyle : BorderStyle -> Property namespace animation class id
+borderRightStyle : BorderStyle compatible -> Property namespace animation class id
 borderRightStyle =
-    prop1 "border-right-style" borderStyleToString
+    prop1 "border-right-style"
 
 
 {-| Sets [`border-top-style`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-top-style)
 
     borderTopStyle dashed
 -}
-borderTopStyle : BorderStyle -> Property namespace animation class id
+borderTopStyle : BorderStyle compatible -> Property namespace animation class id
 borderTopStyle =
-    prop1 "border-top-style" borderStyleToString
+    prop1 "border-top-style"
 
 
 {-| Sets [`border-style`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-style)
 
     borderStyle dashed
 -}
-borderStyle : BorderStyle -> Property namespace animation class id
+borderStyle : BorderStyle compatible -> Property namespace animation class id
 borderStyle =
-    prop1 "border-style" borderStyleToString
+    prop1 "border-style"
 
 
 {-| Sets [`border-bottom-width`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-bottom-width)
 
     borderBottomWidth (em 4)
 -}
-borderBottomWidth : Length -> Property namespace animation class id
+borderBottomWidth : Length compatible -> Property namespace animation class id
 borderBottomWidth =
-    prop1 "border-bottom-width" lengthToString
+    prop1 "border-bottom-width"
 
 
 {-| Sets [`border-inline-end-width`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-inline-end-width)
 
     borderInlineEndWidth (em 4)
 -}
-borderInlineEndWidth : Length -> Property namespace animation class id
+borderInlineEndWidth : Length compatible -> Property namespace animation class id
 borderInlineEndWidth =
-    prop1 "border-inline-end-width" lengthToString
+    prop1 "border-inline-end-width"
 
 
 {-| Sets [`border-left-width`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-left-width)
 
     borderLeftWidth (em 4)
 -}
-borderLeftWidth : Length -> Property namespace animation class id
+borderLeftWidth : Length compatible -> Property namespace animation class id
 borderLeftWidth =
-    prop1 "border-left-width" lengthToString
+    prop1 "border-left-width"
 
 
 {-| Sets [`border-right-width`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-right-width)
 
     borderRightWidth (em 4)
 -}
-borderRightWidth : Length -> Property namespace animation class id
+borderRightWidth : Length compatible -> Property namespace animation class id
 borderRightWidth =
-    prop1 "border-right-width" lengthToString
+    prop1 "border-right-width"
 
 
 {-| Sets [`border-top-width`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-top-width)
@@ -2833,9 +2718,9 @@ borderRightWidth =
     borderTopWidth  (em 4)
     borderTopWidth2 (em 4) (px 2)
 -}
-borderTopWidth : Length -> Property namespace animation class id
+borderTopWidth : Length compatible -> Property namespace animation class id
 borderTopWidth =
-    prop1 "border-top-width" lengthToString
+    prop1 "border-top-width"
 
 
 {-| Sets [`border-top-width`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-top-width)
@@ -2843,9 +2728,9 @@ borderTopWidth =
     borderTopWidth  (em 4)
     borderTopWidth2 (em 4) (px 2)
 -}
-borderTopWidth2 : Length -> Length -> Property namespace animation class id
+borderTopWidth2 : Length compatibleA -> Length compatibleB -> Property namespace animation class id
 borderTopWidth2 =
-    prop2 "border-top-width" lengthToString lengthToString
+    prop2 "border-top-width"
 
 
 {-| Sets [`border-bottom-left-radius`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-bottom-left-radius)
@@ -2853,9 +2738,9 @@ borderTopWidth2 =
     borderBottomLeftRadius  (em 4)
     borderBottomLeftRadius2 (em 4) (px 2)
 -}
-borderBottomLeftRadius : Length -> Property namespace animation class id
+borderBottomLeftRadius : Length compatible -> Property namespace animation class id
 borderBottomLeftRadius =
-    prop1 "border-bottom-left-radius" lengthToString
+    prop1 "border-bottom-left-radius"
 
 
 {-| Sets [`border-bottom-left-radius`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-bottom-left-radius)
@@ -2863,9 +2748,9 @@ borderBottomLeftRadius =
     borderBottomLeftRadius  (em 4)
     borderBottomLeftRadius2 (em 4) (px 2)
 -}
-borderBottomLeftRadius2 : Length -> Length -> Property namespace animation class id
+borderBottomLeftRadius2 : Length compatibleA -> Length compatibleB -> Property namespace animation class id
 borderBottomLeftRadius2 =
-    prop2 "border-bottom-left-radius" lengthToString lengthToString
+    prop2 "border-bottom-left-radius"
 
 
 {-| Sets [`border-bottom-right-radius`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-bottom-right-radius)
@@ -2873,9 +2758,9 @@ borderBottomLeftRadius2 =
     borderBottomRightRadius  (em 4)
     borderBottomRightRadius2 (em 4) (px 2)
 -}
-borderBottomRightRadius : Length -> Property namespace animation class id
+borderBottomRightRadius : Length compatible -> Property namespace animation class id
 borderBottomRightRadius =
-    prop1 "border-bottom-right-radius" lengthToString
+    prop1 "border-bottom-right-radius"
 
 
 {-| Sets [`border-bottom-right-radius`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-bottom-right-radius)
@@ -2883,9 +2768,9 @@ borderBottomRightRadius =
     borderBottomRightRadius  (em 4)
     borderBottomRightRadius2 (em 4) (px 2)
 -}
-borderBottomRightRadius2 : Length -> Length -> Property namespace animation class id
+borderBottomRightRadius2 : Length compatibleA -> Length compatibleB -> Property namespace animation class id
 borderBottomRightRadius2 =
-    prop2 "border-bottom-right-radius" lengthToString lengthToString
+    prop2 "border-bottom-right-radius"
 
 
 {-| Sets [`border-top-left-radius`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-top-left-radius)
@@ -2893,9 +2778,9 @@ borderBottomRightRadius2 =
     borderTopLeftRadius  (em 4)
     borderTopLeftRadius2 (em 4) (px 2)
 -}
-borderTopLeftRadius : Length -> Property namespace animation class id
+borderTopLeftRadius : Length compatible -> Property namespace animation class id
 borderTopLeftRadius =
-    prop1 "border-top-left-radius" lengthToString
+    prop1 "border-top-left-radius"
 
 
 {-| Sets [`border-top-left-radius`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-top-left-radius)
@@ -2903,9 +2788,9 @@ borderTopLeftRadius =
     borderTopLeftRadius  (em 4)
     borderTopLeftRadius2 (em 4) (px 2)
 -}
-borderTopLeftRadius2 : Length -> Length -> Property namespace animation class id
+borderTopLeftRadius2 : Length compatibleA -> Length compatibleB -> Property namespace animation class id
 borderTopLeftRadius2 =
-    prop2 "border-top-left-radius" lengthToString lengthToString
+    prop2 "border-top-left-radius"
 
 
 {-| Sets [`border-top-right-radius`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-top-right-radius)
@@ -2913,9 +2798,9 @@ borderTopLeftRadius2 =
     borderTopRightRadius  (em 4)
     borderTopRightRadius2 (em 4) (px 2)
 -}
-borderTopRightRadius : Length -> Property namespace animation class id
+borderTopRightRadius : Length compatible -> Property namespace animation class id
 borderTopRightRadius =
-    prop1 "border-top-right-radius" lengthToString
+    prop1 "border-top-right-radius"
 
 
 {-| Sets [`border-top-right-radius`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-top-right-radius)
@@ -2923,9 +2808,9 @@ borderTopRightRadius =
     borderTopRightRadius  (em 4)
     borderTopRightRadius2 (em 4) (px 2)
 -}
-borderTopRightRadius2 : Length -> Length -> Property namespace animation class id
+borderTopRightRadius2 : Length compatibleA -> Length compatibleB -> Property namespace animation class id
 borderTopRightRadius2 =
-    prop2 "border-top-right-radius" lengthToString lengthToString
+    prop2 "border-top-right-radius"
 
 
 {-| Sets [`border-radius`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-radius)
@@ -2935,9 +2820,9 @@ borderTopRightRadius2 =
     borderRadius3 (em 4) (px 2) (pct 5)
     borderRadius4 (em 4) (px 2) (pct 5) (px 3)
 -}
-borderRadius : Length -> Property namespace animation class id
+borderRadius : Length compatible -> Property namespace animation class id
 borderRadius =
-    prop1 "border-radius" lengthToString
+    prop1 "border-radius"
 
 
 {-| Sets [`border-radius`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-radius)
@@ -2947,9 +2832,9 @@ borderRadius =
     borderRadius3 (em 4) (px 2) (pct 5)
     borderRadius4 (em 4) (px 2) (pct 5) (px 3)
 -}
-borderRadius2 : Length -> Length -> Property namespace animation class id
+borderRadius2 : Length compatibleA -> Length compatibleB -> Property namespace animation class id
 borderRadius2 =
-    prop2 "border-radius" lengthToString lengthToString
+    prop2 "border-radius"
 
 
 {-| Sets [`border-radius`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-radius)
@@ -2959,9 +2844,9 @@ borderRadius2 =
     borderRadius3 (em 4) (px 2) (pct 5)
     borderRadius4 (em 4) (px 2) (pct 5) (px 3)
 -}
-borderRadius3 : Length -> Length -> Length -> Property namespace animation class id
+borderRadius3 : Length compatibleA -> Length compatibleB -> Length compatibleC -> Property namespace animation class id
 borderRadius3 =
-    prop3 "border-radius" lengthToString lengthToString lengthToString
+    prop3 "border-radius"
 
 
 {-| Sets [`border-radius`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-radius)
@@ -2971,9 +2856,9 @@ borderRadius3 =
     borderRadius3 (em 4) (px 2) (pct 5)
     borderRadius4 (em 4) (px 2) (pct 5) (px 3)
 -}
-borderRadius4 : Length -> Length -> Length -> Length -> Property namespace animation class id
+borderRadius4 : Length compatibleB -> Length compatibleB -> Length compatibleC -> Length compatibleD -> Property namespace animation class id
 borderRadius4 =
-    prop4 "border-radius" lengthToString lengthToString lengthToString lengthToString
+    prop4 "border-radius"
 
 
 {-| Sets [`border-spacing`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-spacing)
@@ -2981,9 +2866,9 @@ borderRadius4 =
     borderSpacing  (em 4)
     borderSpacing2 (em 4) (px 2)
 -}
-borderSpacing : Length -> Property namespace animation class id
+borderSpacing : Length compatible -> Property namespace animation class id
 borderSpacing =
-    prop1 "border-spacing" lengthToString
+    prop1 "border-spacing"
 
 
 {-| Sets [`border-spacing`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-spacing)
@@ -2991,9 +2876,9 @@ borderSpacing =
     borderSpacing  (em 4)
     borderSpacing2 (em 4) (px 2)
 -}
-borderSpacing2 : Length -> Length -> Property namespace animation class id
+borderSpacing2 : Length compatibleA -> Length compatibleB -> Property namespace animation class id
 borderSpacing2 =
-    prop2 "border-spacing" lengthToString lengthToString
+    prop2 "border-spacing"
 
 
 {-| Sets [`border-color`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-color)
@@ -3003,9 +2888,9 @@ borderSpacing2 =
     borderColor3 (rgb 12 11 10) (hex "FFBBCC") inherit
     borderColor4 (rgb 12 11 10) (hex "FFBBCC") inherit (rgb 1 2 3)
 -}
-borderColor : Color -> Property namespace animation class id
+borderColor : Color compatible -> Property namespace animation class id
 borderColor =
-    prop1 "border-color" colorToString
+    prop1 "border-color"
 
 
 {-| Sets [`border-color`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-color)
@@ -3015,9 +2900,9 @@ borderColor =
     borderColor3 (rgb 12 11 10) (hex "FFBBCC") inherit
     borderColor4 (rgb 12 11 10) (hex "FFBBCC") inherit (rgb 1 2 3)
 -}
-borderColor2 : Color -> Color -> Property namespace animation class id
+borderColor2 : Color compatibleA -> Color compatibleB -> Property namespace animation class id
 borderColor2 =
-    prop2 "border-color" colorToString colorToString
+    prop2 "border-color"
 
 
 {-| Sets [`border-color`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-color)
@@ -3027,9 +2912,9 @@ borderColor2 =
     borderColor3 (rgb 12 11 10) (hex "FFBBCC") inherit
     borderColor4 (rgb 12 11 10) (hex "FFBBCC") inherit (rgb 1 2 3)
 -}
-borderColor3 : Color -> Color -> Color -> Property namespace animation class id
+borderColor3 : Color compatibleA -> Color compatibleB -> Color compatibleC -> Property namespace animation class id
 borderColor3 =
-    prop3 "border-color" colorToString colorToString colorToString
+    prop3 "border-color"
 
 
 {-| Sets [`border-color`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-color)
@@ -3039,39 +2924,39 @@ borderColor3 =
     borderColor3 (rgb 12 11 10) (hex "FFBBCC") inherit
     borderColor4 (rgb 12 11 10) (hex "FFBBCC") inherit (rgb 1 2 3)
 -}
-borderColor4 : Color -> Color -> Color -> Color -> Property namespace animation class id
+borderColor4 : Color compatibleA -> Color compatibleB -> Color compatibleC -> Color compatibleD -> Property namespace animation class id
 borderColor4 =
-    prop4 "border-color" colorToString colorToString colorToString colorToString
+    prop4 "border-color"
 
 
 {-| -}
-overflowX : Overflow -> Property namespace animation class id
+overflowX : Overflow compatible -> Property namespace animation class id
 overflowX =
-    prop1 "overflow-x" overflowToString
+    prop1 "overflow-x"
 
 
 {-| -}
-overflowY : Overflow -> Property namespace animation class id
+overflowY : Overflow compatible -> Property namespace animation class id
 overflowY =
-    prop1 "overflow-y" overflowToString
+    prop1 "overflow-y"
 
 
 {-| -}
-whiteSpace : WhiteSpace -> Property namespace animation class id
+whiteSpace : WhiteSpace compatible -> Property namespace animation class id
 whiteSpace =
-    prop1 "white-space" whiteSpaceToString
+    prop1 "white-space"
 
 
 {-| -}
-backgroundColor : Color -> Property namespace animation class id
+backgroundColor : Color compatible -> Property namespace animation class id
 backgroundColor =
-    prop1 "background-color" colorToString
+    prop1 "background-color"
 
 
 {-| -}
-color : Color -> Property namespace animation class id
+color : Color compatible -> Property namespace animation class id
 color =
-    prop1 "color" colorToString
+    prop1 "color"
 
 
 {-| -}
@@ -3092,9 +2977,9 @@ You can specify multiple line decorations with `textDecorations`.
     ~ textDecorations2 [ underline, overline ] wavy
     ~ textDecorations3 [ underline, overline ] wavy (rgb 128 64 32)
 -}
-textDecoration : TextDecorationLine -> Property namespace animation class id
+textDecoration : TextDecorationLine a -> Property namespace animation class id
 textDecoration =
-    prop1 "text-decoration" textDecorationLineToString
+    prop1 "text-decoration"
 
 
 {-| Sets [`text-decoration`](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)
@@ -3109,9 +2994,9 @@ You can specify multiple line decorations with `textDecorations`.
     ~ textDecorations2 [ underline, overline ] wavy
     ~ textDecorations3 [ underline, overline ] wavy (rgb 128 64 32)
 -}
-textDecoration2 : TextDecorationLine -> TextDecorationStyle -> Property namespace animation class id
+textDecoration2 : TextDecorationLine compatibleA -> TextDecorationStyle compatibleB -> Property namespace animation class id
 textDecoration2 =
-    prop2 "text-decoration" textDecorationLineToString textDecorationStyleToString
+    prop2 "text-decoration"
 
 
 {-| Sets [`text-decoration`](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)
@@ -3126,9 +3011,9 @@ You can specify multiple line decorations with `textDecorations`.
     ~ textDecorations2 [ underline, overline ] wavy
     ~ textDecorations3 [ underline, overline ] wavy (rgb 128 64 32)
 -}
-textDecoration3 : TextDecorationLine -> TextDecorationStyle -> Color -> Property namespace animation class id
+textDecoration3 : TextDecorationLine compatibleA -> TextDecorationStyle compatibleB -> Color compatibleC -> Property namespace animation class id
 textDecoration3 =
-    prop3 "text-decoration" textDecorationLineToString textDecorationStyleToString colorToString
+    prop3 "text-decoration"
 
 
 {-| Sets [`text-decoration`](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)
@@ -3137,9 +3022,9 @@ textDecoration3 =
     ~ textDecorations2 [ underline, overline ] wavy
     ~ textDecorations3 [ underline, overline ] wavy (rgb 128 64 32)
 -}
-textDecorations : List TextDecorationLine -> Property namespace animation class id
+textDecorations : List (TextDecorationLine compatible) -> Property namespace animation class id
 textDecorations =
-    prop1 "text-decoration" textDecorationLinesToString
+    prop1 "text-decoration" << valuesOrNone
 
 
 {-| Sets [`text-decoration`](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)
@@ -3148,9 +3033,9 @@ textDecorations =
     ~ textDecorations2 [ underline, overline ] wavy
     ~ textDecorations3 [ underline, overline ] wavy (rgb 128 64 32)
 -}
-textDecorations2 : List TextDecorationLine -> TextDecorationStyle -> Property namespace animation class id
+textDecorations2 : List (TextDecorationLine compatibleA) -> TextDecorationStyle compatibleB -> Property namespace animation class id
 textDecorations2 =
-    prop2 "text-decoration" textDecorationLinesToString textDecorationStyleToString
+    prop2 "text-decoration" << valuesOrNone
 
 
 {-| Sets [`text-decoration`](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration)
@@ -3159,9 +3044,9 @@ textDecorations2 =
     ~ textDecorations2 [ underline, overline ] wavy
     ~ textDecorations3 [ underline, overline ] wavy (rgb 128 64 32)
 -}
-textDecorations3 : List TextDecorationLine -> TextDecorationStyle -> Color -> Property namespace animation class id
+textDecorations3 : List (TextDecorationLine compatibleA) -> TextDecorationStyle compatibleB -> Color compatibleC -> Property namespace animation class id
 textDecorations3 =
-    prop3 "text-decoration" textDecorationLinesToString textDecorationStyleToString colorToString
+    prop3 "text-decoration" << valuesOrNone
 
 
 {-| Sets [`text-decoration-line`](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-line)
@@ -3172,38 +3057,27 @@ You can specify multiple line decorations with `textDecorationLines`.
 
     ~ textDecorationLines  [ underline, overline ]
 -}
-textDecorationLine : TextDecorationLine -> Property namespace animation class id
+textDecorationLine : TextDecorationLine compatible -> Property namespace animation class id
 textDecorationLine =
-    prop1 "text-decoration-line" textDecorationLineToString
+    prop1 "text-decoration-line"
 
 
 {-| Sets [`text-decoration-line`](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-line)
 
     ~ textDecorationLines  [ underline, overline ]
 -}
-textDecorationLines : List TextDecorationLine -> Property namespace animation class id
+textDecorationLines : List (TextDecorationLine compatible) -> Property namespace animation class id
 textDecorationLines =
-    prop1 "text-decoration-line" textDecorationLinesToString
+    prop1 "text-decoration-line" << valuesOrNone
 
 
 {-| Sets [`text-decoration-style`](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-style)
 
     ~ textDecorationStyle dotted
 -}
-textDecorationStyle : TextDecorationStyle -> Property namespace animation class id
+textDecorationStyle : TextDecorationStyle compatible -> Property namespace animation class id
 textDecorationStyle =
-    prop1 "text-decoration-style" textDecorationStyleToString
-
-
-{-| -}
-outline : Float -> Length -> BorderStyle -> OpacityStyle -> Property namespace animation class id
-outline =
-    prop4
-        "outline"
-        toString
-        lengthToString
-        (\str -> " " ++ borderStyleToString str ++ " ")
-        opacityStyleToString
+    prop1 "text-decoration-style"
 
 
 {-| Sets [`animation-name`](https://developer.mozilla.org/en-US/docs/Web/CSS/animation-name)
@@ -4351,3 +4225,16 @@ updateLast update list =
 
         first :: rest ->
             first :: updateLast update rest
+
+
+numberToString : number -> String
+numberToString num =
+    toString (num + 0)
+
+
+valuesOrNone : List (Value compatible) -> Value {}
+valuesOrNone list =
+    if List.isEmpty list then
+        { value = "none" }
+    else
+        { value = String.join " " (List.map .value list) }


### PR DESCRIPTION
This makes a lot more things type-checkable.

Definitely introduced regressions around `initial` and the like (see https://github.com/rtfeldman/elm-css/issues/48), but worth switching over now and fixing those later so that new work can use the new system.