### PR TITLE
Add hex color validations

### DIFF
--- a/src/Css.elm
+++ b/src/Css.elm
@@ -4189,8 +4189,8 @@ backgroundColor =
 
 {-| -}
 color : ColorValue compatible -> Mixin
-color =
-  prop1 "color"
+color c =
+  propertyWithWarnings c.warnings "color" c.value
 
 
 {-| -}

--- a/src/Css.elm
+++ b/src/Css.elm
@@ -863,14 +863,14 @@ hex str =
         "#" ++ str
     warnings =
       if contains (regex "^#([a-fA-F0-9]{8}|[a-fA-F0-9]{6}|[a-fA-F0-9]{4}|[a-fA-F0-9]{3})$") value then
+        []
+      else
         [ String.join " "
             [ "The syntax of a hex-color is a token whose value consists of 3, 4, 6, or 8 hexadecimal digits."
             , value
             , "is not valid."
             , "Please see: https://drafts.csswg.org/css-color/#hex-notation"]
         ]
-      else
-        []
   in
     { value = value
     , color = Compatible

--- a/src/Css.elm
+++ b/src/Css.elm
@@ -57,6 +57,7 @@ import Css.Helpers exposing (toCssIdentifier, identifierToString)
 import Css.Preprocess.Resolve as Resolve
 import Css.Preprocess as Preprocess exposing (Mixin, unwrapSnippet)
 import Css.Structure as Structure exposing (MediaQuery(MediaQuery))
+import Regex exposing (regex, contains)
 import String
 
 
@@ -854,13 +855,17 @@ tools which express these as e.g. `#abcdef0`, etc.
 -}
 hex : String -> Color
 hex str =
-  -- TODO emit warnings for invalid hex chars
   let
     value =
       if String.slice 0 1 str == "#" then
         str
       else
         "#" ++ str
+    warnings =
+      if contains (regex "^#([a-fA-F0-9]{6}|[a-fA-F0-9]{3})$") value then
+        [ "Hexadecimal color values can only contain three or six characters of '0-9' and/or 'A-F'. " ++ value ++ " is not valid." ]
+      else
+        []
   in
     { value = value
     , color = Compatible
@@ -868,7 +873,7 @@ hex str =
     , green = 0
     , blue = 0
     , alpha = 1
-    , warnings = []
+    , warnings = warnings
     }
 
 

--- a/src/Css.elm
+++ b/src/Css.elm
@@ -862,8 +862,13 @@ hex str =
       else
         "#" ++ str
     warnings =
-      if contains (regex "^#([a-fA-F0-9]{6}|[a-fA-F0-9]{3})$") value then
-        [ "Hexadecimal color values can only contain three or six characters of '0-9' and/or 'A-F'. " ++ value ++ " is not valid." ]
+      if contains (regex "^#([a-fA-F0-9]{8}|[a-fA-F0-9]{6}|[a-fA-F0-9]{4}|[a-fA-F0-9]{3})$") value then
+        [ String.join " "
+            [ "The syntax of a hex-color is a token whose value consists of 3, 4, 6, or 8 hexadecimal digits."
+            , value
+            , "is not valid."
+            , "Please see: https://drafts.csswg.org/css-color/#hex-notation"]
+        ]
       else
         []
   in

--- a/src/Css.elm
+++ b/src/Css.elm
@@ -2296,8 +2296,8 @@ prop4 key argA argB argC argD =
     textDecorationColor (rgb 12 11 10)
 -}
 textDecorationColor : ColorValue compatible -> Mixin
