### PR TITLE
Namespace IDs

### DIFF
--- a/src/Css/Namespace.elm
+++ b/src/Css/Namespace.elm
@@ -23,7 +23,7 @@ applyNamespaceToRepeatable name selector =
             ClassSelector (name ++ str)
 
         IdSelector str ->
-            IdSelector str
+            IdSelector (name ++ str)
 
         PseudoClassSelector str ->
             PseudoClassSelector str

--- a/tests/Compile.elm
+++ b/tests/Compile.elm
@@ -102,7 +102,7 @@ dreamwriter =
               display: none !important;
             }
 
-            #Page {
+            #dreamwriterPage {
               width: 100%;
               height: 100%;
               box-sizing: border-box;

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -582,20 +582,20 @@ pseudoElements =
 
         output =
             """
-            #Page {
+            #pseudoElementsPage {
                 margin: 10px;
                 color: #aaa;
             }
 
-            #Page::before {
+            #pseudoElementsPage::before {
                 color: #fff;
             }
 
-            #Page::after {
+            #pseudoElementsPage::after {
                 color: #000;
             }
 
-            #Page::-webkit-scrollbar {
+            #pseudoElementsPage::-webkit-scrollbar {
                 display: none;
             }
             """
@@ -616,28 +616,28 @@ pseudoClasses =
 
         output =
             """
-            #Page {
+            #pseudoClassesPage {
                 color: #fff;
                 background-color: #aaa;
             }
 
-            #Page:hover {
+            #pseudoClassesPage:hover {
                 margin-top: 10px;
             }
 
-            #Page:hover:focus {
+            #pseudoClassesPage:hover:focus {
                 color: #000;
             }
 
-            #Page:first {
+            #pseudoClassesPage:first {
                 font-size: 3em;
             }
 
-            #Page:disabled {
+            #pseudoClassesPage:disabled {
                 margin-top: 20px;
             }
 
-            #Page:any-link {
+            #pseudoClassesPage:any-link {
                 color: #f00;
             }
             """

--- a/tests/fixtures/homepage-compiled.css
+++ b/tests/fixtures/homepage-compiled.css
@@ -15,14 +15,14 @@ nav {
     color: rgb(255, 255, 255);
 }
 
-#ReactiveLogo {
+#homepageReactiveLogo {
     display: inline-block;
     margin-left: 150px;
     margin-right: 80px;
     vertical-align: middle;
 }
 
-#BuyTickets {
+#homepageBuyTickets {
     padding: 16px;
     padding-left: 24px;
     padding-right: 24px;


### PR DESCRIPTION
This resolves rtfeldman/elm-css#298.

According to the README, IDs should be namespaced. This changes `applyNamespaceToRepeatable` so that `IdSelector` values are handled accordingly, similar to `ClassSelector` values, and updates the related tests.