### PR TITLE
Resolve multiple sibling pseudo classes correctly

### DIFF
--- a/test/Fixtures.elm
+++ b/test/Fixtures.elm
@@ -339,3 +339,34 @@ colorHexWarning =
 colorHexAbbrWarning : Stylesheet
 colorHexAbbrWarning =
     (stylesheet << namespace "colorHexAbbrWarning") [ body [ color (hex "#00i") ] ]
+
+
+pseudoElementStylesheet : Stylesheet
+pseudoElementStylesheet =
+    (stylesheet << namespace "pseudoElements")
+        [ (#) Page
+            [ margin (px 10)
+            , before
+                [ color (hex "#fff") ]
+            , after
+                [ color (hex "#000") ]
+            ]
+        ]
+
+
+pseudoClassStylesheet : Stylesheet
+pseudoClassStylesheet =
+    (stylesheet << namespace "pseudoClasses")
+        [ (#) Page
+            [ color (hex "#fff")
+            , hover
+                [ marginTop (px 10)
+                , focus
+                    [ color (hex "#000") ]
+                ]
+            , first
+                [ fontSize (em 3) ]
+            , disabled
+                [ marginTop (px 20) ]
+            ]
+        ]

--- a/test/Tests.elm
+++ b/test/Tests.elm
@@ -32,6 +32,8 @@ all =
         , fonts
         , weightWarning
         , hexWarning
+        , pseudoClasses
+        , pseudoElements
         , Properties.all
         , Selectors.all
         ]
@@ -580,4 +582,70 @@ hexWarning =
                 \_ ->
                     outdented (prettyPrint input2)
                         |> Expect.equal (outdented output2)
+            ]
+
+
+pseudoElements : Test
+pseudoElements =
+    let
+        input =
+            Fixtures.pseudoElementStylesheet
+
+        output =
+            """
+            #Page {
+                margin: 10px;
+            }
+
+            #Page::before {
+                color: #fff;
+            }
+
+            #Page::after {
+                color: #000;
+            }
+            """
+    in
+        describe "pseudo elements"
+            [ test "pretty prints the expected output" <|
+                \_ ->
+                    outdented (prettyPrint input)
+                        |> Expect.equal (outdented output)
+            ]
+
+
+pseudoClasses : Test
+pseudoClasses =
+    let
+        input =
+            Fixtures.pseudoClassStylesheet
+
+        output =
+            """
+            #Page {
+                color: #fff;
+            }
+
+            #Page:hover {
+                margin-top: 10px;
+            }
+
+            #Page:hover:focus {
+                color: #000;
+            }
+
+            #Page:first {
+                font-size: 3em;
+            }
+
+            #Page:disabled {
+                margin-top: 20px;
+            }
+            """
+    in
+        describe "pseudo classes"
+            [ test "pretty prints the expected output" <|
+                \_ ->
+                    outdented (prettyPrint input)
+                        |> Expect.equal (outdented output)
             ]


### PR DESCRIPTION
This PR aims to fix issue #136 .

The issue was: when resolving multiple sibling pseudo classes like:

```elm
[ a 
    [ color (hex "#000")
    , hover
        [ color (hex "#111") ]
    , active
        [ color (hex "#222") ]
    , disabled
        [ color (hex "#333") ]
    ]
]
```

the code written would resolve `a`, and next up, it would resolve `a:hover` and since `:hover` is a complete new styleblock definition, it got appended to the list of styleblock declarations. What happens next is that `:active` would get resolved, but since the latest styleblock is now an `a:hover`, it would think it's a nested pseudo class.

I have fixed this issue, by popping the last declaration, and using that to resolve pseudo classes. And in the end, using `List.tail` to get rid of the `a` declaration. This seems to fix my issues, and the issue shows in #136 as you can see in the written tests for this.

@rtfeldman since this issue was assigned to you, did you have any other concerns about this?