### PR TITLE
Resolve pseudo elements

### DIFF
--- a/src/Css/Preprocess/Resolve.elm
+++ b/src/Css/Preprocess/Resolve.elm
@@ -276,29 +276,11 @@ applyMixins mixins declarations =
                 }
 
         (ExtendSelector selector nestedMixins) :: rest ->
-            let
-                handleInitial declarationsAndWarnings =
-                    let
-                        result =
-                            applyMixins nestedMixins declarationsAndWarnings.declarations
-                    in
-                        { warnings = declarationsAndWarnings.warnings ++ result.warnings
-                        , declarations = result.declarations
-                        }
-
-                initialResult =
-                    declarations
-                        |> Structure.concatMapLastStyleBlock (Structure.appendToLastSelector selector)
-                        |> List.map (\declaration -> { declarations = [ declaration ], warnings = [] })
-                        |> mapLast handleInitial
-                        |> concatDeclarationsAndWarnings
-
-                nextResult =
-                    applyMixins rest initialResult.declarations
-            in
-                { warnings = initialResult.warnings ++ nextResult.warnings
-                , declarations = nextResult.declarations
-                }
+            applyNestedMixinsToLast
+                nestedMixins
+                rest
+                (Structure.appendToLastSelector selector)
+                declarations
 
         (NestSnippet selectorCombinator snippets) :: rest ->
             let
@@ -364,31 +346,11 @@ applyMixins mixins declarations =
                     |> concatDeclarationsAndWarnings
 
         (Preprocess.WithPseudoElement pseudoElement nestedMixins) :: rest ->
-            -- TODO: Duplicate code with branch `ExtendSelector`
-            -- except for the `concatMapLastStyleBlock` call.
-            let
-                handleInitial declarationsAndWarnings =
-                    let
-                        result =
-                            applyMixins nestedMixins declarationsAndWarnings.declarations
-                    in
-                        { warnings = declarationsAndWarnings.warnings ++ result.warnings
-                        , declarations = result.declarations
-                        }
-
-                initialResult =
-                    declarations
-                        |> Structure.concatMapLastStyleBlock (Structure.appendPseudoElementToLastSelector pseudoElement)
-                        |> List.map (\declaration -> { declarations = [ declaration ], warnings = [] })
-                        |> mapLast handleInitial
-                        |> concatDeclarationsAndWarnings
-
-                nextResult =
-                    applyMixins rest initialResult.declarations
-            in
-                { warnings = initialResult.warnings ++ nextResult.warnings
-                , declarations = nextResult.declarations
-                }
+            applyNestedMixinsToLast
+                nestedMixins
+                rest
+                (Structure.appendPseudoElementToLastSelector pseudoElement)
+                declarations
 
         (Preprocess.WithMedia mediaQueries nestedMixins) :: rest ->
             let
@@ -410,6 +372,33 @@ applyMixins mixins declarations =
         (Preprocess.ApplyMixins otherMixins) :: rest ->
             declarations
                 |> applyMixins (otherMixins ++ rest)
+
+
+applyNestedMixinsToLast : List Mixin -> List Mixin -> (Structure.StyleBlock -> List Structure.StyleBlock) -> List Structure.Declaration -> DeclarationsAndWarnings
+applyNestedMixinsToLast nestedMixins rest f declarations =
+    let
+        handleInitial declarationsAndWarnings =
+            let
+                result =
+                    applyMixins nestedMixins declarationsAndWarnings.declarations
+            in
+                { warnings = declarationsAndWarnings.warnings ++ result.warnings
+                , declarations = result.declarations
+                }
+
+        initialResult =
+            declarations
+                |> Structure.concatMapLastStyleBlock f
+                |> List.map (\declaration -> { declarations = [ declaration ], warnings = [] })
+                |> mapLast handleInitial
+                |> concatDeclarationsAndWarnings
+
+        nextResult =
+            applyMixins rest initialResult.declarations
+    in
+        { warnings = initialResult.warnings ++ nextResult.warnings
+        , declarations = nextResult.declarations
+        }
 
 
 expandStyleBlock : Preprocess.StyleBlock -> DeclarationsAndWarnings

--- a/src/Css/Structure.elm
+++ b/src/Css/Structure.elm
@@ -276,10 +276,8 @@ appendPseudoElementToLastSelector pseudo styleBlock =
 
 
 applyPseudoElement : PseudoElement -> Selector -> Selector
-applyPseudoElement pseudo selector =
-    case selector of
-        Selector sequence selectors _ ->
-            Selector sequence selectors <| Just pseudo
+applyPseudoElement pseudo (Selector sequence selectors _) =
+    Selector sequence selectors <| Just pseudo
 
 
 concatMapLastStyleBlock : (StyleBlock -> List StyleBlock) -> List Declaration -> List Declaration

--- a/src/Css/Structure.elm
+++ b/src/Css/Structure.elm
@@ -263,6 +263,25 @@ appendToLastSelector selector styleBlock =
                 ]
 
 
+appendPseudoElementToLastSelector : PseudoElement -> StyleBlock -> List StyleBlock
+appendPseudoElementToLastSelector pseudo styleBlock =
+    case styleBlock of
+        StyleBlock only [] properties ->
+            [ StyleBlock only [] properties
+            , StyleBlock (applyPseudoElement pseudo only) [] []
+            ]
+
+        a ->
+            [ a ]
+
+
+applyPseudoElement : PseudoElement -> Selector -> Selector
+applyPseudoElement pseudo selector =
+    case selector of
+        Selector sequence selectors _ ->
+            Selector sequence selectors <| Just pseudo
+
+
 concatMapLastStyleBlock : (StyleBlock -> List StyleBlock) -> List Declaration -> List Declaration
 concatMapLastStyleBlock update declarations =
     case declarations of


### PR DESCRIPTION
See issue #129. This implements resolving of pseudo **elements** (like, before/after).

The test suite is undergoing maintenance right now, so I have not been able to get those working (#135).

I do have results by changing `examples/HomepageCss.elm` and compiling it to CSS. I changed the bottom style block to:

```elm
        , (#) BuyTickets
            [ padding (px 16)
            , paddingLeft (px 24)
            , paddingRight (px 24)
            , marginLeft (px 50)
            , marginRight auto
            , color (rgb 255 255 255)
            , backgroundColor (rgb 27 217 130)
            , verticalAlign middle
            , descendants
                [ nav
                    [ color (hex "#aaa")
                    , before
                       [ color (hex "#bbb") ]
                    , after
                       [ color (hex "#ccc") ]
                    ]
                ]
            , before
                [ color (hex "#ddd") ]
            ]
```

And the output of this becomes:

```css
#BuyTickets {
    padding: 16px;
    padding-left: 24px;
    padding-right: 24px;
    margin-left: 50px;
    margin-right: auto;
    color: rgb(255, 255, 255);
    background-color: rgb(27, 217, 130);
    vertical-align: middle;
}

#BuyTickets ::before {
    color: #ddd;
}

#BuyTickets  nav {
    color: #aaa;
}

#BuyTickets  nav ::before {
    color: #bbb;
}

#BuyTickets  nav ::after {
    color: #ccc;
}
```

@rtfeldman I *am* sceptical of the refactor I did in [this refactor commit](https://github.com/rtfeldman/elm-css/commit/d7e2aec2e4044a8104cc9a4938403ebdb1fc1917). The logic is so much the same, I simply moved it all in its own function for `ExtendSelector` and `WithPseudoElement`. If you'd rather have the duplication and have it more readable, I can squash the commit out.

If there are any other questions or concerns, I'd love to hear it 👍 