-textDecorationColor =
-  prop1 "text-decoration-color"
+textDecorationColor c =
+  propertyWithWarnings c.warnings "text-decoration-color" c.value
 
 
 {-| Sets [`text-align-last`](https://developer.mozilla.org/en-US/docs/Web/CSS/text-align-last).
@@ -3757,8 +3757,8 @@ borderImageWidth4 =
     borderBlockStartColor (rgb 101 202 0)
 -}
 borderBlockStartColor : ColorValue compatible -> Mixin
-borderBlockStartColor =
-  prop1 "border-block-start-color"
+borderBlockStartColor c =
+  propertyWithWarnings c.warnings "border-block-start-color" c.value
 
 
 {-| Sets [`border-bottom-color`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-bottom-color)
@@ -3766,8 +3766,8 @@ borderBlockStartColor =
     borderBottomColor (rgb 101 202 0)
 -}
 borderBottomColor : ColorValue compatible -> Mixin
-borderBottomColor =
-  prop1 "border-bottom-color"
+borderBottomColor c =
+  propertyWithWarnings c.warnings "border-bottom-color" c.value
 
 
 {-| Sets [`border-inline-start-color`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-inline-start-color)
@@ -3775,8 +3775,8 @@ borderBottomColor =
     borderInlineStartColor (rgb 101 202 0)
 -}
 borderInlineStartColor : ColorValue compatible -> Mixin
-borderInlineStartColor =
-  prop1 "border-inline-start-color"
+borderInlineStartColor c =
+  propertyWithWarnings c.warnings "border-inline-start-color" c.value
 
 
 {-| Sets [`border-inline-end-color`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-inline-end-color)
@@ -3784,8 +3784,8 @@ borderInlineStartColor =
     borderInlineEndColor (rgb 101 202 0)
 -}
 borderInlineEndColor : ColorValue compatible -> Mixin
-borderInlineEndColor =
-  prop1 "border-inline-end-color"
+borderInlineEndColor c =
+  propertyWithWarnings c.warnings "border-inline-end-color" c.value
 
 
 {-| Sets [`border-left-color`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-left-color)
@@ -3793,8 +3793,8 @@ borderInlineEndColor =
     borderLeftColor (rgb 101 202 0)
 -}
 borderLeftColor : ColorValue compatible -> Mixin
-borderLeftColor =
-  prop1 "border-left-color"
+borderLeftColor c =
+  propertyWithWarnings c.warnings "border-left-color" c.value
 
 
 {-| Sets [`border-right-color`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-right-color)
@@ -3802,8 +3802,8 @@ borderLeftColor =
     borderRightColor (rgb 101 202 0)
 -}
 borderRightColor : ColorValue compatible -> Mixin
-borderRightColor =
-  prop1 "border-right-color"
+borderRightColor c =
+  propertyWithWarnings c.warnings "border-right-color" c.value
 
 
 {-| Sets [`border-top-color`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-top-color)
@@ -3811,8 +3811,8 @@ borderRightColor =
     borderTopColor (rgb 101 202 0)
 -}
 borderTopColor : ColorValue compatible -> Mixin
-borderTopColor =
-  prop1 "border-top-color"
+borderTopColor c =
+  propertyWithWarnings c.warnings "border-top-color" c.value
 
 
 {-| Sets [`border-block-end-color`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-block-end-color)
@@ -3820,8 +3820,8 @@ borderTopColor =
     borderBlockEndColor (rgb 101 202 0)
 -}
 borderBlockEndColor : ColorValue compatible -> Mixin
-borderBlockEndColor =
-  prop1 "border-block-end-color"
+borderBlockEndColor c =
+  propertyWithWarnings c.warnings "border-block-end-color" c.value
 
 
 {-| Sets [`border-block-end-style`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-block-end-style)
@@ -4117,8 +4117,8 @@ borderSpacing2 =
     borderColor4 (rgb 12 11 10) (hex "FFBBCC") inherit (rgb 1 2 3)
 -}
 borderColor : ColorValue compatible -> Mixin
-borderColor =
-  prop1 "border-color"
+borderColor c =
+  propertyWithWarnings c.warnings "border-color" c.value
 
 
 {-| Sets [`border-color`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-color)
@@ -4129,8 +4129,14 @@ borderColor =
     borderColor4 (rgb 12 11 10) (hex "FFBBCC") inherit (rgb 1 2 3)
 -}
 borderColor2 : ColorValue compatibleA -> ColorValue compatibleB -> Mixin
-borderColor2 =
-  prop2 "border-color"
+borderColor2 c1 c2 =
+  let
+    warnings =
+      c1.warnings ++ c2.warnings
+    value =
+      String.join " " [ c1.value, c2.value ]
+  in
+    propertyWithWarnings warnings "border-color" value
 
 
 {-| Sets [`border-color`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-color)
@@ -4141,8 +4147,14 @@ borderColor2 =
     borderColor4 (rgb 12 11 10) (hex "FFBBCC") inherit (rgb 1 2 3)
 -}
 borderColor3 : ColorValue compatibleA -> ColorValue compatibleB -> ColorValue compatibleC -> Mixin
-borderColor3 =
-  prop3 "border-color"
+borderColor3 c1 c2 c3 =
+  let
+    warnings =
+      c1.warnings ++ c2.warnings ++ c3.warnings
+    value =
+      String.join " " [ c1.value, c2.value, c3.value ]
+  in
+    propertyWithWarnings warnings "border-color" value
 
 
 {-| Sets [`border-color`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-color)
@@ -4153,8 +4165,14 @@ borderColor3 =
     borderColor4 (rgb 12 11 10) (hex "FFBBCC") inherit (rgb 1 2 3)
 -}
 borderColor4 : ColorValue compatibleA -> ColorValue compatibleB -> ColorValue compatibleC -> ColorValue compatibleD -> Mixin
-borderColor4 =
-  prop4 "border-color"
+borderColor4 c1 c2 c3 c4 =
+  let
+    warnings =
+      c1.warnings ++ c2.warnings ++ c3.warnings ++ c4.warnings
+    value =
+      String.join " " [ c1.value, c2.value, c3.value, c4.value]
+  in
+    propertyWithWarnings warnings "border-color" value
 
 
 {-| -}
@@ -4183,8 +4201,8 @@ whiteSpace =
 
 {-| -}
 backgroundColor : ColorValue compatible -> Mixin
-backgroundColor =
-  prop1 "background-color"
+backgroundColor c =
+  propertyWithWarnings c.warnings "background-color" c.value
 
 
 {-| -}

--- a/test/Fixtures.elm
+++ b/test/Fixtures.elm
@@ -324,3 +324,14 @@ fontWeightWarning : Stylesheet
 fontWeightWarning =
   (stylesheet << namespace "fontWeightWarning")
     [ body [ fontWeight (int 22) ] ]
+
+
+colorHexWarning : Stylesheet
+colorHexWarning =
+  (stylesheet << namespace "colorHexWarning")
+    [ body [ color (hex "ababah") ] ]
+
+colorHexAbbrWarning : Stylesheet
+colorHexAbbrWarning =
+  (stylesheet << namespace "colorHexAbbrWarning")
+    [ body [ color (hex "#00i") ] ]

--- a/test/Tests.elm
+++ b/test/Tests.elm
@@ -30,6 +30,7 @@ all =
     , transformsStyle
     , fonts
     , weightWarning
+    , hexWarning
     , Properties.all
     ]
 
