### PR TITLE
Expose node-elm-compiler processOpts

### DIFF
--- a/elm-css.js
+++ b/elm-css.js
@@ -54,7 +54,8 @@ elmCss(
   program.output,
   program.module,
   program.port,
-  program.pathToMake
+  program.pathToMake,
+  {}
 )
   .then(function(results) {
     console.log(

--- a/index.js
+++ b/index.js
@@ -32,7 +32,7 @@ var KNOWN_MODULES =
     "Css"
   ];
 
-module.exports = function(projectDir, stylesheetsPath, outputDir, stylesheetsModule, stylesheetsPort, pathToMake) {
+module.exports = function(projectDir, stylesheetsPath, outputDir, stylesheetsModule, stylesheetsPort, pathToMake, makeProcessOpts) {
 
   var originalWorkingDir = process.cwd();
   process.chdir(projectDir);
@@ -45,7 +45,8 @@ module.exports = function(projectDir, stylesheetsPath, outputDir, stylesheetsMod
         outputDir,
         stylesheetsModule || "Stylesheets",
         stylesheetsPort || "files",
-        pathToMake
+        pathToMake,
+        makeProcessOpts || {}
       );
     })
     .then(function(result) {
@@ -70,14 +71,14 @@ function createTmpDir() {
   });
 }
 
-function generateCssFiles(stylesheetsPath, emitterDest, outputDir, stylesheetsModule, stylesheetsPort, pathToMake) {
-  return emit(stylesheetsPath, emitterDest, stylesheetsModule, stylesheetsPort, pathToMake)
+function generateCssFiles(stylesheetsPath, emitterDest, outputDir, stylesheetsModule, stylesheetsPort, pathToMake, makeProcessOpts) {
+  return emit(stylesheetsPath, emitterDest, stylesheetsModule, stylesheetsPort, pathToMake, makeProcessOpts)
     .then(writeResults(outputDir));
 }
 
-function emit(src, dest, stylesheetsModule, stylesheetsPort, pathToMake) {
+function emit(src, dest, stylesheetsModule, stylesheetsPort, pathToMake, makeProcessOpts) {
     // Compile the temporary file.
-  return compileEmitter(src, {output: dest, yes: true, pathToMake: pathToMake})
+  return compileEmitter(src, {output: dest, yes: true, pathToMake: pathToMake, processOpts: makeProcessOpts})
     .then(extractCssResults(dest, stylesheetsModule, stylesheetsPort));
 }
 


### PR DESCRIPTION
Hello, first I wanted to say thank you for the recent update to the latest `node-elm-compiler`, which enabled this PR.

I was wanting a bit more granular control over the underlying elm-make process (specifically to be able to turn toggle `stdio: 'ignore'`) so this PR exposes the `node-elm-compiler` `processOpts` option.

It's only available through the node API and not through the CLI, and I don't think that would be a commonly desired feature.

Please let me know if there are any questions. Thanks again!