### PR TITLE
Add working code example to illustrate elm-css approach

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,28 +94,22 @@ Then you'll need a special module with a port for `elm-css` to access:
 ```elm
 port module Stylesheets exposing (..)
 
-import Css.File exposing (..)
+import Css.File exposing (CssFileStructure, CssCompilerProgram)
 import MyCss
-import Html exposing (div)
-import Html.App as Html
 
 
 port files : CssFileStructure -> Cmd msg
 
 
-cssFiles : CssFileStructure
-cssFiles =
-    toFileStructure [ ( "styles.css", compile [ MyCss.css ] ) ]
+fileStructure : CssFileStructure
+fileStructure =
+  Css.File.toFileStructure
+    [ ( "index.css", Css.File.compile [ MyCss.css ] ) ]
 
 
-main : Program Never
+main : CssCompilerProgram
 main =
-    Html.program
-        { init = ( (), files cssFiles )
-        , view = \_ -> (div [] [])
-        , update = \_ _ -> ( (), Cmd.none )
-        , subscriptions = \_ -> Sub.none
-        }
+  Css.File.compiler files fileStructure
 ```
 
 Run `elm-css` on the file containing this `Stylesheets` module.


### PR DESCRIPTION
Hey guys. Current version of README contains an outdated example of Stylesheets module which cost me some time of head scratching to understand why it was impossible to use `elm-css` as described in the file. Frustrating experience.

Stylesheets module in the `examples` folder is working exactly according to the description so I think it makes sense to put this working code excerpt into README as well.

Thanks for great job. :-)