### PR TITLE
Add full media query support

### DIFF
--- a/elm-package.json
+++ b/elm-package.json
@@ -10,6 +10,7 @@
         "Css",
         "Css.Colors",
         "Css.Elements",
+        "Css.Media",
         "Css.File",
         "Css.Namespace"
     ],

--- a/src/Css.elm
+++ b/src/Css.elm
@@ -6,13 +6,10 @@ module Css
         , Snippet
         , Mixin
         , Color
-        , MediaQuery
         , Length
         , IntOrAuto
         , stylesheet
         , each
-        , media
-        , withMedia
         , withClass
         , everything
         , children
@@ -458,11 +455,6 @@ module Css
         , stackedFractions
         , ordinal
         , slashedZero
-        , screen
-        , print
-        , projection
-        , tv
-        , mediaQuery
         , src
         , qt
         , fontFamilies
@@ -612,11 +604,8 @@ module Css
 # Combinators
 @docs children, descendants, adjacentSiblings, generalSiblings
 
-# Media Queries
-@docs screen, tv, projection, print
-
 # Properties
-@docs property, flex, flex2, flex3, medium, alignSelf, alignItems, justifyContent, order, flexDirection, flexFlow1, flexFlow2, flexWrap, flexBasis, flexGrow, flexShrink, transformStyle, transformBox, transform, transforms, currentColor, underline, overline, lineThrough, textOrientation, textDecoration, textDecoration2, textDecoration3, textDecorationLine, textDecorations, textDecorations2, textDecorations3, textDecorationLine, textDecorationLines, textDecorationStyle, textEmphasisColor, capitalize, uppercase, lowercase, fullWidth, hanging, eachLine, textIndent, textIndent2, textIndent3, clip, ellipsis, textOverflow, optimizeSpeed, optimizeLegibility, geometricPrecision, textRendering, textTransform, textAlign, textAlignLast, left, right, center, textJustify, justifyAll, start, end, matchParent, true, verticalAlign, display, opacity, minContent, maxContent, fitContent, fillAvailable, width, minWidth, maxWidth, height, minHeight, maxHeight, padding, padding2, padding3, padding4, paddingTop, paddingBottom, paddingRight, paddingLeft, paddingBlockStart, paddingBlockEnd, paddingInlineStart, paddingInlineEnd, margin, margin2, margin3, margin4, marginTop, marginBottom, marginRight, marginLeft, marginBlockStart, marginBlockEnd, marginInlineStart, marginInlineEnd, boxSizing, overflow, overflowX, overflowY, overflowWrap, whiteSpace, backgroundColor, color, withMedia, each, media, mediaQuery, textShadow, textShadow2, textShadow3, textShadow4, boxShadow, boxShadow2, boxShadow3, boxShadow4, boxShadow5, boxShadow6, lineHeight, letterSpacing, fontFace, fontFamily, fontSize, fontStyle, fontWeight, fontVariant, fontVariant2, fontVariant3, fontVariantLigatures, fontVariantCaps, fontVariantNumeric, fontVariantNumeric2, fontVariantNumeric3, fontFamilies, fontVariantNumerics, fontFeatureSettings, fontFeatureSettingsList, cursor, outline, outline3, outlineColor, outlineWidth, outlineStyle, outlineOffset, zIndex, spaceAround, spaceBetween, resize, fill
+@docs property, flex, flex2, flex3, medium, alignSelf, alignItems, justifyContent, order, flexDirection, flexFlow1, flexFlow2, flexWrap, flexBasis, flexGrow, flexShrink, transformStyle, transformBox, transform, transforms, currentColor, underline, overline, lineThrough, textOrientation, textDecoration, textDecoration2, textDecoration3, textDecorationLine, textDecorations, textDecorations2, textDecorations3, textDecorationLine, textDecorationLines, textDecorationStyle, textEmphasisColor, capitalize, uppercase, lowercase, fullWidth, hanging, eachLine, textIndent, textIndent2, textIndent3, clip, ellipsis, textOverflow, optimizeSpeed, optimizeLegibility, geometricPrecision, textRendering, textTransform, textAlign, textAlignLast, left, right, center, textJustify, justifyAll, start, end, matchParent, true, verticalAlign, display, opacity, minContent, maxContent, fitContent, fillAvailable, width, minWidth, maxWidth, height, minHeight, maxHeight, padding, padding2, padding3, padding4, paddingTop, paddingBottom, paddingRight, paddingLeft, paddingBlockStart, paddingBlockEnd, paddingInlineStart, paddingInlineEnd, margin, margin2, margin3, margin4, marginTop, marginBottom, marginRight, marginLeft, marginBlockStart, marginBlockEnd, marginInlineStart, marginInlineEnd, boxSizing, overflow, overflowX, overflowY, overflowWrap, whiteSpace, backgroundColor, color, each, textShadow, textShadow2, textShadow3, textShadow4, boxShadow, boxShadow2, boxShadow3, boxShadow4, boxShadow5, boxShadow6, lineHeight, letterSpacing, fontFace, fontFamily, fontSize, fontStyle, fontWeight, fontVariant, fontVariant2, fontVariant3, fontVariantLigatures, fontVariantCaps, fontVariantNumeric, fontVariantNumeric2, fontVariantNumeric3, fontFamilies, fontVariantNumerics, fontFeatureSettings, fontFeatureSettingsList, cursor, outline, outline3, outlineColor, outlineWidth, outlineStyle, outlineOffset, zIndex, spaceAround, spaceBetween, resize, fill
 
 # Values
 
@@ -644,9 +633,6 @@ module Css
 # Pseudo-Elements
 @docs after, before, firstLetter, firstLine, selection
 
-# Media Queries
-@docs MediaQuery, screen, print, tv, projection
-
 # Source
 @docs src
 
@@ -666,19 +652,14 @@ deprecated or discouraged.
 @docs thin, medium, thick, blink
 -}
 
+import Color
 import Css.Helpers exposing (toCssIdentifier, identifierToString)
-import Css.Preprocess.Resolve as Resolve
 import Css.Preprocess as Preprocess exposing (Mixin, unwrapSnippet)
-import Css.Structure as Structure
+import Css.Preprocess.Resolve as Resolve
+import Css.Structure as Structure exposing (..)
+import Hex
 import String
 import Tuple
-import Hex
-import Color
-
-
-{-| -}
-type alias MediaQuery =
-    Structure.MediaQuery
 
 
 {-| -}
@@ -696,40 +677,12 @@ type alias Mixin =
     Preprocess.Mixin
 
 
-type Compatible
-    = Compatible
-
-
 type PseudoClass
     = PseudoClass String (List Mixin)
 
 
 type PseudoElement
     = PseudoElement String (List Mixin)
-
-
-{-| -}
-screen : MediaQuery
-screen =
-    Structure.MediaQuery "screen"
-
-
-{-| -}
-print : MediaQuery
-print =
-    Structure.MediaQuery "print"
-
-
-{-| -}
-projection : MediaQuery
-projection =
-    Structure.MediaQuery "projection"
-
-
-{-| -}
-tv : MediaQuery
-tv =
-    Structure.MediaQuery "tv"
 
 
 
@@ -800,10 +753,6 @@ type alias Value compatible =
 
 type alias All compatible =
     { compatible | value : String, all : Compatible }
-
-
-type alias Number compatible =
-    { compatible | value : String, number : Compatible }
 
 
 type alias None compatible =
@@ -1183,6 +1132,7 @@ type alias ExplicitLength units =
     , lengthOrNoneOrMinMaxDimension : Compatible
     , textIndent : Compatible
     , flexBasis : Compatible
+    , absoluteLength : Compatible
     , lengthOrNumberOrAutoOrNoneOrContent : Compatible
     , fontSize : Compatible
     , lengthOrAutoOrCoverOrContain : Compatible
@@ -1371,12 +1321,23 @@ visible =
 
 {-| The `scroll` [`overflow`](https://developer.mozilla.org/en-US/docs/Web/CSS/overflow#Values) value.
 This can also represent a `scroll` [`background-attachment`](https://developer.mozilla.org/en-US/docs/Web/CSS/background-attachment) value.
+It can also be used in the overflow-block and oveflow-line media features.
 -}
-scroll : Overflow (BackgroundAttachment {})
+scroll :
+    { value : String
+    , scroll : Compatible
+    , overflow : Compatible
+    , backgroundAttachment : Compatible
+    , blockAxisOverflow : Compatible
+    , inlineAxisOverflow : Compatible
+    }
 scroll =
     { value = "scroll"
+    , scroll = Compatible
     , overflow = Compatible
     , backgroundAttachment = Compatible
+    , blockAxisOverflow = Compatible
+    , inlineAxisOverflow = Compatible
     }
 
 
@@ -2266,6 +2227,7 @@ lengthConverter units unitLabel numericValue =
     , flexBasis = Compatible
     , lengthOrNumberOrAutoOrNoneOrContent = Compatible
     , fontSize = Compatible
+    , absoluteLength = Compatible
     , lengthOrAutoOrCoverOrContain = Compatible
     }
 
@@ -3889,6 +3851,12 @@ none :
     , transform : Compatible
     , backgroundImage : Compatible
     , value : String
+    , updateFrequency : Compatible
+    , blockAxisOverflow : Compatible
+    , inlineAxisOverflow : Compatible
+    , pointerDevice : Compatible
+    , hoverCapability : Compatible
+    , scriptingSupport : Compatible
     }
 none =
     { value = "none"
@@ -3906,6 +3874,12 @@ none =
     , transform = Compatible
     , borderStyle = Compatible
     , backgroundImage = Compatible
+    , updateFrequency = Compatible
+    , blockAxisOverflow = Compatible
+    , inlineAxisOverflow = Compatible
+    , pointerDevice = Compatible
+    , hoverCapability = Compatible
+    , scriptingSupport = Compatible
     }
 
 
