### PR TITLE
Fix pseudo elements and classes not resolving when chained with `each` 

### DIFF
--- a/src/Css/Preprocess/Resolve.elm
+++ b/src/Css/Preprocess/Resolve.elm
@@ -279,7 +279,7 @@ applyMixins mixins declarations =
             applyNestedMixinsToLast
                 nestedMixins
                 rest
-                (Structure.appendToLastSelector selector)
+                (Structure.appendRepeatableToLastSelector selector)
                 declarations
 
         (NestSnippet selectorCombinator snippets) :: rest ->

--- a/src/Css/Structure.elm
+++ b/src/Css/Structure.elm
@@ -245,46 +245,35 @@ extendLastSelector selector declarations =
             first :: extendLastSelector selector rest
 
 
-appendToLastSelector : RepeatableSimpleSelector -> StyleBlock -> List StyleBlock
-appendToLastSelector selector styleBlock =
+appendToLastSelector : (Selector -> Selector) -> StyleBlock -> List StyleBlock
+appendToLastSelector f styleBlock =
     case styleBlock of
         StyleBlock only [] properties ->
             [ StyleBlock only [] properties
-            , StyleBlock (appendRepeatableSelector selector only) [] []
+            , StyleBlock (f only) [] []
             ]
 
         StyleBlock first rest properties ->
             let
                 newRest =
-                    List.map (appendRepeatableSelector selector) rest
+                    List.map f rest
 
                 newFirst =
-                    appendRepeatableSelector selector first
+                    f first
             in
                 [ StyleBlock first rest properties
                 , StyleBlock newFirst newRest []
                 ]
+
+
+appendRepeatableToLastSelector : RepeatableSimpleSelector -> StyleBlock -> List StyleBlock
+appendRepeatableToLastSelector selector styleBlock =
+    appendToLastSelector (appendRepeatableSelector selector) styleBlock
 
 
 appendPseudoElementToLastSelector : PseudoElement -> StyleBlock -> List StyleBlock
 appendPseudoElementToLastSelector pseudo styleBlock =
-    case styleBlock of
-        StyleBlock only [] properties ->
-            [ StyleBlock only [] properties
-            , StyleBlock (applyPseudoElement pseudo only) [] []
-            ]
-
-        StyleBlock first rest properties ->
-            let
-                newRest =
-                    List.map (applyPseudoElement pseudo) rest
-
-                newFirst =
-                    applyPseudoElement pseudo first
-            in
-                [ StyleBlock first rest properties
-                , StyleBlock newFirst newRest []
-                ]
+    appendToLastSelector (applyPseudoElement pseudo) styleBlock
 
 
 applyPseudoElement : PseudoElement -> Selector -> Selector

--- a/src/Css/Structure.elm
+++ b/src/Css/Structure.elm
@@ -257,9 +257,12 @@ appendToLastSelector selector styleBlock =
             let
                 newRest =
                     mapLast (appendRepeatableSelector selector) rest
+
+                newFirst =
+                    appendRepeatableSelector selector first
             in
                 [ StyleBlock first rest properties
-                , StyleBlock first newRest []
+                , StyleBlock newFirst newRest []
                 ]
 
 

--- a/src/Css/Structure.elm
+++ b/src/Css/Structure.elm
@@ -274,8 +274,17 @@ appendPseudoElementToLastSelector pseudo styleBlock =
             , StyleBlock (applyPseudoElement pseudo only) [] []
             ]
 
-        a ->
-            [ a ]
+        StyleBlock first rest properties ->
+            let
+                newRest =
+                    List.map (applyPseudoElement pseudo) rest
+
+                newFirst =
+                    applyPseudoElement pseudo first
+            in
+                [ StyleBlock first rest properties
+                , StyleBlock newFirst newRest []
+                ]
 
 
 applyPseudoElement : PseudoElement -> Selector -> Selector

