### PR TITLE
Add support for more white-space values

### DIFF
--- a/src/Css.elm
+++ b/src/Css.elm
@@ -5417,6 +5417,7 @@ type alias Normal =
     , fontWeight : Compatible
     , featureTagValue : Compatible
     , overflowWrap : Compatible
+    , whiteSpace : Compatible
     }
 
 
@@ -5429,6 +5430,7 @@ normal =
     , fontWeight = Compatible
     , featureTagValue = Compatible
     , overflowWrap = Compatible
+    , whiteSpace = Compatible
     }
 
 

--- a/src/Css.elm
+++ b/src/Css.elm
@@ -1825,6 +1825,7 @@ type alias BasicProperty =
     , lengthOrAutoOrCoverOrContain : Compatible
     , intOrAuto : Compatible
     , touchAction : Compatible
+    , whiteSpace : Compatible
     }
 
 
@@ -1899,6 +1900,7 @@ initial =
     , lengthOrAutoOrCoverOrContain = Compatible
     , intOrAuto = Compatible
     , touchAction = Compatible
+    , whiteSpace = Compatible
     }
 
 

--- a/src/Css.elm
+++ b/src/Css.elm
@@ -443,6 +443,9 @@ module Css
         , plus
         , pointer
         , position
+        , pre
+        , preLine
+        , preWrap
         , preserve3d
         , print
         , progress
@@ -7532,6 +7535,46 @@ textDecorationLines =
 textDecorationStyle : TextDecorationStyle compatible -> Style
 textDecorationStyle =
     prop1 "text-decoration-style"
+
+
+
+{- WHITE-SPACE -}
+
+
+{-| The `pre` [`white-space`](https://developer.mozilla.org/en-US/docs/Web/CSS/white-space) value.
+
+    whiteSpace pre
+
+-}
+pre : WhiteSpace {}
+pre =
+    { value = "pre"
+    , whiteSpace = Compatible
+    }
+
+
+{-| The `pre-wrap` [`white-space`](https://developer.mozilla.org/en-US/docs/Web/CSS/white-space) value.
+
+    whiteSpace preWrap
+
+-}
+preWrap : WhiteSpace {}
+preWrap =
+    { value = "pre-wrap"
+    , whiteSpace = Compatible
+    }
+
+
+{-| The `pre-line` [`white-space`](https://developer.mozilla.org/en-US/docs/Web/CSS/white-space) value.
+
+    whiteSpace preLine
+
+-}
+preLine : WhiteSpace {}
+preLine =
+    { value = "pre-line"
+    , whiteSpace = Compatible
+    }
 
 
 {-| Sets [`animation-name`](https://developer.mozilla.org/en-US/docs/Web/CSS/animation-name)

--- a/src/Css.elm
+++ b/src/Css.elm
@@ -5410,8 +5410,18 @@ larger =
 -- Styles --
 
 
+type alias Normal =
+    { value : String
+    , warnings : List String
+    , fontStyle : Compatible
+    , fontWeight : Compatible
+    , featureTagValue : Compatible
+    , overflowWrap : Compatible
+    }
+
+
 {-| -}
-normal : Wrap (FontStyleOrFeatureTagValue (FontWeight {}))
+normal : Normal
 normal =
     { value = "normal"
     , warnings = []

--- a/tests/Properties.elm
+++ b/tests/Properties.elm
@@ -589,7 +589,10 @@ all =
             [ ( backgroundColor (rgb 129 20 100) |> important, "rgb(129, 20, 100) !important" )
             ]
         , testProperty { function = "whiteSpace", property = "white-space" }
-            [ ( whiteSpace noWrap, "nowrap" )
+            [ ( whiteSpace initial, "initial" )
+            , ( whiteSpace unset, "unset" )
+            , ( whiteSpace inherit, "inherit" )
+            , ( whiteSpace noWrap, "nowrap" )
             ]
         ]
 

--- a/tests/Properties.elm
+++ b/tests/Properties.elm
@@ -588,6 +588,9 @@ all =
         , testProperty { function = "important", property = "background-color" }
             [ ( backgroundColor (rgb 129 20 100) |> important, "rgb(129, 20, 100) !important" )
             ]
+        , testProperty { function = "whiteSpace", property = "white-space" }
+            [ ( whiteSpace noWrap, "nowrap" )
+            ]
         ]
 
 

--- a/tests/Properties.elm
+++ b/tests/Properties.elm
@@ -598,6 +598,7 @@ all =
             [ ( whiteSpace initial, "initial" )
             , ( whiteSpace unset, "unset" )
             , ( whiteSpace inherit, "inherit" )
+            , ( whiteSpace normal, "normal" )
             , ( whiteSpace noWrap, "nowrap" )
             ]
         ]

--- a/tests/Properties.elm
+++ b/tests/Properties.elm
@@ -229,6 +229,9 @@ all =
             , ( overflowY hidden, "hidden" )
             , ( overflowY scroll, "scroll" )
             ]
+        , testProperty { function = "overflowWrap", property = "overflow-wrap" }
+            [ ( overflowWrap normal, "normal" )
+            ]
         , testProperty { function = "overflow", property = "overflow" }
             [ ( overflow initial, "initial" )
             , ( overflow unset, "unset" )
@@ -365,6 +368,9 @@ all =
             , ( fontWeight (int 700), "700" )
             , ( fontWeight (int 800), "800" )
             , ( fontWeight (int 900), "900" )
+            ]
+        , testProperty { function = "fontStyle", property = "font-style" }
+            [ ( fontStyle normal, "normal" )
             ]
         , testProperty { function = "fontFeatureSettings", property = "font-feature-settings" }
             [ ( fontFeatureSettings (featureTag "smcp"), "\"smcp\" 1" )

--- a/tests/Properties.elm
+++ b/tests/Properties.elm
@@ -600,6 +600,9 @@ all =
             , ( whiteSpace inherit, "inherit" )
             , ( whiteSpace normal, "normal" )
             , ( whiteSpace noWrap, "nowrap" )
+            , ( whiteSpace pre, "pre" )
+            , ( whiteSpace preWrap, "pre-wrap" )
+            , ( whiteSpace preLine, "pre-line" )
             ]
         ]
 

--- a/tests/Selectors.elm
+++ b/tests/Selectors.elm
@@ -44,7 +44,7 @@ elements =
         , testSelector "li" li
         , testSelector "main" main_
         , testSelector "p" p
-        , testSelector "pre" pre
+        , testSelector "pre" Css.Elements.pre
         , testSelector "dd" dd
         , testSelector "dl" dl
         , testSelector "dt" dt


### PR DESCRIPTION
This PR adds support for the other possible values for the `white-space` property; previously only `nowrap` was supported. In particular this should resolve https://github.com/rtfeldman/elm-css/issues/285. Hopefully I've done this correctly, I don't fully understand all this dark type system magic yet :slightly_smiling_face:.