### PR TITLE
WIP: Examples fixes and make the CLI tool more elm-y

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Wouldn't it be sweet if those problems went away?
 2. Share code between your render logic and your CSS stylesheets, so you can easily keep identifier names and URLs synchronized
 3. Use union types instead of strings for class names, IDs, and animation names, so typos will result in compile errors instead of bugs
 4. Automatically namespace all your classes, ids, and animation names to avoid name conflicts between stylesheets.
-5. Assemble your stylesheets by writing normal Elm code, so you have access to your full suite of programming tools. elm-css doesn't need a special notion of "parameterized mixins" because you can already write arbitrary Elm functions...and not just to parameterize mixins, but to parameterize anything!
+5. Assemble your stylesheets by writing normal Elm code, so you have access to your full suite of programming tools. `elm-css` doesn't need a special notion of "parameterized mixins" because you can already write arbitrary Elm functions...and not just to parameterize mixins, but to parameterize anything!
 
 Here's an example:
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,16 @@ Wouldn't it be sweet if those problems went away?
 4. Automatically namespace all your classes, ids, and animation names to avoid name conflicts between stylesheets.
 5. Assemble your stylesheets by writing normal Elm code, so you have access to your full suite of programming tools. `elm-css` doesn't need a special notion of "parameterized mixins" because you can already write arbitrary Elm functions...and not just to parameterize mixins, but to parameterize anything!
 
