### PR TITLE
Avoid validating formatting of node_modules

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,5 +47,5 @@ install:
   - cd ..
 
 script:
-  - elm-format --validate .
+  - elm-format --validate src tests examples readme-example
   - npm test


### PR DESCRIPTION
I noticed that builds on travis were failing because files inside of `node_modules` were being run through `elm-format`.

Hope this helps! Thanks!