### PR TITLE
Resolve collision

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,11 +43,8 @@ There are a few examples to check out!
 Here's an example:
 
 ```elm
-
-namespacer = namespace "dreamwriter"
-
 css =
-  (stylesheet << namespacer.rules)
+  (stylesheet << withNamespace "dreamwriter")
     [ body
         [ overflowX auto
         , minWidth (px 1280)

--- a/examples/src/SharedStyles.elm
+++ b/examples/src/SharedStyles.elm
@@ -1,6 +1,6 @@
 module SharedStyles (..) where
 
-import Html.CssHelpers exposing (namespace)
+import Html.CssHelpers exposing (withNamespace)
 
 
 type CssClasses
@@ -13,4 +13,4 @@ type CssIds
 
 
 homepageNamespace =
-  namespace "homepage"
+  withNamespace "homepage"

--- a/src/Html/CssHelpers.elm
+++ b/src/Html/CssHelpers.elm
@@ -4,6 +4,7 @@ module Html.CssHelpers (namespace) where
 
 @docs namespace
 -}
+
 import Css exposing (Snippet)
 import Css.Helpers exposing (toCssIdentifier, identifierToString)
 import Html exposing (Attribute)

--- a/src/Html/CssHelpers.elm
+++ b/src/Html/CssHelpers.elm
@@ -6,7 +6,6 @@ module Html.CssHelpers (namespace) where
 -}
 import Css exposing (Snippet)
 import Css.Helpers exposing (toCssIdentifier, identifierToString)
-import Css.Namespace
 import Html exposing (Attribute)
 import Html.Attributes as Attr
 import String
@@ -24,7 +23,6 @@ type alias Namespace name class id =
   , classList : List ( class, Bool ) -> Attribute
   , id : id -> Attribute
   , name : name
-  , rules : List Snippet -> List Snippet
   }
 
 
@@ -33,8 +31,7 @@ type alias Namespace name class id =
 they accept union types and automatically incorporate the given namespace. Also
 note that `class` accepts a `List` instead of a single element; this is so you
 can specify multiple classes without having to call `classList` passing tuples
-that all end in `True`. Also returns `rules`, which you can use to namespace a
-list of rules.
+that all end in `True`.
 
     -- Put this before your view code to specify a namespace.
     { id, class, classList } = namespace "homepage"
@@ -55,7 +52,6 @@ namespace name =
   , classList = namespacedClassList name
   , id = toCssIdentifier >> Attr.id
   , name = name
-  , rules = Css.Namespace.namespace name
   }
 
 

--- a/src/Html/CssHelpers.elm
+++ b/src/Html/CssHelpers.elm
@@ -1,4 +1,4 @@
-module Html.CssHelpers (namespace) where
+module Html.CssHelpers (withNamespace) where
 
 {-| Helper functions for using elm-css with elm-html.
 
@@ -35,7 +35,7 @@ can specify multiple classes without having to call `classList` passing tuples
 that all end in `True`.
 
     -- Put this before your view code to specify a namespace.
-    { id, class, classList } = namespace "homepage"
+    { id, class, classList } = withNamespace "homepage"
 
     view =
         h1 [ id Hero, class [ Fancy ] ] [ text "Hello, World!" ]
@@ -47,8 +47,8 @@ The above would generate this DOM element:
 
     <h1 id="Hero" class="homepage_Fancy">Hello, World!</h1>
 -}
-namespace : name -> Namespace name class id
-namespace name =
+withNamespace : name -> Namespace name class id
+withNamespace name =
   { class = namespacedClass name
   , classList = namespacedClassList name
   , id = toCssIdentifier >> Attr.id


### PR DESCRIPTION
Instead of adding `rules`, just resolve the collision by renaming `CssHelpers.namespace` to `CssHelpers.withNamespace`