### PR TITLE
Remove warnings

### DIFF
--- a/src/Css/Foreign.elm
+++ b/src/Css/Foreign.elm
@@ -176,7 +176,6 @@ global snippets =
         |> Preprocess.stylesheet
         |> List.singleton
         |> Resolve.compile
-        |> .css
         |> VirtualDom.text
         |> List.singleton
         |> VirtualDom.node "style" []

--- a/src/Css/Preprocess.elm
+++ b/src/Css/Preprocess.elm
@@ -20,7 +20,6 @@ type alias Property =
     { key : String
     , value : String
     , important : Bool
-    , warnings : List String
     }
 
 

--- a/src/Css/Preprocess/Resolve.elm
+++ b/src/Css/Preprocess/Resolve.elm
@@ -1,87 +1,42 @@
 module Css.Preprocess.Resolve exposing (compile)
 
 {-| Functions responsible for resolving Preprocess data structures into
-Structure data structures and gathering warnings along the way.
+Structure data structures.
 -}
 
 import Css.Preprocess as Preprocess exposing (Snippet(Snippet), SnippetDeclaration, Style(AppendProperty, ExtendSelector, NestSnippet), unwrapSnippet)
 import Css.Structure as Structure exposing (mapLast)
 import Css.Structure.Output as Output
 import String
-import Tuple
 
 
-compile : List Preprocess.Stylesheet -> { warnings : List String, css : String }
+compile : List Preprocess.Stylesheet -> String
 compile styles =
-    let
-        results =
-            List.map compile1 styles
-    in
-    { warnings = List.concatMap .warnings results
-    , css = String.join "\n\n" (List.map .css results)
-    }
+    String.join "\n\n" (List.map compile1 styles)
 
 
-compile1 : Preprocess.Stylesheet -> { warnings : List String, css : String }
+compile1 : Preprocess.Stylesheet -> String
 compile1 sheet =
-    let
-        ( structureStylesheet, warnings ) =
-            toStructure sheet
-    in
-    { warnings = warnings
-    , css = Output.prettyPrint (Structure.dropEmpty structureStylesheet)
-    }
+    Output.prettyPrint (Structure.dropEmpty (toStructure sheet))
 
 
-type alias DeclarationsAndWarnings =
-    { declarations : List Structure.Declaration
-    , warnings : List String
-    }
-
-
-resolveMediaRule : List Structure.MediaQuery -> List Preprocess.StyleBlock -> DeclarationsAndWarnings
+resolveMediaRule : List Structure.MediaQuery -> List Preprocess.StyleBlock -> List Structure.Declaration
 resolveMediaRule mediaQueries styleBlocks =
     let
-        handleStyleBlock : Preprocess.StyleBlock -> DeclarationsAndWarnings
+        handleStyleBlock : Preprocess.StyleBlock -> List Structure.Declaration
         handleStyleBlock styleBlock =
-            let
-                { declarations, warnings } =
-                    expandStyleBlock styleBlock
-            in
-            { declarations = List.map (toMediaRule mediaQueries) declarations
-            , warnings = warnings
-            }
-
-        results =
-            List.map handleStyleBlock styleBlocks
+            List.map (toMediaRule mediaQueries) (expandStyleBlock styleBlock)
     in
-    { warnings = List.concatMap .warnings results
-    , declarations = List.concatMap .declarations results
-    }
+    List.concatMap handleStyleBlock styleBlocks
 
 
-resolveSupportsRule : String -> List Snippet -> DeclarationsAndWarnings
+resolveSupportsRule : String -> List Snippet -> List Structure.Declaration
 resolveSupportsRule str snippets =
     let
-        { declarations, warnings } =
+        declarations =
             extract (List.concatMap unwrapSnippet snippets)
     in
