### PR TITLE
Rename `Mixin` to `Style`

### DIFF
--- a/src/Css.elm
+++ b/src/Css.elm
@@ -19,7 +19,7 @@ module Css
         , descendants
         , adjacentSiblings
         , generalSiblings
-        , styles
+        , batch
         , all
         , property
         , selector
@@ -611,7 +611,7 @@ module Css
 @docs listStyle, listStyle2, listStyle3
 
 # Style
-@docs Snippet, Style, styles, stylesheet, compile
+@docs Snippet, Style, batch, stylesheet, compile
 
 # Statements
 @docs class, id, selector, everything
@@ -7041,7 +7041,7 @@ stylesheet =
 {-| Create a style from multiple other styles.
 
     underlineOnHover =
-        styles
+        batch
             [ textDecoration none
 
             , hover
@@ -7066,8 +7066,8 @@ stylesheet =
           ]
       ]
 -}
-styles : List Style -> Style
-styles =
+batch : List Style -> Style
+batch =
     Preprocess.ApplyStyles
 
 
@@ -7081,19 +7081,19 @@ styles =
         ]
 -}
 id : id -> List Style -> Snippet
-id identifier styleList =
+id identifier styles =
     [ Structure.IdSelector (identifierToString "" identifier) ]
         |> Structure.UniversalSelectorSequence
-        |> makeSnippet styleList
+        |> makeSnippet styles
 
 
 makeSnippet : List Style -> Structure.SimpleSelectorSequence -> Snippet
-makeSnippet styleList sequence =
+makeSnippet styles sequence =
     let
         selector =
             Structure.Selector sequence [] Nothing
     in
-        [ Preprocess.StyleBlockDeclaration (Preprocess.StyleBlock selector [] styleList) ]
+        [ Preprocess.StyleBlockDeclaration (Preprocess.StyleBlock selector [] styles) ]
             |> Preprocess.Snippet
 
 
@@ -7107,10 +7107,10 @@ makeSnippet styleList sequence =
         ]
 -}
 class : class -> List Style -> Snippet
-class class styleList =
+class class styles =
     [ Structure.ClassSelector (identifierToString "" class) ]
         |> Structure.UniversalSelectorSequence
-        |> makeSnippet styleList
+        |> makeSnippet styles
 
 
 
@@ -7144,9 +7144,9 @@ and [universal selectors](https://developer.mozilla.org/en-US/docs/Web/CSS/Unive
         ]
 -}
 selector : String -> List Style -> Snippet
-selector selectorStr styleList =
+selector selectorStr styles =
     Structure.CustomSelector selectorStr []