@@ -6332,65 +6306,6 @@ backgroundSize2 =
 color : ColorValue compatible -> Mixin
 color c =
     propertyWithWarnings c.warnings "color" c.value
-
-
-{-| -}
-mediaQuery : String -> List Snippet -> Snippet
-mediaQuery queryString snippets =
-    media [ Structure.MediaQuery queryString ] snippets
-
-
-{-| -}
-media : List Structure.MediaQuery -> List Snippet -> Snippet
-media mediaQueries snippets =
-    let
-        snippetDeclarations : List Preprocess.SnippetDeclaration
-        snippetDeclarations =
-            List.concatMap unwrapSnippet snippets
-
-        extractStyleBlocks : List Preprocess.SnippetDeclaration -> List Preprocess.StyleBlock
-        extractStyleBlocks declarations =
-            case declarations of
-                [] ->
-                    []
-
-                (Preprocess.StyleBlockDeclaration styleBlock) :: rest ->
-                    styleBlock :: extractStyleBlocks rest
-
-                first :: rest ->
-                    extractStyleBlocks rest
-
-        mediaRuleFromStyleBlocks : Preprocess.SnippetDeclaration
-        mediaRuleFromStyleBlocks =
-            Preprocess.MediaRule mediaQueries
-                (extractStyleBlocks snippetDeclarations)
-
-        nestedMediaRules : List Preprocess.SnippetDeclaration -> List Preprocess.SnippetDeclaration
-        nestedMediaRules declarations =
-            case declarations of
-                [] ->
-                    []
-
-                (Preprocess.StyleBlockDeclaration _) :: rest ->
-                    -- These will already have been handled previously, with appropriate
-                    -- bundling, so don't create duplicates here.
-                    nestedMediaRules rest
-
-                (Preprocess.MediaRule nestedMediaQueries styleBlocks) :: rest ->
-                    -- nest the media queries
-                    (Preprocess.MediaRule (mediaQueries ++ nestedMediaQueries) styleBlocks)
-                        :: nestedMediaRules rest
-
-                first :: rest ->
-                    first :: nestedMediaRules rest
-    in
-        Preprocess.Snippet (mediaRuleFromStyleBlocks :: (nestedMediaRules snippetDeclarations))
-
-
-{-| -}
-withMedia : List Structure.MediaQuery -> List Mixin -> Mixin
-withMedia =
-    Preprocess.WithMedia
 
 
 

