### PR TITLE
Allow color to be inherit, unset and initial

### DIFF
--- a/src/Css.elm
+++ b/src/Css.elm
@@ -648,6 +648,7 @@ type alias BasicProperty =
     , all : Compatible
     , alignItems : Compatible
     , boxSizing : Compatible
+    , color : Compatible
     , cursor : Compatible
     , display : Compatible
     , flexBasis : Compatible
@@ -676,6 +677,7 @@ type alias BasicProperty =
     , units : IncompatibleUnits
     , numericValue : Float
     , unitLabel : String
+    , warnings : List String
     }
 
 
@@ -709,6 +711,7 @@ initial =
     , textIndent = Compatible
     , textDecorationStyle = Compatible
     , boxSizing = Compatible
+    , color = Compatible
     , cursor = Compatible
     , display = Compatible
     , all = Compatible
@@ -732,6 +735,7 @@ initial =
     , units = IncompatibleUnits
     , numericValue = 0
     , unitLabel = ""
+    , warnings = []
     }
 
 

--- a/test/Properties.elm
+++ b/test/Properties.elm
@@ -325,6 +325,9 @@ all =
         , testProperty "color"
             [ ( color (hsl 120 0.5 0.5), "hsl(120, 50%, 50%)" )
             , ( color (hsla 120 0.5 0.5 0.5), "hsla(120, 50%, 50%, 0.5)" )
+            , ( color inherit , "inherit" )
+            , ( color unset, "unset" )
+            , ( color initial, "initial" )
             ]
         , testProperty "cursor"
             [ ( cursor pointer, "pointer" )


### PR DESCRIPTION
This aims to fix issue #148 . [The CSS spec](https://developer.mozilla.org/nl/docs/Web/CSS/color) allows color to assume the following global values:

```css
/* Global values */
color: inherit;
color: initial;
color: unset;
```