### PR TITLE
Fix hex and hsla color mixing

### DIFF
--- a/elm-package.json
+++ b/elm-package.json
@@ -15,7 +15,8 @@
     ],
     "dependencies": {
         "elm-lang/core": "5.0.0 <= v < 6.0.0",
-        "rtfeldman/elm-css-util": "1.0.2 <= v < 2.0.0"
+        "rtfeldman/elm-css-util": "1.0.2 <= v < 2.0.0",
+        "rtfeldman/hex": "1.0.0 <= v < 2.0.0"
     },
     "elm-version": "0.18.0 <= v < 0.19.0"
 }

--- a/examples/elm-package.json
+++ b/examples/elm-package.json
@@ -12,7 +12,8 @@
         "elm-lang/core": "5.0.0 <= v < 6.0.0",
         "elm-lang/html": "2.0.0 <= v < 3.0.0",
         "rtfeldman/elm-css-helpers": "2.0.0 <= v < 3.0.0",
-        "rtfeldman/elm-css-util": "1.0.2 <= v < 2.0.0"
+        "rtfeldman/elm-css-util": "1.0.2 <= v < 2.0.0",
+        "rtfeldman/hex": "1.0.0 <= v < 2.0.0"
     },
     "elm-version": "0.18.0 <= v <= 0.18.0"
 }

--- a/readme-example/elm-package.json
+++ b/readme-example/elm-package.json
@@ -12,7 +12,8 @@
         "elm-lang/core": "5.0.0 <= v < 6.0.0",
         "elm-lang/html": "2.0.0 <= v < 3.0.0",
         "rtfeldman/elm-css-helpers": "2.0.1 <= v < 3.0.0",
-        "rtfeldman/elm-css-util": "1.0.2 <= v < 2.0.0"
+        "rtfeldman/elm-css-util": "1.0.2 <= v < 2.0.0",
+        "rtfeldman/hex": "1.0.0 <= v < 2.0.0"
     },
     "elm-version": "0.18.0 <= v < 0.19.0"
 }

--- a/tests/Colors.elm
+++ b/tests/Colors.elm
@@ -1,0 +1,90 @@
+module Colors exposing (all)
+
+import Css exposing (..)
+import Expect exposing (Expectation)
+import Fuzz exposing (Fuzzer)
+import Hex
+import Test exposing (..)
+
+
+all : Test
+all =
+    describe "colors"
+        [ hexTests
+        ]
+
+
+hexTests : Test
+hexTests =
+    describe "hex color mixing"
+        [ test "fff works" <|
+            \() ->
+                hex "fff"
+                    |> expectEqualsRgba ( 255, 255, 255, 1 )
+        , test "#fff works" <|
+            \() ->
+                hex "#fff"
+                    |> expectEqualsRgba ( 255, 255, 255, 1 )
+        , test "000 works" <|
+            \() ->
+                hex "000"
+                    |> expectEqualsRgba ( 0, 0, 0, 1 )
+        , test "#0f0 works" <|
+            \() ->
+                hex "#0f0"
+                    |> expectEqualsRgba ( 0, 255, 0, 1 )
+        , test "#00f works" <|
+            \() ->
+                hex "#00f"
+                    |> expectEqualsRgba ( 0, 0, 255, 1 )
+        , test "#f00 works" <|
+            \() ->
+                hex "#f00"
+                    |> expectEqualsRgba ( 255, 0, 0, 1 )
+        , test "#000 works" <|
+            \() ->
+                hex "#000"
+                    |> expectEqualsRgba ( 0, 0, 0, 1 )
+        , fuzz (Fuzz.tuple4 ( hexInt, hexInt, hexInt, hexInt )) "a valid 8-char hex string" <|
+            \tuple ->
+                tuple
+                    |> fromRgba8
+                    |> hex
+                    |> expectEqualsRgba (alphaToPercentage tuple)
+        ]
+
+
+alphaToPercentage : ( Int, Int, Int, Int ) -> ( Int, Int, Int, Float )
+alphaToPercentage ( r, g, b, a ) =
+    ( r, g, b, toFloat a / 255 )
+
+
+fromRgba8 : ( Int, Int, Int, Int ) -> String
+fromRgba8 ( r, g, b, a ) =
+    [ r, g, b, a ]
+        |> List.map (Hex.toString >> String.padLeft 2 '0')
+        |> String.join ""
+
+
+smallHexInt : Fuzzer Int
+smallHexInt =
+    Fuzz.intRange 0 15
+
+
+hexInt : Fuzzer Int
+hexInt =
+    Fuzz.intRange 0 255
+
+
+expectEqualsRgba :
+    ( Int, Int, Int, Float )
+    -> { record | red : Int, green : Int, blue : Int, alpha : Float }
+    -> Expectation
+expectEqualsRgba ( expectedRed, expectedGreen, expectedBlue, expectedAlpha ) { red, green, blue, alpha } =
+    { red = red, green = green, blue = blue, alpha = alpha }
+        |> Expect.equal
+            { red = expectedRed
+            , green = expectedGreen
+            , blue = expectedBlue
+            , alpha = expectedAlpha
+            }

