### PR TITLE
Improve travis build speed on Linux using sysconfcpus

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ sudo: false
 cache:
   directories:
     - test/elm-stuff/build-artifacts
+    - sysconfcpus
 
 os:
   - linux
@@ -18,6 +19,15 @@ before_install:
     then brew update; brew install nvm; mkdir ~/.nvm; export NVM_DIR=~/.nvm; source $(brew --prefix nvm)/nvm.sh;
     fi
   - echo -e "Host github.com\n\tStrictHostKeyChecking no\n" >> ~/.ssh/config
+  - | # epic build time improvement - see https://github.com/elm-lang/elm-compiler/issues/1473#issuecomment-245704142
+    if [ ! -d sysconfcpus/bin ];
+    then
+      git clone https://github.com/obmarg/libsysconfcpus.git;
+      cd libsysconfcpus;
+      ./configure --prefix=$TRAVIS_BUILD_DIR/sysconfcpus;
+      make && make install;
+      cd ..;
+    fi
 
 install:
   - nvm install $TARGET_NODE_VERSION
@@ -26,9 +36,11 @@ install:
   - npm --version
   - cd test
   - npm install -g elm@$ELM_VERSION elm-test
+  - mv $(npm config get prefix)/bin/elm-make $(npm config get prefix)/bin/elm-make-old
+  - echo "#\!/bin/bash\\n\\n$TRAVIS_BUILD_DIR/sysconfcpus/bin/sysconfcpus -n 2 elm-make-old \"\$@\"" > $(npm config get prefix)/bin/elm-make
+  - chmod +x $(npm config get prefix)/bin/elm-make
   - npm install
-  - git clone https://github.com/NoRedInk/elm-ops-tooling
-  - elm-ops-tooling/with_retry.rb elm package install --yes
+  - elm package install --yes
 
 script:
   - npm test


### PR DESCRIPTION
As seen at [`elm-test`](https://github.com/elm-community/elm-test/pull/70) the build times are significantly faster using `sysconfcpus` to set the number of CPUs available. All the credits go to @jvoigtlaender @obmarg and @rtfeldman.