### PR TITLE
Address TODO under importToString

### DIFF
--- a/src/Css/Preprocess.elm
+++ b/src/Css/Preprocess.elm
@@ -4,7 +4,7 @@ module Css.Preprocess (..) where
 the data structures found in this module.
 -}
 
-import Css.Structure as Structure exposing (mapLast, concatMapLast)
+import Css.Structure as Structure exposing (mapLast, concatMapLast, NameOrUri)
 
 
 stylesheet : List Snippet -> Stylesheet
@@ -26,7 +26,7 @@ type alias Property =
 
 type alias Stylesheet =
   { charset : Maybe String
-  , imports : List ( String, List Structure.MediaQuery )
+  , imports : List ( NameOrUri, List Structure.MediaQuery )
   , namespaces : List ( String, String )
   , snippets : List Snippet
   }

--- a/src/Css/Structure.elm
+++ b/src/Css/Structure.elm
@@ -25,7 +25,7 @@ are specified once rather than intermingled with normal declarations:
 -}
 type alias Stylesheet =
   { charset : Maybe String
-  , imports : List ( String, List MediaQuery )
+  , imports : List ( NameOrUri, List MediaQuery )
   , namespaces : List ( String, String )
   , declarations : List Declaration
   }
@@ -63,6 +63,13 @@ type Declaration
 -}
 type StyleBlock
   = StyleBlock Selector (List Selector) (List Property)
+
+
+{-| Named location or uri.
+-}
+type NameOrUri
+  = Name String
+  | Uri String
 
 
 {-| A media query.

--- a/src/Css/Structure/Output.elm
+++ b/src/Css/Structure/Output.elm
@@ -22,10 +22,25 @@ charsetToString charset =
     |> Maybe.withDefault ""
 
 
-importToString : ( String, List MediaQuery ) -> String
+importToString : ( NameOrUri, List MediaQuery ) -> String
 importToString ( name, mediaQueries ) =
-  -- TODO
-  "@import \"" ++ name ++ toString mediaQueries ++ "\""
+  let
+    toMq query =
+      String.join ", "
+        <| List.map
+            (\q ->
+              case q of
+                MediaQuery mq ->
+                  mq
+            )
+            query
+  in
+    case name of
+      Name nm ->
+        "@import \"" ++ nm ++ "\" " ++ toMq mediaQueries
+
+      Uri uri ->
+        "@import url(\"" ++ uri ++ "\") " ++ toMq mediaQueries
 
 
 namespaceToString : ( String, String ) -> String


### PR DESCRIPTION
Implemented it like this since I need it for the project I'm working on. Handles most common cases. Will add a test if you approve. I suspect `NameOrUri` should be moved to Css.elm and possibly renamed to `NameOrUrl` with an `Url` tag instead of `Uri` to be more inline with the CSS semantics.