### PR TITLE
Fix divide by zero error in arithmetic tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ install:
   - nvm use $TARGET_NODE_VERSION
   - node --version
   - npm --version
-  - npm install -g elm@0.18.0 elm-test@0.18.3 elm-format@exp
+  - npm install -g elm@0.18.0 elm-test@0.18.11 elm-format@exp
   - mv $(npm config get prefix)/bin/elm-make $(npm config get prefix)/bin/elm-make-old
   - printf '%s\n\n' '#!/bin/bash' 'echo "Running elm-make with sysconfcpus -n 2"' '$TRAVIS_BUILD_DIR/sysconfcpus/bin/sysconfcpus -n 2 elm-make-old "$@"' > $(npm config get prefix)/bin/elm-make
   - chmod +x $(npm config get prefix)/bin/elm-make

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,7 +15,7 @@ install:
   - node --version
   - npm --version
   - cd tests
-  - npm install -g elm@0.18.0 elm-test@0.18.3 elm-format@exp
+  - npm install -g elm@0.18.0 elm-test@0.18.11 elm-format@exp
   - npm install
   - elm-package install --yes
 

--- a/tests/Arithmetic.elm
+++ b/tests/Arithmetic.elm
@@ -46,7 +46,7 @@ all =
         , describe "|/|"
             [ fuzzArithmetic3 "it divides" <|
                 \first second third ->
-                    if second == 0 then
+                    if second == 0 || third == 0 then
                         -- Skip tests of division by zero.
                         Expect.pass
                     else


### PR DESCRIPTION
Every now and then, when I ran the arithmetic tests with a certain seed, it would fail because the 3rd number would be `0`.

There was a catch for the second number being `0`, but I also added it for the third number.

The test would do `number1 |/| number2 |/| number3 |/|`.