-        |> makeSnippet styleList
+        |> makeSnippet styles
 
 
 {-| A [`*` selector](https://developer.mozilla.org/en-US/docs/Web/CSS/Universal_selectors).
@@ -7169,9 +7169,9 @@ selector selectorStr styleList =
 
 -}
 everything : List Style -> Snippet
-everything styleList =
+everything styles =
     Structure.UniversalSelectorSequence []
-        |> makeSnippet styleList
+        |> makeSnippet styles
 
 
 {-| Define a custom property.
@@ -7658,7 +7658,7 @@ generalSiblings =
 
 {-| -}
 each : List (List Style -> Snippet) -> List Style -> Snippet
-each snippetCreators styleList =
+each snippetCreators styles =
     let
         selectorsToSnippet selectors =
             case selectors of
@@ -7666,7 +7666,7 @@ each snippetCreators styleList =
                     Preprocess.Snippet []
 
                 first :: rest ->
-                    [ Preprocess.StyleBlockDeclaration (Preprocess.StyleBlock first rest styleList) ]
+                    [ Preprocess.StyleBlockDeclaration (Preprocess.StyleBlock first rest styles) ]
                         |> Preprocess.Snippet
     in
         List.map ((|>) []) snippetCreators

--- a/src/Css/Elements.elm
+++ b/src/Css/Elements.elm
@@ -27,12 +27,12 @@ module Css.Elements exposing (html, body, article, header, footer, h1, h2, h3, h
 @docs svg, path, rect, circle, ellipse, line, polyline, polygon
 -}
 
-import Css.Preprocess exposing (Mixin, Snippet(Snippet), StyleBlock(StyleBlock), SnippetDeclaration(StyleBlockDeclaration))
+import Css.Preprocess exposing (Style, Snippet(Snippet), StyleBlock(StyleBlock), SnippetDeclaration(StyleBlockDeclaration))
 import Css.Structure as Structure
 
 
-typeSelector : String -> List Mixin -> Snippet
-typeSelector selectorStr mixins =
+typeSelector : String -> List Style -> Snippet
+typeSelector selectorStr styles =
     let
         sequence =
             Structure.TypeSelectorSequence (Structure.TypeSelector selectorStr) []
@@ -40,7 +40,7 @@ typeSelector selectorStr mixins =
         selector =
             Structure.Selector sequence [] Nothing
     in
-        [ StyleBlockDeclaration (StyleBlock selector [] mixins) ]
+        [ StyleBlockDeclaration (StyleBlock selector [] styles) ]
             |> Snippet
 
 
@@ -50,14 +50,14 @@ typeSelector selectorStr mixins =
 
 {-| Selector for a html element.
 -}
-html : List Mixin -> Snippet
+html : List Style -> Snippet
 html =
     typeSelector "html"
 
 
 {-| Selector for a body element.
 -}
-body : List Mixin -> Snippet
+body : List Style -> Snippet
 body =
     typeSelector "body"
 
@@ -68,77 +68,77 @@ body =
 
 {-| Selector for an article element.
 -}
-article : List Mixin -> Snippet
+article : List Style -> Snippet
 article =
     typeSelector "article"
 
 
 {-| Selector for a header element.
 -}
-header : List Mixin -> Snippet
+header : List Style -> Snippet
 header =
     typeSelector "header"
 
 
 {-| Selector for a footer element.
 -}
-footer : List Mixin -> Snippet
+footer : List Style -> Snippet
 footer =
     typeSelector "footer"
 
 
 {-| Selector for an h1 element.
 -}
-h1 : List Mixin -> Snippet
+h1 : List Style -> Snippet
 h1 =
     typeSelector "h1"
 
 
 {-| Selector for an h2 element.
 -}
-h2 : List Mixin -> Snippet
+h2 : List Style -> Snippet
 h2 =
     typeSelector "h2"
 
 
 {-| Selector for an h3 element.
 -}
-h3 : List Mixin -> Snippet
+h3 : List Style -> Snippet
 h3 =
     typeSelector "h3"
 
 
 {-| Selector for an h4 element.
 -}
-h4 : List Mixin -> Snippet
+h4 : List Style -> Snippet
 h4 =
     typeSelector "h4"
 
 
 {-| Selector for an h5 element.
 -}
-h5 : List Mixin -> Snippet
+h5 : List Style -> Snippet
 h5 =
     typeSelector "h5"
 
 
 {-| Selector for an h6 element.
 -}
-h6 : List Mixin -> Snippet
+h6 : List Style -> Snippet
 h6 =
     typeSelector "h6"
 
 
 {-| Selector for a nav element.
 -}
-nav : List Mixin -> Snippet
+nav : List Style -> Snippet
 nav =
     typeSelector "nav"
 
 
 {-| Selector for a section element.
 -}
-section : List Mixin -> Snippet
+section : List Style -> Snippet
 section =
     typeSelector "section"
 
@@ -149,56 +149,56 @@ section =
 
 {-| Selector for a div element.
 -}
-div : List Mixin -> Snippet
+div : List Style -> Snippet
 div =
     typeSelector "div"
 
 
 {-| Selector for an hr element.
 -}
-hr : List Mixin -> Snippet
+hr : List Style -> Snippet
 hr =
     typeSelector "hr"
 
 
 {-| Selector for an li element.
 -}
-li : List Mixin -> Snippet
+li : List Style -> Snippet
 li =
     typeSelector "li"
 
 
 {-| Selector for a main element.
 -}
-main_ : List Mixin -> Snippet
+main_ : List Style -> Snippet
 main_ =
     typeSelector "main"
 
 
 {-| Selector for an ol element.
 -}
-ol : List Mixin -> Snippet
+ol : List Style -> Snippet
 ol =
     typeSelector "ol"
 
 
 {-| Selector for a p element.
 -}
-p : List Mixin -> Snippet
+p : List Style -> Snippet
 p =
     typeSelector "p"
 
 
 {-| Selector for a ul element.
 -}
-ul : List Mixin -> Snippet
+ul : List Style -> Snippet
 ul =
     typeSelector "ul"
 
 
 {-| Selector for a pre element.
 -}
-pre : List Mixin -> Snippet
+pre : List Style -> Snippet
 pre =
     typeSelector "pre"
 
@@ -209,49 +209,49 @@ pre =
 
 {-| Selector for an `<a>` element.
 -}
-a : List Mixin -> Snippet
+a : List Style -> Snippet
 a =
     typeSelector "a"
 
 
 {-| Selector for a code element.
 -}
-code : List Mixin -> Snippet
+code : List Style -> Snippet
 code =
     typeSelector "code"
 
 
 {-| Selector for a small element.
 -}
-small : List Mixin -> Snippet
+small : List Style -> Snippet
 small =
     typeSelector "small"
 
 
 {-| Selector for a span element.
 -}
-span : List Mixin -> Snippet
+span : List Style -> Snippet
 span =
     typeSelector "span"
 
 
 {-| Selector for a strong element.
 -}
-strong : List Mixin -> Snippet
+strong : List Style -> Snippet
 strong =
     typeSelector "strong"
 
 
 {-| Selector for a i element.
 -}
-i : List Mixin -> Snippet
+i : List Style -> Snippet
 i =
     typeSelector "i"
 
 
 {-| Selector for a em element.
 -}
-em : List Mixin -> Snippet
+em : List Style -> Snippet
 em =
     typeSelector "em"
 
@@ -262,28 +262,28 @@ em =
 
 {-| Selector for a img element.
 -}
-img : List Mixin -> Snippet
+img : List Style -> Snippet
 img =
     typeSelector "img"
 
 
 {-| Selector for an audio element.
 -}
-audio : List Mixin -> Snippet
+audio : List Style -> Snippet
 audio =
     typeSelector "audio"
 
 
 {-| Selector for a video element.
 -}
-video : List Mixin -> Snippet
+video : List Style -> Snippet
 video =
     typeSelector "video"
 
 
 {-| Selector for a canvas element.
 -}
-canvas : List Mixin -> Snippet
+canvas : List Style -> Snippet
 canvas =
     typeSelector "canvas"
 
@@ -294,70 +294,70 @@ canvas =
 
 {-| Selector for a caption element.
 -}
-caption : List Mixin -> Snippet
+caption : List Style -> Snippet
 caption =
     typeSelector "caption"
 
 
 {-| Selector for a col element.
 -}
-col : List Mixin -> Snippet
+col : List Style -> Snippet
 col =
     typeSelector "col"
 
 
 {-| Selector for a colgroup element.
 -}
-colgroup : List Mixin -> Snippet
+colgroup : List Style -> Snippet
 colgroup =
     typeSelector "colgroup"
 
 
 {-| Selector for a table element.
 -}
-table : List Mixin -> Snippet
+table : List Style -> Snippet
 table =
     typeSelector "table"
 
 
 {-| Selector for a tbody element.
 -}
-tbody : List Mixin -> Snippet
+tbody : List Style -> Snippet
 tbody =
     typeSelector "tbody"
 
 
 {-| Selector for a td element.
 -}
-td : List Mixin -> Snippet
+td : List Style -> Snippet
 td =
     typeSelector "td"
 
 
 {-| Selector for a tfoot element.
 -}
-tfoot : List Mixin -> Snippet
+tfoot : List Style -> Snippet
 tfoot =
     typeSelector "tfoot"
 
 
 {-| Selector for a th element.
 -}
-th : List Mixin -> Snippet
+th : List Style -> Snippet
 th =
     typeSelector "th"
 
 
 {-| Selector for a thead element.
 -}
-thead : List Mixin -> Snippet
+thead : List Style -> Snippet
 thead =
     typeSelector "thead"
 
 
 {-| Selector for a tr element.
 -}
-tr : List Mixin -> Snippet
+tr : List Style -> Snippet
 tr =
     typeSelector "tr"
 
@@ -368,139 +368,139 @@ tr =
 
 {-| Selector for a button element.
 -}
-button : List Mixin -> Snippet
+button : List Style -> Snippet
 button =
     typeSelector "button"
 
 
 {-| Selector for a fieldset element.
 -}
-fieldset : List Mixin -> Snippet
+fieldset : List Style -> Snippet
 fieldset =
     typeSelector "fieldset"
 
 
 {-| Selector for a form element.
 -}
-form : List Mixin -> Snippet
+form : List Style -> Snippet
 form =
     typeSelector "form"
 
 
 {-| Selector for an input element.
 -}
-input : List Mixin -> Snippet
+input : List Style -> Snippet
 input =
     typeSelector "input"
 
 
 {-| Selector for a label element.
 -}
-label : List Mixin -> Snippet
+label : List Style -> Snippet
 label =
     typeSelector "label"
 
 
 {-| Selector for a legend element.
 -}
-legend : List Mixin -> Snippet
+legend : List Style -> Snippet
 legend =
     typeSelector "legend"
 
 
 {-| Selector for an optgroup element.
 -}
-optgroup : List Mixin -> Snippet
+optgroup : List Style -> Snippet
 optgroup =
     typeSelector "optgroup"
 
 
 {-| Selector for an option element.
 -}
-option : List Mixin -> Snippet
+option : List Style -> Snippet
 option =
     typeSelector "option"
 
 
 {-| Selector for a progress element.
 -}
-progress : List Mixin -> Snippet
+progress : List Style -> Snippet
 progress =
     typeSelector "progress"
 
 
 {-| Selector for a select element.
 -}
-select : List Mixin -> Snippet
+select : List Style -> Snippet
 select =
     typeSelector "select"
 
 
 {-| Selector for a textarea element.
 -}
-textarea : List Mixin -> Snippet
+textarea : List Style -> Snippet
 textarea =
     typeSelector "textarea"
 
 
 {-| Selector for a blockquote element.
 -}
-blockquote : List Mixin -> Snippet
+blockquote : List Style -> Snippet
 blockquote =
     typeSelector "blockquote"
 
 
 {-| Selector for a svg element.
 -}
-svg : List Mixin -> Snippet
+svg : List Style -> Snippet
 svg =
     typeSelector "svg"
 
 
 {-| Selector for a path element.
 -}
-path : List Mixin -> Snippet
+path : List Style -> Snippet
 path =
     typeSelector "path"
 
 
 {-| Selector for a rect element.
 -}
-rect : List Mixin -> Snippet
+rect : List Style -> Snippet
 rect =
     typeSelector "rect"
 
 
 {-| Selector for a circle element.
 -}
-circle : List Mixin -> Snippet
+circle : List Style -> Snippet
 circle =
     typeSelector "circle"
 
 
 {-| Selector for a ellipse element.
 -}
-ellipse : List Mixin -> Snippet
+ellipse : List Style -> Snippet
 ellipse =
     typeSelector "ellipse"
 
 
 {-| Selector for a line element.
 -}
-line : List Mixin -> Snippet
+line : List Style -> Snippet
 line =
     typeSelector "line"
 
 
 {-| Selector for a polyline element.
 -}
-polyline : List Mixin -> Snippet
+polyline : List Style -> Snippet
 polyline =
     typeSelector "polyline"
 
 
 {-| Selector for a polygon element.
 -}
-polygon : List Mixin -> Snippet
+polygon : List Style -> Snippet
 polygon =
     typeSelector "polygon"

--- a/src/Css/Namespace.elm
+++ b/src/Css/Namespace.elm
@@ -61,24 +61,24 @@ applyNamespaceToStyle name style =
             applyNamespaceToProperty name property
                 |> Preprocess.AppendProperty
 
-        Preprocess.ExtendSelector selector styleList ->
-            List.map (applyNamespaceToStyle name) styleList
+        Preprocess.ExtendSelector selector styles ->
+            List.map (applyNamespaceToStyle name) styles
                 |> Preprocess.ExtendSelector (applyNamespaceToRepeatable name selector)
 
         Preprocess.NestSnippet combinator snippets ->
             List.map (applyNamespaceToSnippet name) snippets
                 |> Preprocess.NestSnippet combinator
 
-        Preprocess.WithPseudoElement pseudoElement styleList ->
-            List.map (applyNamespaceToStyle name) styleList
+        Preprocess.WithPseudoElement pseudoElement styles ->
+            List.map (applyNamespaceToStyle name) styles
                 |> Preprocess.WithPseudoElement pseudoElement
 
-        Preprocess.WithMedia mediaQueries styleList ->
-            List.map (applyNamespaceToStyle name) styleList
+        Preprocess.WithMedia mediaQueries styles ->
+            List.map (applyNamespaceToStyle name) styles
                 |> Preprocess.WithMedia mediaQueries
 
-        Preprocess.ApplyStyles styleList ->
-            List.map (applyNamespaceToStyle name) styleList
+        Preprocess.ApplyStyles styles ->
+            List.map (applyNamespaceToStyle name) styles
                 |> Preprocess.ApplyStyles
 
 
@@ -93,10 +93,10 @@ applyNamespaceToProperty name property =
 
 
 applyNamespaceToStyleBlock : String -> Preprocess.StyleBlock -> Preprocess.StyleBlock
-applyNamespaceToStyleBlock name (Preprocess.StyleBlock firstSelector otherSelectors styleList) =
+applyNamespaceToStyleBlock name (Preprocess.StyleBlock firstSelector otherSelectors styles) =
     Preprocess.StyleBlock (applyNamespaceToSelector name firstSelector)
         (List.map (applyNamespaceToSelector name) otherSelectors)
-        (List.map (applyNamespaceToStyle name) styleList)
+        (List.map (applyNamespaceToStyle name) styles)
 
 
 applyNamespaceToSnippet : String -> Snippet -> Snippet

--- a/src/Css/Namespace.elm
+++ b/src/Css/Namespace.elm
@@ -5,7 +5,7 @@ module Css.Namespace exposing (namespace)
 -}
 
 import Css.Helpers exposing (toCssIdentifier, identifierToString)
-import Css.Preprocess as Preprocess exposing (SnippetDeclaration, Snippet(Snippet), Mixin(AppendProperty, ExtendSelector, NestSnippet), unwrapSnippet)
+import Css.Preprocess as Preprocess exposing (SnippetDeclaration, Snippet(Snippet), Style(AppendProperty, ExtendSelector, NestSnippet), unwrapSnippet)
 import Css.Structure as Structure exposing (mapLast, SimpleSelectorSequence(UniversalSelectorSequence, TypeSelectorSequence, CustomSelector), RepeatableSimpleSelector(IdSelector, ClassSelector, PseudoClassSelector))
 
 
@@ -54,32 +54,32 @@ applyNamespaceToSelector name (Structure.Selector sequence chain pseudoElement) 
             pseudoElement
 
 
-applyNamespaceToMixin : String -> Mixin -> Mixin
-applyNamespaceToMixin name mixin =
-    case mixin of
+applyNamespaceToStyle : String -> Style -> Style
+applyNamespaceToStyle name style =
+    case style of
         Preprocess.AppendProperty property ->
             applyNamespaceToProperty name property
                 |> Preprocess.AppendProperty
 
-        Preprocess.ExtendSelector selector mixins ->
-            List.map (applyNamespaceToMixin name) mixins
+        Preprocess.ExtendSelector selector styleList ->
+            List.map (applyNamespaceToStyle name) styleList
                 |> Preprocess.ExtendSelector (applyNamespaceToRepeatable name selector)
 
         Preprocess.NestSnippet combinator snippets ->
             List.map (applyNamespaceToSnippet name) snippets
                 |> Preprocess.NestSnippet combinator
 
-        Preprocess.WithPseudoElement pseudoElement mixins ->
-            List.map (applyNamespaceToMixin name) mixins
+        Preprocess.WithPseudoElement pseudoElement styleList ->
+            List.map (applyNamespaceToStyle name) styleList
                 |> Preprocess.WithPseudoElement pseudoElement
 
-        Preprocess.WithMedia mediaQueries mixins ->
-            List.map (applyNamespaceToMixin name) mixins
+        Preprocess.WithMedia mediaQueries styleList ->
+            List.map (applyNamespaceToStyle name) styleList
                 |> Preprocess.WithMedia mediaQueries
 
-        Preprocess.ApplyMixins mixins ->
-            List.map (applyNamespaceToMixin name) mixins
-                |> Preprocess.ApplyMixins
+        Preprocess.ApplyStyles styleList ->
+            List.map (applyNamespaceToStyle name) styleList
+                |> Preprocess.ApplyStyles
 
 
 applyNamespaceToProperty : String -> Preprocess.Property -> Preprocess.Property
@@ -93,10 +93,10 @@ applyNamespaceToProperty name property =
 
 
 applyNamespaceToStyleBlock : String -> Preprocess.StyleBlock -> Preprocess.StyleBlock
-applyNamespaceToStyleBlock name (Preprocess.StyleBlock firstSelector otherSelectors mixins) =
+applyNamespaceToStyleBlock name (Preprocess.StyleBlock firstSelector otherSelectors styleList) =
     Preprocess.StyleBlock (applyNamespaceToSelector name firstSelector)
         (List.map (applyNamespaceToSelector name) otherSelectors)
-        (List.map (applyNamespaceToMixin name) mixins)
+        (List.map (applyNamespaceToStyle name) styleList)
 
 
 applyNamespaceToSnippet : String -> Snippet -> Snippet

--- a/src/Css/Preprocess.elm
+++ b/src/Css/Preprocess.elm
@@ -103,8 +103,8 @@ mapLastProperty update style =
         AppendProperty property ->
             AppendProperty (update property)
 
-        ExtendSelector selector styleList ->
-            ExtendSelector selector (mapAllLastProperty update styleList)
+        ExtendSelector selector styles ->
+            ExtendSelector selector (mapAllLastProperty update styles)
 
         NestSnippet _ _ ->
             style
@@ -120,10 +120,10 @@ mapLastProperty update style =
 
 
 mapAllLastProperty : (Property -> Property) -> List Style -> List Style
-mapAllLastProperty update styleList =
-    case styleList of
+mapAllLastProperty update styles =
+    case styles of
         [] ->
-            styleList
+            styles
 
         only :: [] ->
             [ mapLastProperty update only ]
@@ -138,16 +138,16 @@ unwrapSnippet (Snippet declarations) =
 
 
 toPropertyPairs : List Style -> List ( String, String )
-toPropertyPairs styleList =
-    case styleList of
+toPropertyPairs styles =
+    case styles of
         [] ->
             []
 
         (AppendProperty property) :: rest ->
             (propertyToPair property) :: (toPropertyPairs rest)
 
-        (ApplyStyles styleList) :: rest ->
-            (toPropertyPairs styleList) ++ (toPropertyPairs rest)
+        (ApplyStyles styles) :: rest ->
+            (toPropertyPairs styles) ++ (toPropertyPairs rest)
 
         _ :: rest ->
             toPropertyPairs rest

--- a/src/Css/Preprocess.elm
+++ b/src/Css/Preprocess.elm
@@ -32,13 +32,13 @@ type alias Stylesheet =
     }
 
 