-    { declarations = [ Structure.SupportsRule str declarations ]
-    , warnings = warnings
-    }
-
-
-resolveDocumentRule : String -> String -> String -> String -> Preprocess.StyleBlock -> DeclarationsAndWarnings
-resolveDocumentRule str1 str2 str3 str4 styleBlock =
-    -- TODO give these more descriptive names
-    let
-        { declarations, warnings } =
-            expandStyleBlock styleBlock
-    in
-    { declarations =
-        List.map (toDocumentRule str1 str2 str3 str4) declarations
-    , warnings = warnings
-    }
+    [ Structure.SupportsRule str declarations ]
 
 
 toMediaRule : List Structure.MediaQuery -> Structure.Declaration -> Structure.Declaration
@@ -119,84 +74,24 @@ toMediaRule mediaQueries declaration =
             declaration
 
 
-resolvePageRule : String -> List Preprocess.Property -> DeclarationsAndWarnings
-resolvePageRule str pageRuleProperties =
-    let
-        ( warnings, properties ) =
-            extractWarnings pageRuleProperties
-    in
-    { declarations = [ Structure.PageRule str properties ]
-    , warnings = warnings
-    }
-
-
-resolveFontFace : List Preprocess.Property -> DeclarationsAndWarnings
-resolveFontFace fontFaceProperties =
-    let
-        ( warnings, properties ) =
-            extractWarnings fontFaceProperties
-    in
-    { declarations = [ Structure.FontFace properties ]
-    , warnings = warnings
-    }
-
-
-resolveKeyframes : String -> List Structure.KeyframeProperty -> DeclarationsAndWarnings
-resolveKeyframes str properties =
-    { declarations = [ Structure.Keyframes str properties ]
-    , warnings = []
-    }
-
-
-resolveViewport : List Preprocess.Property -> DeclarationsAndWarnings
-resolveViewport viewportProperties =
-    let
-        ( warnings, properties ) =
-            extractWarnings viewportProperties
-    in
-    { declarations = [ Structure.Viewport properties ]
-    , warnings = warnings
-    }
-
-
-resolveCounterStyle : List Preprocess.Property -> DeclarationsAndWarnings
-resolveCounterStyle counterStyleProperties =
-    let
-        ( warnings, properties ) =
-            extractWarnings counterStyleProperties
-    in
-    { declarations = [ Structure.Viewport properties ]
-    , warnings = warnings
-    }
-
-
-resolveFontFeatureValues : List ( String, List Preprocess.Property ) -> DeclarationsAndWarnings
+resolveFontFeatureValues : List ( String, List Preprocess.Property ) -> List Structure.Declaration
 resolveFontFeatureValues tuples =
     let
         expandTuples tuplesToExpand =
             case tuplesToExpand of
                 [] ->
-                    ( [], [] )
+                    []
 
-                ( str, tupleProperties ) :: rest ->
-                    let
-                        ( warnings, properties ) =
-                            extractWarnings tupleProperties
+                properties :: rest ->
+                    properties :: expandTuples rest
 
-                        ( nextWarnings, nextTuples ) =
-                            expandTuples rest
-                    in
-                    ( warnings ++ nextWarnings, ( str, properties ) :: nextTuples )
-
-        ( warnings, newTuples ) =
+        newTuples =
             expandTuples tuples
     in
-    { declarations = [ Structure.FontFeatureValues newTuples ]
-    , warnings = warnings
-    }
+    [ Structure.FontFeatureValues newTuples ]
 
 
-toDeclarations : SnippetDeclaration -> DeclarationsAndWarnings
+toDeclarations : SnippetDeclaration -> List Structure.Declaration
 toDeclarations snippetDeclaration =
     case snippetDeclaration of
         Preprocess.StyleBlockDeclaration styleBlock ->
@@ -210,83 +105,47 @@ toDeclarations snippetDeclaration =
 
         -- TODO give these more descriptive names
         Preprocess.DocumentRule str1 str2 str3 str4 styleBlock ->
-            resolveDocumentRule str1 str2 str3 str4 styleBlock
+            List.map (toDocumentRule str1 str2 str3 str4) (expandStyleBlock styleBlock)
 
-        Preprocess.PageRule str pageRuleProperties ->
-            resolvePageRule str pageRuleProperties
+        Preprocess.PageRule str properties ->
+            [ Structure.PageRule str properties ]
 
