### PR TITLE
WIP: Add `@font-face`

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,9 @@
   },
   "devDependencies": {
     "chai": "3.4.1",
-    "mocha": "2.3.4"
+    "mocha": "2.3.4",
+    "node-elm-compiler": "2.3.2",
+    "tmp": "0.0.28"
   },
   "engineStrict": true,
   "engines": {

--- a/tests/AtRules.elm
+++ b/tests/AtRules.elm
@@ -1,0 +1,86 @@
+module AtRules exposing (all)
+
+import Test exposing (..)
+import Expect exposing (Expectation)
+import TestUtil exposing (outdented, prettyPrint)
+import Fixtures
+
+
+all : Test
+all =
+    describe "at-rules"
+        [ mediaQueryTests
+        , nestedAtRules
+        ]
+
+
+mediaQueryTests : Test
+mediaQueryTests =
+    let
+        input =
+            Fixtures.mediaQueryAtRule
+
+        output =
+            """
+          body {
+              padding: 0;
+          }
+
+          @media print {
+              body {
+                  margin: 2em;
+              }
+          }
+
+          @media screen and ( max-width: 600px ) {
+              body {
+                  margin: 3em;
+              }
+          }
+
+          button {
+              margin: auto;
+          }
+      """
+    in
+        describe "@media test"
+            [ test "pretty prints the expected output" <|
+                \_ ->
+                    outdented (prettyPrint input)
+                        |> Expect.equal (outdented output)
+            ]
+
+
+nestedAtRules : Test
+nestedAtRules =
+    let
+        input =
+            Fixtures.nestedAtRule
+
+        output =
+            """
+          button {
+              padding: 0;
+          }
+
+          body {
+              margin: auto;
+          }
+
+          @media print {
+              body {
+                  margin: 2em;
+              }
+          }
+
+          a {
+              text-decoration: none;
+          }
+      """
+    in
+        describe "nested @media test"
+            [ test "pretty prints the expected output" <|
+                \_ ->
+                    outdented (prettyPrint input)
+                        |> Expect.equal (outdented output)
+            ]

--- a/tests/AtRules.elm
+++ b/tests/AtRules.elm
@@ -11,7 +11,40 @@ all =
     describe "at-rules"
         [ mediaQueryTests
         , nestedAtRules
+        , fontFaceTests
         ]
+
+
+fontFaceTests : Test
+fontFaceTests =
+    let
+        input =
+            Fixtures.fontFaceAtRule
+
+        output =
+            """
+        @font-face {
+          font-family: "MyFontName";
+          src: url(https://example.com/fonts/MyFont-Weird.ttf),
+            url(https://example.com/fonts/MyFont-Odd.ttf);
+          font-variant: small-caps;
+          font-weight: 500;
+          font-style: italic;
+        }
+
+        @font-face {
+          font-family: "MyFontName";
+          src: url(https://example.com/fonts/MyFont-Bold.woff);
+          font-weight: bold;
+        }
+    """
+    in
+        describe "@font-face"
+            [ test "pretty prints the expected output" <|
+                \_ ->
+                    outdented (prettyPrint input)
+                        |> Expect.equal (outdented output)
+            ]
 
 
 mediaQueryTests : Test

--- a/tests/Fixtures.elm
+++ b/tests/Fixtures.elm
@@ -32,8 +32,8 @@ divWidthHeight =
         ]
 
 
-atRule : Stylesheet
-atRule =
+mediaQueryAtRule : Stylesheet
+mediaQueryAtRule =
     (stylesheet << namespace "homepage")
         [ body [ padding zero ]
         , (media [ print ]) [ body [ margin (Css.em 2) ] ]

--- a/tests/Fixtures.elm
+++ b/tests/Fixtures.elm
@@ -32,6 +32,28 @@ divWidthHeight =
         ]
 
 
+fontFaceAtRule : Stylesheet
+fontFaceAtRule =
+    -- NOTE: The following code is aspirational and does not compile (yet)
+    (stylesheet << namespace "homepage")
+        [ fontFace
+            [ fontFamily "MyFontName"
+            , src
+                [ url "https://example.com/fonts/MyFont-Weird.ttf"
+                , url "https://example.com/fonts/MyFont-Odd.ttf"
+                ]
+            , fontVariant smallCaps
+            , fontWeight <| int 500
+            , fontStyle italic
+            ]
+        , fontFace
+            [ fontFamily "MyFontName"
+            , src <| url "https://example.com/fonts/MyFont-Bold.woff"
+            , fontWeight bold
+            ]
+        ]
+
+
 mediaQueryAtRule : Stylesheet
 mediaQueryAtRule =
     (stylesheet << namespace "homepage")

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -10,6 +10,7 @@ import Fixtures
 import Properties
 import Selectors
 import Colors
+import AtRules
 
 
 all : Test
@@ -23,8 +24,6 @@ all =
         , divWidthHeight
         , leftRightTopBottom
         , borders
-        , atRule
-        , nestedAtRule
         , bug99
         , bug140
         , universal
@@ -42,6 +41,7 @@ all =
         , Properties.all
         , Selectors.all
         , Arithmetic.all
+        , AtRules.all
         , backgrounds
         ]
 
@@ -138,78 +138,6 @@ leftRightTopBottom =
         """
     in
         describe "left & right, top & bottom property/value duality test"
-            [ test "pretty prints the expected output" <|
-                \_ ->
-                    outdented (prettyPrint input)
-                        |> Expect.equal (outdented output)
-            ]
-
-
-atRule : Test
-atRule =
-    let
-        input =
-            Fixtures.atRule
-
-        output =
-            """
-          body {
-              padding: 0;
-          }
-
-          @media print {
-              body {
-                  margin: 2em;
-              }
-          }
-
-          @media screen and ( max-width: 600px ) {
-              body {
-                  margin: 3em;
-              }
-          }
-
-          button {
-              margin: auto;
-          }
-      """
-    in
-        describe "@media test"
-            [ test "pretty prints the expected output" <|
-                \_ ->
-                    outdented (prettyPrint input)
-                        |> Expect.equal (outdented output)
-            ]
-
-
-nestedAtRule : Test
-nestedAtRule =
-    let
-        input =
-            Fixtures.nestedAtRule
-
-        output =
-            """
-          button {
-              padding: 0;
-          }
-
-          body {
-              margin: auto;
-          }
-
-          @media print {
-              body {
-                  margin: 2em;
-              }
-          }
-
-          a {
-              text-decoration: none;
-          }
-      """
-    in
-        describe "nested @media test"
             [ test "pretty prints the expected output" <|
                 \_ ->
                     outdented (prettyPrint input)


### PR DESCRIPTION
**This code is currently in-progress and should not be merged**

This PR will add [`@font-face` support](https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face) for the most commonly used attributes:

* `font-family`
* `src`
* `font-variant`
* `font-weight`
* `font-style`

It does not implement `unicode-range`, `font-feature-settings`, or `font-stretch`. Other authors are encouraged to add these in later.

## Questions for elm-css core team

There already exist functions called `fontFamily` and `src` in elm-css. They seem to be incompatible with the semantics of `@font-face`. To wit:

`fontFamily` takes only `FontFamily a`, which only allows for `serif`, `sansSerif`, `monospace`, `cursive` and `fantasy`. In this case, we're defining a brand new font with a new name. The docs suggest using `fontFamilies` if you want custom-named fonts, but that doesn't make sense here because we're defining _one_ font name.

`src` is of type `ImportType compatible -> String`, and I just really don't know what to do about that.