### PR TITLE
Add `display:table` and its derivatives

### DIFF
--- a/src/Css.elm
+++ b/src/Css.elm
@@ -251,6 +251,16 @@ module Css
         , block
         , inlineBlock
         , inline
+        , table
+        , inlineTable
+        , tableCell
+        , tableRow
+        , tableColumn
+        , tableCaption
+        , tableRowGroup
+        , tableColumnGroup
+        , tableHeaderGroup
+        , tableFooterGroup
         , listItem
         , inlineListItem
         , none
@@ -574,8 +584,10 @@ module Css
 
 {-| Functions for building stylesheets.
 
+
+
 # Misc
-@docs Stylesheet, asPairs, absolute, all, allPetiteCaps, allSmallCaps, withClass, auto, baseline, block, bold, bolder, border, border2, border3, borderBlockEnd, borderBlockEnd2, borderBlockEnd3, borderBlockEndColor, borderBlockEndStyle, borderBlockStart, borderBlockStart2, borderBlockStart3, borderBlockStartColor, borderBlockStartStyle, borderBottom, borderBottom2, borderBottom3, borderBottomColor, borderBottomLeftRadius, borderBottomLeftRadius2, borderBottomRightRadius, borderBottomRightRadius2, borderBottomStyle, borderBottomWidth, borderBox, borderColor, borderColor2, borderColor3, borderColor4, borderImageOutset, borderImageOutset2, borderImageOutset3, borderImageOutset4, borderImageWidth, borderImageWidth2, borderImageWidth3, borderImageWidth4, borderInlineEnd, borderInlineEnd2, borderInlineEnd3, borderInlineEndColor, borderInlineEndStyle, borderInlineEndWidth, borderInlineStart, borderInlineStart2, borderInlineStart3, borderInlineStartColor, borderInlineStartStyle, borderLeft, borderLeft2, borderLeft3, borderLeftColor, borderLeftStyle, borderLeftWidth, borderRadius, borderRadius2, borderRadius3, borderRadius4, borderRight, borderRight2, borderRight3, borderRightColor, borderRightStyle, borderRightWidth, borderStyle, borderCollapse, borderTop, borderTop2, borderTop3, borderTopColor, borderTopLeftRadius, borderTopLeftRadius2, borderTopRightRadius, borderTopRightRadius2, borderTopStyle, borderTopWidth, bottom, column, columnReverse, commonLigatures, content, contentBox, contextual, cursive, dashed, diagonalFractions, discretionaryLigatures, dotted, double, fantasy, fillBox, fixed, flat, displayFlex, flexEnd, flexStart, groove, hex, hidden, historicalLigatures, hsl, hsla, important, inherit, initial, inline, inlineBlock, inlineListItem, inset, italic, large, larger, lighter, liningNums, listItem, matrix, matrix3d, middle, monospace, noCommonLigatures, noContextual, noDiscretionaryLigatures, noHistoricalLigatures, noWrap, none, normal, oblique, oldstyleNums, ordinal, outset, perspective, petiteCaps, position, float, preserve3d, proportionalNums, relative, rgb, rgba, ridge, rotate, rotate3d, rotateX, rotateY, rotateZ, row, rowReverse, sansSerif, scale, scale2, scale3d, scaleX, scaleY, scroll, serif, skew, skew2, skewX, skewY, slashedZero, small, smallCaps, smaller, solid, stackedFractions, static, sticky, stretch, sub, super, tabularNums, textBottom, textTop, titlingCaps, top, translate, translate2, translate3d, translateX, translateY, translateZ, transparent, unicase, unset, viewBox, visible, wavy, wrap, wrapReverse, xLarge, xSmall, xxLarge, xxSmall, backgroundRepeat, backgroundRepeat2, repeatX, repeatY, repeat, space, round, noRepeat, backgroundAttachment, local, backgroundBlendMode, multiply, overlay, darken, lighten, colorDodge, colorBurn, hardLight, softLight, difference, exclusion, hue, saturation, luminosity, screenBlendMode, backgroundClip, paddingBox, backgroundImage, url, backgroundPosition, backgroundPosition2, backgroundOrigin, backgroundSize, backgroundSize2, cover, contain
+@docs Stylesheet, asPairs, absolute, all, allPetiteCaps, allSmallCaps, withClass, auto, baseline, block, bold, bolder, border, border2, border3, borderBlockEnd, borderBlockEnd2, borderBlockEnd3, borderBlockEndColor, borderBlockEndStyle, borderBlockStart, borderBlockStart2, borderBlockStart3, borderBlockStartColor, borderBlockStartStyle, borderBottom, borderBottom2, borderBottom3, borderBottomColor, borderBottomLeftRadius, borderBottomLeftRadius2, borderBottomRightRadius, borderBottomRightRadius2, borderBottomStyle, borderBottomWidth, borderBox, borderColor, borderColor2, borderColor3, borderColor4, borderImageOutset, borderImageOutset2, borderImageOutset3, borderImageOutset4, borderImageWidth, borderImageWidth2, borderImageWidth3, borderImageWidth4, borderInlineEnd, borderInlineEnd2, borderInlineEnd3, borderInlineEndColor, borderInlineEndStyle, borderInlineEndWidth, borderInlineStart, borderInlineStart2, borderInlineStart3, borderInlineStartColor, borderInlineStartStyle, borderLeft, borderLeft2, borderLeft3, borderLeftColor, borderLeftStyle, borderLeftWidth, borderRadius, borderRadius2, borderRadius3, borderRadius4, borderRight, borderRight2, borderRight3, borderRightColor, borderRightStyle, borderRightWidth, borderStyle, borderCollapse, borderTop, borderTop2, borderTop3, borderTopColor, borderTopLeftRadius, borderTopLeftRadius2, borderTopRightRadius, borderTopRightRadius2, borderTopStyle, borderTopWidth, bottom, column, columnReverse, commonLigatures, content, contentBox, contextual, cursive, dashed, diagonalFractions, discretionaryLigatures, dotted, double, fantasy, fillBox, fixed, flat, displayFlex, flexEnd, flexStart, groove, hex, hidden, historicalLigatures, hsl, hsla, important, inherit, initial, inline, inlineBlock, table, inlineTable, tableCell, tableRow, tableColumn, tableCaption, tableRowGroup, tableColumnGroup, tableHeaderGroup, tableFooterGroup, inlineListItem, inset, italic, large, larger, lighter, liningNums, listItem, matrix, matrix3d, middle, monospace, noCommonLigatures, noContextual, noDiscretionaryLigatures, noHistoricalLigatures, noWrap, none, normal, oblique, oldstyleNums, ordinal, outset, perspective, petiteCaps, position, float, preserve3d, proportionalNums, relative, rgb, rgba, ridge, rotate, rotate3d, rotateX, rotateY, rotateZ, row, rowReverse, sansSerif, scale, scale2, scale3d, scaleX, scaleY, scroll, serif, skew, skew2, skewX, skewY, slashedZero, small, smallCaps, smaller, solid, stackedFractions, static, sticky, stretch, sub, super, tabularNums, textBottom, textTop, titlingCaps, top, translate, translate2, translate3d, translateX, translateY, translateZ, transparent, unicase, unset, viewBox, visible, wavy, wrap, wrapReverse, xLarge, xSmall, xxLarge, xxSmall, backgroundRepeat, backgroundRepeat2, repeatX, repeatY, repeat, space, round, noRepeat, backgroundAttachment, local, backgroundBlendMode, multiply, overlay, darken, lighten, colorDodge, colorBurn, hardLight, softLight, difference, exclusion, hue, saturation, luminosity, screenBlendMode, backgroundClip, paddingBox, backgroundImage, url, backgroundPosition, backgroundPosition2, backgroundOrigin, backgroundSize, backgroundSize2, cover, contain
 @docs listStyleType, disc, circle, square, decimal, decimalLeadingZero, lowerRoman, upperRoman, lowerGreek, lowerAlpha, lowerLatin, upperAlpha, upperLatin, arabicIndic, armenian, bengali, cjkEarthlyBranch, cjkHeavenlyStem, devanagari, georgian, gujarati, gurmukhi, kannada, khmer, lao, malayalam, myanmar, oriya, telugu, thai
 @docs listStylePosition, inside, outside
 @docs listStyle, listStyle2, listStyle3
@@ -3657,7 +3669,16 @@ table =
     }
 
 
