### PR TITLE
Improve font documentation and fix tutorial error

### DIFF
--- a/Tutorial.md
+++ b/Tutorial.md
@@ -39,7 +39,7 @@ stylesheet { name = "homepage" }
       ]
 
   , (.) MenuItem
-      [ fontFamily [ "Georga", "serif" ]
+      [ fontFamilies [ "Georga", "serif" ]
       , fontWeight bold
       ]
   ]

--- a/src/Css.elm
+++ b/src/Css.elm
@@ -4435,13 +4435,19 @@ qt str =
     toString str
 
 
-{-| -}
+{-| For when your font is one of [`serif`](#serif), [`sansSerif`](#sansSerif), [`monospace`](#monospace), [`cursive`](#cursive) or [`fantasy`](#fantasy).
+If you want to refer to a font by its name (like Helvetica or Arial), use [`fontFamilies`](#fontFamilies) instead.
+-}
 fontFamily : FontFamily a -> Mixin
 fontFamily =
     prop1 "font-family"
 
 
-{-| -}
+{-| For multiple font families:
+
+    fontFamilies  ["Verdana", "Arial"]
+    fontFamilies  [(qt "Gill Sans Extrabold"), "Helvetica", .value sansSerif]
+-}
 fontFamilies : List String -> Mixin
 fontFamilies =
     prop1 "font-family" << stringsToValue


### PR DESCRIPTION
As per the suggestion I received in https://github.com/rtfeldman/elm-css/issues/158, this PR fixes a tiny error in the tutorial. Since I came across that error by searching for a way to set fonts by their name (like "Helvetica" instead of sansSerif or whatever), I took the liberty of adding a bit of documentation to `fontFamily` pointing to `fontFamilies`, since that's the first place I went looking. After all, the CSS property is called `font-family`, and there is no `font-families` one.