-        Preprocess.FontFace fontFaceProperties ->
-            resolveFontFace fontFaceProperties
+        Preprocess.FontFace properties ->
+            [ Structure.FontFace properties ]
 
         Preprocess.Keyframes str properties ->
-            resolveKeyframes str properties
+            [ Structure.Keyframes str properties ]
 
-        Preprocess.Viewport viewportProperties ->
-            resolveViewport viewportProperties
+        Preprocess.Viewport properties ->
+            [ Structure.Viewport properties ]
 
-        Preprocess.CounterStyle counterStyleProperties ->
-            resolveCounterStyle counterStyleProperties
+        Preprocess.CounterStyle properties ->
+            [ Structure.CounterStyle properties ]
 
         Preprocess.FontFeatureValues tuples ->
             resolveFontFeatureValues tuples
 
 
-concatDeclarationsAndWarnings : List DeclarationsAndWarnings -> DeclarationsAndWarnings
-concatDeclarationsAndWarnings declarationsAndWarnings =
-    case declarationsAndWarnings of
-        [] ->
-            { declarations = []
-            , warnings = []
-            }
-
-        { declarations, warnings } :: rest ->
-            let
-                result =
-                    concatDeclarationsAndWarnings rest
-            in
-            { declarations = declarations ++ result.declarations
-            , warnings = warnings ++ result.warnings
-            }
-
-
-extract : List SnippetDeclaration -> DeclarationsAndWarnings
+extract : List SnippetDeclaration -> List Structure.Declaration
 extract snippetDeclarations =
     case snippetDeclarations of
         [] ->
-            { declarations = [], warnings = [] }
+            []
 
         first :: rest ->
-            let
-                nextResult =
-                    extract rest
-
-                { declarations, warnings } =
-                    toDeclarations first
-            in
-            { declarations = declarations ++ nextResult.declarations
-            , warnings = warnings ++ nextResult.warnings
-            }
+            toDeclarations first ++ extract rest
 
 
-applyStyles : List Style -> List Structure.Declaration -> DeclarationsAndWarnings
+applyStyles : List Style -> List Structure.Declaration -> List Structure.Declaration
 applyStyles styles declarations =
     case styles of
         [] ->
-            { declarations = declarations, warnings = [] }
+            declarations
 
-        (AppendProperty propertyToAppend) :: rest ->
-            let
-                ( warnings, property ) =
-                    extractWarning propertyToAppend
-
-                result =
-                    declarations
-                        |> Structure.appendProperty property
-                        |> applyStyles rest
-            in
-            { declarations = result.declarations
-            , warnings = warnings ++ result.warnings
-            }
+        (AppendProperty property) :: rest ->
+            declarations
+                |> Structure.appendProperty property
+                |> applyStyles rest
 
         (ExtendSelector selector nestedStyles) :: rest ->
             applyNestedStylesToLast
@@ -303,7 +162,7 @@ applyStyles styles declarations =
                         (originalTuples ++ (( selectorCombinator, newSequence ) :: newTuples))
                         (oneOf [ newPseudoElement, originalPseudoElement ])
 
-                expandDeclaration : SnippetDeclaration -> DeclarationsAndWarnings
+                expandDeclaration : SnippetDeclaration -> List Structure.Declaration
                 expandDeclaration declaration =
                     case declaration of
                         Preprocess.StyleBlockDeclaration (Preprocess.StyleBlock firstSelector otherSelectors nestedStyles) ->
@@ -321,8 +180,7 @@ applyStyles styles declarations =
                                             [ Structure.StyleBlockDeclaration (Structure.StyleBlock first rest [])
                                             ]
                             in
-                            [ applyStyles nestedStyles newDeclarations ]
-                                |> concatDeclarationsAndWarnings
+                            applyStyles nestedStyles newDeclarations
 
                         Preprocess.MediaRule mediaQueries styleBlocks ->
                             resolveMediaRule mediaQueries styleBlocks
@@ -332,22 +190,22 @@ applyStyles styles declarations =
 
                         -- TODO give these more descriptive names
                         Preprocess.DocumentRule str1 str2 str3 str4 styleBlock ->
