### PR TITLE
Readme/example: Change ID from list to single item

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ import MyCss
 view =
     Html.div []
         [ Html.div [ class [ MyCss.NavBar ] ] [ Html.text "this has the NavBar class" ]
-        , Html.div [ id [ MyCss.Page ] ] [ Html.text "this has the Page id" ]
+        , Html.div [ id MyCss.Page ] [ Html.text "this has the Page id" ]
         ]
 
 ```

--- a/readme-example/src/Main.elm
+++ b/readme-example/src/Main.elm
@@ -11,5 +11,5 @@ main : Html msg
 main =
     Html.div []
         [ Html.div [ class [ MyCss.NavBar ] ] [ Html.text "this has the navbar class" ]
-        , Html.div [ id [ MyCss.Page ] ] [ Html.text "this has the Page id" ]
+        , Html.div [ id MyCss.Page ] [ Html.text "this has the Page id" ]
         ]


### PR DESCRIPTION
In the readme example, shouldn't the `id` function be taking a single identifier for the css ID instead of a list? I understand that it still works as a list, but it seems more normal to have it as a single identifier, and it may otherwise cause some head-scratching for newcomers (as it did with me).

This PR contains the needed changes if you agree.