-{-| Sets the display style to [`tableRow`](https://developer.mozilla.org/en-US/docs/Web/CSS/display#Values)
+{-| Sets the display style to [`inline-table`](https://developer.mozilla.org/en-US/docs/Web/CSS/display#Values)
+-}
+inlineTable : Display {}
+inlineTable =
+    { value = "inline-table"
+    , display = Compatible
+    }
+
+
+{-| Sets the display style to [`table-row`](https://developer.mozilla.org/en-US/docs/Web/CSS/display#Values)
 -}
 tableRow : Display {}
 tableRow =
@@ -3666,11 +3687,65 @@ tableRow =
     }
 
 
-{-| Sets the display style to [`tableCell`](https://developer.mozilla.org/en-US/docs/Web/CSS/display#Values)
+{-| Sets the display style to [`table-cell`](https://developer.mozilla.org/en-US/docs/Web/CSS/display#Values)
 -}
 tableCell : Display {}
 tableCell =
     { value = "table-cell"
+    , display = Compatible
+    }
+
+
+{-| Sets the display style to [`table-column`](https://developer.mozilla.org/en-US/docs/Web/CSS/display#Values)
+-}
+tableColumn : Display {}
+tableColumn =
+    { value = "table-column"
+    , display = Compatible
+    }
+
+
+{-| Sets the display style to [`table-caption`](https://developer.mozilla.org/en-US/docs/Web/CSS/display#Values)
+-}
+tableCaption : Display {}
+tableCaption =
+    { value = "table-caption"
+    , display = Compatible
+    }
+
+
+{-| Sets the display style to [`table-row-group`](https://developer.mozilla.org/en-US/docs/Web/CSS/display#Values)
+-}
+tableRowGroup : Display {}
+tableRowGroup =
+    { value = "table-row-group"
+    , display = Compatible
+    }
+
+
+{-| Sets the display style to [`table-column-group`](https://developer.mozilla.org/en-US/docs/Web/CSS/display#Values)
+-}
+tableColumnGroup : Display {}
+tableColumnGroup =
+    { value = "table-column-group"
+    , display = Compatible
+    }
+
+
+{-| Sets the display style to [`table-header-group`](https://developer.mozilla.org/en-US/docs/Web/CSS/display#Values)
+-}
+tableHeaderGroup : Display {}
+tableHeaderGroup =
+    { value = "table-header-group"
+    , display = Compatible
+    }
+
+
+{-| Sets the display style to [`table-footer-group`](https://developer.mozilla.org/en-US/docs/Web/CSS/display#Values)
+-}
+tableFooterGroup : Display {}
+tableFooterGroup =
+    { value = "table-footer-group"
     , display = Compatible
     }
 

--- a/tests/Properties.elm
+++ b/tests/Properties.elm
@@ -203,16 +203,16 @@ all =
             , ( display listItem, "list-item" )
             , ( display inlineListItem, "inline-list-item" )
             , ( displayFlex, "flex" )
+            , ( display table, "table" )
+            , ( display inlineTable, "inline-table" )
+            , ( display tableCell, "table-cell" )
+            , ( display tableColumn, "table-column" )
+            , ( display tableColumnGroup, "table-column-group" )
+            , ( display tableFooterGroup, "table-footer-group" )
+            , ( display tableHeaderGroup, "table-header-group" )
+            , ( display tableRow, "table-row" )
+            , ( display tableRowGroup, "table-row-group" )
               -- TODO display: contents;
-              -- TODO display: table;
-              -- TODO display: inline-table;
-              -- TODO display: table-cell;
-              -- TODO display: table-column;
-              -- TODO display: table-column-group;
-              -- TODO display: table-footer-group;
-              -- TODO display: table-header-group;
-              -- TODO display: table-row;
-              -- TODO display: table-row-group;
               -- TODO display: flex;
               -- TODO display: inline-flex;
               -- TODO display: grid;

--- a/tests/Selectors.elm
+++ b/tests/Selectors.elm
@@ -63,7 +63,7 @@ elements =
         , testSelector "caption" caption
         , testSelector "col" col
         , testSelector "colgroup" colgroup
-        , testSelector "table" table
+        , testSelector "table" Css.Elements.table
         , testSelector "tbody" tbody
         , testSelector "td" td
         , testSelector "tfoot" tfoot


### PR DESCRIPTION
adressing #183 

The basic table properties were implemented, but not exposed. This
PR adds

* table
* inlineTable
* tableCell
* tableRow
* tableColumn
* tableCaption
* tableRowGroup
* tableColumnGroup
* tableHeaderGroup
* tableFooterGroup

and their associated tests

further notes:
* `table` is already a selector (the table html
element) and thus `display table` will have to become `display Css.table` in
most actual use cases where elm-css is imported as `exposing (..)`. A specific `displayTable` property (analogous todisplayFlex) is a possible fix.
* In the comments, I've changed the text in the link to the css value instead of the elm-css value (`inline-table` instead of `inlineTable`). This is consistent with other links to the MDN documentation. 
* Is the ordering of the properties alright? 