--- a/src/Css/Structure.elm
+++ b/src/Css/Structure.elm
@@ -256,7 +256,7 @@ appendToLastSelector selector styleBlock =
         StyleBlock first rest properties ->
             let
                 newRest =
-                    mapLast (appendRepeatableSelector selector) rest
+                    List.map (appendRepeatableSelector selector) rest
 
                 newFirst =
                     appendRepeatableSelector selector first

--- a/test/Fixtures.elm
+++ b/test/Fixtures.elm
@@ -72,7 +72,7 @@ bug99 =
 bug140 : Stylesheet
 bug140 =
     stylesheet
-        [ each [ input, selector "textarea" ]
+        [ each [ input, select, selector "textarea"]
             [ focus
                 [ borderColor (hex "#000000")
                 ]

--- a/test/Fixtures.elm
+++ b/test/Fixtures.elm
@@ -76,6 +76,9 @@ bug140 =
             [ focus
                 [ borderColor (hex "#000000")
                 ]
+            , after
+                [ color (hex "#aaaaaa")
+                ]
             ]
         ]
 

--- a/test/Fixtures.elm
+++ b/test/Fixtures.elm
@@ -69,6 +69,17 @@ bug99 =
         ]
 
 
+bug140 : Stylesheet
+bug140 =
+    stylesheet
+        [ each [ input, selector "textarea" ]
+            [ focus
+                [ borderColor (hex "#000000")
+                ]
+            ]
+        ]
+
+
 simpleEach : Stylesheet
 simpleEach =
     stylesheet

--- a/test/Tests.elm
+++ b/test/Tests.elm
@@ -22,6 +22,7 @@ all =
         , atRule
         , nestedAtRule
         , bug99
+        , bug140
         , universal
         , multiSelector
         , multiDescendent
@@ -203,6 +204,28 @@ nestedAtRule =
       """
     in
         describe "nested @media test"
+            [ test "pretty prints the expected output" <|
+                \_ ->
+                    outdented (prettyPrint input)
+                        |> Expect.equal (outdented output)
+            ]
+
+
+{-| Regression test for https://github.com/rtfeldman/elm-css/issues/140
+-}
+bug140 : Test
+bug140 =
+    let
+        input =
+            Fixtures.bug140
+
+        output =
+            """
+input:focus, textarea:focus {
+    border-color: #000000;
+}        """
+    in
+        describe "`each` with pseudo classes"
             [ test "pretty prints the expected output" <|
                 \_ ->
                     outdented (prettyPrint input)

--- a/test/Tests.elm
+++ b/test/Tests.elm
@@ -223,7 +223,12 @@ bug140 =
             """
 input:focus, select:focus, textarea:focus {
     border-color: #000000;
-}        """
+}
+
+input::after, select::after, textarea::after {
+    color: #aaaaaa;
+}
+            """
     in
         describe "`each` with pseudo classes"
             [ test "pretty prints the expected output" <|

--- a/test/Tests.elm
+++ b/test/Tests.elm
@@ -221,7 +221,7 @@ bug140 =
 
         output =
             """
-input:focus, textarea:focus {
+input:focus, select:focus, textarea:focus {
     border-color: #000000;
 }        """
     in


### PR DESCRIPTION
This attempts to fix issue #140 .

While working on the fix, [I noticed that `mapLast` is used instead of `List.map`](https://github.com/rtfeldman/elm-css/blob/7c58295a3b21efc6b7a6904e64df36bf36a58529/src/Css/Structure.elm#L259) when resolving chained pseudo classes. @rtfeldman even though I changed it to `List.map`, I can't figure out if it's a correct assumption that `mapLast` was at fault here. Could I have regressed something by changing it to `List.map`? I've thought about it, and couldn't find a scenario that would fail tests.

Also, while working on it, I realised the same issue applied to pseudo *elements*, so I fixed that as well, and introduced a nice refactor to remove some duplication.

Thoughts and concerns? :)