### PR TITLE
Update example dependencies to run on Elm 0.17.1

### DIFF
--- a/examples/elm-package.json
+++ b/examples/elm-package.json
@@ -9,10 +9,10 @@
     ],
     "exposed-modules": [],
     "dependencies": {
-        "elm-lang/core": "4.0.0 <= v <= 4.0.0",
+        "elm-lang/core": "4.0.0 <= v <= 5.0.0",
         "elm-lang/html": "1.0.0 <= v < 2.0.0",
         "rtfeldman/elm-css-helpers": "2.0.0 <= v < 3.0.0",
         "rtfeldman/elm-css-util": "1.0.1 <= v < 2.0.0"
     },
-    "elm-version": "0.17.0 <= v <= 0.17.0"
+    "elm-version": "0.17.0 <= v <= 0.18.0"
 }


### PR DESCRIPTION
I was unable to build the examples with Elm 0.17.1 until I relaxed the elm-version constraint.

While doing that I also relaxed the core constraint to allow the new 4.0.x releases.
