### PR TITLE
Replace Html.Styled.Internal with VirtualDom.Styled

### DIFF
--- a/src/Css/Foreign.elm
+++ b/src/Css/Foreign.elm
@@ -164,8 +164,8 @@ import Css.Preprocess as Preprocess
 import Css.Preprocess.Resolve as Resolve
 import Css.Structure as Structure
 import Html.Styled
-import Html.Styled.Internal exposing (makeSnippet)
 import VirtualDom
+import VirtualDom.Styled exposing (makeSnippet)
 
 
 {-| Add global styles to the page. This compiles directly to a `<style>` element.
@@ -180,7 +180,7 @@ global snippets =
         |> VirtualDom.text
         |> List.singleton
         |> VirtualDom.node "style" []
-        |> Html.Styled.Internal.Unstyled
+        |> VirtualDom.Styled.unstyledNode
 
 
 {-| -}

--- a/src/Html/Styled.elm
+++ b/src/Html/Styled.elm
@@ -1,4 +1,111 @@
-module Html.Styled exposing (Attribute, Html, a, abbr, address, article, aside, audio, b, bdi, bdo, blockquote, body, br, button, canvas, caption, cite, code, col, colgroup, datalist, dd, del, details, dfn, div, dl, dt, em, embed, fieldset, figcaption, figure, footer, form, fromUnstyled, h1, h2, h3, h4, h5, h6, header, hr, i, iframe, img, input, ins, kbd, keygen, label, legend, li, main_, map, mark, math, menu, menuitem, meter, nav, node, object, ol, optgroup, option, output, p, param, pre, progress, q, rp, rt, ruby, s, samp, section, select, small, source, span, strong, sub, summary, sup, table, tbody, td, text, textarea, tfoot, th, thead, time, toUnstyled, tr, track, u, ul, var, video, wbr)
+module Html.Styled
+    exposing
+        ( Attribute
+        , Html
+        , a
+        , abbr
+        , address
+        , article
+        , aside
+        , audio
+        , b
+        , bdi
+        , bdo
+        , blockquote
+        , body
+        , br
+        , button
+        , canvas
+        , caption
+        , cite
+        , code
+        , col
+        , colgroup
+        , datalist
+        , dd
+        , del
+        , details
+        , dfn
+        , div
+        , dl
+        , dt
+        , em
+        , embed
+        , fieldset
+        , figcaption
+        , figure
+        , footer
+        , form
+        , fromUnstyled
+        , h1
+        , h2
+        , h3
+        , h4
+        , h5
+        , h6
+        , header
+        , hr
+        , i
+        , iframe
+        , img
+        , input
+        , ins
+        , kbd
+        , keygen
+        , label
+        , legend
+        , li
+        , main_
+        , map
+        , mark
+        , math
+        , menu
+        , menuitem
+        , meter
+        , nav
+        , node
+        , object
+        , ol
+        , optgroup
+        , option
+        , output
+        , p
+        , param
+        , pre
+        , progress
+        , q
+        , rp
+        , rt
+        , ruby
+        , s
+        , samp
+        , section
+        , select
+        , small
+        , source
+        , span
+        , strong
+        , sub
+        , summary
+        , sup
+        , table
+        , tbody
+        , td
+        , text
+        , textarea
+        , tfoot
+        , th
+        , thead
+        , time
+        , toUnstyled
+        , tr
+        , track
+        , u
+        , ul
+        , var
+        , video
+        , wbr
+        )
 
 {-| Drop-in replacement for the `Html` module from the `elm-lang/html` package.
 The only functions added are `toUnstyled` and `fromUnstyled`:
@@ -98,8 +205,8 @@ expect to use frequently will be closer to the top.
 
 -}
 
-import Html.Styled.Internal as Internal exposing (Classname, InternalAttribute(..), StyledHtml(..))
-import VirtualDom exposing (Node)
+import VirtualDom
+import VirtualDom.Styled
 
 
 {-| Styled [`Html`](http://package.elm-lang.org/packages/elm-lang/html/latest/Html#Html).
@@ -112,7 +219,7 @@ You can convert the other way using [`fromUnstyled`](#fromUnstyled).
 
 -}
 type alias Html msg =
-    StyledHtml msg
+    VirtualDom.Styled.Node msg
 
 
 {-| An [`Attribute`](http://package.elm-lang.org/packages/elm-lang/html/latest/Html#Attribute) which supports the [`css`](http://package.elm-lang.org/packages/rtfeldman/elm-css/latest/Html-Styled-Attributes#css) attribute.
@@ -122,7 +229,7 @@ type by using [`fromUnstyled`](http://package.elm-lang.org/packages/elm-lang/htm
 
 -}
 type alias Attribute msg =
-    InternalAttribute msg
+    VirtualDom.Styled.Property msg
 
 
 
@@ -131,56 +238,32 @@ type alias Attribute msg =
 
 {-| -}
 node : String -> List (Attribute msg) -> List (Html msg) -> Html msg
-node elemType =
-    Element elemType
+node =
+    VirtualDom.Styled.node
 
 
 {-| -}
 text : String -> Html msg
-text str =
-    VirtualDom.text str
-        |> Unstyled
+text =
+    VirtualDom.Styled.text
 
 
 {-| -}
 map : (a -> b) -> Html a -> Html b
-map transform html =
-    case html of
-        Element classname attributes children ->
-            Element
-                classname
-                (List.map (Internal.mapAttribute transform) attributes)
-                (List.map (map transform) children)
-
-        KeyedElement classname attributes children ->
-            KeyedElement
-                classname
-                (List.map (Internal.mapAttribute transform) attributes)
-                (List.map (\( key, child ) -> ( key, map transform child )) children)
-
-        Unstyled vdom ->
-            VirtualDom.map transform vdom
-                |> Unstyled
+map =
+    VirtualDom.Styled.map
 
 
 {-| -}
-toUnstyled : Html msg -> Node msg
-toUnstyled html =
-    case html of
-        Unstyled vdom ->
-            vdom
-
-        Element elemType attributes children ->
-            Internal.unstyle elemType attributes children
-
-        KeyedElement elemType attributes children ->
-            Internal.unstyleKeyed elemType attributes children
+toUnstyled : Html msg -> VirtualDom.Node msg
+toUnstyled =
+    VirtualDom.Styled.toUnstyled
 
 
 {-| -}
-fromUnstyled : Node msg -> StyledHtml msg
+fromUnstyled : VirtualDom.Node msg -> Html msg
 fromUnstyled =
-    Internal.Unstyled
+    VirtualDom.Styled.unstyledNode
 
 
 

--- a/src/Html/Styled/Attributes.elm
+++ b/src/Html/Styled/Attributes.elm
@@ -204,9 +204,9 @@ Attributes that can be attached to any HTML tag but are less commonly used.
 
 import Css.Preprocess exposing (Style)
 import Html.Styled exposing (Attribute, Html)
-import Html.Styled.Internal as Internal exposing (InternalAttribute(InternalAttribute))
 import Json.Encode as Json
 import VirtualDom
+import VirtualDom.Styled
 
 
 -- This library does not include low, high, or optimum because the idea of a
@@ -234,14 +234,14 @@ recommendation is to use this function lightly.
 
 -}
 style : List ( String, String ) -> Attribute msg
-style pairs =
-    InternalAttribute (VirtualDom.style pairs) [] ""
+style =
+    VirtualDom.style >> fromUnstyled
 
 
 {-| -}
 fromUnstyled : VirtualDom.Property msg -> Attribute msg
-fromUnstyled prop =
-    InternalAttribute prop [] ""
+fromUnstyled =
+    VirtualDom.Styled.unstyledProperty
 
 
 {-| This function makes it easier to build a space-separated class attribute.
@@ -288,8 +288,8 @@ Read more about the difference between properties and attributes [here].
 
 -}
 property : String -> Json.Value -> Attribute msg
-property name val =
-    InternalAttribute (VirtualDom.property name val) [] ""
+property =
+    VirtualDom.Styled.property
 
 
 stringProperty : String -> String -> Attribute msg
@@ -315,15 +315,15 @@ Read more about the difference between properties and attributes [here].
 
 -}
 attribute : String -> String -> Attribute msg
-attribute name val =
-    InternalAttribute (VirtualDom.attribute name val) [] ""
+attribute =
+    VirtualDom.Styled.attribute
 
 
 {-| Transform the messages produced by an `Attribute`.
 -}
 map : (a -> msg) -> Attribute a -> Attribute msg
 map =
-    Internal.mapAttribute
+    VirtualDom.Styled.mapProperty
 
 
 
@@ -1166,12 +1166,12 @@ css : List Style -> Attribute msg
 css styles =
     let
         classname =
-            Internal.getClassname styles
+            VirtualDom.Styled.getClassname styles
+
+        classProperty =
+            VirtualDom.property "className" (Json.string classname)
     in
-    InternalAttribute
-        (Internal.classProperty classname)
-        styles
-        classname
+    VirtualDom.Styled.Property classProperty styles classname
 
 
 {-| Takes a function that creates an element, and pre-applies styles to it.

--- a/src/Html/Styled/Events.elm
+++ b/src/Html/Styled/Events.elm
@@ -57,9 +57,9 @@ of events as seen in the [TodoMVC] example.
 -}
 
 import Html.Styled as Html exposing (Attribute)
-import Html.Styled.Internal as Internal exposing (InternalAttribute(InternalAttribute))
 import Json.Decode as Json
 import VirtualDom
+import VirtualDom.Styled
 
 
 -- MOUSE EVENTS
@@ -206,15 +206,15 @@ It really does help!
 
 -}
 on : String -> Json.Decoder msg -> Attribute msg
-on eventName decoder =
-    InternalAttribute (VirtualDom.on eventName decoder) [] ""
+on =
+    VirtualDom.Styled.on
 
 
 {-| Same as `on` but you can set a few options.
 -}
 onWithOptions : String -> Options -> Json.Decoder msg -> Attribute msg
-onWithOptions eventName options decoder =
-    InternalAttribute (VirtualDom.onWithOptions eventName options decoder) [] ""
+onWithOptions =
+    VirtualDom.Styled.onWithOptions
 
 
 {-| Options for an event listener. If `stopPropagation` is true, it means the

--- a/src/Html/Styled/Keyed.elm
+++ b/src/Html/Styled/Keyed.elm
@@ -25,7 +25,7 @@ removed, etc. Common examples include:
 -}
 
 import Html.Styled exposing (Attribute, Html)
-import Html.Styled.Internal as Internal exposing (StyledHtml(..))
+import VirtualDom.Styled
 
 
 {-| Works just like `Html.node`, but you add a unique identifier to each child
@@ -33,13 +33,9 @@ node. You want this when you have a list of nodes that is changing: adding
 nodes, removing nodes, etc. In these cases, the unique identifiers help make
 the DOM modifications more efficient.
 -}
-node :
-    String
-    -> List (Attribute msg)
-    -> List ( String, Html msg )
-    -> Html msg
-node elemType =
-    KeyedElement elemType
+node : String -> List (Attribute msg) -> List ( String, Html msg ) -> Html msg
+node =
+    VirtualDom.Styled.keyedNode
 
 
 {-| -}

--- a/src/Html/Styled/Lazy.elm
+++ b/src/Html/Styled/Lazy.elm
@@ -6,9 +6,8 @@ module Html.Styled.Lazy exposing (lazy, lazy2, lazy3)
 
 -}
 
-import Html.Styled as Html exposing (Html)
-import Html.Styled.Internal exposing (StyledHtml(Unstyled))
-import VirtualDom exposing (Node)
+import Html.Styled exposing (Html)
+import VirtualDom.Styled
 
 
 {-| A performance optimization that delays the building of virtual DOM nodes.
@@ -19,22 +18,19 @@ and if so, we just stop. No need to build up the tree structure and diff it,
 we know if the input to `view` is the same, the output must be the same!
 -}
 lazy : (a -> Html msg) -> a -> Html msg
-lazy fn arg =
-    VirtualDom.lazy (Html.toUnstyled << fn) arg
-        |> Unstyled
+lazy =
+    VirtualDom.Styled.lazy
 
 
 {-| Same as `lazy` but checks on two arguments.
 -}
 lazy2 : (a -> b -> Html msg) -> a -> b -> Html msg
-lazy2 fn arg1 arg2 =
-    VirtualDom.lazy2 (\a b -> Html.toUnstyled (fn a b)) arg1 arg2
-        |> Unstyled
+lazy2 =
+    VirtualDom.Styled.lazy2
 
 
 {-| Same as `lazy` but checks on three arguments.
 -}
 lazy3 : (a -> b -> c -> Html msg) -> a -> b -> c -> Html msg
-lazy3 fn arg1 arg2 arg3 =
-    VirtualDom.lazy3 (\a b c -> Html.toUnstyled (fn a b c)) arg1 arg2 arg3
-        |> Unstyled
+lazy3 =
+    VirtualDom.Styled.lazy3


### PR DESCRIPTION
So, to introduce `Svg.Styled` (#339) we need at first to move `Html.Styled.Internal` functionality to some common place. This PR replaces it with the `VirtualDom.Styled` module which should now serve as a base for `Html.Styled` and `Svg.Styled`.

If the idea is OK, we should also discuss whether this module should be exposed. If yes, we should add documentation and clean up its API:  `makeSnippet` function should be moved to another place; `getClassname` function and `Property` constructor shouldn't be exposed. They are currently exposed because `Html.Styled.css` function needs to render classes as the `className` _property_ and `Svg.Styled.css` will need to use the `class` _attribute_, so we'll need to find a better way how to achieve that.