### PR TITLE
Fix elm-css cli for Elm version 0.17.

### DIFF
--- a/examples/elm-package.json
+++ b/examples/elm-package.json
@@ -11,7 +11,8 @@
     "dependencies": {
         "elm-lang/core": "4.0.0 <= v <= 4.0.0",
         "elm-lang/html": "1.0.0 <= v < 2.0.0",
-        "rtfeldman/elm-css-helpers": "2.0.0 <= v < 3.0.0"
+        "rtfeldman/elm-css-helpers": "2.0.0 <= v < 3.0.0",
+        "rtfeldman/elm-css-util": "1.0.1 <= v < 2.0.0"
     },
     "elm-version": "0.17.0 <= v <= 0.17.0"
 }

--- a/examples/src/SharedStyles.elm
+++ b/examples/src/SharedStyles.elm
@@ -1,4 +1,4 @@
-module SharedStyles (..) where
+module SharedStyles exposing (..)
 
 import Html.CssHelpers exposing (withNamespace)
 

--- a/examples/src/Stylesheets.elm
+++ b/examples/src/Stylesheets.elm
@@ -2,8 +2,23 @@ port module Stylesheets exposing (..)
 
 import Css.File exposing (..)
 import HomepageCss as Homepage
+import Html exposing (div)
+import Html.App as Html
 
 
-port files : CssFileStructure
-port files =
+port files : CssFileStructure -> Cmd msg
+
+
+cssFiles : CssFileStructure
+cssFiles =
     toFileStructure [ ( "homepage.css", compile Homepage.css ) ]
+
+
+main : Program Never
+main =
+    Html.program
+        { init = ( (), files cssFiles )
+        , view = \_ -> (div [] [])
+        , update = \_ _ -> ( (), Cmd.none )
+        , subscriptions = \_ -> Sub.none
+        }


### PR DESCRIPTION
Due to the changes in the port system on both the JavaScript and Elm
side the cli application was no longer able to extract the generated
CSS from the Elm appliation.

This commit fixes the issue in the CLI and updates the example code so
the two work together again.

Resolves #120.

Some comments:

- I had to include elm-css-util in the examples elm-package.json as well, or I'd get an error that Css.Helpers could not be found.
- The one way I could figure out to publish a command now was to create a complete Program and send the command as part of the Program's init step. The one Program currently available is `Html.App`, so that's the one I used. Does someone know an easier way?
- The JavaScript generated by Elm now self-exports `Elm` on `module.exports`.