+
+### Examples
+
+There are a few examples to check out!
+
+- (json-to-elm)[https://github.com/eeue56/json-to-elm] which can see be seen live [here](https://noredink.github.io/json-to-elm)
+- the examples folder contains a working project with a readme
+- the example below:
+
+
 Here's an example:
 
 ```elm

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,18 @@
+### Example
+
+For any elm-css project, you will need a minimum of:
+
+- An elm-html view
+- An elm-css file with the style rules within
+
+If you are using the CLI tool to generate pure CSS from the elm-css files, then you will also need an entry point file. This file will contain a `port files : CssFileStructure` which will tell the CLI tool which files to create.
+
+It is advisible to use a union type for your style classes, so that they can be typechecked.
+
+Inside here you'll find 4 files.
+
+- `SharedStyles` contains the union type for your style classes. This union type needs to be accessed by the CSS file to apply the styles to the tag name. The view file will also use it for giving the divs the correct class, aided by the namespace creator.
+- `HomepageCss` contains the elm-css
+- `HomepageView` contains the views
+- `Stylesheets.elm` is only the entry point, for use with the elm-css cli tool! It contains no styling, but instead links the Css files with their expected output filenames.
+

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,18 +1,18 @@
 ### Example
 
-For any elm-css project, you will need a minimum of:
+For any `elm-css` project, you will need a minimum of:
 
-- An elm-html view
-- An elm-css file with the style rules within
+- An `elm-html` view
+- An `elm-css` file with the style rules within
 
-If you are using the CLI tool to generate pure CSS from the elm-css files, then you will also need an entry point file. This file will contain a `port files : CssFileStructure` which will tell the CLI tool which files to create.
+If you are using the CLI tool to generate pure CSS from the `elm-css` files, then you will also need an entry point file. This file will contain a `port files : CssFileStructure` which will tell the CLI tool which files to create.
 
 It is advisible to use a union type for your style classes, so that they can be typechecked.
 
 Inside here you'll find 4 files.
 
 - `SharedStyles` contains the union type for your style classes. This union type needs to be accessed by the CSS file to apply the styles to the tag name. The view file will also use it for giving the divs the correct class, aided by the namespace creator.
-- `HomepageCss` contains the elm-css
+- `HomepageCss` contains the `elm-css`
 - `HomepageView` contains the views
-- `Stylesheets.elm` is only the entry point, for use with the elm-css cli tool! It contains no styling, but instead links the Css files with their expected output filenames.
+- `Stylesheets.elm` is only the entry point, for use with the `elm-css` cli tool! It contains no styling, but instead links the Css files with their expected output filenames.
 

--- a/index.js
+++ b/index.js
@@ -139,6 +139,20 @@ function noMatchingPortMessage(stylesheetsModule, stylesheetsPort, ports){
   return errorMessage.trim();
 }
 
+/*
+This is a poor man's type error. To get better error messages, might be worth
+considered moving to how elm-static-site does it instead, and use Elm's compiler
+for type errors!
+*/
+function portTypeErrorMessage(stylesheetsModule, stylesheetsPort){
+  var errorMessage = `
+The type of the port ${stylesheetsPort} was not what I wanted!
+I was expecting a list but got ${typeof stylesheetsPort}!
+`;
+
+  return errorMessage.trim();
+}
+
 function extractCssResults(dest, stylesheetsModule, stylesheetsPort) {
   return function () {
     return new Promise(function (resolve, reject) {
@@ -159,6 +173,11 @@ function extractCssResults(dest, stylesheetsModule, stylesheetsPort) {
       }
 
       var stylesheets = worker.ports[stylesheetsPort];
+
+      if (!Array.isArray(stylesheets)){
+        return reject(portTypeErrorMessage(stylesheetsModule, stylesheetsPort));
+      }
+
       var failures = stylesheets.filter(function(result) {
         return !result.success;
       });

--- a/index.js
+++ b/index.js
@@ -144,10 +144,10 @@ This is a poor man's type error. To get better error messages, might be worth
 considered moving to how elm-static-site does it instead, and use Elm's compiler
 for type errors!
 */
-function portTypeErrorMessage(stylesheetsModule, stylesheetsPort){
+function portTypeErrorMessage(stylesheetsModule, stylesheetsPort, portValue){
   var errorMessage = `
 The type of the port ${stylesheetsPort} was not what I wanted!
-I was expecting a list but got ${typeof stylesheetsPort}!
+I was expecting a List CssFileStructure but got ${typeof portValue}!
 `;
 
   return errorMessage.trim();
@@ -175,7 +175,7 @@ function extractCssResults(dest, stylesheetsModule, stylesheetsPort) {
       var stylesheets = worker.ports[stylesheetsPort];
 
       if (!Array.isArray(stylesheets)){
-        return reject(portTypeErrorMessage(stylesheetsModule, stylesheetsPort));
+        return reject(portTypeErrorMessage(stylesheetsModule, stylesheetsPort, stylesheets));
       }
 
       var failures = stylesheets.filter(function(result) {

--- a/index.js
+++ b/index.js
@@ -4,6 +4,34 @@ var path = require("path");
 var compile = require("node-elm-compiler").compile;
 var jsEmitterFilename = "emitter.js";
 
+var KNOWN_MODULES =
+  [
+    "Native",
+    "fullscreen",
+    "embed",
+    "worker",
+    "Basics",
+    "Maybe",
+    "List",
+    "Array",
+    "Char",
+    "Color",
+    "Transform2D",
+    "Text",
+    "Graphics",
+    "Debug",
+    "Result",
+    "Task",
+    "Signal",
+    "String",
+    "Dict",
+    "Json",
+    "Regex",
+    "VirtualDom",
+    "Html",
+    "Css"
+  ];
+
 // elmModuleName is optional, and is by default inferred based on the filename.
 module.exports = function(projectDir, stylesheetsPath, outputDir, stylesheetsModule, stylesheetsPort) {
 
@@ -54,11 +82,83 @@ function emit(src, dest, stylesheetsModule, stylesheetsPort) {
     .then(extractCssResults(dest, stylesheetsModule, stylesheetsPort));
 }
 
+function suggestModulesNames(Elm){
+  return Object.keys(Elm).filter(function(key){
+    return KNOWN_MODULES.indexOf(key) === -1;
+  })
+}
+
+function missingEntryModuleMessage(stylesheetsModule, Elm){
+  var errorMessage = "I couldn't find the entry module " + stylesheetsModule + ".\n";
+  var suggestions = suggestModulesNames(Elm);
+
+  if (suggestions.length > 1){
+    errorMessage += "\nMaybe you meant one of these: " + suggestions.join(",");
+  } else if (suggestions.length === 1){
+    errorMessage += "\nMaybe you meant: " + suggestions;
+  }
+
+  errorMessage += "\nYou can pass me a different module to use with --module=<moduleName>";
+
+  return errorMessage;
+}
+
+function noPortsMessage(stylesheetsModule, stylesheetsPort){
+  var errorMessage = "The module " + stylesheetsModule + " doesn't expose any ports!\n";
+
+  errorMessage += "\nI was looking for a port called `" + stylesheetsPort + "` but couldn't find it!";
+  errorMessage += "\n\nTry adding something like";
+  errorMessage += `
+port ${stylesheetsPort} : CssFileStructure
+port ${stylesheetsPort} =
+  toFileStructure
+    []
+
+to ${stylesheetsModule}!
+`;
+
+  return errorMessage.trim();
+}
+
+function noMatchingPortMessage(stylesheetsModule, stylesheetsPort, ports){
+  var errorMessage = `The module ${stylesheetsModule} has no port called ${stylesheetsPort}.\n`;
+  errorMessage += "\nI was looking for a port called `" + stylesheetsPort + "` but couldn't find it!";
+
+  var portKeys = Object.keys(ports);
+
+  if (portKeys.length === 1){
+    errorMessage += "\nHowever, I did find the port: " + portKeys[0];
+    errorMessage += "\nMaybe you meant that instead?";
+  } else {
+    errorMessage += "\nHowever, I did find the ports : " + Object.keys(ports).join(",");
+  }
+
+  errorMessage += "\n\nYou can specify which port to use by doing";
+  errorMessage += "\nelm-css -p <port-name>";
+
+  return errorMessage.trim();
+}
+
 function extractCssResults(dest, stylesheetsModule, stylesheetsPort) {
   return function () {
     return new Promise(function (resolve, reject) {
       var Elm = require(dest);
-      var stylesheets = Elm.worker(Elm[stylesheetsModule]).ports[stylesheetsPort];
+
+      if (!(stylesheetsModule in Elm)){
+        return reject(missingEntryModuleMessage(stylesheetsModule, Elm));
+      }
+
+      var worker = Elm.worker(Elm[stylesheetsModule]);
+
+      if (Object.keys(worker.ports).length === 0){
+        return reject(noPortsMessage(stylesheetsModule, stylesheetsPort));
+      }
+
+      if (!(stylesheetsPort in worker.ports)){
+        return reject(noMatchingPortMessage(stylesheetsModule, stylesheetsPort, worker.ports));
+      }
+
+      var stylesheets = worker.ports[stylesheetsPort];
       var failures = stylesheets.filter(function(result) {
         return !result.success;
       });


### PR DESCRIPTION
- Adds a high-level README to the examples folder

- Adds useful error messages for when you've given the cli tool a bad entry file, e.g

<img width="750" alt="screen shot 2016-03-05 at 00 06 15" src="https://cloud.githubusercontent.com/assets/1139198/13544126/8d647a32-e26a-11e5-9978-b6b679b3ceb5.png">

- Adds useful error messages for when you've given the cli tool a file without any ports

<img width="763" alt="screen shot 2016-03-05 at 00 14 05" src="https://cloud.githubusercontent.com/assets/1139198/13544130/9d350bd4-e26a-11e5-9be0-1582488cd0bb.png">

- Adds useful error messages for when you've given a cli tool a file with ports of a different name

<img width="768" alt="screen shot 2016-03-05 at 00 39 36" src="https://cloud.githubusercontent.com/assets/1139198/13544148/ca9434ba-e26a-11e5-8665-f3ab2ce5b45d.png">

- Adds useful error message for the type of the port was wrong

<img width="758" alt="screen shot 2016-03-05 at 00 53 24" src="https://cloud.githubusercontent.com/assets/1139198/13544351/c9bcf430-e26c-11e5-9baf-0cb3b99b5511.png">