@@ -533,11 +534,11 @@ hexWarning =
     output1 =
       """
            Invalid Stylesheet:
-           Hexadecimal color values can only contain three or six characters of '0-9' and/or 'A-F'. #ababah is not valid."""
+           The syntax of a hex-color is a token whose value consists of 3, 4, 6, or 8 hexadecimal digits. #ababah is not valid. Please see: https://drafts.csswg.org/css-color/#hex-notation"""
     output2 =
       """
            Invalid Stylesheet:
-           Hexadecimal color values can only contain three or six characters of '0-9' and/or 'A-F'. #00i is not valid."""
+           The syntax of a hex-color is a token whose value consists of 3, 4, 6, or 8 hexadecimal digits. #00i is not valid. Please see: https://drafts.csswg.org/css-color/#hex-notation"""
   in
     suite
       "colorHexWarning"

--- a/test/Tests.elm
+++ b/test/Tests.elm
@@ -533,12 +533,12 @@ hexWarning =
       Fixtures.colorHexAbbrWarning
     output1 =
       """
-           Invalid Stylesheet:
-           The syntax of a hex-color is a token whose value consists of 3, 4, 6, or 8 hexadecimal digits. #ababah is not valid. Please see: https://drafts.csswg.org/css-color/#hex-notation"""
+            Invalid Stylesheet:
+            The syntax of a hex-color is a token whose value consists of 3, 4, 6, or 8 hexadecimal digits. #ababah is not valid. Please see: https://drafts.csswg.org/css-color/#hex-notation"""
     output2 =
       """
-           Invalid Stylesheet:
-           The syntax of a hex-color is a token whose value consists of 3, 4, 6, or 8 hexadecimal digits. #00i is not valid. Please see: https://drafts.csswg.org/css-color/#hex-notation"""
+            Invalid Stylesheet:
+            The syntax of a hex-color is a token whose value consists of 3, 4, 6, or 8 hexadecimal digits. #00i is not valid. Please see: https://drafts.csswg.org/css-color/#hex-notation"""
   in
     suite
       "colorHexWarning"

--- a/test/Tests.elm
+++ b/test/Tests.elm
@@ -522,3 +522,31 @@ weightWarning =
           , actual = outdented (prettyPrint input)
           }
       ]
+
+hexWarning : Test
+hexWarning =
+  let
+    input1 =
+      Fixtures.colorHexWarning
+    input2 =
+      Fixtures.colorHexAbbrWarning
+    output1 =
+      """
+           Invalid Stylesheet:
+           Hexadecimal color values can only contain three or six characters of '0-9' and/or 'A-F'. #ababah is not valid."""
+    output2 =
+      """
+           Invalid Stylesheet:
+           Hexadecimal color values can only contain three or six characters of '0-9' and/or 'A-F'. #00i is not valid."""
+  in
+    suite
+      "colorHexWarning"
+      [ (expect "pretty prints the expected output")
+          { expected = outdented output1
+          , actual = outdented (prettyPrint input1)
+          }
+      , (expect "pretty prints the expected output")
+          { expected = outdented output2
+          , actual = outdented (prettyPrint input2)
+          }
+      ]


### PR DESCRIPTION
I've been looking to get into Elm, and this project seems a great effort to be able to reduce the errors in writing CSS in combination with Elm.

The first item in issue #32 , validation checks are asked for hex values. I have implemented these.

Any feedback is very much welcome as I'm still learning!