### PR TITLE
Add dl, dt and dd elements

### DIFF
--- a/src/Css/Elements.elm
+++ b/src/Css/Elements.elm
@@ -204,6 +204,8 @@ pre =
 
 
 {-| Selector for a dl element.
+
+    https://developer.mozilla.org/en-US/docs/Web/HTML/Element/dl
 -}
 dl : List Style -> Snippet
 dl =
@@ -211,6 +213,8 @@ dl =
 
 
 {-| Selector for a dt element.
+
+    https://developer.mozilla.org/en-US/docs/Web/HTML/Element/dt
 -}
 dt : List Style -> Snippet
 dt =
@@ -218,6 +222,8 @@ dt =
 
 
 {-| Selector for a dd element.
+
+    https://developer.mozilla.org/en-US/docs/Web/HTML/Element/dd
 -}
 dd : List Style -> Snippet
 dd =

--- a/src/Css/Elements.elm
+++ b/src/Css/Elements.elm
@@ -1,4 +1,4 @@
-module Css.Elements exposing (html, body, article, header, footer, h1, h2, h3, h4, h5, h6, nav, section, div, hr, li, main_, ol, p, ul, pre, a, code, small, span, strong, i, em, img, audio, video, canvas, caption, col, colgroup, table, tbody, td, tfoot, th, thead, tr, button, fieldset, form, input, label, legend, optgroup, option, progress, select, textarea, blockquote, svg, path, rect, circle, ellipse, line, polyline, polygon)
+module Css.Elements exposing (html, body, article, header, footer, h1, h2, h3, h4, h5, h6, nav, section, div, hr, li, main_, ol, p, ul, pre, dl, dt, dd, a, code, small, span, strong, i, em, img, audio, video, canvas, caption, col, colgroup, table, tbody, td, tfoot, th, thead, tr, button, fieldset, form, input, label, legend, optgroup, option, progress, select, textarea, blockquote, svg, path, rect, circle, ellipse, line, polyline, polygon)
 
 {-| Selectors for HTML elements.
 
@@ -12,7 +12,7 @@ module Css.Elements exposing (html, body, article, header, footer, h1, h2, h3, h
 @docs div, hr, li, main_, ol, p, ul, pre, blockquote
 
 # Inline text semantics
-@docs a, code, small, span, strong, i, em
+@docs a, code, small, span, strong, i, em, dl, dt, dd
 
 # Image and multimedia
 @docs img, audio, video, canvas
@@ -201,6 +201,27 @@ ul =
 pre : List Style -> Snippet
 pre =
     typeSelector "pre"
+
+
+{-| Selector for a dl element.
+-}
+dl : List Style -> Snippet
+dl =
+    typeSelector "dl"
+
+
+{-| Selector for a dt element.
+-}
+dt : List Style -> Snippet
+dt =
+    typeSelector "dt"
+
+
+{-| Selector for a dd element.
+-}
+dd : List Style -> Snippet
+dd =
+    typeSelector "dd"
 
 
 

--- a/tests/Selectors.elm
+++ b/tests/Selectors.elm
@@ -50,6 +50,9 @@ elements =
         , testSelector "p" p
         , testSelector "ul" ul
         , testSelector "pre" pre
+        , testSelector "dd" dd
+        , testSelector "dl" dl
+        , testSelector "dt" dt
         , testSelector "a" a
         , testSelector "code" code
         , testSelector "small" Css.Elements.small


### PR DESCRIPTION
`dl`, `dt` and `dd` elements are missing

https://developer.mozilla.org/en-US/docs/Web/HTML/Element/dl
https://developer.mozilla.org/en-US/docs/Web/HTML/Element/dt
https://developer.mozilla.org/en-US/docs/Web/HTML/Element/dd