-type Mixin
+type Style
     = AppendProperty Property
-    | ExtendSelector Structure.RepeatableSimpleSelector (List Mixin)
+    | ExtendSelector Structure.RepeatableSimpleSelector (List Style)
     | NestSnippet Structure.SelectorCombinator (List Snippet)
-    | WithPseudoElement Structure.PseudoElement (List Mixin)
-    | WithMedia (List Structure.MediaQuery) (List Mixin)
-    | ApplyMixins (List Mixin)
+    | WithPseudoElement Structure.PseudoElement (List Style)
+    | WithMedia (List Structure.MediaQuery) (List Style)
+    | ApplyStyles (List Style)
 
 
 type Snippet
@@ -59,7 +59,7 @@ type SnippetDeclaration
 
 
 type StyleBlock
-    = StyleBlock Structure.Selector (List Structure.Selector) (List Mixin)
+    = StyleBlock Structure.Selector (List Structure.Selector) (List Style)
 
 
 toMediaRule : List Structure.MediaQuery -> Structure.Declaration -> Structure.Declaration
@@ -97,33 +97,33 @@ toMediaRule mediaQueries declaration =
             declaration
 
 
-mapLastProperty : (Property -> Property) -> Mixin -> Mixin
-mapLastProperty update mixin =
-    case mixin of
+mapLastProperty : (Property -> Property) -> Style -> Style
+mapLastProperty update style =
+    case style of
         AppendProperty property ->
             AppendProperty (update property)
 