-                            resolveDocumentRule str1 str2 str3 str4 styleBlock
+                            List.map (toDocumentRule str1 str2 str3 str4) (expandStyleBlock styleBlock)
 
-                        Preprocess.PageRule str pageRuleProperties ->
-                            resolvePageRule str pageRuleProperties
+                        Preprocess.PageRule str properties ->
+                            [ Structure.PageRule str properties ]
 
-                        Preprocess.FontFace fontFaceProperties ->
-                            resolveFontFace fontFaceProperties
+                        Preprocess.FontFace properties ->
+                            [ Structure.FontFace properties ]
 
                         Preprocess.Keyframes str properties ->
-                            resolveKeyframes str properties
+                            [ Structure.Keyframes str properties ]
 
-                        Preprocess.Viewport viewportProperties ->
-                            resolveViewport viewportProperties
+                        Preprocess.Viewport properties ->
+                            [ Structure.Viewport properties ]
 
-                        Preprocess.CounterStyle counterStyleProperties ->
-                            resolveCounterStyle counterStyleProperties
+                        Preprocess.CounterStyle properties ->
+                            [ Structure.CounterStyle properties ]
 
                         Preprocess.FontFeatureValues tuples ->
                             resolveFontFeatureValues tuples
@@ -356,7 +214,7 @@ applyStyles styles declarations =
                 |> List.concatMap unwrapSnippet
                 |> List.map expandDeclaration
                 |> (++) [ applyStyles rest declarations ]
-                |> concatDeclarationsAndWarnings
+                |> List.concat
 
         (Preprocess.WithPseudoElement pseudoElement nestedStyles) :: rest ->
             applyNestedStylesToLast
@@ -377,10 +235,8 @@ applyStyles styles declarations =
                                 |> Structure.MediaRule mediaQueries
                             ]
             in
-            [ applyStyles rest declarations
-            , applyStyles nestedStyles newDeclarations
-            ]
-                |> concatDeclarationsAndWarnings
+            applyStyles rest declarations
+                ++ applyStyles nestedStyles newDeclarations
 
         (Preprocess.ApplyStyles otherStyles) :: rest ->
             declarations
@@ -403,28 +259,22 @@ applyStyles styles declarations =
 -}
 
 
-applyNestedStylesToLast : List Style -> List Style -> (Structure.StyleBlock -> List Structure.StyleBlock) -> List Structure.Declaration -> DeclarationsAndWarnings
+applyNestedStylesToLast : List Style -> List Style -> (Structure.StyleBlock -> List Structure.StyleBlock) -> List Structure.Declaration -> List Structure.Declaration
 applyNestedStylesToLast nestedStyles rest f declarations =
     let
-        handleInitial declarationsAndWarnings =
-            let
-                result =
-                    applyStyles nestedStyles declarationsAndWarnings.declarations
-            in
-            { warnings = declarationsAndWarnings.warnings ++ result.warnings
-            , declarations = result.declarations
-            }
+        handleInitial declarations =
+            applyStyles nestedStyles declarations
 
         initialResult =
             lastDeclaration declarations
                 |> Maybe.map insertStylesToNestedDecl
-                |> Maybe.withDefault { warnings = [], declarations = [] }
+                |> Maybe.withDefault []
 
         insertStylesToNestedDecl lastDecl =
             Structure.concatMapLastStyleBlock f lastDecl
-                |> List.map (\declaration -> { declarations = [ declaration ], warnings = [] })
+                |> List.map (\declaration -> [ declaration ])
                 |> mapLast handleInitial
-                |> concatDeclarationsAndWarnings
+                |> List.concat
 
         nextResult =
             lastDeclaration declarations
@@ -440,7 +290,7 @@ applyNestedStylesToLast nestedStyles rest f declarations =
            or an `AppendProperty` after an `ExtendSelector` or `WithPseudoElement`.
         -}
         newDeclarations =
