### PR TITLE
fixes generation of css in readme/example

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,15 +106,30 @@ if they get out of sync with your view code, you'll get a nice build error.
 To generate CSS, you'll need a special module with a port for elm-css to access:
 
 ```elm
-module Stylesheets exposing (..)
+port module Stylesheets exposing (..)
 
-import Css.File exposing (CssFileStructure)
+import Css.File exposing (..)
 import MyCss
+import Html exposing (div)
+import Html.App as Html
 
 
-port files : CssFileStructure
-port files =
-    Css.File.toFileStructure [ ( "styles.css", Css.File.compile MyCss.css ) ]
+port files : CssFileStructure -> Cmd msg
+
+
+cssFiles : CssFileStructure
+cssFiles =
+    toFileStructure [ ( "styles.css", compile MyCss.css ) ]
+
+
+main : Program Never
+main =
+    Html.program
+        { init = ( (), files cssFiles )
+        , view = \_ -> (div [] [])
+        , update = \_ _ -> ( (), Cmd.none )
+        , subscriptions = \_ -> Sub.none
+        }
 ```
 
 Run `elm-css` on the file containing this `Stylesheets` module.

--- a/readme-example/elm-package.json
+++ b/readme-example/elm-package.json
@@ -1,17 +1,18 @@
 {
     "version": "1.0.0",
-    "summary": "helpful summary of your project, less than 80 characters",
-    "repository": "https://github.com/user/project.git",
+    "summary": "Readme example for elm-css",
+    "repository": "https://github.com/rtfeldman/elm-css.git",
     "license": "BSD3",
     "source-directories": [
-        "src"
+        "src",
+        "../src"
     ],
     "exposed-modules": [],
     "dependencies": {
-        "elm-lang/core": "3.0.0 <= v < 4.0.0",
-        "evancz/elm-html": "4.0.2 <= v < 5.0.0",
-        "rtfeldman/elm-css": "2.0.0 <= v < 3.0.0",
-        "rtfeldman/elm-css-helpers": "1.1.0 <= v < 2.0.0"
+        "elm-lang/core": "4.0.0 <= v <= 4.0.0",
+        "elm-lang/html": "1.0.0 <= v < 2.0.0",
+        "rtfeldman/elm-css-helpers": "2.0.0 <= v < 3.0.0",
+        "rtfeldman/elm-css-util": "1.0.1 <= v < 2.0.0"
     },
-    "elm-version": "0.16.0 <= v < 0.17.0"
+    "elm-version": "0.17.0 <= v <= 0.17.0"
 }

--- a/readme-example/src/Main.elm
+++ b/readme-example/src/Main.elm
@@ -1,4 +1,4 @@
-module Main (main) where
+module Main exposing (main)
 
 import Html exposing (Html)
 import MyCss
@@ -6,13 +6,10 @@ import Html.CssHelpers
 
 
 { id, class, classList } =
-  Html.CssHelpers.withNamespace "dreamwriter"
-
-
-main : Html
+    Html.CssHelpers.withNamespace "dreamwriter"
+main : Html msg
 main =
-  Html.div
-    []
-    [ Html.div [ class [ MyCss.NavBar ] ] [ Html.text "this has the navbar class" ]
-    , Html.div [ id [ MyCss.Page ] ] [ Html.text "this has the Page id" ]
-    ]
+    Html.div []
+        [ Html.div [ class [ MyCss.NavBar ] ] [ Html.text "this has the navbar class" ]
+        , Html.div [ id [ MyCss.Page ] ] [ Html.text "this has the Page id" ]
+        ]

--- a/readme-example/src/MyCss.elm
+++ b/readme-example/src/MyCss.elm
@@ -1,4 +1,4 @@
-module MyCss (CssClasses(..), CssIds(..), css) where
+module MyCss exposing (CssClasses(..), CssIds(..), css)
 
 import Css exposing (..)
 import Css.Elements exposing (body, li)
@@ -6,42 +6,40 @@ import Css.Namespace exposing (namespace)
 
 
 type CssClasses
-  = NavBar
+    = NavBar
 
 
 type CssIds
-  = Page
+    = Page
 
 
 css =
-  (stylesheet << namespace "dreamwriter")
-    [ body
-        [ overflowX auto
-        , minWidth (px 1280)
-        ]
-    , (#)
-        Page
-        [ backgroundColor (rgb 200 128 64)
-        , color (hex "CCFFFF")
-        , width (pct 100)
-        , height (pct 100)
-        , boxSizing borderBox
-        , padding (px 8)
-        , margin zero
-        ]
-    , (.)
-        NavBar
-        [ margin zero
-        , padding zero
-        , children
-            [ li
-                [ (display inlineBlock) |> important
-                , color primaryAccentColor
+    (stylesheet << namespace "dreamwriter")
+        [ body
+            [ overflowX auto
+            , minWidth (px 1280)
+            ]
+        , (#) Page
+            [ backgroundColor (rgb 200 128 64)
+            , color (hex "CCFFFF")
+            , width (pct 100)
+            , height (pct 100)
+            , boxSizing borderBox
+            , padding (px 8)
+            , margin zero
+            ]
+        , (.) NavBar
+            [ margin zero
+            , padding zero
+            , children
+                [ li
+                    [ (display inlineBlock) |> important
+                    , color primaryAccentColor
+                    ]
                 ]
             ]
         ]
-    ]
 
 
 primaryAccentColor =
-  hex "ccffaa"
+    hex "ccffaa"

--- a/readme-example/src/Stylesheets.elm
+++ b/readme-example/src/Stylesheets.elm
@@ -1,10 +1,24 @@
-module Stylesheets (..) where
+port module Stylesheets exposing (..)
 
-import Css.File exposing (CssFileStructure)
+import Css.File exposing (..)
 import MyCss
+import Html exposing (div)
+import Html.App as Html
 
 
-port files : CssFileStructure
-port files =
-  Css.File.toFileStructure
-    [ ( "styles.css", Css.File.compile MyCss.css ) ]
+port files : CssFileStructure -> Cmd msg
+
+
+cssFiles : CssFileStructure
+cssFiles =
+    toFileStructure [ ( "styles.css", compile MyCss.css ) ]
+
+
+main : Program Never
+main =
+    Html.program
+        { init = ( (), files cssFiles )
+        , view = \_ -> (div [] [])
+        , update = \_ _ -> ( (), Cmd.none )
+        , subscriptions = \_ -> Sub.none
+        }


### PR DESCRIPTION
This updates the `Stylesheets` module in the readme.
I also updated the `readme-example` to make it work with Elm v0.17.


resolves #130 