-        ExtendSelector selector mixins ->
-            ExtendSelector selector (mapAllLastProperty update mixins)
+        ExtendSelector selector styleList ->
+            ExtendSelector selector (mapAllLastProperty update styleList)
 
         NestSnippet _ _ ->
-            mixin
+            style
 
         WithPseudoElement _ _ ->
-            mixin
+            style
 
         WithMedia _ _ ->
-            mixin
+            style
 
-        ApplyMixins otherMixins ->
-            ApplyMixins (mapLast (mapLastProperty update) otherMixins)
+        ApplyStyles otherStyles ->
+            ApplyStyles (mapLast (mapLastProperty update) otherStyles)
 
 
-mapAllLastProperty : (Property -> Property) -> List Mixin -> List Mixin
-mapAllLastProperty update mixins =
-    case mixins of
+mapAllLastProperty : (Property -> Property) -> List Style -> List Style
+mapAllLastProperty update styleList =
+    case styleList of
         [] ->
-            mixins
+            styleList
 
         only :: [] ->
             [ mapLastProperty update only ]
@@ -137,17 +137,17 @@ unwrapSnippet (Snippet declarations) =
     declarations
 
 
-toPropertyPairs : List Mixin -> List ( String, String )
-toPropertyPairs mixins =
-    case mixins of
+toPropertyPairs : List Style -> List ( String, String )
+toPropertyPairs styleList =
+    case styleList of
         [] ->
             []
 
         (AppendProperty property) :: rest ->
             (propertyToPair property) :: (toPropertyPairs rest)
 