-            case ( List.head nextResult.declarations, List.head <| List.reverse declarations ) of
+            case ( List.head nextResult, List.head <| List.reverse declarations ) of
                 ( Just nextResultParent, Just originalParent ) ->
                     List.take (List.length declarations - 1) declarations
                         ++ [ if originalParent /= nextResultParent then
@@ -452,9 +302,7 @@ applyNestedStylesToLast nestedStyles rest f declarations =
                 _ ->
                     declarations
     in
-    { warnings = initialResult.warnings ++ nextResult.warnings
-    , declarations = newDeclarations ++ withoutParent initialResult.declarations ++ withoutParent nextResult.declarations
-    }
+    newDeclarations ++ withoutParent initialResult ++ withoutParent nextResult
 
 
 lastDeclaration : List Structure.Declaration -> Maybe (List Structure.Declaration)
@@ -470,27 +318,25 @@ lastDeclaration declarations =
             lastDeclaration xs
 
 
-expandStyleBlock : Preprocess.StyleBlock -> DeclarationsAndWarnings
+expandStyleBlock : Preprocess.StyleBlock -> List Structure.Declaration
 expandStyleBlock (Preprocess.StyleBlock firstSelector otherSelectors styles) =
     [ Structure.StyleBlockDeclaration (Structure.StyleBlock firstSelector otherSelectors []) ]
         |> applyStyles styles
 
 
-toStructure : Preprocess.Stylesheet -> ( Structure.Stylesheet, List String )
+toStructure : Preprocess.Stylesheet -> Structure.Stylesheet
 toStructure { charset, imports, namespaces, snippets } =
     let
-        { warnings, declarations } =
+        declarations =
             snippets
                 |> List.concatMap unwrapSnippet
                 |> extract
     in
-    ( { charset = charset
-      , imports = imports
-      , namespaces = namespaces
-      , declarations = declarations
-      }
-    , warnings
-    )
+    { charset = charset
+    , imports = imports
+    , namespaces = namespaces
+    , declarations = declarations
+    }
 
 
 toDocumentRule : String -> String -> String -> String -> Structure.Declaration -> Structure.Declaration
@@ -502,18 +348,6 @@ toDocumentRule str1 str2 str3 str4 declaration =
         _ ->
             -- TODO do something more interesting here?
             declaration
-
-
-extractWarnings : List Preprocess.Property -> ( List String, List Structure.Property )
-extractWarnings properties =
-    ( List.concatMap .warnings properties
-    , List.map (\prop -> Tuple.second (extractWarning prop)) properties
-    )
-
-
-extractWarning : Preprocess.Property -> ( List String, Structure.Property )
-extractWarning { warnings, key, value, important } =
-    ( warnings, { key = key, value = value, important = important } )
 
 
 collectSelectors : List Structure.Declaration -> List Structure.Selector

--- a/src/Css/Preprocess/Resolve.elm
+++ b/src/Css/Preprocess/Resolve.elm
@@ -290,7 +290,7 @@ applyNestedStylesToLast nestedStyles rest f declarations =
            or an `AppendProperty` after an `ExtendSelector` or `WithPseudoElement`.
         -}
         newDeclarations =
-            case ( List.head nextResult, List.head <| List.reverse declarations ) of
+            case ( List.head nextResult, last declarations ) of
                 ( Just nextResultParent, Just originalParent ) ->
                     List.take (List.length declarations - 1) declarations
                         ++ [ if originalParent /= nextResultParent then
@@ -376,3 +376,16 @@ oneOf maybes =
 
                 Just _ ->
                     maybe
+
+
+last : List a -> Maybe a
+last list =
+    case list of
+        [] ->
+            Nothing
+
+        singleton :: [] ->
+            Just singleton
+
+        first :: rest ->
+            last rest

--- a/src/Css/Preprocess/Resolve.elm
+++ b/src/Css/Preprocess/Resolve.elm
@@ -272,7 +272,7 @@ applyNestedStylesToLast nestedStyles rest f declarations =
 
         insertStylesToNestedDecl lastDecl =
             Structure.concatMapLastStyleBlock f lastDecl
-                |> List.map (\declaration -> [ declaration ])
+                |> List.map List.singleton
                 |> mapLast handleInitial
                 |> List.concat
 

--- a/src/DEPRECATED/Css/File.elm
+++ b/src/DEPRECATED/Css/File.elm
@@ -8,7 +8,6 @@ module DEPRECATED.Css.File
         , compile
         , compiler
         , stylesheet
-        , toFileStructure
         , uniqueClass
         , uniqueSvgClass
         )
