### PR TITLE
Add brief reasons for different elm-css usage approaches

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ if you write `color "blah"` or `margin (rgb 1 2 3)`, you'll get a type mismatch.
 * [namespaces](http://package.elm-lang.org/packages/rtfeldman/elm-css/latest/Css-Namespace#namespace)
 * [nested media queries](https://davidwalsh.name/write-media-queries-sass) (and nested selectors in general, like how [Sass](http://sass-lang.com/) does them)
 
-There are two popular approaches to use it.
+There are two popular approaches to using it; you can use either or combine both of these, depending on your needs and preferences.
 
 #### Approach 1: Inline Styles
 
@@ -77,6 +77,8 @@ One way to use elm-css is for inline styles, using the `asPairs` function:
 
     button [ styles [ position absolute, left (px 5) ] ]
         [ text "Whee!" ]
+
+This approach is the simplest way to get started with `elm-css`. One advantage of inline styles is that these can be dynamically changed at runtime; a limitation is that CSS selectors cannot be used with inline styles.
 
 #### Approach 2: Generating CSS files
 

--- a/README.md
+++ b/README.md
@@ -70,19 +70,21 @@ There are two popular approaches to using it; you can use either or combine both
 
 #### Approach 1: Inline Styles
 
-One way to use elm-css is for inline styles, using the `asPairs` function:
+One way to use `elm-css` is for inline styles, using the `asPairs` function:
 
-    styles =
-        Css.asPairs >> Html.Attributes.style
+```elm
+styles =
+    Css.asPairs >> Html.Attributes.style
 
-    button [ styles [ position absolute, left (px 5) ] ]
-        [ text "Whee!" ]
+button [ styles [ position absolute, left (px 5) ] ]
+    [ text "Whee!" ]
+```
 
 This approach is the simplest way to get started with `elm-css`. One advantage of inline styles is that these can be dynamically changed at runtime; a limitation is that CSS selectors cannot be used with inline styles.
 
 #### Approach 2: Generating CSS files
 
-You can also use elm-css as a CSS preprocessor which generates separate .css files.
+You can also use `elm-css` as a CSS preprocessor which generates separate .css files.
 
 To do this, you will need to install both the node module and the Elm library:
 
@@ -162,7 +164,7 @@ There are a few examples to check out!
 - the [examples](https://github.com/rtfeldman/elm-css/tree/master/examples) folder, which contains a working project with a README
 - the example above
 
-#### Using elm-css with Elm view code
+#### Using `elm-css` with Elm view code
 
 Here's how to use `elm-css` in your projects:
 


### PR DESCRIPTION
I recently started using `elm-css`, and lacking a reason to choose one approach over the other I defaulted to using the first approach. After briefly discussing the differences with @rtfeldman on the Elm Slack a
while back, I decided that the second approach would better suit me. This is an attempt to briefly document the functional differences between the two approaches to hopefully help others make this choice.

I've also added some formatting while editing the `README`. Thanks!