### PR TITLE
Remove duplicated program name in elm-css usage

### DIFF
--- a/elm-css.js
+++ b/elm-css.js
@@ -8,7 +8,7 @@ var sourcePath = null;
 
 program
   .version(pkg.version)
-  .usage('elm-css PATH # path to your Stylesheets.elm file')
+  .usage('PATH # path to your Stylesheets.elm file')
   .option('-o, --output [outputDir]', '(optional) directory in which to write CSS file', process.cwd())
   .option('-m, --module [moduleName]', '(optional) name of stylesheets module in your project', null, 'Stylesheets')
   .option('-p, --port [portName]', '(optional) name of the port from which to read CSS results', null, 'files')


### PR DESCRIPTION
Commander will automatically include the program name in the usage
information, so including it here means it is duplicated in the final
output like this:

```
$ elm-css -h

  Usage: elm-css elm-css PATH # path to your Stylesheets.elm file

  Options:

  [ etc ]
```