### PR TITLE
Bugfix: Pseudoclasses in each

### DIFF
--- a/tests/Fixtures.elm
+++ b/tests/Fixtures.elm
@@ -468,6 +468,7 @@ nestedEach =
             [ span
             , \s -> span [ focus s ]
             , \s -> span [ focus [ hover s ] ]
+            , \s -> span [ descendants [ span [ active s ] ] ]
             ]
             [ color (hex "FF0000")
             ]

--- a/tests/Fixtures.elm
+++ b/tests/Fixtures.elm
@@ -459,3 +459,16 @@ backgrounds =
             , backgroundPosition2 (pct 10) zero
             ]
         ]
+
+
+nestedEach : Stylesheet
+nestedEach =
+    (stylesheet << namespace "nested-each")
+        [ each
+            [ span
+            , \s -> span [ focus s ]
+            , \s -> span [ focus [ hover s ] ]
+            ]
+            [ color (hex "FF0000")
+            ]
+        ]

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -728,3 +728,20 @@ bug280 =
                 prettyPrint input
                     |> Expect.equal actual
         ]
+
+
+nestedEach : Test
+nestedEach =
+    let
+        input =
+            Fixtures.nestedEach
+
+        actual =
+            "span, span:focus, span:focus:hover {\n    color: #FF0000;\n}"
+    in
+    describe "nestedEach"
+        [ test "pretty prints the actual output" <|
+            \_ ->
+                prettyPrint input
+                    |> Expect.equal actual
+        ]

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -736,12 +736,16 @@ nestedEach =
         input =
             Fixtures.nestedEach
 
-        actual =
-            "span, span:focus, span:focus:hover {\n    color: #FF0000;\n}"
+        output =
+            """
+            span, span:focus, span:focus:hover, span  span:active {
+                color: #FF0000;
+            }
+            """
     in
     describe "nestedEach"
         [ test "pretty prints the actual output" <|
             \_ ->
-                prettyPrint input
-                    |> Expect.equal actual
+                outdented (prettyPrint input)
+                    |> Expect.equal (outdented output)
         ]


### PR DESCRIPTION
This should resolve issue #295 . This was quite a hard one to figure out, as I needed to read through almost all logic inside `Structure.elm` to figure out what was going on 😅 .

I haven't quite been able to figure out the crazy possibilities, like this nesting:

```
each
    [ span [ descendants [ span [ hover [ children [ color (hex "#000") ] ] ] ]
    ]
```

Nesting combinators inside selectors seems to not work yet (they get ignored now). That's because we would need to update a different "field" of a selector which we don't have access to when we're dealing with sequences.

PS:
Sequence = span:hover
Combinator = span span