### PR TITLE
Allow to specify (optional) path to elm-make

### DIFF
--- a/elm-css.js
+++ b/elm-css.js
@@ -13,6 +13,7 @@ program
   .option('-m, --module [moduleName]', '(optional) name of stylesheets module in your project', null, 'Stylesheets')
   .option('-p, --port [portName]', '(optional) name of the port from which to read CSS results', null, 'files')
   .option('-r, --root [projectDir]', '(optional) root directory of the project', process.cwd())
+  .option('-e, --pathToMake [pathToMake]', '(optional) path to elm-make')
   .action(function(src) {
     sourcePath = src;
   })
@@ -29,7 +30,8 @@ elmCss(
   sourcePath,
   program.output,
   program.module,
-  program.port
+  program.port,
+  program.pathToMake
 ).then(function (results) {
   console.log(chalk.green('Successfully generated output! The following css files were created: '));
   results.forEach(function (result) {

--- a/index.js
+++ b/index.js
@@ -33,7 +33,7 @@ var KNOWN_MODULES =
   ];
 
 // elmModuleName is optional, and is by default inferred based on the filename.
-module.exports = function(projectDir, stylesheetsPath, outputDir, stylesheetsModule, stylesheetsPort) {
+module.exports = function(projectDir, stylesheetsPath, outputDir, stylesheetsModule, stylesheetsPort, pathToMake) {
 
   var originalWorkingDir = process.cwd();
   process.chdir(projectDir);
@@ -45,7 +45,8 @@ module.exports = function(projectDir, stylesheetsPath, outputDir, stylesheetsMod
         path.join(tmpDirPath, jsEmitterFilename),
         outputDir,
         stylesheetsModule || "Stylesheets",
-        stylesheetsPort || "files"
+        stylesheetsPort || "files",
+        pathToMake
       );
     })
     .then(function(result) {
@@ -70,14 +71,14 @@ function createTmpDir() {
   });
 }
 
-function generateCssFiles(stylesheetsPath, emitterDest, outputDir, stylesheetsModule, stylesheetsPort) {
-  return emit(stylesheetsPath, emitterDest, stylesheetsModule, stylesheetsPort)
+function generateCssFiles(stylesheetsPath, emitterDest, outputDir, stylesheetsModule, stylesheetsPort, pathToMake) {
+  return emit(stylesheetsPath, emitterDest, stylesheetsModule, stylesheetsPort, pathToMake)
     .then(writeResults(outputDir));
 }
 
-function emit(src, dest, stylesheetsModule, stylesheetsPort) {
+function emit(src, dest, stylesheetsModule, stylesheetsPort, pathToMake) {
     // Compile the temporary file.
-  return compileEmitter(src, {output: dest, yes: true})
+  return compileEmitter(src, {output: dest, yes: true, pathToMake: pathToMake})
     .then(extractCssResults(dest, stylesheetsModule, stylesheetsPort));
 }
 


### PR DESCRIPTION
This allows to automate elm-css compilation in a encapsulated environment - 
where installing elm globally is not possible. For instance, on Heroku.