### PR TITLE
Support more `text-transform` values

### DIFF
--- a/src/Css.elm
+++ b/src/Css.elm
@@ -1616,6 +1616,7 @@ type alias BasicProperty =
     , textRendering : Compatible
     , textIndent : Compatible
     , textDecorationStyle : Compatible
+    , textTransform : Compatible
     , length : Compatible
     , lengthOrAuto : Compatible
     , lengthOrNone : Compatible
@@ -1675,6 +1676,7 @@ initial =
     , textRendering = Compatible
     , textIndent = Compatible
     , textDecorationStyle = Compatible
+    , textTransform = Compatible
     , borderStyle = Compatible
     , boxSizing = Compatible
     , color = Compatible

--- a/src/Css.elm
+++ b/src/Css.elm
@@ -4075,6 +4075,7 @@ none :
     , transform : Compatible
     , backgroundImage : Compatible
     , value : String
+    , textTransform : Compatible
     }
 none =
     { value = "none"
@@ -4092,6 +4093,7 @@ none =
     , transform = Compatible
     , borderStyle = Compatible
     , backgroundImage = Compatible
+    , textTransform = Compatible
     }
 
 

--- a/tests/Properties.elm
+++ b/tests/Properties.elm
@@ -172,6 +172,9 @@ all =
             , ( textTransform lowercase, "lowercase" )
             , ( textTransform none, "none" )
             , ( textTransform fullWidth, "full-width" )
+            , ( textTransform inherit, "inherit" )
+            , ( textTransform initial, "initial" )
+            , ( textTransform unset, "unset" )
             ]
         , testProperty "line-height"
             [ ( lineHeight (px 1), "1px" )

--- a/tests/Properties.elm
+++ b/tests/Properties.elm
@@ -166,6 +166,12 @@ all =
             , ( textDecorationLines [ none ], "none" )
             , ( textDecorationLines [ underline, overline, lineThrough ], "underline overline line-through" )
             ]
+        , testProperty "text-transform"
+            [ ( textTransform capitalize, "capitalize" )
+            , ( textTransform uppercase, "uppercase" )
+            , ( textTransform lowercase, "lowercase" )
+            , ( textTransform fullWidth, "full-width" )
+            ]
         , testProperty "line-height"
             [ ( lineHeight (px 1), "1px" )
             , ( lineHeight (pct 10), "10%" )

--- a/tests/Properties.elm
+++ b/tests/Properties.elm
@@ -170,6 +170,7 @@ all =
             [ ( textTransform capitalize, "capitalize" )
             , ( textTransform uppercase, "uppercase" )
             , ( textTransform lowercase, "lowercase" )
+            , ( textTransform none, "none" )
             , ( textTransform fullWidth, "full-width" )
             ]
         , testProperty "line-height"


### PR DESCRIPTION
This PR:

- adds tests for the `text-transform` properties already supported;

- adds support for the `none` property for `text-transform` (fixing https://github.com/rtfeldman/elm-css/issues/244);

- adds support for `inherit`, `initial`, and `unset` properties for `text-transform`, which I noticed https://developer.mozilla.org/en-US/docs/Web/CSS/text-transform also says should be supported.

Hope this helps :slightly_smiling_face:.