### PR TITLE
💥 Rename (.) to class and (#) to id 💥

### DIFF
--- a/examples/src/HomepageCss.elm
+++ b/examples/src/HomepageCss.elm
@@ -18,17 +18,17 @@ css =
             [ display inlineBlock
             , paddingBottom (px 12)
             ]
-        , (.) NavLink
+        , class NavLink
             [ margin (px 12)
             , color (rgb 255 255 255)
             ]
-        , (#) ReactiveLogo
+        , id ReactiveLogo
             [ display inlineBlock
             , marginLeft (px 150)
             , marginRight (px 80)
             , verticalAlign middle
             ]
-        , (#) BuyTickets
+        , id BuyTickets
             [ padding (px 16)
             , paddingLeft (px 24)
             , paddingRight (px 24)

--- a/readme-example/src/MyCss.elm
+++ b/readme-example/src/MyCss.elm
@@ -19,7 +19,7 @@ css =
             [ overflowX auto
             , minWidth (px 1280)
             ]
-        , (#) Page
+        , id Page
             [ backgroundColor (rgb 200 128 64)
             , color (hex "CCFFFF")
             , width (pct 100)
@@ -28,7 +28,7 @@ css =
             , padding (px 8)
             , margin zero
             ]
-        , (.) NavBar
+        , class NavBar
             [ margin zero
             , padding zero
             , children

--- a/src/Css.elm
+++ b/src/Css.elm
@@ -24,8 +24,8 @@ module Css
         , property
         , selector
         , important
-        , (#)
-        , (.)
+        , id
+        , class
         , (|*|)
         , (|+|)
         , (|-|)
@@ -584,7 +584,7 @@ module Css
 @docs Snippet, Mixin, mixin, stylesheet, compile
 
 # Statements
-@docs (#), (.), selector, everything
+@docs class, id, selector, everything
 
 # Combinators
 @docs children, descendants, adjacentSiblings, generalSiblings
@@ -6729,7 +6729,7 @@ properties in elm-css are implemented as mixins.
             ]
 
     stylesheet
-      [ (.) FancyLink
+      [ class FancyLink
           [ color (rgb 128 64 32)
           , underlineOnHover
           ]
@@ -6738,7 +6738,7 @@ properties in elm-css are implemented as mixins.
 ...has the same result as:
 
     stylesheet
-      [ (.) FancyLink
+      [ class FancyLink
           [ color (rgb 128 64 32)
           , textDecoration none
           , hover
@@ -6754,15 +6754,15 @@ mixin =
 {-| An [id selector](https://developer.mozilla.org/en-US/docs/Web/CSS/ID_selectors).
 
     stylesheet
-        [ (#) NavBar
+        [ id NavBar
             [ width 960 px
             , backgroundColor (rgb 123 42 208)
             ]
         ]
 -}
-(#) : id -> List Mixin -> Snippet
-(#) id mixins =
-    [ Structure.IdSelector (identifierToString "" id) ]
+id : id -> List Mixin -> Snippet
+id identifier mixins =
+    [ Structure.IdSelector (identifierToString "" identifier) ]
         |> Structure.UniversalSelectorSequence
         |> makeSnippet mixins
 
@@ -6780,14 +6780,14 @@ makeSnippet mixins sequence =
 {-| A [class selector](https://developer.mozilla.org/en-US/docs/Web/CSS/Class_selectors).
 
     stylesheet
-        [ (.) LoginFormButton
+        [ class LoginFormButton
             [ fontWeight normal
             , color (rgb 128 64 32)
             ]
         ]
 -}
-(.) : class -> List Mixin -> Snippet
-(.) class mixins =
+class : class -> List Mixin -> Snippet
+class class mixins =
     [ Structure.ClassSelector (identifierToString "" class) ]
         |> Structure.UniversalSelectorSequence
         |> makeSnippet mixins
@@ -6831,7 +6831,7 @@ selector selectorStr mixins =
 
 {-| A [`*` selector](https://developer.mozilla.org/en-US/docs/Web/CSS/Universal_selectors).
 
-    (.) Foo
+    class Foo
       [ children
           [ everything
               [ color (rgb 14 15 16)

--- a/tests/CompileFixtures.elm
+++ b/tests/CompileFixtures.elm
@@ -50,8 +50,8 @@ dreamwriter =
                     ]
                 ]
             ]
-        , ((.) Hidden) [ (display none) |> important ]
-        , ((#) Page)
+        , (class Hidden) [ (display none) |> important ]
+        , (id Page)
             [ width (pct 100)
             , height (pct 100)
             , boxSizing borderBox
@@ -66,7 +66,7 @@ dreamwriter =
 basicStyle1 : Stylesheet
 basicStyle1 =
     (stylesheet << namespace "basic1")
-        [ (.) BasicStyle1
+        [ class BasicStyle1
             [ display none ]
         ]
 
@@ -74,6 +74,6 @@ basicStyle1 =
 basicStyle2 : Stylesheet
 basicStyle2 =
     (stylesheet << namespace "basic2")
-        [ (.) BasicStyle2
+        [ class BasicStyle2
             [ display none ]
         ]

--- a/tests/Fixtures.elm
+++ b/tests/Fixtures.elm
@@ -358,7 +358,7 @@ colorHexAbbrWarning =
 pseudoElementStylesheet : Stylesheet
 pseudoElementStylesheet =
     (stylesheet << namespace "pseudoElements")
-        [ (#) Page
+        [ id Page
             [ margin (px 10)
             , before
                 [ color (hex "#fff") ]
@@ -372,7 +372,7 @@ pseudoElementStylesheet =
 pseudoClassStylesheet : Stylesheet
 pseudoClassStylesheet =
     (stylesheet << namespace "pseudoClasses")
-        [ (#) Page
+        [ id Page
             [ color (hex "#fff")
             , hover
                 [ marginTop (px 10)

--- a/tests/Selectors.elm
+++ b/tests/Selectors.elm
@@ -16,8 +16,8 @@ all =
 nonElements : Test
 nonElements =
     describe "non-elements"
-        [ testSelector ".foo" ((.) "foo")
-        , testSelector "#foo" ((#) "foo")
+        [ testSelector ".foo" (class "foo")
+        , testSelector "#foo" (id "foo")
         , testSelector "div:hover" (\children -> div [ hover children ])
         , testSelector "div::before" (\children -> div [ before children ])
         ]


### PR DESCRIPTION
💥 Big breaking change! 💥

This has been a long time coming, but it seems like the right choice:

Replace `(.)` with `class` and `(#)` with `id`.

Even though these are nicer names, I've avoided doing this because I wanted to avoid namespace clashes in the case where you're defining styles in the same file as some view code, and you have `import Css exposing (..)` and `import Html.Attributes exposing (..)` in the same file.

However, what I realized is that:

1. This already comes up with stuff like `src`, and if you do `import Html.Attributes as Attr exposing (..)` followed by `Attr.src` to disambiguate and resolve the compiler error, it's not a huge deal.
2. In practice, if you're writing views and styles in the same file, you're probably shadowing `class` anyway using a namespace helper (e.g. `{ class, classList, id } = ...`) so the only downside would be that you'd have to say `Css.class` instead of `(.)` - which is more verbose, but reads better. Seems like a win overall.

My default plan is to merge this, but I want to leave it open for a bit in case someone brings up a compelling point I missed. It's a big change, after all!