### PR TITLE
Compile `AngleOrDirection` to correct CSS string

### DIFF
--- a/src/Css.elm
+++ b/src/Css.elm
@@ -4336,7 +4336,7 @@ linearGradient2 dir stop1 stop2 stops =
         [ stop1, stop2 ]
             ++ stops
             |> collectStops
-            |> (::) ("to " ++ dir.value)
+            |> (::) dir.value
             |> cssFunction "linear-gradient"
     , backgroundImage = Compatible
     , listStyleTypeOrPositionOrImage = Compatible
@@ -4371,7 +4371,7 @@ stop2 c len =
 -}
 toTop : AngleOrDirection {}
 toTop =
-    { value = "top"
+    { value = "to top"
     , angleOrDirection = Compatible
     }
 
@@ -4380,7 +4380,7 @@ toTop =
 -}
 toTopRight : AngleOrDirection {}
 toTopRight =
-    { value = "top right"
+    { value = "to top right"
     , angleOrDirection = Compatible
     }
 
@@ -4389,7 +4389,7 @@ toTopRight =
 -}
 toRight : AngleOrDirection {}
 toRight =
-    { value = "right"
+    { value = "to right"
     , angleOrDirection = Compatible
     }
 
@@ -4398,7 +4398,7 @@ toRight =
 -}
 toBottomRight : AngleOrDirection {}
 toBottomRight =
-    { value = "bottom right"
+    { value = "to bottom right"
     , angleOrDirection = Compatible
     }
 
@@ -4407,7 +4407,7 @@ toBottomRight =
 -}
 toBottom : AngleOrDirection {}
 toBottom =
-    { value = "bottom"
+    { value = "to bottom"
     , angleOrDirection = Compatible
     }
 
@@ -4416,7 +4416,7 @@ toBottom =
 -}
 toBottomLeft : AngleOrDirection {}
 toBottomLeft =
-    { value = "bottom left"
+    { value = "to bottom left"
     , angleOrDirection = Compatible
     }
 
@@ -4425,7 +4425,7 @@ toBottomLeft =
 -}
 toLeft : AngleOrDirection {}
 toLeft =
-    { value = "left"
+    { value = "to left"
     , angleOrDirection = Compatible
     }
 
@@ -4434,7 +4434,7 @@ toLeft =
 -}
 toTopLeft : AngleOrDirection {}
 toTopLeft =
-    { value = "top left"
+    { value = "to top left"
     , angleOrDirection = Compatible
     }
 

--- a/tests/Fixtures.elm
+++ b/tests/Fixtures.elm
@@ -474,3 +474,21 @@ nestedEach =
             [ color (hex "FF0000")
             ]
         ]
+
+
+linearGradientWithAngle : Stylesheet
+linearGradientWithAngle =
+    (stylesheet << namespace "linearGradient2Angle")
+        [ div
+            [ backgroundImage <| linearGradient2 (deg 10) (stop <| hex "000") (stop <| hex "222") []
+            ]
+        ]
+
+
+linearGradientWithDirection : Stylesheet
+linearGradientWithDirection =
+    (stylesheet << namespace "linearGradient2Direction")
+        [ div
+            [ backgroundImage <| linearGradient2 toBottomLeft (stop <| hex "000") (stop <| hex "222") []
+            ]
+        ]

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -737,12 +737,12 @@ bug335 =
         [ test "linearGradient2 does not prepend an angle value with the \"to\" keyword." <|
             \_ ->
                 Expect.false
-                    "Expected compiled angle not to include \"to\""
+                    "Expected compiled angle not to include \"to\"."
                     (String.contains "to" compiledWithAngle)
         , test "linearGradient2 prepend a direction value with the \"to\" keyword." <|
             \_ ->
                 Expect.true
-                    "Expected compiled direction to include \"to\""
+                    "Expected compiled direction to include \"to\"."
                     (String.contains "to" compiledWithDirection)
         ]
 

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -724,6 +724,29 @@ bug280 =
         ]
 
 
+bug335 : Test
+bug335 =
+    let
+        compiledWithAngle =
+            prettyPrint Fixtures.linearGradientWithAngle
+
+        compiledWithDirection =
+            prettyPrint Fixtures.linearGradientWithDirection
+    in
+    describe "Github Issue #335: https://github.com/rtfeldman/elm-css/issues/335"
+        [ test "linearGradient2 does not prepend an angle value with the \"to\" keyword." <|
+            \_ ->
+                Expect.false
+                    "Expected compiled angle not to include \"to\""
+                    (String.contains "to" compiledWithAngle)
+        , test "linearGradient2 prepend a direction value with the \"to\" keyword." <|
+            \_ ->
+                Expect.true
+                    "Expected compiled direction to include \"to\""
+                    (String.contains "to" compiledWithDirection)
+        ]
+
+
 nestedEach : Test
 nestedEach =
     let


### PR DESCRIPTION
This fixes the bug described in issue #335  . The fix seems a little naive to me. It looks like a value of type `AngleOrDirection` will have an `angle` field when it is of type `Angle`. The other idea was to use the presence of this field on the `dir` argument to infer an angle or direction value . But since it looks like the built-in direction values are only used in the context of a gradient, adding `"to"` to the value was easier. Let me know if this assumption is incorrect. 

The `mocha *.js` part of `npm test` fails for me. The error message is `Elm compiler "/Users/maxhallinan/Stuff/elm-css/tests" did not have permission to run. Do you need to give it executable permissions?`. This test fails on master too. Unfortunately, I do not have time to debug this now but it does not seem related to the changes on this branch.