### PR TITLE
Media query API

### DIFF
--- a/src/Css/Media.elm
+++ b/src/Css/Media.elm
@@ -90,6 +90,8 @@ module Css.Media
 
 {-| Functions for building `@media` queries.
 
+<https://developer.mozilla.org/en-US/docs/Web/CSS/Media_Queries/Using_media_queries>
+
 
 # Data Structures
 

--- a/src/Css/Structure.elm
+++ b/src/Css/Structure.elm
@@ -78,26 +78,23 @@ type StyleBlock
 
 
 type MediaType
-    = All
-    | Print
+    = Print
     | Screen
     | Speech
 
 
-{-| A media feature.
+{-| A media feature expression.
 -}
-type alias MediaFeature =
-    { key : String, value : Maybe String }
+type alias MediaExpression =
+    { feature : String, value : Maybe String }
 
 
 {-| The components that make up a media query
 -}
 type MediaQuery
-    = FeatureQuery MediaFeature
-    | TypeQuery MediaType
-    | And MediaQuery MediaQuery
-    | Or MediaQuery MediaQuery
-    | Not MediaQuery
+    = AllQuery (List MediaExpression)
+    | OnlyQuery MediaType (List MediaExpression)
+    | NotQuery MediaType (List MediaExpression)
     | CustomQuery String
 
 

--- a/tests/Fixtures.elm
+++ b/tests/Fixtures.elm
@@ -2,7 +2,7 @@ module Fixtures exposing (..)
 
 import Css exposing (..)
 import Css.Elements exposing (..)
-import Css.Media exposing (media, mediaQuery, print, withMedia)
+import Css.Media exposing (media, mediaQuery, only, print, withMedia)
 import Css.Namespace exposing (namespace)
 
 
@@ -37,7 +37,7 @@ atRule : Stylesheet
 atRule =
     (stylesheet << namespace "homepage")
         [ body [ padding zero ]
-        , media print [ body [ margin (Css.em 2) ] ]
+        , media [ only print [] ] [ body [ margin (Css.em 2) ] ]
         , mediaQuery [ "screen and ( max-width: 600px )" ]
             [ body [ margin (Css.em 3) ] ]
         , button [ margin auto ]
@@ -50,7 +50,7 @@ nestedAtRule =
         [ button [ padding zero ]
         , body
             [ margin auto
-            , withMedia [ print ] [ margin (Css.em 2) ]
+            , withMedia [ only print [] ] [ margin (Css.em 2) ]
             ]
         , a [ textDecoration none ]
         ]

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -130,7 +130,7 @@ atRule =
               }
           }
 
-          @media only screen and ( max-width: 600px ) {
+          @media screen and ( max-width: 600px ) {
               body {
                   margin: 3em;
               }
@@ -716,7 +716,7 @@ bug280 =
             Fixtures.mediaQueryIndentation
 
         actual =
-            "@media only (max-width: 515px) {\n    .mdl-layout__header > .mdl-layout-icon {\n        display: none;\n    }\n}"
+            "@media (max-width: 515px) {\n    .mdl-layout__header > .mdl-layout-icon {\n        display: none;\n    }\n}"
     in
     describe "bug280"
         [ test "pretty prints the expected output" <|


### PR DESCRIPTION
This implements #307.

There were no real surprises in the implementation.

I considered renaming `Expression` to `Feature` or `MediaFeature` -- technically `Expression` is the correct term, but `Feature` might be more intuitive. What do you think?

There is a choice in how we render `media [ all [color] ] [ ... ]`:

1. `@media (color) { ... }`
2. `@media only all and (color) { ... }`

Having read [this SO answer](https://stackoverflow.com/questions/8549529/what-is-the-difference-between-screen-and-only-screen-in-media-queries/14168210#14168210), I think both should be ignored by old browsers so it shouldn't matter. I went with option (1).