@@ -28,7 +27,7 @@ and that one way is planned to be `Html.Styled`!
 
 Functions for writing CSS files from elm-css.
 
-@docs Stylesheet, stylesheet, compile, compiler, toFileStructure, CssFileStructure, CssCompilerProgram
+@docs Stylesheet, stylesheet, compile, compiler, CssFileStructure, CssCompilerProgram
 
 
 ## Automatically-generated unique classes
@@ -47,28 +46,15 @@ type alias CssFileStructure =
     List
         { filename : String
         , content : String
-        , success : Bool
         }
-
-
-{-| Translate a list of filenames and [`prettyPrint`](#prettyPrint) results
-to a list of tuples suitable for being sent to a port in a Stylesheets.elm file.
--}
-toFileStructure : List ( String, { css : String, warnings : List String } ) -> CssFileStructure
-toFileStructure stylesheets =
-    let
-        asTuple ( filename, { css, warnings } ) =
-            { success = List.isEmpty warnings, filename = filename, content = css }
-    in
-    List.map asTuple stylesheets
 
 
 {-| Compile the given stylesheets to a CSS string, or to an error
 message if it could not be compiled.
 -}
-compile : List Stylesheet -> { css : String, warnings : List String }
-compile =
-    Resolve.compile
+compile : List Stylesheet -> { css : String }
+compile stylesheets =
+    { css = Resolve.compile stylesheets }
 
 
 {-| Create a program that compiles an elm-css stylesheet to a CSS file.

--- a/src/VirtualDom/Styled.elm
+++ b/src/VirtualDom/Styled.elm
@@ -185,7 +185,6 @@ getClassname styles =
             |> Preprocess.stylesheet
             |> List.singleton
             |> Resolve.compile
-            |> .css
             |> Murmur3.hashString murmurSeed
             |> Hex.toString
             |> String.cons '_'
@@ -427,7 +426,6 @@ toDeclaration dict =
         |> Preprocess.stylesheet
         |> List.singleton
         |> Resolve.compile
-        |> .css
 
 
 snippetFromPair : ( Classname, List Style ) -> Preprocess.Snippet

--- a/tests/Compile.elm
+++ b/tests/Compile.elm
@@ -1,10 +1,8 @@
 module Compile exposing (..)
 
 import CompileFixtures
-import Css exposing (..)
 import Css.Preprocess.Resolve exposing (compile)
 import Expect
-import Fuzz exposing (Fuzzer, tuple3, tuple4)
 import Test exposing (..)
 import TestUtil exposing (..)
 

--- a/tests/Compile.elm
+++ b/tests/Compile.elm
@@ -9,53 +9,6 @@ import Test exposing (..)
 import TestUtil exposing (..)
 
 
-getRgbaWarnings : ( Int, Int, Int, Float ) -> Int
-getRgbaWarnings ( red, green, blue, alpha ) =
-    rgba red green blue alpha |> .warnings |> List.length
-
-
-getRgbWarnings : ( Int, Int, Int ) -> Int
-getRgbWarnings ( red, green, blue ) =
-    rgb red green blue |> .warnings |> List.length
-
-
-colorWarnings : Test
-colorWarnings =
-    describe "color warnings"
-        [ describe "rgb"
-            [ fuzz (tuple3 ( validRgbValue, validRgbValue, validRgbValue ))
-                "does not warn when everything is valid"
-                (getRgbWarnings >> Expect.equal 0)
-            , fuzz (tuple3 ( invalidRgbValue, validRgbValue, validRgbValue ))
-                "warns for invalid r values"
-                (getRgbWarnings >> Expect.equal 1)
-            , fuzz (tuple3 ( validRgbValue, invalidRgbValue, validRgbValue ))
-                "warns for invalid g values"
-                (getRgbWarnings >> Expect.equal 1)
-            , fuzz (tuple3 ( validRgbValue, validRgbValue, invalidRgbValue ))
-                "warns for invalid b values"
-                (getRgbWarnings >> Expect.equal 1)
-            ]
-        , describe "rgba"
-            [ fuzz (tuple4 ( validRgbValue, validRgbValue, validRgbValue, validAlphaValue ))
-                "does not warn when everything is valid"
-                (getRgbaWarnings >> Expect.equal 0)
-            , fuzz (tuple4 ( invalidRgbValue, validRgbValue, validRgbValue, validAlphaValue ))
-                "warns for invalid r values"
-                (getRgbaWarnings >> Expect.equal 1)
-            , fuzz (tuple4 ( validRgbValue, invalidRgbValue, validRgbValue, validAlphaValue ))
-                "warns for invalid g values"
-                (getRgbaWarnings >> Expect.equal 1)
-            , fuzz (tuple4 ( validRgbValue, validRgbValue, invalidRgbValue, validAlphaValue ))
-                "warns for invalid b values"
-                (getRgbaWarnings >> Expect.equal 1)
-            , fuzz (tuple4 ( validRgbValue, validRgbValue, validRgbValue, invalidAlphaValue ))
-                "warns for invalid a values"
-                (getRgbaWarnings >> Expect.equal 1)
-            ]
-        ]
-
-
 unstyledDiv : Test
 unstyledDiv =
     let
@@ -146,12 +99,6 @@ compileTest =
         [ test "compile output" <|
             \() ->
                 input
-                    |> .css
                     |> outdented
                     |> Expect.equal (outdented output)
-        , test "compile warnings" <|
-            \() ->
-                input
-                    |> .warnings
-                    |> Expect.equal []
         ]

--- a/tests/TestUtil.elm
+++ b/tests/TestUtil.elm
@@ -17,14 +17,7 @@ outdented str =
 
 prettyPrint : Stylesheet -> String
 prettyPrint sheet =
-    let
-        { warnings, css } =
-            compile [ sheet ]
-    in
-    if List.isEmpty warnings then
-        css
-    else
-        "Invalid Stylesheet:\n" ++ String.join "\n" warnings
+    compile [ sheet ]
 
 
 validRgbValue : Fuzzer Int

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -1,6 +1,5 @@
 module Tests exposing (..)
 
-import Css.Preprocess exposing (Stylesheet)
 import Expect exposing (Expectation)
 import Fixtures
 import Test exposing (..)
@@ -532,45 +531,6 @@ fonts =
                 outdented (prettyPrint input)
                     |> Expect.equal (outdented output)
         ]
-
-
-weightWarning : Test
-weightWarning =
-    let
-        input =
-            Fixtures.fontWeightWarning
-
-        output =
-            """
-            Invalid Stylesheet:
-            fontWeight 22 is invalid. Valid weights are: 100, 200, 300, 400, 500, 600, 700, 800, 900. Please see https://developer.mozilla.org/en-US/docs/Web/CSS/font-weight#Values"""
-    in
-    describe "fontWeightWarning"
-        [ test "pretty prints the expected output" <|
-            \_ ->
-                outdented (prettyPrint input)
-                    |> Expect.equal (outdented output)
-        ]
-
-
-hexWarning : Test
-hexWarning =
-    describe "invalid hex colors"
-        [ test "prints a warning for an invalid hex color" <|
-            \_ ->
-                expectInvalidStylesheet Fixtures.colorHexWarning
-        , test "prints a warning for an invalid abbreviated hex color" <|
-            \_ ->
-                expectInvalidStylesheet Fixtures.colorHexAbbrWarning
-        ]
-
-
-expectInvalidStylesheet : Stylesheet -> Expectation
-expectInvalidStylesheet stylesheet =
-    stylesheet
-        |> prettyPrint
-        |> String.contains "Invalid Stylesheet"
-        |> Expect.true "Stylesheet was valid, but should have been invalid."
 
 
 pseudoElements : Test


### PR DESCRIPTION
As part of the plan to make doing things in realtime first-class, I'm taking out the concept of warnings. These add a lot of overhead at runtime, and were a nice-to-have at build time anyway; there are other build-time tools that can check compiled CSS for validity.