### PR TITLE
Add a debug compilation mode

### DIFF
--- a/src/Css.elm
+++ b/src/Css.elm
@@ -1,6 +1,7 @@
 module Css
     exposing
         ( compile
+        , compileWithWarnings
         , asPairs
         , Stylesheet
         , Snippet
@@ -603,7 +604,7 @@ module Css
 @docs listStyle, listStyle2, listStyle3
 
 # Style
-@docs Snippet, Mixin, mixin, stylesheet, compile
+@docs Snippet, Mixin, mixin, stylesheet, compile, compileWithWarnings
 
 # Statements
 @docs class, id, selector, everything
@@ -7599,6 +7600,38 @@ message if it could not be compiled.
 compile : List Stylesheet -> { css : String, warnings : List String }
 compile =
     Resolve.compile
+
+
+{-| Compile the stylesheets, and inject warnings in a red box in the browser.
+
+For debug purposes.
+-}
+compileWithWarnings : List Stylesheet -> { warnings : List String, css : String }
+compileWithWarnings styles =
+    let
+        {warnings,css} =
+            compile styles
+
+        allWarnings =
+            List.map ((++) " - ") warnings
+            |> String.join "\\A" 
+            |> (++) ("CSS compiled with " ++ (toString (List.length warnings)) ++ " warnings :\\A\\A")
+
+    in
+        { css = css ++ """\nbody:after {
+    content: " """ ++ allWarnings ++ """ ";
+    padding: 40px;
+    background: #e13232;
+    color: white;
+    word-wrap: break-word;
+    white-space: pre-wrap;
+    font-family: monospace;
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    z-index: 99999;
+}""" , warnings = warnings }
 
 
 collectSelectors : List Preprocess.SnippetDeclaration -> List Structure.Selector

--- a/src/Css.elm
+++ b/src/Css.elm
@@ -7631,6 +7631,8 @@ compileWithWarnings styles =
     left: 0;
     right: 0;
     z-index: 99999;
+    max-height: 50%;
+    overflow: auto;
 }""" , warnings = warnings }
 
 


### PR DESCRIPTION
This adds a compilation function that provides debugging facilities by "injecting" the warnings in the browser. 

```elm
compileWithWarnings : List Stylesheet -> { warnings : List String, css : String }
```

And the trick is :

```css
body:after {
    content: "CSS compiled with 1 warnings :\n\n - Keyframe must be between 0 and 100 (those are percents).";
    padding: 40px;
    background: #e13232;
    color: white;
    word-wrap: break-word;
    white-space: pre-wrap;
    font-family: monospace;
    position: fixed;
    top: 0;
    left: 0;
    right: 0;
    z-index: 99999;
}

```

and looks like this : 
![screenshot from 2017-02-17 03-27-40](https://cloud.githubusercontent.com/assets/197573/23050203/19811f2a-f4c1-11e6-8ff6-b706a45c6810.png)
