### PR TITLE
Fix properties not resolving after or inbetween an ExtendSelector and/or WithPseudoElement

### DIFF
--- a/examples/elm-package.json
+++ b/examples/elm-package.json
@@ -9,10 +9,10 @@
     ],
     "exposed-modules": [],
     "dependencies": {
-        "elm-lang/core": "4.0.0 <= v <= 4.0.0",
+        "elm-lang/core": "4.0.0 <= v <= 5.0.0",
         "elm-lang/html": "1.0.0 <= v < 2.0.0",
         "rtfeldman/elm-css-helpers": "2.0.0 <= v < 3.0.0",
         "rtfeldman/elm-css-util": "1.0.1 <= v < 2.0.0"
     },
-    "elm-version": "0.17.0 <= v <= 0.17.0"
+    "elm-version": "0.17.0 <= v <= 0.18.0"
 }

--- a/src/Css/Preprocess/Resolve.elm
+++ b/src/Css/Preprocess/Resolve.elm
@@ -418,9 +418,26 @@ applyNestedMixinsToLast nestedMixins rest f declarations =
         withoutParent decls =
             List.tail decls
                 |> Maybe.withDefault []
+
+        {- We recreate the declarations if necessary. It is possible that
+           there was an `AppendProperty` in between two `ExtendSelectors` or two `WithPseudoElements`
+           or an `AppendProperty` after an `ExtendSelector` or `WithPseudoElement`.
+        -}
+        newDeclarations =
+            case ( List.head nextResult.declarations, List.head <| List.reverse declarations ) of
+                ( Just nextResultParent, Just originalParent ) ->
+                    List.take (List.length declarations - 1) declarations
+                        ++ [ if originalParent /= nextResultParent then
+                                nextResultParent
+                             else
+                                originalParent
+                           ]
+
+                _ ->
+                    declarations
     in
         { warnings = initialResult.warnings ++ nextResult.warnings
-        , declarations = declarations ++ (withoutParent initialResult.declarations ) ++ (withoutParent nextResult.declarations)
+        , declarations = newDeclarations ++ (withoutParent initialResult.declarations) ++ (withoutParent nextResult.declarations)
         }
 
 

--- a/test/Fixtures.elm
+++ b/test/Fixtures.elm
@@ -350,6 +350,7 @@ pseudoElementStylesheet =
                 [ color (hex "#fff") ]
             , after
                 [ color (hex "#000") ]
+            , color (hex "#aaa")
             ]
         ]
 
@@ -368,5 +369,6 @@ pseudoClassStylesheet =
                 [ fontSize (em 3) ]
             , disabled
                 [ marginTop (px 20) ]
+            , backgroundColor (hex "#aaa")
             ]
         ]

--- a/test/Tests.elm
+++ b/test/Tests.elm
@@ -595,6 +595,7 @@ pseudoElements =
             """
             #Page {
                 margin: 10px;
+                color: #aaa;
             }
 
             #Page::before {
@@ -624,6 +625,7 @@ pseudoClasses =
             """
             #Page {
                 color: #fff;
+                background-color: #aaa;
             }
 
             #Page:hover {


### PR DESCRIPTION
This is a follow-up on #142 that aims to fix the comment in issue #136 .

I added a compare that checks if the first declaration matches the one from the parent. If it does not match, it means that variable `rest` had an `AppendProperty` that should belong to the parent. If so, we replace the last declaration inside the `declarations` variable with the changed one.