### PR TITLE
Add support for compiling many stylesheets

### DIFF
--- a/examples/src/Stylesheets.elm
+++ b/examples/src/Stylesheets.elm
@@ -11,7 +11,7 @@ port files : CssFileStructure -> Cmd msg
 
 cssFiles : CssFileStructure
 cssFiles =
-    toFileStructure [ ( "homepage.css", compile Homepage.css ) ]
+    toFileStructure [ ( "homepage.css", compile [ Homepage.css ] ) ]
 
 
 main : Program Never

--- a/src/Css.elm
+++ b/src/Css.elm
@@ -5502,10 +5502,11 @@ stringsToValue list =
         { value = String.join ", " (List.map (\s -> s) list) }
 
 
-{-| Compile the given stylesheet to a CSS string, or to an error
+
+{-| Compile the given stylesheets to a CSS string, or to an error
 message if it could not be compiled.
 -}
-compile : Stylesheet -> { css : String, warnings : List String }
+compile : List Stylesheet -> { css : String, warnings : List String }
 compile =
     Resolve.compile
 

--- a/src/Css/File.elm
+++ b/src/Css/File.elm
@@ -33,6 +33,6 @@ toFileStructure stylesheets =
 
 {-| Convenience re-export of Css.compile
 -}
-compile : Stylesheet -> { css : String, warnings : List String }
+compile : List Stylesheet -> { css : String, warnings : List String }
 compile =
     Css.compile

--- a/src/Css/Preprocess/Resolve.elm
+++ b/src/Css/Preprocess/Resolve.elm
@@ -1,16 +1,29 @@
 module Css.Preprocess.Resolve exposing (compile)
 
+
 {-| Functions responsible for resolving Preprocess data structures into
 Structure data structures and gathering warnings along the way.
 -}
 
+import String
 import Css.Preprocess as Preprocess exposing (SnippetDeclaration, Snippet(Snippet), Mixin(AppendProperty, ExtendSelector, NestSnippet), unwrapSnippet)
 import Css.Structure as Structure exposing (mapLast)
 import Css.Structure.Output as Output
 
 
-compile : Preprocess.Stylesheet -> { warnings : List String, css : String }
-compile sheet =
+compile : List Preprocess.Stylesheet -> { warnings: List String, css: String }
+compile styles =
+    let
+        results =
+            List.map compile1 styles
+    in
+        { warnings = List.concatMap .warnings results
+        , css = String.join "\n\n" (List.map .css results)
+        }
+
+
+compile1 : Preprocess.Stylesheet -> { warnings : List String, css : String }
+compile1 sheet =
     let
         ( structureStylesheet, warnings ) =
             toStructure sheet

--- a/test/Compile.elm
+++ b/test/Compile.elm
@@ -14,6 +14,7 @@ all =
         [ unstyledDiv
         , dreamwriter
         , colorWarnings
+        , compileTest
         ]
 
 
@@ -127,4 +128,40 @@ dreamwriter =
                 \() ->
                     outdented (prettyPrint input)
                         |> Expect.equal (outdented output)
+            ]
+
+
+compileTest : Test
+compileTest =
+    let
+        input =
+            compile
+                [ CompileFixtures.basicStyle1
+                , CompileFixtures.basicStyle2
+                ]
+
+        output =
+            """
+            .basic1BasicStyle1 {
+                display: none;
+            }
+
+            .basic2BasicStyle2 {
+                display: none;
+            }
+            """
+    in
+        describe "compiles multiple stylesheets"
+            [ test "compile output" <|
+                \() ->
+                    input
+                        |> .css
+                        |> outdented
+                        |> Expect.equal (outdented output)
+
+            , test "compile warnings" <|
+                \() ->
+                    input
+                        |> .warnings
+                        |> Expect.equal []
             ]

--- a/test/CompileFixtures.elm
+++ b/test/CompileFixtures.elm
@@ -17,6 +17,8 @@ pageDefaultText =
 
 type CssClasses
     = Hidden
+    | BasicStyle1
+    | BasicStyle2
 
 
 type CssIds
@@ -58,4 +60,20 @@ dreamwriter =
             , backgroundColor pageBackground
             , color pageDefaultText
             ]
+        ]
+
+
+basicStyle1 : Stylesheet
+basicStyle1 =
+    (stylesheet << namespace "basic1")
+        [ (.) BasicStyle1
+            [ display none ]
+        ]
+
+
+basicStyle2 : Stylesheet
+basicStyle2 =
+    (stylesheet << namespace "basic2")
+        [ (.) BasicStyle2
+            [ display none ]
         ]

--- a/test/TestUtil.elm
+++ b/test/TestUtil.elm
@@ -19,7 +19,7 @@ prettyPrint : Css.Stylesheet -> String
 prettyPrint sheet =
     let
         { warnings, css } =
-            Css.compile sheet
+            Css.compile [ sheet ]
     in
         if List.isEmpty warnings then
             css


### PR DESCRIPTION
I'm open to rename the function, but I wasn't sure what the convention was for describing an _n_ number of arguments. Maybe it's something like `compileN`?