### PR TITLE
Remove space before pseudo element in compiled CSS

### DIFF
--- a/src/Css/Structure/Output.elm
+++ b/src/Css/Structure/Output.elm
@@ -124,11 +124,14 @@ selectorToString (Selector simpleSelectorSequence chain pseudoElement) =
         segments =
             [ simpleSelectorSequenceToString simpleSelectorSequence ]
                 ++ List.map selectorChainToString chain
-                ++ [ Maybe.withDefault "" (Maybe.map pseudoElementToString pseudoElement) ]
+
+        pseudoElementsString =
+            String.join "" [ Maybe.withDefault "" (Maybe.map pseudoElementToString pseudoElement) ]
     in
         segments
             |> List.filter (not << String.isEmpty)
             |> String.join " "
+            |> (flip (++)) pseudoElementsString
 
 
 combinatorToString : SelectorCombinator -> String


### PR DESCRIPTION
Right now compiled CSS with pseudo elements looks like `.selector ::before {}`. This space before the pseudo element is misinterpreted by browsers. This whole rule will apply `::before` to `.selector`'s children.