--- a/src/Css/Media.elm
+++ b/src/Css/Media.elm
@@ -1,0 +1,1168 @@
+module Css.Media
+    exposing
+        ( MediaQueryComponent
+        , MediaQuery
+        , media
+        , mediaQuery
+        , withMedia
+        , withMediaQuery
+        , only
+        , not
+        , or
+        , all
+        , screen
+        , print
+        , speech
+        , braille
+        , embossed
+        , handheld
+        , projection
+        , tty
+        , tv
+        , aural
+        , minWidth
+        , width
+        , maxWidth
+        , minHeight
+        , height
+        , maxHeight
+        , Landscape
+        , Portrait
+        , landscape
+        , portrait
+        , orientation
+        , Ratio
+        , ratio
+        , minAspectRatio
+        , aspectRatio
+        , maxAspectRatio
+        , Resolution
+        , dpi
+        , dpcm
+        , dppx
+        , minResolution
+        , resolution
+        , maxResolution
+        , Progressive
+        , Interlace
+        , progressive
+        , interlace
+        , scan
+        , grid
+        , Slow
+        , Fast
+        , slow
+        , fast
+        , update
+        , Paged
+        , OptionalPaged
+        , paged
+        , optionalPaged
+        , overflowBlock
+        , overflowInline
+        , Bits
+        , bits
+        , minColor
+        , color
+        , maxColor
+        , minColorIndex
+        , colorIndex
+        , maxColorIndex
+        , minMonochrome
+        , monochrome
+        , maxMonochrome
+        , SRGB
+        , P3
+        , Rec2020
+        , srgb
+        , p3
+        , rec2020
+        , colorGamut
+        , Fine
+        , Coarse
+        , fine
+        , coarse
+        , pointer
+        , anyPointer
+        , CanHover
+        , canHover
+        , hover
+        , anyHover
+        , InitialOnly
+        , Enabled
+        , initialOnly
+        , enabled
+        , scripting
+        )
+
+{-| Functions for composing
+[media queries](https://developer.mozilla.org/en-US/docs/Web/CSS/Media_Queries/Using_media_queries).
+
+# Basics
+@docs MediaQueryComponent, MediaQuery
+
+# Query constructors
+@docs media, withMedia, mediaQuery, withMediaQuery
+
+# Query composition
+@docs only, not, or
+
+# Media Types
+@docs all, screen, print, speech, aural, braille, embossed, tv, tty,
+      handheld, projection
+
+# Viewport/Page Dimensions Media Features
+@docs minWidth, width, maxWidth, minHeight, height, maxHeight, Ratio, ratio,
+      minAspectRatio, aspectRatio, maxAspectRatio, Landscape, Portrait,
+      landscape, portrait, orientation
+
+# Display Quality Media Features
+@docs Resolution, dpi, dpcm, dppx, minResolution, resolution, maxResolution,
+      scan, Progressive, Interlace, progressive, interlace, scan, grid, Slow,
+      Fast, slow, fast, update, Paged, OptionalPaged, paged, optionalPaged,
+      overflowBlock, overflowInline
+
+# Color Media Features
+@docs Bits, bits, minColor, color, maxColor, minMonochrome, monochrome,
+      maxMonochrome, minColorIndex, colorIndex, maxColorIndex, SRGB, P3,
+      Rec2020, srgb, p3, rec2020, colorGamut
+
+# Interaction Media Features
+@docs Fine, Coarse, fine, coarse, pointer, anyPointer, CanHover, canHover,
+      hover, anyHover
+
+# Scripting Media Features
+@docs InitialOnly, Enabled, initialOnly, enabled, scripting
+
+-}
+
+import Css
+import Css.Preprocess as Preprocess exposing (Snippet, unwrapSnippet)
+import Css.Structure as Structure exposing (..)
+
+
+-- {- TODO: docs }
+{--Basics--}
+
+
+{-| The basic unit of a media query. Includes all media modifiers,
+media types, media features, and the `or` separator.
+Components are put together in lists, which are given to the media function.
+-}
+type alias MediaQueryComponent =
+    Structure.MediaQueryComponent
+
+
+{-| One query of a media rule. A media rule can have multiple queries.
+The CSS below contains 1 rule, with 2 queries.
+
+```css
+@media print, screen and (monochrome) {
+    body {
+        color: black;
+    }
+}
+```
+
+The above rule roughly translates as:
+_If the device is a printer or is a monoschrome screen, the body color is black._
+
+In elm-css, queries are joined into rules using a special `MediaQueryComponent`
+returned by the `or` function.
+-}
+type alias MediaQuery =
+    Structure.MediaQuery
+
+
+type alias Value compatible =
+    { compatible | value : String }
+
+
+
+{--Query constructors--}
+
+
+{-| Combines media query components into media queries.
+
+    (stylesheet << namespace "homepage")
+        [  media [ screen, Media.minWidth (px 300), Media.maxWidth (px 800) ]
+               [ footer [ Css.maxWidth (px 300) ] ]
+        ]
+
+The above code translates into the following css.
+
+```css
+@media screen and (min-width: 300px) and (max-width: 800px) {
+    footer {
+        max-width: 300px;
+    }
+}
+```
+-}
+media : List MediaQueryComponent -> List Snippet -> Snippet
+media components snippets =
+    mediaQuery (componentsToStringQueries components) snippets
+
+
+{-| Manually specify a media query using a List of strings.
+
+    mediaQuery ["screen and (min-width: 320px)", "screen and (max-height: 400px)" ]
+        [ body [ fontSize (px 14)] ]
+
+
+The above code translates into the following css.
+
+```css
+@media screen and (min-width: 320px), screen and (min-height: 400px) {
+    body {
+        font-size: 14px;
+    }
+}
+```
+-}
+mediaQuery : List String -> List Snippet -> Snippet
+mediaQuery stringQueries snippets =
+    let
+        mediaQueries =
+            List.map (\q -> Structure.MediaQuery q) stringQueries
+
+        snippetDeclarations : List Preprocess.SnippetDeclaration
+        snippetDeclarations =
+            List.concatMap unwrapSnippet snippets
+
+        extractStyleBlocks : List Preprocess.SnippetDeclaration -> List Preprocess.StyleBlock
+        extractStyleBlocks declarations =
+            case declarations of
+                [] ->
+                    []
+
+                (Preprocess.StyleBlockDeclaration styleBlock) :: rest ->
+                    styleBlock :: extractStyleBlocks rest
+
+                first :: rest ->
+                    extractStyleBlocks rest
+
+        mediaRuleFromStyleBlocks : Preprocess.SnippetDeclaration
+        mediaRuleFromStyleBlocks =
+            Preprocess.MediaRule mediaQueries
+                (extractStyleBlocks snippetDeclarations)
+
+        nestedMediaRules : List Preprocess.SnippetDeclaration -> List Preprocess.SnippetDeclaration
+        nestedMediaRules declarations =
+            case declarations of
+                [] ->
+                    []
+
+                (Preprocess.StyleBlockDeclaration _) :: rest ->
+                    -- These will already have been handled previously, with appropriate
+                    -- bundling, so don't create duplicates here.
+                    nestedMediaRules rest
+
+                (Preprocess.MediaRule nestedMediaQueries styleBlocks) :: rest ->
+                    -- nest the media queries
+                    (Preprocess.MediaRule (mediaQueries ++ nestedMediaQueries) styleBlocks)
+                        :: nestedMediaRules rest
+
+                first :: rest ->
+                    first :: nestedMediaRules rest
+    in
+        Preprocess.Snippet (mediaRuleFromStyleBlocks :: (nestedMediaRules snippetDeclarations))
+
+
+{-| Combines media query components into media queries that are nested under selectors.
+
+    (stylesheet << namespace "homepage")
+        [ footer
+            [ widthmedia [ screen, Media.minWidth (px 300), Media.maxWidth (px 800) ]
+                [ Css.maxWidth (px 300) ]
+        ]
+
+```css
+@media screen and (min-width: 300px) and (max-width: 800px) {
+    footer {
+        max-width: 300px;
+    }
+}
+```
+-}
+withMedia : List MediaQueryComponent -> List Css.Mixin -> Css.Mixin
+withMedia components =
+    components
+        |> componentsToStringQueries
+        |> List.map (\q -> Structure.MediaQuery q)
+        |> Preprocess.WithMedia
+
+
+{-| Manually specify a media query that is nested under an element or class
+using a List of strings.
+
+    body
+      [ mediaQuery ["screen and (min-width: 320px)", "screen and (max-height: 400px)"
+          [ fontSize (px 14px) ]
+      ]
+
+
+The above code translates into the following css.
+
+```css
+@media screen and (min-width: 320px), screen and (min-height: 400px) {
+    body {
+        font-size: 14px;
+    }
+}
+```
+-}
+withMediaQuery : List String -> List Css.Mixin -> Css.Mixin
+withMediaQuery queries =
+    queries
+        |> List.map (\q -> Structure.MediaQuery q)
+        |> Preprocess.WithMedia
+
+
+
+{--Query Composition--}
+
+
+{-| Media modifier to force old browsers to ignore a media query they won't understand.
+
+    media [ only, screen, minResolution (dppx 2) ] [ ... ]
+-}
+only : MediaQueryComponent
+only =
+    PrependMediaModifier (MediaModifier "only")
+
+
+{-| Media modifier to negate a query
+
+    media [ not, screen, color ] [ body [ Css.color (hex "000000") ] ]
+-}
+not : MediaQueryComponent
+not =
+    PrependMediaModifier (MediaModifier "not")
+
+
+{-| Combine media queries, where matching either query should apply the following CSS properties.
+
+    media [ screen, or, print ] [ ... ]
+
+The rule above will apply to either screens or printers.
+-}
+or : MediaQueryComponent
+or =
+    AppendOrSeparator MediaOrSeparator
+
+
+
+{--Media Types --}
+
+
+{-| Media type  for all devices. This is assumed by default if no other media type is specified.
+-}
+all : MediaQueryComponent
+all =
+    Structure.AppendMediaType (Structure.MediaType "all")
+
+
+{-| Media type for printers
+
+    media [ print ] [ a [ color (hex 000000), textDecoration none ] ]
+-}
+print : MediaQueryComponent
+print =
+    Structure.AppendMediaType (Structure.MediaType "print")
+
+
+{-| Media type for any device not matched by print or speech.
+
+    media [ screen, maxWidth (px 600) ] [ (.) MobileNav display none ]
+-}
+screen : MediaQueryComponent
+screen =
+    Structure.AppendMediaType (Structure.MediaType "screen")
+
+
+{-| Media type for screenreaders and similar devices that read out a page
+
+    media [ not, speech ] [ (.) SROnly [ display none ] ]
+-}
+speech : MediaQueryComponent
+speech =
+    Structure.AppendMediaType (Structure.MediaType "speech")
+
+
+{-| Media type aural devices. Will be deprecated in CSS 4 Media queries.
+-}
+aural : MediaQueryComponent
+aural =
+    Structure.AppendMediaType (Structure.MediaType "aural")
+
+
+{-| Media type for TTY devices (text terminals). Will be deprecated in CSS 4 Media queries.
+-}
+tty : MediaQueryComponent
+tty =
+    Structure.AppendMediaType (Structure.MediaType "tty")
+
+
+{-| Media type for televisions.  Will be deprecated in CSS 4 Media queries.
+-}
+tv : MediaQueryComponent
+tv =
+    Structure.AppendMediaType (Structure.MediaType "tv")
+
+
+{-| Media type for projectors. Will be deprecated in CSS 4 Media queries.
+-}
+projection : MediaQueryComponent
+projection =
+    Structure.AppendMediaType (Structure.MediaType "projection")
+
+
+{-| Media type for paged braille readers. Will be deprecated in CSS 4 Media queries.
+-}
+embossed : MediaQueryComponent
+embossed =
+    Structure.AppendMediaType (Structure.MediaType "embossed")
+
+
+{-| Media type braille devices. Will be deprecated in CSS 4 Media queries.
+-}
+braille : MediaQueryComponent
+braille =
+    Structure.AppendMediaType (Structure.MediaType "braille")
+
+
+{-| Media type handheld devices. Will be deprecated in CSS 4 Media queries.
+-}
+handheld : MediaQueryComponent
+handheld =
+    Structure.AppendMediaType (Structure.MediaType "handheld")
+
+
+
+{--Viewport/Page Dimensions Media Features--}
+
+
+{-| A length that is not in any way relative to the window size
+(percent, vh, vw, and so on), such as px, pt, cm, em, rem, and so on.
+-}
+type alias AbsoluteLength compatible =
+    { compatible | value : String, absoluteLength : Compatible }
+
+
+{-| Media feature [`min-width`](https://drafts.csswg.org/mediaqueries/#width)
+Queries the width of the output device.
+
+    media [ Media.minWidth (px 600) ] [ (.) Container [ Css.maxWidth (px 500) ] ]
+-}
+minWidth : AbsoluteLength compatible -> MediaQueryComponent
+minWidth value =
+    feature "min-width" value
+
+
+{-| Media feature [`width`](https://drafts.csswg.org/mediaqueries/#width)
+
+    media [ Media.width (px 200) ] [ ... ]
+-}
+width : AbsoluteLength compatible -> MediaQueryComponent
+width value =
+    feature "width" value
+
+
+{-| Media feature [`max-width`](https://drafts.csswg.org/mediaqueries/#width)
+
+    media [ Media.maxWidth (px 800) ] [ (.) MobileNav [ display none] ]
+-}
+maxWidth : AbsoluteLength compatible -> MediaQueryComponent
+maxWidth value =
+    feature "max-width" value
+
+
+{-| Media feature [`min-height`](https://drafts.csswg.org/mediaqueries/#height)
+
+    media [ Media.minHeight(px 400) ] [ (.) TopBanner [ display block] ]
+-}
+minHeight : AbsoluteLength compatible -> MediaQueryComponent
+minHeight value =
+    feature "min-height" value
+
+
+{-| Media feature [`height`](https://drafts.csswg.org/mediaqueries/#height)
+-}
+height : AbsoluteLength compatible -> MediaQueryComponent
+height value =
+    feature "height" value
+
+
+{-| Media feature [`max-height`](https://drafts.csswg.org/mediaqueries/#height)
+
+    media [ Media.maxHeight(px 399) ] [ (.) TopBanner [ display none] ]
+-}
+maxHeight : AbsoluteLength compatible -> MediaQueryComponent
+maxHeight value =
+    feature "max-height" value
+
+
+{-| -}
+type alias Ratio =
+    { value : String, ratio : Compatible }
+
+
+{-| Create a ratio.
+
+    --a ratio of 4/3
+    ratio 4 3
+-}
+ratio : Int -> Int -> Ratio
+ratio numerator denominator =
+    { value = (toString numerator) ++ "/" ++ (toString denominator), ratio = Compatible }
+
+
+{-| Media feature [`min-aspect-ratio`](https://drafts.csswg.org/mediaqueries/#aspect-ratio)
+
+    media [ minAspectRatio (ratio 1 1) ] [ ... ]
+-}
+minAspectRatio : Ratio -> MediaQueryComponent
+minAspectRatio value =
+    feature "min-aspect-ratio" value
+
+
+{-| Media feature [`aspect-ratio`](https://drafts.csswg.org/mediaqueries/#aspect-ratio)
+
+    media [ aspectRatio (ratio 16 10) ] [ ... ]
+-}
+aspectRatio : Ratio -> MediaQueryComponent
+aspectRatio value =
+    feature "aspect-ratio" value
+
+
+{-| Media feature [`max-aspect-ratio`](https://drafts.csswg.org/mediaqueries/#aspect-ratio)
+
+    media [ maxAspectRatio (ratio 16 9) ] [ ... ]
+-}
+maxAspectRatio : Ratio -> MediaQueryComponent
+maxAspectRatio value =
+    feature "max-aspect-ratio" value
+
+
+type alias Orientation a =
+    { a | value : String, orientation : Compatible }
+
+
+{-| -}
+type alias Landscape =
+    { value : String, orientation : Compatible }
+
+
+{-| -}
+type alias Portrait =
+    { value : String, orientation : Compatible }
+
+
+{-| CSS value [`landscape`](https://drafts.csswg.org/mediaqueries/#valdef-media-orientation-portrait)
+-}
+landscape : Landscape
+landscape =
+    { value = "landscape", orientation = Compatible }
+
+
+{-| CSS value [`portrait`](https://drafts.csswg.org/mediaqueries/#valdef-media-orientation-portrait)
+-}
+portrait : Portrait
+portrait =
+    { value = "portrait", orientation = Compatible }
+
+
+{-| Media feature [`orientation`](https://drafts.csswg.org/mediaqueries/#orientation).
+Accepts `portrait` or `landscape`.
+-}
+orientation : Orientation a -> MediaQueryComponent
+orientation value =
+    feature "orientation" value
+
+
+
+{--Display Quality Media Features --}
+
+
+{-| Display Resolution. https://www.w3.org/TR/css3-values/#resolution-value
+-}
+type alias Resolution =
+    { value : String, resolution : Compatible }
+
+
+{-| `dpi`: Dots per inch. https://www.w3.org/TR/css3-values/#resolution-value
+
+    dpi 166
+-}
+dpi : Float -> Resolution
+dpi value =
+    { value = (toString value) ++ "dpi", resolution = Compatible }
+
+
+{-| `dpcm`: Dots per centimeter. https://www.w3.org/TR/css3-values/#resolution-value
+
+    dpcm 65
+-}
+dpcm : Float -> Resolution
+dpcm value =
+    { value = (toString value) ++ "dpcm", resolution = Compatible }
+
+
+{-| `dppx`: Dots per pixel. https://www.w3.org/TR/css3-values/#resolution-value
+
+    dppx 1.5
+-}
+dppx : Float -> Resolution
+dppx value =
+    { value = (toString value) ++ "dppx", resolution = Compatible }
+
+
+{-| Media feature [`min-resolution`](https://drafts.csswg.org/mediaqueries/#resolution).
+Describes the resolution of the output device.
+
+    media [ minResolution (dpi 600) ] [ (.) HiResImg [ display block ] ]
+-}
+minResolution : Resolution -> MediaQueryComponent
+minResolution value =
+    feature "min-resolution" value
+
+
+{-| Media feature [`resolution`](https://drafts.csswg.org/mediaqueries/#resolution)
+Describes the resolution of the output device.
+
+    media [ resolution (dppx 2) ] [ img [ width (pct 50) ] ]
+-}
+resolution : Resolution -> MediaQueryComponent
+resolution value =
+    feature "resolution" value
+
+
+{-| Media feature [`max-resolution`](https://drafts.csswg.org/mediaqueries/#resolution)
+Describes the resolution of the output device.
+
+    media [ maxResolution (dpcm 65) ] [ (.) HiResImg [ display none ] ]
+-}
+maxResolution : Resolution -> MediaQueryComponent
+maxResolution value =
+    feature "max-resolution" value
+
+
+type alias ScanningProcess a =
+    { a | value : String, scanningProcess : Compatible }
+
+
+{-| -}
+type alias Progressive =
+    { value : String, scanningProcess : Compatible }
+
+
+{-| -}
+type alias Interlace =
+    { value : String, scanningProcess : Compatible }
+
+
+{-| CSS value [`progressive`](https://drafts.csswg.org/mediaqueries/#valdef-media-scan-progressive)
+-}
+progressive : Progressive
+progressive =
+    { value = "progressive", scanningProcess = Compatible }
+
+
+{-| CSS value [`interlace`](https://drafts.csswg.org/mediaqueries/#valdef-media-scan-interlace)
+-}
+interlace : Interlace
+interlace =
+    { value = "interlace", scanningProcess = Compatible }
+
+
+{-| Media feature [`scan`](https://drafts.csswg.org/mediaqueries/#scan).
+Queries scanning process of the device. Accepts `innterlace` (some TVs) or `progressive` (most things).
+-}
+scan : ScanningProcess a -> MediaQueryComponent
+scan value =
+    feature "scan" value
+
+
+{-| Media feature [`grid`](https://drafts.csswg.org/mediaqueries/#grid).
+Queries whether the output device is a grid or bitmap.
+-}
+grid : MediaQueryComponent
+grid =
+    booleanFeature "grid"
+
+
+type alias UpdateFrequency a =
+    { a | value : String, updateFrequency : Compatible }
+
+
+{-| -}
+type alias Slow =
+    { value : String, updateFrequency : Compatible }
+
+
+{-| -}
+type alias Fast =
+    { value : String, updateFrequency : Compatible }
+
+
+{-| CSS value [`slow`](https://drafts.csswg.org/mediaqueries/#valdef-media-update-slow)
+-}
+slow : Slow
+slow =
+    { value = "slow", updateFrequency = Compatible }
+
+
+{-| CSS value [`fast`](https://drafts.csswg.org/mediaqueries/#valdef-media-update-fast)
+-}
+fast : Fast
+fast =
+    { value = "fast", updateFrequency = Compatible }
+
+
+{-| Media feature [`update`](https://drafts.csswg.org/mediaqueries/#update)
+The update frequency of the device. Accepts `none`, `slow`, or `fast`
+-}
+update : UpdateFrequency a -> MediaQueryComponent
+update value =
+    feature "update" value
+
+
+type alias BlockAxisOverflow a =
+    { a | value : String, blockAxisOverflow : Compatible }
+
+
+{-| -}
+type alias Paged =
+    { value : String, blockAxisOverflow : Compatible }
+
+
+{-| -}
+type alias OptionalPaged =
+    { value : String, blockAxisOverflow : Compatible }
+
+
+{-| CSS value [`paged`](https://drafts.csswg.org/mediaqueries/#valdef-media-overflow-block-paged)
+-}
+paged : Paged
+paged =
+    { value = "paged", blockAxisOverflow = Compatible }
+
+
+{-| CSS value [`optional-paged`](https://drafts.csswg.org/mediaqueries/#valdef-media-overflow-block-optional-paged)
+-}
+optionalPaged : OptionalPaged
+optionalPaged =
+    { value = "optional-paged", blockAxisOverflow = Compatible }
+
+
+{-| Media feature [`overflow-block`](https://drafts.csswg.org/mediaqueries/#overflow-block)
+Describes the behavior of the device when content overflows the initial containing block in the block axis.
+-}
+overflowBlock : BlockAxisOverflow a -> MediaQueryComponent
+overflowBlock value =
+    feature "overflow-block" value
+
+
+type alias InlineAxisOverflow a =
+    { a | value : String, inlineAxisOverflow : Compatible }
+
+
+{-| Media feature [`overflow-inline`](https://drafts.csswg.org/mediaqueries/#overflow-inline).
+Describes the behavior of the device when content overflows the initial containing block in the inline axis.
+-}
+overflowInline : InlineAxisOverflow a -> MediaQueryComponent
+overflowInline value =
+    feature "overflow-inline" value
+
+
+
+{--Color Media Features--}
+
+
+{-| -}
+type alias Bits =
+    { value : String, bits : Compatible }
+
+
+{-| Get a bumber of bits
+
+    bits 8
+-}
+bits : Int -> Bits
+bits value =
+    { value = (toString value), bits = Compatible }
+
+
+{-| Media Feature [`min-nncolor`](https://drafts.csswg.org/mediaqueries/#color)
+Queries the user agent's bits per color channel
+
+    media [ screen, minColor (bits 256) ] [ a [ Css.color (hex "D9534F") ] ]
+-}
+minColor : Bits -> MediaQueryComponent
+minColor value =
+    feature "min-color" value
+
+
+{-| Media feature [`color`](https://drafts.csswg.org/mediaqueries/#color)
+
+    media [ not, color ] [ body [Css.color (hex "000000")] ]
+-}
+color : MediaQueryComponent
+color =
+    booleanFeature "color"
+
+
+{-| Media feature [`max-color`](https://drafts.csswg.org/mediaqueries/#color)
+Queries the user agent's bits per color channel
+
+    media [ screen, maxColor (bits 8) ] [ a [ Css.color (hex "FF0000") ] ]
+-}
+maxColor : Bits -> MediaQueryComponent
+maxColor value =
+    feature "max-color" value
+
+
+{-| Media feature [`monochrome`](https://drafts.csswg.org/mediaqueries/#monochrome)
+
+    media [ monochrome ] [ body [Css.color (hex "000000")] ]
+-}
+monochrome : MediaQueryComponent
+monochrome =
+    booleanFeature "monochrome"
+
+
+{-| Media Feature [`min-monochrome`](https://drafts.csswg.org/mediaqueries/#monochrome)
+-}
+minMonochrome : Bits -> MediaQueryComponent
+minMonochrome value =
+    feature "min-monochrome" value
+
+
+{-| Media feature [`max-monochrome`](https://drafts.csswg.org/mediaqueries/#monochrome)
+-}
+maxMonochrome : Bits -> MediaQueryComponent
+maxMonochrome value =
+    feature "max-monochrome" value
+
+
+{-| Media feature [`color-index`](https://drafts.csswg.org/mediaqueries/#color-index)
+Queries the  number of colors in the user agent's color lookup table.
+
+    media [ screen, colorIndex (int 16777216) ] [ a [ Css.color (hex "D9534F") ] ]
+-}
+colorIndex : Number a -> MediaQueryComponent
+colorIndex value =
+    feature "color-index" value
+
+
+{-| Media Feature [`min-color-index`](https://drafts.csswg.org/mediaqueries/nn#color-index)
+Queries the  number of colors in the user agent's color lookup table.
+
+    media [screen, minColorIndex (int 16777216)] [ a [ Css.color (hex "D9534F")] ]
+-}
+minColorIndex : Number a -> MediaQueryComponent
+minColorIndex value =
+    feature "min-color-index" value
+
+
+{-| Media feature [`max-color-index`](https://drafts.csswg.org/mediaqueries/#color-index).
+Queries the number of colors in the user agent's color lookup table.
+
+    media [screen, maxColorIndex (int 256)] [ a [ Css.color (hex "FF0000")] ]
+-}
+maxColorIndex : Number a -> MediaQueryComponent
+maxColorIndex value =
+    feature "max-color-index" value
+
+
+type alias ColorGamut a =
+    { a | value : String, colorGamut : Compatible }
+
+
+{-| -}
+type alias SRGB =
+    { value : String, colorGamut : Compatible }
+
+
+{-| -}
+type alias P3 =
+    { value : String, colorGamut : Compatible }
+
+
+{-| -}
+type alias Rec2020 =
+    { value : String, colorGamut : Compatible }
+
+
+{-| CSS value [`srgb`](https://drafts.csswg.org/mediaqueries/#valdef-media-color-gamut-srgb)
+-}
+srgb : SRGB
+srgb =
+    { value = "srgb", colorGamut = Compatible }
+
+
+{-| CSS value [`p3`](https://drafts.csswg.org/mediaqueries/#valdef-media-color-gamut-p3)
+-}
+p3 : P3
+p3 =
+    { value = "p3", colorGamut = Compatible }
+
+
+{-| CSS value [`rec2020`](https://drafts.csswg.org/mediaqueries/#valdef-media-color-gamut-rec2020)
+-}
+rec2020 : Rec2020
+rec2020 =
+    { value = "rec2020", colorGamut = Compatible }
+
+
+{-| Media feature [`color-gamut`](https://drafts.csswg.org/mediaqueries/#color-gamut).
+Describes the approximate range of colors supported by the user agent and device.
+
+    media [screen, colorGamut rec2020] [ (.) HiColorImg [ display block ] ]
+-}
+colorGamut : ColorGamut a -> MediaQueryComponent
+colorGamut value =
+    feature "color-gamut" value
+
+
+
+{--Interaction Media Features--}
+
+
+{-| Describes the presence and accuracy of a pointing device such as a mouse
+https://drafts.csswg.org/mediaqueries/#pointer
+-}
+type alias PointerDevice a =
+    { a | value : String, pointerDevice : Compatible }
+
+
+{-| -}
+type alias Fine =
+    { value : String, pointerDevice : Compatible }
+
+
+{-| -}
+type alias Coarse =
+    { value : String, pointerDevice : Compatible }
+
+
+{-| CSS Value [`fine`](https://drafts.csswg.org/mediaqueries/#valdef-media-pointer-fine)
+-}
+fine : Fine
+fine =
+    { value = "fine", pointerDevice = Compatible }
+
+
+{-| CSS Value [`coarse`](https://drafts.csswg.org/mediaqueries/#valdef-media-pointer-coarse)
+-}
+coarse : Coarse
+coarse =
+    { value = "coarse", pointerDevice = Compatible }
+
+
+{-| Media feature [`pointer`](https://drafts.csswg.org/mediaqueries/#pointer)
+Queries the presence and accuracy of a pointing device, such as a mouse, touchscreen, or Wii remote.
+Reflects the capabilities of the primary input mechanism.
+Accepts `none`, `fine`, and `coarse`.
+
+
+    media [ Media.pointer coarse ] [ a [ display block, Css.height (px 24) ] ]
+-}
+pointer : PointerDevice a -> MediaQueryComponent
+pointer value =
+    feature "pointer" value
+
+
+{-| Media feature [`any-pointer`](https://drafts.csswg.org/mediaqueries/#any-input)
+Queries the presence and accuracy of a pointing device, such as a mouse, touchscreen, or Wii remote.
+Reflects the capabilities of the most capable input mechanism.
+Accepts `none`, `fine`, and `coarse`.
+
+    media [ anyPointer coarse ] [ a [ display block, Css.height (px 24) ] ]
+-}
+anyPointer : PointerDevice a -> MediaQueryComponent
+anyPointer value =
+    feature "any-pointer" value
+
+
+{-| -}
+type alias HoverCapability a =
+    { a | value : String, hoverCapability : Compatible }
+
+
+{-| -}
+type alias CanHover =
+    { value : String, hoverCapability : Compatible }
+
+
+{-| The value [`hover`](https://drafts.csswg.org/mediaqueries/#valdef-media-hover-hover).
+Named `canHover` to avoid conflict with the media feature of the same name
+-}
+canHover : CanHover
+canHover =
+    { value = "hover", hoverCapability = Compatible }
+
+
+{-| Media feature [`hover`](https://drafts.csswg.org/mediaqueries/#hover).
+Queries the if the user agent's primary input mechanism has the ability to hover over elements.
+Accepts `none` or `canHover`.
+
+    media [ Media.hover canHover ] [ a [ Css.hover [ textDecoration underline] ] ]
+-}
+hover : HoverCapability a -> MediaQueryComponent
+hover value =
+    feature "hover" value
+
+
+{-| Media feature [`any-hover`](https://drafts.csswg.org/mediaqueries/#any-input)
+Queries the if any of user agent's input mechanisms have the ability to hover over elements
+Accepts `none` or `canHover`.
+
+    media [ anyHover canHover ] [ a [ Css.hover [ textDecoration underline] ] ]
+-}
+anyHover : HoverCapability a -> MediaQueryComponent
+anyHover value =
+    feature "any-hover" value
+
+
+
+{--Scripting Media Features--}
+
+
+{-| -}
+type alias ScriptingSupport a =
+    { a | value : String, scriptingSupport : Compatible }
+
+
+{-| -}
+type alias InitialOnly =
+    { value : String, scriptingSupport : Compatible }
+
+
+{-| -}
+type alias Enabled =
+    { value : String, scriptingSupport : Compatible }
+
+
+{-| CSS value [`initial-only`](https://drafts.csswg.org/mediaqueries/#valdef-media-scripting-initial-only).
+-}
+initialOnly : InitialOnly
+initialOnly =
+    { value = "initial-only", scriptingSupport = Compatible }
+
+
+{-| CSS value [`enabled`](https://drafts.csswg.org/mediaqueries/#valdef-media-scripting-enabled).
+-}
+enabled : Enabled
+enabled =
+    { value = "enabled", scriptingSupport = Compatible }
+
+
+{-| The [`scripting`](https://drafts.csswg.org/mediaqueries/#scripting) media feature
+for querying the user agents support for scripting languages like JavaScript.
+Accepts `none`, `initialOnly`, and `enabled`.
+
+    media [scripting none] [ (.) NoScript [ display block ] ]
+-}
+scripting : ScriptingSupport a -> MediaQueryComponent
+scripting value =
+    feature "scripting" value
+
+
+
+{--Private Helper functions--}
+
+
+feature : String -> Value a -> MediaQueryComponent
+feature key arg =
+    Structure.AppendMediaFeature { key = key, value = (Just arg.value) }
+
+
+booleanFeature : String -> MediaQueryComponent
+booleanFeature key =
+    Structure.AppendMediaFeature { key = key, value = Nothing }
+
+
+componentsToStringQueries : List MediaQueryComponent -> List String
+componentsToStringQueries components =
+    components
+        |> List.foldr splitOnOr []
+        |> List.map buildQuery
+
+
+splitOnOr : MediaQueryComponent -> List (List MediaQueryComponent) -> List (List MediaQueryComponent)
+splitOnOr item splitLists =
+    case item of
+        AppendOrSeparator _ ->
+            [] :: splitLists
+
+        _ ->
+            case List.head splitLists of
+                Nothing ->
+                    [ item ] :: splitLists
+
+                Just head ->
+                    (item :: head) :: (List.drop 1 splitLists)
+
+
+buildQuery : List MediaQueryComponent -> String
+buildQuery components =
+    let
+        start =
+            components
+                |> List.filter notFeature
+                |> List.map componentToString
+                |> String.join " "
+
+        end =
+            components
+                |> List.filter isFeature
+                |> List.map componentToString
+                |> String.join " and "
+    in
+        if (String.isEmpty start) || (String.isEmpty end) then
+            (start ++ end)
+        else
+            (start ++ " and " ++ end)
+
+
+notFeature : MediaQueryComponent -> Bool
+notFeature component =
+    Basics.not (isFeature component)
+
+
+isFeature : MediaQueryComponent -> Bool
+isFeature component =
+    case component of
+        AppendMediaFeature _ ->
+            True
+
+        _ ->
+            False
+
+
+componentToString : MediaQueryComponent -> String
+componentToString component =
+    case component of
+        PrependMediaModifier (MediaModifier modifier) ->
+            modifier
+
+        AppendMediaType (MediaType mediaType) ->
+            mediaType
+
+        AppendMediaFeature mediaFeature ->
+            featureToString mediaFeature
+
+        AppendOrSeparator _ ->
+            Debug.crash "should never get here"
+
+
+featureToString : MediaFeature -> String
+featureToString mediaFeature =
+    case mediaFeature.value of
+        Just value ->
+            "(" ++ mediaFeature.key ++ ": " ++ value ++ ")"
+
+        Nothing ->
+            "(" ++ mediaFeature.key ++ ")"

--- a/src/Css/Structure.elm
+++ b/src/Css/Structure.elm
@@ -6,6 +6,16 @@ elm-css DSL, collecting warnings, or
 -}
 
 
+{-| For typing
+-}
+type Compatible
+    = Compatible
+
+
+type alias Number compatible =
+    { compatible | value : String, number : Compatible }
+
+
 {-| A property consisting of a key, a value, and a flag for whether or not
 the property is `!important`.
 -}
@@ -63,6 +73,39 @@ type Declaration
 -}
 type StyleBlock
     = StyleBlock Selector (List Selector) (List Property)
+
+
+{-| A media modifier. It can be `not` or `only`
+-}
+type MediaModifier
+    = MediaModifier String
+
+
+{-| A media type. It can be things like all, screen, screen, speech
+-}
+type MediaType
+    = MediaType String
+
+
+{-| A media feature.
+-}
+type alias MediaFeature =
+    { key : String, value : Maybe String }
+
+
+{-| In an or in a media query, rendered as a `,`
+-}
+type MediaOrSeparator
+    = MediaOrSeparator
+
+
+{-| The components that make up a media query
+-}
+type MediaQueryComponent
+    = PrependMediaModifier MediaModifier
+    | AppendMediaType MediaType
+    | AppendMediaFeature MediaFeature
+    | AppendOrSeparator MediaOrSeparator
 
 
 {-| A media query.

--- a/src/Css/Structure/Output.elm
+++ b/src/Css/Structure/Output.elm
@@ -65,7 +65,7 @@ prettyPrintDeclaration declaration =
 
                 query =
                     (List.map (\(MediaQuery str) -> str) mediaQueries)
-                        |> String.join " "
+                        |> String.join ",\n"
             in
                 "@media " ++ query ++ " {\n" ++ indent blocks ++ "\n}"
 

--- a/tests/Fixtures.elm
+++ b/tests/Fixtures.elm
@@ -32,29 +32,6 @@ divWidthHeight =
         ]
 
 
-atRule : Stylesheet
-atRule =
-    (stylesheet << namespace "homepage")
-        [ body [ padding zero ]
-        , (media [ print ]) [ body [ margin (Css.em 2) ] ]
-        , mediaQuery "screen and ( max-width: 600px )"
-            [ body [ margin (Css.em 3) ] ]
-        , button [ margin auto ]
-        ]
-
-
-nestedAtRule : Stylesheet
-nestedAtRule =
-    (stylesheet << namespace "homepage")
-        [ button [ padding zero ]
-        , body
-            [ margin auto
-            , (withMedia [ print ]) [ margin (Css.em 2) ]
-            ]
-        , a [ textDecoration none ]
-        ]
-
-
 bug99 : Stylesheet
 bug99 =
     stylesheet

--- a/tests/Media.elm
+++ b/tests/Media.elm
@@ -1,0 +1,405 @@
+module Media exposing (all)
+
+import Compile
+import Css exposing (..)
+import Css.Elements exposing (p, button, body, a)
+import Css.Media as Media exposing (..)
+import Css.Namespace exposing (namespace)
+import Expect
+import Test exposing (..)
+import TestUtil exposing (outdented, prettyPrint)
+
+
+all : Test
+all =
+    describe "media"
+        [ Compile.all
+        , mediaFeatures
+        , mediaTypes
+        , testMedia
+        , testWithMedia
+        , testMediaQuery
+        , testWithMediaQuery
+        ]
+
+
+mediaTypes =
+    describe "media types"
+        [ testMediaType "all" Media.all
+        , testMediaType "screen" screen
+        , testMediaType "print" print
+        , testMediaType "speech" speech
+        , testMediaType "aural" aural
+        , testMediaType "embossed" embossed
+        , testMediaType "braille" braille
+        , testMediaType "handheld" handheld
+        , testMediaType "tv" tv
+        , testMediaType "tty" tty
+        , testMediaType "projection" projection
+        ]
+
+
+testMediaType str component =
+    let
+        actual =
+            prettyPrint ((stylesheet << namespace "test") [ basicMediaQuery component ])
+
+        expectedBody =
+            "\n        p {\n    background-color: #FF0000;\n"
+
+        expected =
+            "@media " ++ str ++ " {" ++ expectedBody ++ "}\n}"
+    in
+        describe (str ++ " media type")
+            [ test "pretty prints the expected output" <| \() -> Expect.equal expected actual ]
+
+
+mediaFeatures =
+    describe "media features"
+        [ testFeature "min-width"
+            [ ( Media.minWidth (px 600), "600px" )
+            , ( Media.minWidth (em 300), "300em" )
+            ]
+        , testFeature "width"
+            [ ( Media.width (pt 400), "400pt" )
+            , ( Media.width (Css.rem 500), "500rem" )
+            ]
+        , testFeature "max-width"
+            [ ( Media.maxWidth (cm 400), "400cm" )
+            , ( Media.maxWidth (pc 500), "500pc" )
+            ]
+        , testFeature "min-height"
+            [ ( Media.minHeight (pt 400), "400pt" )
+            , ( Media.minHeight (Css.rem 500), "500rem" )
+            ]
+        , testFeature "height"
+            [ ( Media.height (pt 400), "400pt" )
+            , ( Media.height (Css.rem 500), "500rem" )
+            ]
+        , testFeature "max-height"
+            [ ( Media.maxHeight (pt 400), "400pt" )
+            , ( Media.maxHeight (Css.rem 500), "500rem" )
+            ]
+        , testFeature "min-aspect-ratio"
+            [ ( minAspectRatio (ratio 4 3), "4/3" ) ]
+        , testFeature "aspect-ratio"
+            [ ( aspectRatio (ratio 16 10), "16/10" ) ]
+        , testFeature "max-aspect-ratio"
+            [ ( maxAspectRatio (ratio 16 9), "16/9" ) ]
+        , testFeature "orientation"
+            [ ( orientation landscape, "landscape" )
+            , ( orientation portrait, "portrait" )
+            ]
+        , testFeature "min-resolution"
+            [ ( minResolution (dpi 102), "102dpi" ) ]
+        , testFeature "resolution"
+            [ ( resolution (dpcm 100), "100dpcm" ) ]
+        , testFeature "max-resolution"
+            [ ( maxResolution (dppx 2), "2dppx" )
+            , ( maxResolution (dppx 1.9), "1.9dppx" )
+            ]
+        , testFeature "scan"
+            [ ( scan progressive, "progressive" )
+            , ( scan interlace, "interlace" )
+            ]
+        , testFeature "update"
+            [ ( update none, "none" )
+            , ( update slow, "slow" )
+            , ( update fast, "fast" )
+            ]
+        , testFeature "overflow-block"
+            [ ( overflowBlock none, "none" )
+            , ( overflowBlock scroll, "scroll" )
+            , ( overflowBlock paged, "paged" )
+            , ( overflowBlock optionalPaged, "optional-paged" )
+            ]
+        , testFeature "overflow-inline"
+            [ ( overflowInline none, "none" )
+            , ( overflowInline scroll, "scroll" )
+            ]
+        , testFeature "min-color"
+            [ ( minColor (bits 8), "8" ) ]
+        , testBooleanFeature "color" Media.color
+        , testFeature "max-color"
+            [ ( maxColor (bits 24), "24" ) ]
+        , testFeature "min-color-index"
+            [ ( minColorIndex (int 256), "256" ) ]
+        , testFeature "color-index"
+            [ ( colorIndex (int 32768), "32768" ) ]
+        , testFeature "max-color-index"
+            [ ( maxColorIndex (int 16777216), "16777216" ) ]
+        , testFeature "min-monochrome"
+            [ ( minMonochrome (bits 1), "1" ) ]
+        , testBooleanFeature "monochrome" monochrome
+        , testFeature "max-monochrome"
+            [ ( maxMonochrome (bits 4), "4" ) ]
+        , testFeature "color-gamut"
+            [ ( colorGamut srgb, "srgb" )
+            , ( colorGamut p3, "p3" )
+            , ( colorGamut rec2020, "rec2020" )
+            ]
+        , testFeature "pointer"
+            [ ( Media.pointer none, "none" )
+            , ( Media.pointer fine, "fine" )
+            , ( Media.pointer coarse, "coarse" )
+            ]
+        , testFeature "any-pointer"
+            [ ( anyPointer none, "none" )
+            , ( anyPointer fine, "fine" )
+            , ( anyPointer coarse, "coarse" )
+            ]
+        , testFeature "hover"
+            [ ( Media.hover none, "none" )
+            , ( Media.hover canHover, "hover" )
+            ]
+        , testFeature "any-hover"
+            [ ( anyHover none, "none" )
+            , ( anyHover canHover, "hover" )
+            ]
+        , testFeature "scripting"
+            [ ( scripting none, "none" )
+            , ( scripting initialOnly, "initial-only" )
+            , ( scripting Media.enabled, "enabled" )
+            ]
+        ]
+
+
+testFeature : String -> List ( MediaQueryComponent, String ) -> Test
+testFeature featureName modifierPairs =
+    describe (featureName ++ " media feature")
+        (List.map (expectFeatureWorks featureName) modifierPairs)
+
+
+testBooleanFeature : String -> MediaQueryComponent -> Test
+testBooleanFeature featureName component =
+    let
+        actual =
+            prettyPrint ((stylesheet << namespace "test") [ basicMediaQuery component ])
+
+        expectedBody =
+            "\n        p {\n    background-color: #FF0000;\n"
+
+        expected =
+            "@media (" ++ featureName ++ ") {" ++ expectedBody ++ "}\n}"
+    in
+        describe (featureName ++ " media feature")
+            [ test "pretty prints the expected output" <| \() -> Expect.equal expected actual ]
+
+
+expectFeatureWorks : String -> ( MediaQueryComponent, String ) -> Test
+expectFeatureWorks featureName ( component, expectedStr ) =
+    let
+        actual =
+            prettyPrint ((stylesheet << namespace "test") [ basicMediaQuery component ])
+
+        expectedBody =
+            "\n        p {\n    background-color: #FF0000;\n"
+
+        expected =
+            "@media (" ++ featureName ++ ": " ++ expectedStr ++ ") {" ++ expectedBody ++ "}\n}"
+    in
+        describe "works properly"
+            [ test "pretty prints the expected output" <| \() -> Expect.equal expected actual ]
+
+
+basicMediaQuery component =
+    media [ component ] [ p [ backgroundColor (hex "FF0000") ] ]
+
+
+testMedia =
+    let
+        input =
+            (stylesheet << namespace "homepage")
+                [ body [ padding zero ]
+                , media [ print ] [ body [ margin (Css.em 2) ] ]
+                , media [ screen, Media.maxWidth (px 600) ]
+                    [ body [ margin (Css.em 3) ] ]
+                , button [ margin auto ]
+                , media
+                    [ screen, Media.color, Media.pointer fine, scan interlace, or, grid ]
+                    [ p [ Css.color (hex "FF0000") ] ]
+                , media [ Media.not, screen, Media.color ] [ p [ Css.color (hex "000000") ] ]
+                , media [ only, speech, anyPointer fine ] [ p [ display block ] ]
+                ]
+
+        output =
+            """
+            body {
+                padding: 0;
+            }
+
+            @media print {
+                body {
+                    margin: 2em;
+                }
+            }
+
+            @media screen and (max-width: 600px) {
+                body {
+                    margin: 3em;
+                }
+            }
+
+            button {
+                margin: auto;
+            }
+
+            @media screen and (color) and (pointer: fine) and (scan: interlace),
+            (grid) {
+                p {
+                    color: #FF0000;
+                }
+            }
+
+            @media not screen and (color) {
+                p {
+                    color: #000000;
+                }
+            }
+
+            @media only speech and (any-pointer: fine) {
+                p {
+                    display: block;
+                }
+            }
+            """
+    in
+        describe "@media test"
+            [ test "pretty prints the expected output" <|
+                \_ ->
+                    outdented (prettyPrint input)
+                        |> Expect.equal (outdented output)
+            ]
+
+
+type CssClasses
+    = Container
+
+
+testWithMedia : Test
+testWithMedia =
+    let
+        input =
+            (stylesheet << namespace "homepage")
+                [ button [ padding zero ]
+                , body
+                    [ Css.color (hex "333333")
+                    , (withMedia [ print, or, monochrome ]) [ Css.color (hex "000000") ]
+                    ]
+                , a
+                    [ Css.color (hex "FF0000")
+                    , withMedia [ print ] [ textDecoration none ]
+                    ]
+                , class Container
+                    [ Css.maxWidth (px 800)
+                    , withMedia [ screen, Media.maxWidth (px 375), or, screen, Media.maxHeight (px 667) ]
+                        [ Css.maxWidth (px 300) ]
+                    ]
+                ]
+
+        output =
+            """
+            button {
+                padding: 0;
+            }
+
+            body {
+                color: #333333;
+            }
+
+            @media print,
+            (monochrome) {
+               body {
+                   color: #000000;
+               }
+             }
+
+            a {
+               color: #FF0000;
+            }
+
+            @media print {
+               a {
+                   text-decoration: none;
+               }
+            }
+
+            .homepageContainer {
+               max-width: 800px;
+            }
+
+            @media screen and (max-width: 375px),
+            screen and (max-height: 667px) {
+                .homepageContainer {
+                    max-width: 300px;
+                }
+            }
+            """
+    in
+        describe "nested @media test"
+            [ test "pretty prints the expected output" <|
+                \_ ->
+                    outdented (prettyPrint input)
+                        |> Expect.equal (outdented output)
+            ]
+
+
+testMediaQuery : Test
+testMediaQuery =
+    let
+        input =
+            (stylesheet << namespace "homepage")
+                [ mediaQuery [ "tv", "screen and (scan: interlace)" ]
+                    [ body [ backgroundColor (hex "FFFFFF") ] ]
+                ]
+
+        output =
+            """
+            @media tv,
+            screen and (scan: interlace) {
+                body {
+                    background-color: #FFFFFF;
+                }
+            }
+            """
+    in
+        describe "mediaQuery test"
+            [ test "pretty prints the expected output" <|
+                \_ ->
+                    outdented (prettyPrint input)
+                        |> Expect.equal (outdented output)
+            ]
+
+
+testWithMediaQuery : Test
+testWithMediaQuery =
+    let
+        input =
+            (stylesheet << namespace "homepage")
+                [ body
+                    [ fontSize (px 12)
+                    , withMediaQuery [ "screen and (min-device-width: 600px)", "screen and (min-width: 600px)" ]
+                        [ fontSize (px 14) ]
+                    ]
+                ]
+
+        output =
+            """
+            body {
+                font-size: 12px;
+            }
+
+            @media screen and (min-device-width: 600px),
+            screen and (min-width: 600px) {
+                body {
+                    font-size: 14px;
+                }
+            }
+            """
+    in
+        describe "withMediaQuery test"
+            [ test "pretty prints the expected output" <|
+                \_ ->
+                    outdented (prettyPrint input)
+                        |> Expect.equal (outdented output)
+            ]

--- a/tests/TAGS
+++ b/tests/TAGS
@@ -1,0 +1,142 @@
+
+Arithmetic.elm,134
+module ArithmeticArithmetic1,0
+all =all10,152
+fuzzArithmetic2 =fuzzArithmetic260,2332
+fuzzArithmetic3 =fuzzArithmetic365,2502
+
+Colors.elm,365
+module ColorsColors1,0
+all =all11,172
+hexTests =hexTests18,247
+alphaToPercentage ( r, g, b, a ) =alphaToPercentage58,1576
+fromRgba8 ( r, g, b, a ) =fromRgba863,1691
+smallHexInt =smallHexInt70,1849
+hexInt =hexInt75,1908
+expectEqualsRgba ( expectedRed, expectedGreen, expectedBlue, expectedAlpha ) { red, green, blue, alpha } =expectEqualsRgba83,2080
+
+Compile.elm,313
+module CompileCompile1,0
+all =all12,208
+getRgbaWarnings ( red, green, blue, alpha ) =getRgbaWarnings22,389
+getRgbWarnings ( red, green, blue ) =getRgbWarnings27,537
+colorWarnings =colorWarnings32,649
+unstyledDiv =unstyledDiv69,2481
+dreamwriter =dreamwriter86,2832
+compileTest =compileTest135,3977
+
+CompileFixtures.elm,440
+module CompileFixturesCompileFixtures1,0
+pageBackground =pageBackground9,164
+pageDefaultText =pageDefaultText14,226
+type CssClassesCssClasses18,263
+    = HiddenHidden19,279
+    | BasicStyle1BasicStyle120,292
+    | BasicStyle2BasicStyle221,310
+type CssIdsCssIds24,330
+    = PagePage25,342
+unstyledDiv =unstyledDiv29,380
+dreamwriter =dreamwriter34,447
+basicStyle1 =basicStyle167,1311
+basicStyle2 =basicStyle275,1458
+
+Fixtures.elm,1254
+module FixturesFixtures1,0
+type CssClassesCssClasses8,134
+    = HiddenHidden9,150
+type CssIdsCssIds12,165
+    = PagePage13,177
+type CssAnimationsCssAnimations16,190
+    = WobbleWobble17,209
+unstyledDiv =unstyledDiv21,249
+divWidthHeight =divWidthHeight26,319
+bug99 =bug9936,468
+bug140 =bug14050,754
+simpleEach =simpleEach64,1044
+multiDescendent =multiDescendent82,1402
+universal =universal124,2439
+multiSelector =multiSelector142,2849
+keyValue =keyValue161,3281
+leftRightTopBottom =leftRightTopBottom171,3502
+borders =borders191,3966
+underlineOnHover =underlineOnHover203,4266
+greenOnHover =greenOnHover214,4490
+mixinGreenOnHoverStylesheet =mixinGreenOnHoverStylesheet221,4608
+mixinUnderlineOnHoverStylesheet =mixinUnderlineOnHoverStylesheet231,4848
+manualUnderlineOnHoverStylesheet =manualUnderlineOnHoverStylesheet240,5089
+transformsStylesheet =transformsStylesheet250,5343
+fontStylesheet =fontStylesheet293,6617
+fontWeightWarning =fontWeightWarning321,7391
+colorHexWarning =colorHexWarning326,7525
+colorHexAbbrWarning =colorHexAbbrWarning331,7660
+pseudoElementStylesheet =pseudoElementStylesheet336,7805
+pseudoClassStylesheet =pseudoClassStylesheet350,8138
+backgrounds =backgrounds369,8615
+
+Main.elm,18
+main =main9,154
+
+Media.elm,667
+module MediaMedia1,0
+all =all14,304
+mediaTypes =mediaTypes26,508
+testMediaType str component =testMediaType42,1000
+mediaFeatures =mediaFeatures57,1458
+testFeature featureName modifierPairs =testFeature168,5701
+testBooleanFeature featureName component =testBooleanFeature174,5915
+expectFeatureWorks featureName ( component, expectedStr ) =expectFeatureWorks190,6478
+basicMediaQuery component =basicMediaQuery205,6993
+testMedia =testMedia209,7088
+type CssClassesCssClasses275,8939
+    = ContainerContainer276,8955
+testWithMedia =testWithMedia280,8994
+testMediaQuery =testMediaQuery348,10795
+testWithMediaQuery =testWithMediaQuery375,11528
+
+Properties.elm,203
+module PropertiesProperties1,0
+all =all12,226
+testProperty propertyName modifierPairs =testProperty539,26081
+expectPropertyWorks propertyName ( mixin, expectedStr ) =expectPropertyWorks545,26294
+
+Selectors.elm,173
+module SelectorsSelectors1,0
+all =all11,184
+nonElements =nonElements17,270
+elements =elements28,651
+testSelector expectedOutput applySelector =testSelector88,2707
+
+Tests.elm,900
+module TestsTests1,0
+all =all17,299
+unstyledDiv =unstyledDiv50,984
+divWidthHeight =divWidthHeight67,1363
+simpleEach =simpleEach84,1786
+leftRightTopBottom =leftRightTopBottom116,2488
+bug140 =bug140151,3383
+bug99 =bug99178,3982
+borders =borders210,4526
+multiDescendent =multiDescendent237,5140
+universal =universal287,6185
+multiSelector =multiSelector317,6775
+keyValue =keyValue345,7396
+underlineOnHoverMixin =underlineOnHoverMixin367,7916
+underlineOnHoverManual =underlineOnHoverManual392,8510
+greenOnHoverMixin =greenOnHoverMixin417,9102
+transformsStyle =transformsStyle442,9678
+fonts =fonts471,10790
+weightWarning =weightWarning501,11694
+hexWarning =hexWarning520,12290
+expectInvalidStylesheet stylesheet =expectInvalidStylesheet532,12707
+pseudoElements =pseudoElements540,12931
+pseudoClasses =pseudoClasses570,13571
+backgrounds =backgrounds608,14374
+
+TestUtil.elm,264
+module TestUtilTestUtil1,0
+outdented str =outdented9,147
+prettyPrint sheet =prettyPrint18,324
+validRgbValue =validRgbValue30,584
+validAlphaValue =validAlphaValue35,657
+invalidRgbValue =invalidRgbValue40,730
+invalidAlphaValue =invalidAlphaValue48,897

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -7,6 +7,7 @@ import TestUtil exposing (outdented, prettyPrint)
 import Arithmetic
 import Compile
 import Fixtures
+import Media
 import Properties
 import Selectors
 import Colors
@@ -23,8 +24,6 @@ all =
         , divWidthHeight
         , leftRightTopBottom
         , borders
-        , atRule
-        , nestedAtRule
         , bug99
         , bug140
         , universal
@@ -40,6 +39,7 @@ all =
         , pseudoClasses
         , pseudoElements
         , Properties.all
+        , Media.all
         , Selectors.all
         , Arithmetic.all
         , backgrounds
@@ -138,78 +138,6 @@ leftRightTopBottom =
         """
     in
         describe "left & right, top & bottom property/value duality test"
-            [ test "pretty prints the expected output" <|
-                \_ ->
-                    outdented (prettyPrint input)
-                        |> Expect.equal (outdented output)
-            ]
-
-
-atRule : Test
-atRule =
-    let
-        input =
-            Fixtures.atRule
-
-        output =
-            """
-          body {
-              padding: 0;
-          }
-
-          @media print {
-              body {
-                  margin: 2em;
-              }
-          }
-
-          @media screen and ( max-width: 600px ) {
-              body {
-                  margin: 3em;
-              }
-          }
-
-          button {
-              margin: auto;
-          }
-      """
-    in
-        describe "@media test"
-            [ test "pretty prints the expected output" <|
-                \_ ->
-                    outdented (prettyPrint input)
-                        |> Expect.equal (outdented output)
-            ]
-
-
-nestedAtRule : Test
-nestedAtRule =
-    let
-        input =
-            Fixtures.nestedAtRule
-
-        output =
-            """
-          button {
-              padding: 0;
-          }
-
-          body {
-              margin: auto;
-          }
-
-          @media print {
-              body {
-                  margin: 2em;
-              }
-          }
-
-          a {
-              text-decoration: none;
-          }
-      """
-    in
-        describe "nested @media test"
             [ test "pretty prints the expected output" <|
                 \_ ->
                     outdented (prettyPrint input)


### PR DESCRIPTION
## Overview

This pull request supplements the the elm-css DSL with full support for media queries. 

It takes code like this:


```elm
import Css exposing (..)
import Css.Media as Media exposing (only, media, withMedia, mediaQuery, withMediaQuery, screen, print, or, not, monochrome, maxColorIndex, minResolution, dpi, anyHover)
import Css.Elements exposing (body, li, a)
import Css.Namespace exposing (namespace)

css =
    (stylesheet << namespace "demo")
        [ body [ color (hex "555555") ]
          -- top level media queries, using DSL
        , media [ print, or, monochrome, or, maxColorIndex (int 256) ]
            [ body [ color (hex "000000") ] ]
        , (.) LoResImage [ display block ]
        , (.) HiResImage [ display none ]
          -- supports all of CSS 3 media features
        , media [ only, screen, minResolution (dpi 300) ]
            [ (.) HiResImage [ display block ]
            , (.) LoResImage [ display none ]
            ]
        , a
            [ color (hex "0000FF")
              -- nested DSL media queries
            , withMedia [ print ] [ color (hex "000000"), textDecoration none ]
            , hover [ fontWeight bold ]
              -- supports CSS Level 4 media query features
            , withMedia [ anyHover none ] [ fontWeight bold ]
            ]
        , (.) Container
            [ maxWidth (px 800)
              -- if you want, use string, similar to the current API
            , withMediaQuery [ "screen and max-width: 600px" ] [ maxWidth (px 500) ]
            ]
        , (.) SquareScreenWarning [ display none ]
          -- string at the top level are also ok
        , mediaQuery [ "screen and (aspect-ratio: 4/3)" ] [ (.) SquareScreenWarning [ display block ] ]
        ]
```        

And turns it into CSS like this:

```css
body {
    color: #555555;
}

@media print,
(monochrome),
(max-color-index: 256) {
    body {
        color: #000000;
    }
}

.demoLoResImage {
    display: block;
}

.demoHiResImage {
    display: none;
}

@media only screen and (min-resolution: 300dpi) {
    .demoHiResImage {
        display: block;
    }
}

@media only screen and (min-resolution: 300dpi) {
    .demoLoResImage {
        display: none;
    }
}

a {
    color: #0000FF;
}

a:hover {
    font-weight: bold;
}

@media (any-hover: none) {
    a {
        font-weight: bold;
    }
}

@media print {
    a {
        color: #000000;
        text-decoration: none;
    }
}

.demoContainer {
    max-width: 800px;
}

@media screen and max-width: 600px {
    .demoContainer {
        max-width: 500px;
    }
}

.demoSquareScreenWarning {
    display: none;
}

@media screen and (aspect-ratio: 4/3) {
    .demoSquareScreenWarning {
        display: block;
    }
}
```

Apologies than I've suddenly made a rather big PR without consulting you before hand, @rtfeldman . After filing issue #204 , I started adding a little hack to my program to allow media queries and I was having so much fun playing around with elm that before I knew it, I had added a Media module, and thought I might as well throw in some tests and docs and PR this. 😄 

I would greatly appreciate any feedback or thoughts on how the PR could be improved. I'm open to all suggestions.

The PR includes tests and doc comments for all features.


## Background

I used primarily three references when writing this PR.

- [Media Queries Level 3](https://drafts.csswg.org/mediaqueries-3/)
- [Media Queries Level 4](https://drafts.csswg.org/mediaqueries/)
- Mozilla's concise [Using media queries](https://developer.mozilla.org/en-US/docs/Web/CSS/Media_Queries/Using_media_queries#aspect-ratio)

Basically CSS3 features are implemented in all browsers. CSS4 features are largely unimplemented, but some features have been implemented in some browsers (for example, the [interaction features](http://caniuse.com/#feat=css-media-interaction)). The Level 4 queries are not a finalized W3C standard yet.

This PR covers all CSS3 media query functionality, and includes support all CSS4 media features in the current working draft.

Level 4 includes an improved syntax for composing queries, that includes comparison operators (i.e. `width >= 300px`) and the ability to flexibly use `and`, `not`, and a new `or` keyword throughout the query.

The DSL in this PR however imitates the Level 3 syntax, not level 4.


## Composition

The API lets you build up media queries through a list.

    @media only screen and (min-width: 300px) {}

Becomes:
    
    media [ only, screen, minWidth (px 300) ] []

Although I find it is not often used, CSS3 lets you specify logical ORs by using a comma. Since we can't use a comma, I used `or`.

    @media (max-width: 300px), (max-height: 300px) {}

Becomes:

    media [ maxWidth (px 300), or, maxHeight (px 300) ] []

This PR's API allows construction of invalid media queries. The query below compiles.

    media [ maxWidth (px 300), only, only, screen, screen ]

This could be avoided by making an api with specified arguments like:

    media : MediaModifier -> MediaType -> List MediaFeature

But the problem there is that for the majority of queries, no modifier or media type is needed. I have never used an `only` modifier (which is only there to gracefully degrade legacy browsers.) The `not` modifier is useful for some situations, but usage is relatively rare.

With the exception of `print` and `speech`, media types serve little purpose as their qualities are better reflected in media features. Indeed, the Level 4 spec removes all media types except `all` (default, optional), `screen` (no point in use, well reflected in features), `speech`, and `print`. It also states of the goal of eventually removing all media types.

With that in mind, I went with a single List.


## Module Separation, `Mixin`s vs `MediaQueryComponent`s

There are some naming conflicts between CSS properties and media queries.

- The `color` media feature conflicts with the `color` property
- The `all` media type conflicts with the `all` property.
- The `minWidth`, `width`, `maxWidth`, `minHeight`, `height`, and `maxHeight` media features conflict with their corresponding properties.
- The `not` media modifier conflicts with the `not` pseudo class (although this is not implemented in elm-css yet). It also conflicts with `Basics.not`
- The `hover` media feature conflicts with the `hover` pseudo class

The property functions return `Mixin`s. Media features functions return `MediaQueryComponents`. This ensures correct usage properties and media features at compile time.

Maybe in the future, a more general type that encompasses both mixins and media features can be made, with later runtime analysis to see if it makes sense, with output of warnings of elm crashes to indicate poor usage. This would allow a unified DSL, though it would reduce compile time protections and would require more refactoring of existing code.

So, either the media feature functions need to be prefixed (like `mediaWidth`) and so on or separated into a different module.

With some hesitation I put them in separate module, though I am not against refactoring to use prefixes, and am open to other suggestions. 

Though it is a separate module, it still depends on many `Css` values like `none`, `scroll`, `px`, `pt`, `int` and so on

## Other Notes

- The `dpi`, `dpcm`, and `dppx` units can also be used in the `image-resolution` CSS property. This property is not implemented in browsers or elm-css yet, but is part of the CSS spec.

- I didn't understand some of the overloading magic. Perhaps someone could help me refactor the `hover` media feature/value pair to be overloaded? Currently I am using `hover canHover` as a hack, but the actual spec specifies this: `hover: hover`.

- Some media features can be either boolean or have a value. For example `@media (color) {...}` or `@media (color: 24) {...}`. Mostly I implemented these to accept an argument, except for `color` and `monochrome` where I let them be boolean features since in practice they almost always used in booleans. I suppose we could add `color1` and `monochrome1` but I can't imagine who would use them.


