### PR TITLE
Revise media queries

### DIFF
--- a/src/Css/Media.elm
+++ b/src/Css/Media.elm
@@ -10,6 +10,7 @@ module Css.Media
         , Interlace
         , Landscape
         , MediaQuery
+        , MediaType
         , OptionalPaged
         , P3
         , Paged
@@ -92,9 +93,9 @@ module Css.Media
 @docs Bits
 
 
-# Basics
+# Data Structures
 
-@docs MediaQuery, MediaQuery
+@docs MediaQuery, MediaType
 
 
 # Query constructors
@@ -171,6 +172,15 @@ returned by the `or` function.
 -}
 type alias MediaQuery =
     Structure.MediaQuery
+
+
+{-| A media type.
+
+<https://developer.mozilla.org/en-US/docs/Web/CSS/@media#Media_types>
+
+-}
+type alias MediaType =
+    Structure.MediaType
 
 
 type alias Value compatible =

--- a/src/Css/Media.elm
+++ b/src/Css/Media.elm
@@ -194,14 +194,14 @@ type alias Value compatible =
 {-| Combines media query components into media queries.
 
     (stylesheet << namespace "homepage")
-        [  media [ screen, Media.minWidth (px 300), Media.maxWidth (px 800) ]
+        [  media (and screen (Media.minWidth (px 300))
                [ footer [ Css.maxWidth (px 300) ] ]
         ]
 
 The above code translates into the following css.
 
 ```css
-@media screen and (min-width: 300px) and (max-width: 800px) {
+@media screen and (min-width: 300px) {
     footer {
         max-width: 300px;
     }
@@ -333,7 +333,7 @@ withMediaQuery queries =
 
 {-| Media modifier to negate a query
 
-    media [ not, screen, color ] [ body [ Css.color (hex "000000") ] ]
+    media (not screen) [ body [ Css.color (hex "000000") ] ]
 
 -}
 not : MediaQuery -> MediaQuery
@@ -355,7 +355,7 @@ and =
 
 {-| Combine media queries, where matching either query should apply the following CSS properties.
 
-    media [ or [ screen, print ] ] [ ... ]
+    media (or screen print) [ ... ]
 
 The rule above will apply to either screens or printers.
 
@@ -396,7 +396,7 @@ all =
 
 {-| Media type for printers
 
-    media [ print ] [ a [ color (hex 000000), textDecoration none ] ]
+    media print [ a [ color (hex 000000), textDecoration none ] ]
 
 -}
 print : MediaQuery
@@ -406,7 +406,7 @@ print =
 
 {-| Media type for any device not matched by print or speech.
 
-    media [ screen, maxWidth (px 600) ] [ (.) MobileNav display none ]
+    media (and screen (maxWidth (px 600)) [ Css.class mobileNav display none ]
 
 -}
 screen : MediaQuery
@@ -416,7 +416,7 @@ screen =
 
 {-| Media type for screenreaders and similar devices that read out a page
 
-    media [ not, speech ] [ (.) SROnly [ display none ] ]
+    media (not speech) [ Css.class screenReaderOnly [ display none ] ]
 
 -}
 speech : MediaQuery
@@ -438,7 +438,7 @@ type alias AbsoluteLength compatible =
 {-| Media feature [`min-width`](https://drafts.csswg.org/mediaqueries/#width)
 Queries the width of the output device.
 
-    media [ Media.minWidth (px 600) ] [ (.) Container [ Css.maxWidth (px 500) ] ]
+    media (Media.minWidth (px 600)) [ Css.class Container [ Css.maxWidth (px 500) ] ]
 
 -}
 minWidth : AbsoluteLength compatible -> MediaQuery
@@ -448,7 +448,7 @@ minWidth value =
 
 {-| Media feature [`width`](https://drafts.csswg.org/mediaqueries/#width)
 
-    media [ Media.width (px 200) ] [ ... ]
+    media (Media.width (px 200)) [ ... ]
 
 -}
 width : AbsoluteLength compatible -> MediaQuery
@@ -458,7 +458,7 @@ width value =
 
 {-| Media feature [`max-width`](https://drafts.csswg.org/mediaqueries/#width)
 
-    media [ Media.maxWidth (px 800) ] [ (.) MobileNav [ display none] ]
+    media (Media.maxWidth (px 800)) [ Css.class MobileNav [ display none] ]
 
 -}
 maxWidth : AbsoluteLength compatible -> MediaQuery
@@ -468,7 +468,7 @@ maxWidth value =
 
 {-| Media feature [`min-height`](https://drafts.csswg.org/mediaqueries/#height)
 
-    media [ Media.minHeight(px 400) ] [ (.) TopBanner [ display block] ]
+    media (Media.minHeight(px 400)) [ Css.class TopBanner [ display block] ]
 
 -}
 minHeight : AbsoluteLength compatible -> MediaQuery
@@ -485,7 +485,7 @@ height value =
 
 {-| Media feature [`max-height`](https://drafts.csswg.org/mediaqueries/#height)
 
-    media [ Media.maxHeight(px 399) ] [ (.) TopBanner [ display none] ]
+    media (Media.maxHeight(px 399)) [ Css.class TopBanner [ display none] ]
 
 -}
 maxHeight : AbsoluteLength compatible -> MediaQuery
@@ -511,7 +511,7 @@ ratio numerator denominator =
 
 {-| Media feature [`min-aspect-ratio`](https://drafts.csswg.org/mediaqueries/#aspect-ratio)
 
-    media [ minAspectRatio (ratio 1 1) ] [ ... ]
+    media (minAspectRatio (ratio 1 1)) [ ... ]
 
 -}
 minAspectRatio : Ratio -> MediaQuery
@@ -521,7 +521,7 @@ minAspectRatio value =
 
 {-| Media feature [`aspect-ratio`](https://drafts.csswg.org/mediaqueries/#aspect-ratio)
 
-    media [ aspectRatio (ratio 16 10) ] [ ... ]
+    media (aspectRatio (ratio 16 10)) [ ... ]
 
 -}
 aspectRatio : Ratio -> MediaQuery
@@ -531,7 +531,7 @@ aspectRatio value =
 
 {-| Media feature [`max-aspect-ratio`](https://drafts.csswg.org/mediaqueries/#aspect-ratio)
 
-    media [ maxAspectRatio (ratio 16 9) ] [ ... ]
+    media (maxAspectRatio (ratio 16 9)) [ ... ]
 
 -}
 maxAspectRatio : Ratio -> MediaQuery
@@ -618,7 +618,7 @@ dppx value =
 {-| Media feature [`min-resolution`](https://drafts.csswg.org/mediaqueries/#resolution).
 Describes the resolution of the output device.
 
-    media [ minResolution (dpi 600) ] [ (.) HiResImg [ display block ] ]
+    media (minResolution (dpi 600)) [ Css.class HiResImg [ display block ] ]
 
 -}
 minResolution : Resolution -> MediaQuery
@@ -629,7 +629,7 @@ minResolution value =
 {-| Media feature [`resolution`](https://drafts.csswg.org/mediaqueries/#resolution)
 Describes the resolution of the output device.
 
-    media [ resolution (dppx 2) ] [ img [ width (pct 50) ] ]
+    media (resolution (dppx 2)) [ img [ width (pct 50) ] ]
 
 -}
 resolution : Resolution -> MediaQuery
@@ -640,7 +640,7 @@ resolution value =
 {-| Media feature [`max-resolution`](https://drafts.csswg.org/mediaqueries/#resolution)
 Describes the resolution of the output device.
 
-    media [ maxResolution (dpcm 65) ] [ (.) HiResImg [ display none ] ]
+    media (maxResolution (dpcm 65)) [ Css.class HiResImg [ display none ] ]
 
 -}
 maxResolution : Resolution -> MediaQuery
@@ -798,7 +798,7 @@ bits value =
 {-| Media Feature [`min-nncolor`](https://drafts.csswg.org/mediaqueries/#color)
 Queries the user agent's bits per color channel
 
-    media [ screen, minColor (bits 256) ] [ a [ Css.color (hex "D9534F") ] ]
+    media (screen (minColor (bits 256))) [ a [ Css.color (hex "D9534F") ] ]
 
 -}
 minColor : Bits -> MediaQuery
@@ -808,7 +808,7 @@ minColor value =
 
 {-| Media feature [`color`](https://drafts.csswg.org/mediaqueries/#color)
 
-    media [ not, color ] [ body [Css.color (hex "000000")] ]
+    media (not color) [ body [Css.color (hex "000000")] ]
 
 -}
 color : MediaQuery
@@ -819,7 +819,7 @@ color =
 {-| Media feature [`max-color`](https://drafts.csswg.org/mediaqueries/#color)
 Queries the user agent's bits per color channel
 
-    media [ screen, maxColor (bits 8) ] [ a [ Css.color (hex "FF0000") ] ]
+    media (and screen (maxColor (bits 8))) [ a [ Css.color (hex "FF0000") ] ]
 
 -}
 maxColor : Bits -> MediaQuery
@@ -854,7 +854,7 @@ maxMonochrome value =
 {-| Media feature [`color-index`](https://drafts.csswg.org/mediaqueries/#color-index)
 Queries the number of colors in the user agent's color lookup table.
 
-    media [ screen, colorIndex (int 16777216) ] [ a [ Css.color (hex "D9534F") ] ]
+    media (and screen (colorIndex (int 16777216))) [ a [ Css.color (hex "D9534F") ] ]
 
 -}
 colorIndex : Number a -> MediaQuery
@@ -865,7 +865,7 @@ colorIndex value =
 {-| Media Feature [`min-color-index`](https://drafts.csswg.org/mediaqueries/nn#color-index)
 Queries the number of colors in the user agent's color lookup table.
 
-    media [screen, minColorIndex (int 16777216)] [ a [ Css.color (hex "D9534F")] ]
+    media (and screen (minColorIndex (int 16777216))) [ a [ Css.color (hex "D9534F")] ]
 
 -}
 minColorIndex : Number a -> MediaQuery
@@ -876,7 +876,7 @@ minColorIndex value =
 {-| Media feature [`max-color-index`](https://drafts.csswg.org/mediaqueries/#color-index).
 Queries the number of colors in the user agent's color lookup table.
 
-    media [screen, maxColorIndex (int 256)] [ a [ Css.color (hex "FF0000")] ]
+    media (and screen (maxColorIndex (int 256))) [ a [ Css.color (hex "FF0000")] ]
 
 -}
 maxColorIndex : Number a -> MediaQuery
@@ -927,7 +927,7 @@ rec2020 =
 {-| Media feature [`color-gamut`](https://drafts.csswg.org/mediaqueries/#color-gamut).
 Describes the approximate range of colors supported by the user agent and device.
 
-    media [screen, colorGamut rec2020] [ (.) HiColorImg [ display block ] ]
+    media (and screen (colorGamut rec2020)) [ Css.class HiColorImg [ display block ] ]
 
 -}
 colorGamut : ColorGamut a -> MediaQuery
@@ -975,7 +975,7 @@ Queries the presence and accuracy of a pointing device, such as a mouse, touchsc
 Reflects the capabilities of the primary input mechanism.
 Accepts `none`, `fine`, and `coarse`.
 
-    media [ Media.pointer coarse ] [ a [ display block, Css.height (px 24) ] ]
+    media (Media.pointer coarse) [ a [ display block, Css.height (px 24) ] ]
 
 -}
 pointer : PointerDevice a -> MediaQuery
@@ -988,7 +988,7 @@ Queries the presence and accuracy of a pointing device, such as a mouse, touchsc
 Reflects the capabilities of the most capable input mechanism.
 Accepts `none`, `fine`, and `coarse`.
 
-    media [ anyPointer coarse ] [ a [ display block, Css.height (px 24) ] ]
+    media (anyPointer coarse) [ a [ display block, Css.height (px 24) ] ]
 
 -}
 anyPointer : PointerDevice a -> MediaQuery
@@ -1018,7 +1018,7 @@ canHover =
 Queries the if the user agent's primary input mechanism has the ability to hover over elements.
 Accepts `none` or `canHover`.
 
-    media [ Media.hover canHover ] [ a [ Css.hover [ textDecoration underline] ] ]
+    media (Media.hover canHover) [ a [ Css.hover [ textDecoration underline] ] ]
 
 -}
 hover : HoverCapability a -> MediaQuery
@@ -1030,7 +1030,7 @@ hover value =
 Queries the if any of user agent's input mechanisms have the ability to hover over elements
 Accepts `none` or `canHover`.
 
-    media [ anyHover canHover ] [ a [ Css.hover [ textDecoration underline] ] ]
+    media (anyHover canHover) [ a [ Css.hover [ textDecoration underline] ] ]
 
 -}
 anyHover : HoverCapability a -> MediaQuery
@@ -1075,7 +1075,7 @@ enabled =
 for querying the user agents support for scripting languages like JavaScript.
 Accepts `none`, `initialOnly`, and `enabled`.
 
-    media [scripting none] [ (.) NoScript [ display block ] ]
+    media (scripting none) [ Css.class NoScript [ display block ] ]
 
 -}
 scripting : ScriptingSupport a -> MediaQuery

--- a/src/Css/Preprocess.elm
+++ b/src/Css/Preprocess.elm
@@ -58,6 +58,10 @@ type SnippetDeclaration
     | FontFeatureValues (List ( String, List Property ))
 
 
+type MediaQuery
+    = MediaQuery (Maybe Structure.MediaQuery)
+
+
 type StyleBlock
     = StyleBlock Structure.Selector (List Structure.Selector) (List Style)
 
@@ -163,3 +167,8 @@ propertyToPair property =
                 property.value
     in
     ( property.key, value )
+
+
+unwrapMediaQuery : MediaQuery -> Maybe Structure.MediaQuery
+unwrapMediaQuery (MediaQuery maybeQuery) =
+    maybeQuery

--- a/src/Css/Preprocess.elm
+++ b/src/Css/Preprocess.elm
@@ -4,7 +4,7 @@ module Css.Preprocess exposing (..)
 the data structures found in this module.
 -}
 
-import Css.Structure as Structure exposing (concatMapLast, mapLast)
+import Css.Structure as Structure exposing (MediaQuery, concatMapLast, mapLast)
 
 
 stylesheet : List Snippet -> Stylesheet
@@ -26,7 +26,7 @@ type alias Property =
 
 type alias Stylesheet =
     { charset : Maybe String
-    , imports : List ( String, List Structure.MediaQuery )
+    , imports : List ( String, List MediaQuery )
     , namespaces : List ( String, String )
     , snippets : List Snippet
     }
@@ -37,7 +37,7 @@ type Style
     | ExtendSelector Structure.RepeatableSimpleSelector (List Style)
     | NestSnippet Structure.SelectorCombinator (List Snippet)
     | WithPseudoElement Structure.PseudoElement (List Style)
-    | WithMedia (List Structure.MediaQuery) (List Style)
+    | WithMedia (List MediaQuery) (List Style)
     | ApplyStyles (List Style)
 
 
@@ -47,7 +47,7 @@ type Snippet
 
 type SnippetDeclaration
     = StyleBlockDeclaration StyleBlock
-    | MediaRule (List Structure.MediaQuery) (List StyleBlock)
+    | MediaRule (List MediaQuery) (List StyleBlock)
     | SupportsRule String (List Snippet)
     | DocumentRule String String String String StyleBlock
     | PageRule String (List Property)
@@ -58,15 +58,11 @@ type SnippetDeclaration
     | FontFeatureValues (List ( String, List Property ))
 
 
-type MediaQuery
-    = MediaQuery (Maybe Structure.MediaQuery)
-
-
 type StyleBlock
     = StyleBlock Structure.Selector (List Structure.Selector) (List Style)
 
 
-toMediaRule : List Structure.MediaQuery -> Structure.Declaration -> Structure.Declaration
+toMediaRule : List MediaQuery -> Structure.Declaration -> Structure.Declaration
 toMediaRule mediaQueries declaration =
     case declaration of
         Structure.StyleBlockDeclaration structureStyleBlock ->
@@ -167,8 +163,3 @@ propertyToPair property =
                 property.value
     in
     ( property.key, value )
-
-
-unwrapMediaQuery : MediaQuery -> Maybe Structure.MediaQuery
-unwrapMediaQuery (MediaQuery maybeQuery) =
-    maybeQuery

--- a/src/Css/Structure.elm
+++ b/src/Css/Structure.elm
@@ -77,11 +77,6 @@ type StyleBlock
     = StyleBlock Selector (List Selector) (List Property)
 
 
-{-| A media type. There are 7 possible combinations of these.
-
-<https://developer.mozilla.org/en-US/docs/Web/CSS/@media#Media_types>
-
--}
 type MediaType
     = All
     | Print

--- a/src/Css/Structure.elm
+++ b/src/Css/Structure.elm
@@ -77,16 +77,16 @@ type StyleBlock
     = StyleBlock Selector (List Selector) (List Property)
 
 
-{-| A media modifier. It can be `not` or `only`
--}
-type MediaModifier
-    = MediaModifier String
+{-| A media type. There are 7 possible combinations of these.
 
+<https://developer.mozilla.org/en-US/docs/Web/CSS/@media#Media_types>
 
-{-| A media type. It can be things like all, screen, screen, speech
 -}
 type MediaType
-    = MediaType String
+    = All
+    | Print
+    | Screen
+    | Speech
 
 
 {-| A media feature.
@@ -95,25 +95,15 @@ type alias MediaFeature =
     { key : String, value : Maybe String }
 
 
-{-| In an or in a media query, rendered as a `,`
--}
-type MediaOrSeparator
-    = MediaOrSeparator
-
-
 {-| The components that make up a media query
 -}
-type MediaQueryComponent
-    = PrependMediaModifier MediaModifier
-    | AppendMediaType MediaType
-    | AppendMediaFeature MediaFeature
-    | AppendOrSeparator MediaOrSeparator
-
-
-{-| A media query.
--}
 type MediaQuery
-    = MediaQuery String
+    = FeatureQuery MediaFeature
+    | TypeQuery MediaType
+    | And MediaQuery MediaQuery
+    | Or MediaQuery MediaQuery
+    | Not MediaQuery
+    | CustomQuery String
 
 
 {-| A [CSS3 Selector](https://www.w3.org/TR/css3-selectors/). All selectors

--- a/src/Css/Structure/Output.elm
+++ b/src/Css/Structure/Output.elm
@@ -72,20 +72,26 @@ prettyPrintDeclaration declaration =
                     List.map mediaQueryToString mediaQueries
                         |> String.join ",\n"
 
-                prefix =
+                finalQuery =
                     if String.startsWith "not " query then
-                        ""
+                        -- Media queries can start with `only` or they can start
+                        -- with `not`, but they can't start with both.
+                        -- See https://developer.mozilla.org/en-US/docs/Web/CSS/Media_Queries/Using_media_queries#Pseudo-BNF
+                        query
                     else
                         -- Always emit `only` when we don't have `not`,
-                        -- because without it, older browsers can
-                        -- break, and with it, they'll ignore this declaration. The only
-                        -- downside is emitting extra characters. (That said,
-                        -- `only` and `not` are mutually exclusive.)
+                        -- because without `only`, older browsers can
+                        -- break, and with `only`, they'll ignore this declaration
+                        -- instead of breaking.
+                        --
+                        -- The one downside is emitting extra characters, but if
+                        -- every @media is followed by either `not` or `only`,
+                        -- they will gzip very well.
                         --
                         -- https://stackoverflow.com/questions/8549529/what-is-the-difference-between-screen-and-only-screen-in-media-queries/14168210#14168210
-                        "only "
+                        "only " ++ query
             in
-            "@media " ++ prefix ++ query ++ " {\n" ++ blocks ++ "\n}"
+            "@media " ++ finalQuery ++ " {\n" ++ blocks ++ "\n}"
 
         _ ->
             Debug.crash "not yet implemented :x"

--- a/src/Css/Structure/Output.elm
+++ b/src/Css/Structure/Output.elm
@@ -110,12 +110,10 @@ mediaQueryToString mediaQuery =
             "speech"
 
         And first second ->
-            [ mediaQueryToString first, mediaQueryToString second ]
-                |> String.join " and "
+            "(" ++ mediaQueryToString first ++ " and " ++ mediaQueryToString second ++ ")"
 
         Or first second ->
-            [ mediaQueryToString first, mediaQueryToString second ]
-                |> String.join " or "
+            "(" ++ mediaQueryToString first ++ " or " ++ mediaQueryToString second ++ ")"
 
         Not mediaQuery ->
             let

--- a/src/Css/Structure/Output.elm
+++ b/src/Css/Structure/Output.elm
@@ -139,7 +139,7 @@ mediaFeatureToString mediaFeature =
             "(" ++ mediaFeature.key ++ ": " ++ value ++ ")"
 
         Nothing ->
-            "(" ++ mediaFeature.key ++ ")"
+            mediaFeature.key
 
 
 simpleSelectorSequenceToString : SimpleSelectorSequence -> String

--- a/src/Css/Structure/Output.elm
+++ b/src/Css/Structure/Output.elm
@@ -71,13 +71,21 @@ prettyPrintDeclaration declaration =
                 query =
                     List.map mediaQueryToString mediaQueries
                         |> String.join ",\n"
+
+                prefix =
+                    if String.startsWith "not " query then
+                        ""
+                    else
+                        -- Always emit `only` when we don't have `not`,
+                        -- because without it, older browsers can
+                        -- break, and with it, they'll ignore this declaration. The only
+                        -- downside is emitting extra characters. (That said,
+                        -- `only` and `not` are mutually exclusive.)
+                        --
+                        -- https://stackoverflow.com/questions/8549529/what-is-the-difference-between-screen-and-only-screen-in-media-queries/14168210#14168210
+                        "only "
             in
-            -- Always emit `only` because without it, older browsers can
-            -- break, and with it, they'll ignore this declaration. The only
-            -- downside is emitting extra characters.
-            --
-            -- https://stackoverflow.com/questions/8549529/what-is-the-difference-between-screen-and-only-screen-in-media-queries/14168210#14168210
-            "@media only " ++ query ++ " {\n" ++ blocks ++ "\n}"
+            "@media " ++ prefix ++ query ++ " {\n" ++ blocks ++ "\n}"
 
         _ ->
             Debug.crash "not yet implemented :x"

--- a/tests/Fixtures.elm
+++ b/tests/Fixtures.elm
@@ -37,7 +37,7 @@ atRule : Stylesheet
 atRule =
     (stylesheet << namespace "homepage")
         [ body [ padding zero ]
-        , media [ print ] [ body [ margin (Css.em 2) ] ]
+        , media print [ body [ margin (Css.em 2) ] ]
         , mediaQuery [ "screen and ( max-width: 600px )" ]
             [ body [ margin (Css.em 3) ] ]
         , button [ margin auto ]

--- a/tests/Media.elm
+++ b/tests/Media.elm
@@ -209,13 +209,13 @@ testMedia =
                 padding: 0;
             }
 
-            @media print {
+            @media only print {
                 body {
                     margin: 2em;
                 }
             }
 
-            @media screen and (max-width: 600px) {
+            @media only screen and (max-width: 600px) {
                 body {
                     margin: 3em;
                 }
@@ -225,8 +225,7 @@ testMedia =
                 margin: auto;
             }
 
-            @media screen and (color) and (pointer: fine) and (scan: interlace),
-            (grid) {
+            @media only screen and (color) and (pointer: fine) and (scan: interlace) and (grid) {
                 p {
                     color: #FF0000;
                 }
@@ -235,12 +234,6 @@ testMedia =
             @media not screen and (color) {
                 p {
                     color: #000000;
-                }
-            }
-
-            @media only speech and (any-pointer: fine) {
-                p {
-                    display: block;
                 }
             }
             """
@@ -314,8 +307,7 @@ testWithMedia =
                 color: #333333;
             }
 
-            @media print,
-            (monochrome) {
+            @media only print or (monochrome) {
                body {
                    color: #000000;
                }
@@ -325,7 +317,7 @@ testWithMedia =
                color: #FF0000;
             }
 
-            @media print {
+            @media only print {
                a {
                    text-decoration: none;
                }
@@ -335,8 +327,7 @@ testWithMedia =
                max-width: 800px;
             }
 
-            @media screen and (max-width: 375px),
-            screen and (max-height: 667px) {
+            @media only screen and (max-width: 375px) or screen and (max-height: 667px) {
                 .homepageContainer {
                     max-width: 300px;
                 }
@@ -362,8 +353,7 @@ testMediaQuery =
 
         output =
             """
-            @media tv,
-            screen and (scan: interlace) {
+            @media only tv, screen and (scan: interlace) {
                 body {
                     background-color: #FFFFFF;
                 }
@@ -396,7 +386,7 @@ testWithMediaQuery =
                 font-size: 12px;
             }
 
-            @media screen and (min-device-width: 600px),
+            @media only screen and (min-device-width: 600px),
             screen and (min-width: 600px) {
                 body {
                     font-size: 14px;

--- a/tests/Media.elm
+++ b/tests/Media.elm
@@ -9,11 +9,6 @@ import Test exposing (Test, describe, test, todo)
 import TestUtil exposing (outdented, prettyPrint)
 
 
-noMediaQuery : Test
-noMediaQuery =
-    todo "if you give no media queries, no @media is emitted"
-
-
 mediaTypes : Test
 mediaTypes =
     describe "media types"
@@ -260,6 +255,32 @@ testMedia =
 
 type CssClasses
     = Container
+
+
+nots : Test
+nots =
+    describe "not"
+        [ test "two nots cancel each other out" <|
+            \_ ->
+                let
+                    input =
+                        stylesheet
+                            [ media (Media.not (Media.not (and screen print)))
+                                [ body [ margin (Css.em 5) ] ]
+                            ]
+
+                    output =
+                        """
+                        @media only (screen and print) {
+                            body {
+                                margin: 5em;
+                            }
+                        }
+                        """
+                in
+                outdented (prettyPrint input)
+                    |> Expect.equal (outdented output)
+        ]
 
 
 testWithMedia : Test

--- a/tests/Media.elm
+++ b/tests/Media.elm
@@ -215,7 +215,7 @@ testMedia =
                 }
             }
 
-            @media only screen and (max-width: 600px) {
+            @media only (screen and (max-width: 600px)) {
                 body {
                     margin: 3em;
                 }
@@ -225,13 +225,13 @@ testMedia =
                 margin: auto;
             }
 
-            @media only screen and color and (pointer: fine) and (scan: interlace) and grid {
+            @media only (screen and (color and ((pointer: fine) and ((scan: interlace) and grid)))) {
                 p {
                     color: #FF0000;
                 }
             }
 
-            @media not screen and color {
+            @media not (screen and color) {
                 p {
                     color: #000000;
                 }
@@ -307,7 +307,7 @@ testWithMedia =
                 color: #333333;
             }
 
-            @media only print or monochrome {
+            @media only (print or monochrome) {
                body {
                    color: #000000;
                }
@@ -327,7 +327,7 @@ testWithMedia =
                max-width: 800px;
             }
 
-            @media only screen and (max-width: 375px) or screen and (max-height: 667px) {
+            @media only ((screen and (max-width: 375px)) or (screen and (max-height: 667px))) {
                 .homepageContainer {
                     max-width: 300px;
                 }

--- a/tests/Media.elm
+++ b/tests/Media.elm
@@ -162,7 +162,7 @@ testUnparameterizedFeature featureName component =
             "\n    p {\n        background-color: #FF0000;\n"
 
         expected =
-            "@media only (" ++ featureName ++ ") {" ++ expectedBody ++ "    }\n}"
+            "@media only " ++ featureName ++ " {" ++ expectedBody ++ "    }\n}"
     in
     test ("pretty prints the expected boolean output" ++ featureName ++ " media feature") <| \() -> Expect.equal expected actual
 
@@ -225,13 +225,13 @@ testMedia =
                 margin: auto;
             }
 
-            @media only screen and (color) and (pointer: fine) and (scan: interlace) and (grid) {
+            @media only screen and color and (pointer: fine) and (scan: interlace) and grid {
                 p {
                     color: #FF0000;
                 }
             }
 
-            @media not screen and (color) {
+            @media not screen and color {
                 p {
                     color: #000000;
                 }
@@ -307,7 +307,7 @@ testWithMedia =
                 color: #333333;
             }
 
-            @media only print or (monochrome) {
+            @media only print or monochrome {
                body {
                    color: #000000;
                }

--- a/tests/Media.elm
+++ b/tests/Media.elm
@@ -10,6 +10,10 @@ import Test exposing (..)
 import TestUtil exposing (outdented, prettyPrint)
 
 
+none =
+    todo "if you give no media queries, no @media is emitted"
+
+
 mediaTypes =
     describe "media types"
         [ testMediaType "all" Media.all

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -124,13 +124,13 @@ atRule =
               padding: 0;
           }
 
-          @media print {
+          @media only print {
               body {
                   margin: 2em;
               }
           }
 
-          @media screen and ( max-width: 600px ) {
+          @media only screen and ( max-width: 600px ) {
               body {
                   margin: 3em;
               }
@@ -165,7 +165,7 @@ nestedAtRule =
               margin: auto;
           }
 
-          @media print {
+          @media only print {
               body {
                   margin: 2em;
               }
@@ -716,7 +716,7 @@ bug280 =
             Fixtures.mediaQueryIndentation
 
         actual =
-            "@media (max-width: 515px) {\n    .mdl-layout__header > .mdl-layout-icon {\n        display: none;\n    }\n}"
+            "@media only (max-width: 515px) {\n    .mdl-layout__header > .mdl-layout-icon {\n        display: none;\n    }\n}"
     in
     describe "bug280"
         [ test "pretty prints the expected output" <|


### PR DESCRIPTION
This revises the media query API a bunch.

Some things it does:

## Always emit `only`

Reading up on [`only`](https://stackoverflow.com/questions/8549529/what-is-the-difference-between-screen-and-only-screen-in-media-queries/14168210#14168210), its basic purpose is to prevent older browsers which do not support media queries from breaking. Having older browsers not break seems always desirable, so the only reason not to use `only` across the board is to save 5 characters of emitted CSS. Especially given how well `@media only` will gzip, I don't think that's enough to justify adding complexity to an already complex API.

## Remove deprecated media types

e.g. `tv`, `aural`, `embossed`...

## Rule out invalid combinations of `and` and `or`

Previously it was possible to do things like `[ or, or, or, or ]` - now `or` & `and` take exactly 2 media queries as arguments (and `not` takes 1 argument), so they can only be used in conjunction with existing queries.

## Parenthetical groupings for `and` and `or`

Now `and` and `or` emit parens around their arguments, so the output will have whatever parenthetical groupings your code indicates should be there.