-        (ApplyMixins mixins) :: rest ->
-            (toPropertyPairs mixins) ++ (toPropertyPairs rest)
+        (ApplyStyles styleList) :: rest ->
+            (toPropertyPairs styleList) ++ (toPropertyPairs rest)
 
         _ :: rest ->
             toPropertyPairs rest

--- a/src/Css/Preprocess/Resolve.elm
+++ b/src/Css/Preprocess/Resolve.elm
@@ -269,8 +269,8 @@ extract snippetDeclarations =
 
 
 applyStyles : List Style -> List Structure.Declaration -> DeclarationsAndWarnings
-applyStyles styleList declarations =
-    case styleList of
+applyStyles styles declarations =
+    case styles of
         [] ->
             { declarations = declarations, warnings = [] }
 
@@ -471,9 +471,9 @@ lastDeclaration declarations =
 
 
 expandStyleBlock : Preprocess.StyleBlock -> DeclarationsAndWarnings
-expandStyleBlock (Preprocess.StyleBlock firstSelector otherSelectors styleList) =
+expandStyleBlock (Preprocess.StyleBlock firstSelector otherSelectors styles) =
     [ Structure.StyleBlockDeclaration (Structure.StyleBlock firstSelector otherSelectors []) ]
-        |> applyStyles styleList
+        |> applyStyles styles
 
 
 toStructure : Preprocess.Stylesheet -> ( Structure.Stylesheet, List String )

