### PR TITLE
Add test case for issue #264

### DIFF
--- a/tests/Properties.elm
+++ b/tests/Properties.elm
@@ -585,6 +585,9 @@ all =
             , ( borderRadius3 (em 4) (px 2) (pct 5), "4em 2px 5%" )
             , ( borderRadius4 (em 4) (px 2) (pct 5) (px 3), "4em 2px 5% 3px" )
             ]
+        , testProperty { function = "important", property = "background-color" }
+            [ ( backgroundColor (rgb 129 20 100) |> important, "rgb(129, 20, 100) !important" )
+            ]
         ]
 
 


### PR DESCRIPTION
This covers the issue described in https://github.com/rtfeldman/elm-css/issues/264, and demonstrates that using `!important` does give the expected result when used with `asPairs`.

I wrote this while investigating that issue, to ensure that the correct result was being produced at that level when `!important` is used. As can be seen this already passes, so feel free to close this if you don't think it adds any value. Thanks