### PR TITLE
remove quotes on media queries

### DIFF
--- a/Tutorial.md
+++ b/Tutorial.md
@@ -270,6 +270,10 @@ stylesheet { name = "homepage" }
           [ width (px 1280) ]
       ]
 
+  , mediaQuery "screen and ( max-width: 600px )"
+      [ body
+          [ backgroundColor (hex "FF00FF" ) ]
+      ]
   , ul
       [ padding zero
 
@@ -287,9 +291,15 @@ stylesheet { name = "homepage" }
 The above fanciness compiles to the following:
 
 ```css
-@media "print" {
+@media print {
     body {
         width: 1280px;
+    }
+}
+
+@media screen and ( max-width: 600px ) {
+    body {
+        background-color: #FF00FF;
     }
 }
 
@@ -297,7 +307,7 @@ ul {
     padding: 0;
 }
 
-@media "print" {
+@media print {
     ul {
         margin: 1em auto;
     }

--- a/src/Css/Structure/Output.elm
+++ b/src/Css/Structure/Output.elm
@@ -64,7 +64,7 @@ prettyPrintDeclaration declaration =
             |> String.join "\n\n"
 
         query =
-          (List.map (\(MediaQuery str) -> "\"" ++ str ++ "\"") mediaQueries)
+          (List.map (\(MediaQuery str) ->  str ) mediaQueries)
             |> String.join " "
       in
         "@media " ++ query ++ " {\n" ++ indent blocks ++ "\n}"

--- a/test/Fixtures.elm
+++ b/test/Fixtures.elm
@@ -40,7 +40,7 @@ atRule =
         [ padding zero ]
     , (media [ print ])
         [ body [ margin (em 2) ] ]
-    , mediaQuery "screen and (max-width: 480px)"
+    , mediaQuery "screen and ( max-width: 600px )"
         [ body [ margin (em 3) ] ]
     , button
         [ margin auto ]

--- a/test/Tests.elm
+++ b/test/Tests.elm
@@ -148,13 +148,13 @@ atRule =
               padding: 0;
           }
 
-          @media "print" {
+          @media print {
               body {
                   margin: 2em;
               }
           }
 
-          @media "screen and (max-width: 480px)" {
+          @media screen and ( max-width: 600px ) {
               body {
                   margin: 3em;
               }
@@ -190,7 +190,7 @@ nestedAtRule =
               margin: auto;
           }
 
-          @media "print" {
+          @media print {
               body {
                   margin: 2em;
               }


### PR DESCRIPTION
Hey @rtfeldman, 

I just noticed that the output of  media queries had a syntax error(extra quotes). The output of media queries now is:
```css
@media "print"{
}
// or 
@media "screen and (max-width: 400px)" {
}
```

and the correct syntax according to the [spec](https://developer.mozilla.org/es/docs/CSS/Media_queries) is this one:
```css
@media print{
}
// or 
@media screen and (max-width: 400px) {
}
```

I changed it, updated the docs and the tests.

Let me know if code looks good and sorry for not catching this error in the previous PR. 

Cheers, 