--- a/tests/Fixtures.elm
+++ b/tests/Fixtures.elm
@@ -222,9 +222,9 @@ borders =
         ]
 
 
-underlineOnHover : Mixin
+underlineOnHover : Style
 underlineOnHover =
-    mixin
+    styles
         --~ textDecoration none
         [ color (rgb 128 127 126)
         , hover
@@ -233,15 +233,15 @@ underlineOnHover =
         ]
 
 
-greenOnHover : Mixin
+greenOnHover : Style
 greenOnHover =
-    mixin
+    styles
         [ hover [ color (rgb 0 0 122) ]
         ]
 
 
-mixinGreenOnHoverStylesheet : Stylesheet
-mixinGreenOnHoverStylesheet =
+styleGreenOnHoverStylesheet : Stylesheet
+styleGreenOnHoverStylesheet =
     (stylesheet << namespace "greenOnHoverStylesheetsheet")
         [ button
             [ color (rgb 11 22 33)
@@ -250,8 +250,8 @@ mixinGreenOnHoverStylesheet =
         ]
 
 
-mixinUnderlineOnHoverStylesheet : Stylesheet
-mixinUnderlineOnHoverStylesheet =
+styleUnderlineOnHoverStylesheet : Stylesheet
+styleUnderlineOnHoverStylesheet =
     (stylesheet << namespace "underlineOnHoverStylesheetsheet")
         [ a
             --[ color (rgb 128 64 32) ]

--- a/tests/Fixtures.elm
+++ b/tests/Fixtures.elm
@@ -224,7 +224,7 @@ borders =
 
 underlineOnHover : Style
 underlineOnHover =
-    styles
+    batch
         --~ textDecoration none
         [ color (rgb 128 127 126)
         , hover
@@ -235,7 +235,7 @@ underlineOnHover =
 
 greenOnHover : Style
 greenOnHover =
-    styles
+    batch
         [ hover [ color (rgb 0 0 122) ]
         ]
 

--- a/tests/Properties.elm
+++ b/tests/Properties.elm
@@ -551,21 +551,21 @@ all =
         ]
 
 
-testProperty : String -> List ( Mixin, String ) -> Test
+testProperty : String -> List ( Style, String ) -> Test
 testProperty propertyName modifierPairs =
     describe (propertyName ++ " property")
         (List.map (expectPropertyWorks propertyName) modifierPairs)
 
 
-expectPropertyWorks : String -> ( Mixin, String ) -> Test
-expectPropertyWorks propertyName ( mixin, expectedStr ) =
+expectPropertyWorks : String -> ( Style, String ) -> Test
+expectPropertyWorks propertyName ( style, expectedStr ) =
     describe "works properly"
         [ (test "pretty prints the expected output") <|
             \() ->
-                prettyPrint ((stylesheet << namespace "test") [ p [ mixin ] ])
+                prettyPrint ((stylesheet << namespace "test") [ p [ style ] ])
                     |> Expect.equal ("p {\n    " ++ propertyName ++ ": " ++ expectedStr ++ ";\n}")
         , (test "can be converted to a key-value pair") <|
             \() ->
                 [ ( propertyName, expectedStr ) ]
-                    |> Expect.equal (asPairs [ mixin ])
+                    |> Expect.equal (asPairs [ style ])
         ]

--- a/tests/Selectors.elm
+++ b/tests/Selectors.elm
@@ -84,7 +84,7 @@ elements =
         ]
 
 
-testSelector : String -> (List Mixin -> Snippet) -> Test
+testSelector : String -> (List Style -> Snippet) -> Test
 testSelector expectedOutput applySelector =
     (test (expectedOutput ++ " selector")) <|
         \() ->

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -30,9 +30,9 @@ all =
         , universal
         , multiSelector
         , multiDescendent
-        , underlineOnHoverMixin
+        , underlineOnHoverStyle
         , underlineOnHoverManual
-        , greenOnHoverMixin
+        , greenOnHoverStyle
         , transformsStyle
         , fonts
         , weightWarning
@@ -435,11 +435,11 @@ keyValue =
             ]
 
 