--- a/tests/Compile.elm
+++ b/tests/Compile.elm
@@ -158,7 +158,6 @@ compileTest =
                         |> .css
                         |> outdented
                         |> Expect.equal (outdented output)
-
             , test "compile warnings" <|
                 \() ->
                     input

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -8,12 +8,14 @@ import Compile
 import Fixtures
 import Properties
 import Selectors
+import Colors
 
 
 all : Test
 all =
     describe "elm-css"
         [ Compile.all
+        , Colors.all
         , unstyledDiv
         , keyValue
         , simpleEach

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -1,7 +1,8 @@
 module Tests exposing (all)
 
 import Test exposing (..)
-import Expect
+import Expect exposing (Expectation)
+import Css exposing (Stylesheet)
 import TestUtil exposing (outdented, prettyPrint)
 import Arithmetic
 import Compile
@@ -589,33 +590,22 @@ weightWarning =
 
 hexWarning : Test
 hexWarning =
-    let
-        input1 =
-            Fixtures.colorHexWarning
+    describe "invalid hex colors"
+        [ test "prints a warning for an invalid hex color" <|
+            \_ ->
+                expectInvalidStylesheet Fixtures.colorHexWarning
+        , test "prints a warning for an invalid abbreviated hex color" <|
+            \_ ->
+                expectInvalidStylesheet Fixtures.colorHexAbbrWarning
+        ]
 
-        input2 =
-            Fixtures.colorHexAbbrWarning
 
-        output1 =
-            """
-            Invalid Stylesheet:
-            The syntax of a hex-color is a token whose value consists of 3, 4, 6, or 8 hexadecimal digits. #ababah is not valid. Please see: https://drafts.csswg.org/css-color/#hex-notation"""
-
-        output2 =
-            """
-            Invalid Stylesheet:
-            The syntax of a hex-color is a token whose value consists of 3, 4, 6, or 8 hexadecimal digits. #00i is not valid. Please see: https://drafts.csswg.org/css-color/#hex-notation"""
-    in
-        describe "colorHexWarning"
-            [ test "pretty prints the expected output" <|
-                \_ ->
-                    outdented (prettyPrint input1)
-                        |> Expect.equal (outdented output1)
-            , test "pretty prints the expected output" <|
-                \_ ->
-                    outdented (prettyPrint input2)
-                        |> Expect.equal (outdented output2)
-            ]
+expectInvalidStylesheet : Stylesheet -> Expectation
+expectInvalidStylesheet stylesheet =
+    stylesheet
+        |> prettyPrint
+        |> String.contains "Invalid Stylesheet"
+        |> Expect.true "Stylesheet was valid, but should have been invalid."
 
 
 pseudoElements : Test

--- a/tests/elm-package.json
+++ b/tests/elm-package.json
@@ -12,6 +12,7 @@
         "elm-community/elm-test": "3.0.0 <= v < 4.0.0",
         "elm-lang/core": "5.0.0 <= v < 6.0.0",
         "rtfeldman/elm-css-util": "1.0.2 <= v < 2.0.0",
+        "rtfeldman/hex": "1.0.0 <= v < 2.0.0",
         "rtfeldman/node-test-runner": "3.0.0 <= v < 4.0.0"
     },
     "elm-version": "0.18.0 <= v < 0.19.0"


### PR DESCRIPTION
Fixes https://github.com/rtfeldman/elm-css/issues/203 and also fixes the same thing for `hsla`.

