### PR TITLE
Add ::-webkit-scrollbar pseudo-element

### DIFF
--- a/src/Css.elm
+++ b/src/Css.elm
@@ -295,6 +295,7 @@ module Css
         , firstLetter
         , firstLine
         , selection
+        , webkitScrollbar
         , active
         , any
         , checked
@@ -641,7 +642,7 @@ module Css
 @docs active, any, checked, dir, disabled, empty, enabled, first, firstChild, firstOfType, fullscreen, focus, hover, indeterminate, invalid, lang, lastChild, lastOfType, link, nthChild, nthLastChild, nthLastOfType, nthOfType, onlyChild, onlyOfType, optional, outOfRange, readWrite, required, root, scope, target, valid
 
 # Pseudo-Elements
-@docs after, before, firstLetter, firstLine, selection
+@docs after, before, firstLetter, firstLine, selection, webkitScrollbar
 
 # Media Queries
 @docs MediaQuery, screen, print, tv, projection
@@ -7460,6 +7461,14 @@ firstLine =
 selection : List Mixin -> Mixin
 selection =
     Preprocess.WithPseudoElement (Structure.PseudoElement "selection")
+
+
+{-| A [`::-webkit-scrollbar`](https://developer.mozilla.org/en-US/docs/Web/CSS/%3A%3A-webkit-scrollbar)
+[pseudo-element](https://developer.mozilla.org/en-US/docs/Web/CSS/Pseudo-elements).
+-}
+webkitScrollbar : List Mixin -> Mixin
+webkitScrollbar =
+    Preprocess.WithPseudoElement (Structure.PseudoElement "-webkist-scrollbar")
 
 
 


### PR DESCRIPTION
Add the `::-webkit-scrollbar` pseudo-element, which can be used to stylethe scrollbar in WebKit-based browsers.