-underlineOnHoverMixin : Test
-underlineOnHoverMixin =
+underlineOnHoverStyle : Test
+underlineOnHoverStyle =
     let
         input =
-            Fixtures.mixinUnderlineOnHoverStylesheet
+            Fixtures.styleUnderlineOnHoverStylesheet
 
         output =
             """
@@ -452,7 +452,7 @@ underlineOnHoverMixin =
             }
             """
     in
-        describe "underline on hover link (mixin)"
+        describe "underline on hover link (style)"
             [ test "pretty prints the expected output" <|
                 \_ ->
                     outdented (prettyPrint input)
@@ -485,11 +485,11 @@ underlineOnHoverManual =
             ]
 
 
-greenOnHoverMixin : Test
-greenOnHoverMixin =
+greenOnHoverStyle : Test
+greenOnHoverStyle =
     let
         input =
-            Fixtures.mixinGreenOnHoverStylesheet
+            Fixtures.styleGreenOnHoverStylesheet
 
         output =
             """
@@ -502,7 +502,7 @@ greenOnHoverMixin =
             }
             """
     in
-        describe "green on hover (mixin)"
+        describe "green on hover (style)"
             [ test "pretty prints the expected output" <|
                 \_ ->
                     outdented (prettyPrint input)


### PR DESCRIPTION
It's always been pretty weird that `backgroundColor` returns something called `Mixin`. My thinking was "these work like Mixins from Sass/Stylus/etc" but really what I want to say is just "these compose" and calling them Mixins seems unnecessary in retrospect.

What I should have said in the first place was "`backgroundColor` returns a `Style`, and you can compose `Style`s to make other `Style`s"