### PR TITLE
Remove key-value space

### DIFF
--- a/src/Css.elm
+++ b/src/Css.elm
@@ -7758,7 +7758,7 @@ batch =
 -}
 property : String -> String -> Style
 property key value =
-    Property (key ++ ": " ++ value)
+    Property (key ++ ":" ++ value)
         |> Preprocess.AppendProperty
 
 

--- a/tests/Compile.elm
+++ b/tests/Compile.elm
@@ -33,35 +33,35 @@ dreamwriter =
         output =
             """
             html, body {
-              width: 100%;
-              height: 100%;
-              box-sizing: border-box;
-              padding: 0;
-              margin: 0;
+              width:100%;
+              height:100%;
+              box-sizing:border-box;
+              padding:0;
+              margin:0;
             }
 
             body {
-              min-width: 1280px;
-              overflow-x: auto;
+              min-width:1280px;
+              overflow-x:auto;
             }
 
             body > div {
-              width: 100%;
-              height: 100%;
+              width:100%;
+              height:100%;
             }
 
             .Hidden {
-              display: none !important;
+              display:none !important;
             }
 
             #Page {
-              width: 100%;
-              height: 100%;
-              box-sizing: border-box;
-              margin: 0;
-              padding: 8px;
-              background-color: rgb(100, 90, 128);
-              color: rgb(40, 35, 76);
+              width:100%;
+              height:100%;
+              box-sizing:border-box;
+              margin:0;
+              padding:8px;
+              background-color:rgb(100, 90, 128);
+              color:rgb(40, 35, 76);
             }
         """
     in
@@ -85,11 +85,11 @@ compileTest =
         output =
             """
             .BasicStyle1 {
-                display: none;
+                display:none;
             }
 
             .BasicStyle2 {
-                display: none;
+                display:none;
             }
             """
     in

--- a/tests/Media.elm
+++ b/tests/Media.elm
@@ -25,7 +25,7 @@ testMediaType str mediaType =
             prettyPrint (stylesheet [ basicMediaQuery (only mediaType []) ])
 
         expectedBody =
-            "\n    p {\n        background-color: #FF0000;\n"
+            "\n    p {\n        background-color:#FF0000;\n"
 
         expected =
             "@media only " ++ str ++ " {" ++ expectedBody ++ "    }\n}"
@@ -158,7 +158,7 @@ testUnparameterizedFeature featureName component =
             prettyPrint (stylesheet [ basicMediaQuery (Media.all [ component ]) ])
 
         expectedBody =
-            "\n    p {\n        background-color: #FF0000;\n"
+            "\n    p {\n        background-color:#FF0000;\n"
 
         expected =
             "@media (" ++ featureName ++ ") {" ++ expectedBody ++ "    }\n}"
@@ -173,7 +173,7 @@ expectFeatureWorks featureName n ( component, expectedStr ) =
             prettyPrint (stylesheet [ basicMediaQuery (Media.all [ component ]) ])
 
         expectedBody =
-            "\n    p {\n        background-color: #FF0000;\n"
+            "\n    p {\n        background-color:#FF0000;\n"
 
         expected =
             "@media (" ++ featureName ++ ": " ++ expectedStr ++ ") {" ++ expectedBody ++ "    }\n}"
@@ -205,34 +205,34 @@ testMedia =
         output =
             """
             body {
-                padding: 0;
+                padding:0;
             }
 
             @media only print {
                 body {
-                    margin: 2em;
+                    margin:2em;
                 }
             }
 
             @media only screen and (max-width: 600px) {
                 body {
-                    margin: 3em;
+                    margin:3em;
                 }
             }
 
             button {
-                margin: auto;
+                margin:auto;
             }
 
             @media only screen and (color) and (pointer: fine) and (scan: interlace) and (grid) {
                 p {
-                    color: #FF0000;
+                    color:#FF0000;
                 }
             }
 
             @media not screen and (color) {
                 p {
-                    color: #000000;
+                    color:#000000;
                 }
             }
             """
@@ -273,38 +273,38 @@ testWithMedia =
         output =
             """
             button {
-                padding: 0;
+                padding:0;
             }
 
             body {
-                color: #333333;
+                color:#333333;
             }
 
             @media only print,
              (monochrome) {
                body {
-                   color: #000000;
+                   color:#000000;
                }
              }
 
             a {
-               color: #FF0000;
+               color:#FF0000;
             }
 
             @media only print {
                a {
-                   text-decoration: none;
+                   text-decoration:none;
                }
             }
 
             .Container {
-               max-width: 800px;
+               max-width:800px;
             }
 
             @media only screen and (max-width: 375px),
              only screen and (max-height: 667px) {
                 .Container {
-                    max-width: 300px;
+                    max-width:300px;
                 }
             }
             """
@@ -331,7 +331,7 @@ testMediaQuery =
             @media tv,
              screen and (scan: interlace) {
                 body {
-                    background-color: #FFFFFF;
+                    background-color:#FFFFFF;
                 }
             }
             """
@@ -359,13 +359,13 @@ testWithMediaQuery =
         output =
             """
             body {
-                font-size: 12px;
+                font-size:12px;
             }
 
             @media screen and (min-device-width: 600px),
             screen and (min-width: 600px) {
                 body {
-                    font-size: 14px;
+                    font-size:14px;
                 }
             }
             """

--- a/tests/Properties.elm
+++ b/tests/Properties.elm
@@ -634,5 +634,5 @@ expectPropertyWorks propertyName ( style, expectedStr ) =
         [ test "emitted as expected" <|
             \() ->
                 prettyPrint (stylesheet [ p [ style ] ])
-                    |> Expect.equal ("p {\n    " ++ propertyName ++ ": " ++ expectedStr ++ ";\n}")
+                    |> Expect.equal ("p {\n    " ++ propertyName ++ ":" ++ expectedStr ++ ";\n}")
         ]

--- a/tests/Selectors.elm
+++ b/tests/Selectors.elm
@@ -89,4 +89,4 @@ testSelector expectedOutput applySelector =
     test (expectedOutput ++ " selector") <|
         \() ->
             prettyPrint (stylesheet [ applySelector [ display none ] ])
-                |> Expect.equal (expectedOutput ++ " {\n    display: none;\n}")
+                |> Expect.equal (expectedOutput ++ " {\n    display:none;\n}")

--- a/tests/Styled.elm
+++ b/tests/Styled.elm
@@ -15,36 +15,36 @@ all =
             (\_ ->
                 Query.fromHtml (toUnstyled <| ReadmeExample.view "BUY TICKETS")
                     |> Query.has
-                        [ Selector.text """._3f6e16e1 {
-    background-color: #333333;
-    padding: 20px;
+                        [ Selector.text """._950e85ab {
+    background-color:#333333;
+    padding:20px;
 }"""
-                        , Selector.text """._3f9bfad4 {
-    margin: 12px;
-    color: rgb(255, 255, 255);
+                        , Selector.text """._9052bb8e {
+    margin:12px;
+    color:rgb(255, 255, 255);
 }"""
-                        , Selector.text """._6b223ffd {
-    display: inline-block;
-    padding-bottom: 12px;
+                        , Selector.text """._7bfd0c7b {
+    display:inline-block;
+    padding-bottom:12px;
 }"""
-                        , Selector.text """._cdb78ed8 {
-    display: inline-block;
-    margin-left: 150px;
-    margin-right: 80px;
-    vertical-align: middle;
+                        , Selector.text """._33aa99cc {
+    display:inline-block;
+    margin-left:150px;
+    margin-right:80px;
+    vertical-align:middle;
 }"""
-                        , Selector.text """._d090bd45 {
-    background-color: #222222;
+                        , Selector.text """._1b2cec01 {
+    background-color:#222222;
 }"""
-                        , Selector.text """._dda19319 {
-    padding: 16px;
-    padding-left: 24px;
-    padding-right: 24px;
-    margin-left: 50px;
-    margin-right: auto;
-    color: rgb(255, 255, 255);
-    background-color: rgb(27, 217, 130);
-    vertical-align: middle;
+                        , Selector.text """._4503f439 {
+    padding:16px;
+    padding-left:24px;
+    padding-right:24px;
+    margin-left:50px;
+    margin-right:auto;
+    color:rgb(255, 255, 255);
+    background-color:rgb(27, 217, 130);
+    vertical-align:middle;
 }"""
                         ]
             )

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -30,7 +30,7 @@ divWidthHeight =
             Fixtures.divWidthHeight
 
         expected =
-            "div {\n    width: 32%;\n    height: 50px;\n}"
+            "div {\n    width:32%;\n    height:50px;\n}"
     in
     describe "basic div with fixed width and height"
         [ test "pretty prints the expected output" <|
@@ -49,18 +49,18 @@ simpleEach =
         output =
             """
             span {
-                width: 30px;
-                height: 2em;
+                width:30px;
+                height:2em;
             }
 
             html, body {
-                box-sizing: border-box;
-                display: none;
+                box-sizing:border-box;
+                display:none;
             }
 
             button {
-                color: rgb(22, 23, 24);
-                padding: 0;
+                color:rgb(22, 23, 24);
+                padding:0;
             }
       """
     in
@@ -81,19 +81,19 @@ leftRightTopBottom =
         output =
             """
             div {
-                position: absolute;
-                top: 2em;
-                left: 5px;
-                text-align: left;
-                vertical-align: bottom;
+                position:absolute;
+                top:2em;
+                left:5px;
+                text-align:left;
+                vertical-align:bottom;
             }
 
             a {
-                position: relative;
-                right: 0;
-                text-align: right;
-                bottom: 2em;
-                vertical-align: top;
+                position:relative;
+                right:0;
+                text-align:right;
+                bottom:2em;
+                vertical-align:top;
             }
         """
     in
@@ -114,23 +114,23 @@ atRule =
         output =
             """
           body {
-              padding: 0;
+              padding:0;
           }
 
           @media only print {
               body {
-                  margin: 2em;
+                  margin:2em;
               }
           }
 
           @media screen and ( max-width: 600px ) {
               body {
-                  margin: 3em;
+                  margin:3em;
               }
           }
 
           button {
-              margin: auto;
+              margin:auto;
           }
       """
     in
@@ -151,21 +151,21 @@ nestedAtRule =
         output =
             """
           button {
-              padding: 0;
+              padding:0;
           }
 
           body {
-              margin: auto;
+              margin:auto;
           }
 
           @media only print {
               body {
-                  margin: 2em;
+                  margin:2em;
               }
           }
 
           a {
-              text-decoration: none;
+              text-decoration:none;
           }
       """
     in
@@ -188,11 +188,11 @@ bug140 =
         output =
             """
 input:focus, select:focus, textarea:focus {
-    border-color: #000000;
+    border-color:#000000;
 }
 
 input::after, select::after, textarea::after {
-    color: #aaaaaa;
+    color:#aaaaaa;
 }
             """
     in
@@ -215,19 +215,19 @@ bug99 =
         output =
             """
 article {
-    margin: 0;
+    margin:0;
 }
 
 article > header {
-    margin: 1em;
+    margin:1em;
 }
 
 article > section {
-    margin: 2px;
+    margin:2px;
 }
 
 article > nav {
-    margin: 3%;
+    margin:3%;
 }        """
     in
     describe "Parents do not print duplicate rules for each child."
@@ -247,17 +247,17 @@ borders =
         output =
             """
             button {
-                border-left: 5px dashed rgb(11, 14, 17);
-                border-right: 7px;
-                border-image-outset: 3 4em;
+                border-left:5px dashed rgb(11, 14, 17);
+                border-right:7px;
+                border-image-outset:3 4em;
             }
 
             a {
-                border: 10px solid;
+                border:10px solid;
             }
 
             table {
-                border-spacing: 10px;
+                border-spacing:10px;
             }
         """
     in
@@ -278,36 +278,36 @@ multiDescendent =
         output =
             """
             html, body {
-              box-sizing: border-box;
-              display: none;
+              box-sizing:border-box;
+              display:none;
             }
 
             html > div, body > div {
-              width: 100%;
-              height: 100%;
+              width:100%;
+              height:100%;
             }
 
             h1, h2 {
-              padding: 0;
-              margin: 0;
+              padding:0;
+              margin:0;
             }
 
             h1 > h3, h2 > h3 {
-              width: 100%;
+              width:100%;
             }
 
             h1 > h3 > h4, h2 > h3 > h4 {
-              height: 100%;
+              height:100%;
             }
 
             span {
-              padding: 10px;
-              margin: 11px;
+              padding:10px;
+              margin:11px;
             }
 
             span > h2 > h1 {
-              width: 1px;
-              height: 2%;
+              width:1px;
+              height:2%;
             }
         """
     in
@@ -328,16 +328,16 @@ universal =
         output =
             """
           * {
-            display: none;
+            display:none;
           }
 
           * > * {
-            width: 100%;
-            height: 100%;
+            width:100%;
+            height:100%;
           }
 
           span > * {
-            margin: 11px;
+            margin:11px;
           }
         """
     in
@@ -358,14 +358,14 @@ multiSelector =
         output =
             """
           div.Page.Hidden {
-            display: none;
-            width: 100%;
-            height: 100%;
+            display:none;
+            width:100%;
+            height:100%;
           }
 
           span {
-            padding: 10px;
-            margin: 11px;
+            padding:10px;
+            margin:11px;
           }
         """
     in
@@ -386,8 +386,8 @@ keyValue =
         output =
             """
           body {
-            -webkit-font-smoothing: none;
-            -moz-font-smoothing: none !important;
+            -webkit-font-smoothing:none;
+            -moz-font-smoothing:none !important;
           }
         """
     in
@@ -408,11 +408,11 @@ underlineOnHoverStyle =
         output =
             """
             a {
-                color: rgb(128, 127, 126);
+                color:rgb(128, 127, 126);
             }
 
             a:hover {
-                color: rgb(23, 24, 25);
+                color:rgb(23, 24, 25);
             }
             """
     in
@@ -433,11 +433,11 @@ underlineOnHoverManual =
         output =
             """
             a {
-                color: rgb(128, 127, 126);
+                color:rgb(128, 127, 126);
             }
 
             a:hover {
-                color: rgb(23, 24, 25);
+                color:rgb(23, 24, 25);
             }
             """
     in
@@ -458,11 +458,11 @@ greenOnHoverStyle =
         output =
             """
             button {
-                color: rgb(11, 22, 33);
+                color:rgb(11, 22, 33);
             }
 
             button:hover {
-                color: rgb(0, 0, 122);
+                color:rgb(0, 0, 122);
             }
             """
     in
@@ -483,15 +483,15 @@ transformsStyle =
         output =
             """
             body {
-                transform: none;
-                transform: matrix(1, 2, 3, 4, 5, 6) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16);
-                transform: perspective(1);
-                transform: rotate(90deg) rotateX(3.14rad) rotateY(3.14grad) rotateZ(1turn) rotate3d(1, 1, 1, 90deg);
-                transform: scale(1) scale(1, 1) scaleX(1) scaleY(1) scale3d(1, 1, 1);
-                transform: skew(90deg) skew(90deg, 90deg) skewX(90deg) skewY(90deg);
-                transform: translate(1px) translate(1px, 1px) translateX(1px) translateY(1px) translate3d(1px, 1px, 1px);
-                transform-box: view-box;
-                transform-style: preserve-3d;
+                transform:none;
+                transform:matrix(1, 2, 3, 4, 5, 6) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16);
+                transform:perspective(1);
+                transform:rotate(90deg) rotateX(3.14rad) rotateY(3.14grad) rotateZ(1turn) rotate3d(1, 1, 1, 90deg);
+                transform:scale(1) scale(1, 1) scaleX(1) scaleY(1) scale3d(1, 1, 1);
+                transform:skew(90deg) skew(90deg, 90deg) skewX(90deg) skewY(90deg);
+                transform:translate(1px) translate(1px, 1px) translateX(1px) translateY(1px) translate3d(1px, 1px, 1px);
+                transform-box:view-box;
+                transform-style:preserve-3d;
             }
             """
     in
@@ -512,16 +512,16 @@ fonts =
         output =
             """
             body {
-                line-height: 14px;
-                font-family: serif;
-                font-family: "Gill Sans Extrabold", Helvetica, sans-serif;
-                font-size: x-small;
-                font-style: italic;
-                font-weight: bold;
-                font-weight: 100;
-                font-variant: small-caps;
-                font-variant: common-ligatures slashed-zero;
-                font-variant-numeric: oldstyle-nums tabular-nums stacked-fractions ordinal slashed-zero;
+                line-height:14px;
+                font-family:serif;
+                font-family:"Gill Sans Extrabold", Helvetica, sans-serif;
+                font-size:x-small;
+                font-style:italic;
+                font-weight:bold;
+                font-weight:100;
+                font-variant:small-caps;
+                font-variant:common-ligatures slashed-zero;
+                font-variant-numeric:oldstyle-nums tabular-nums stacked-fractions ordinal slashed-zero;
             }
             """
     in
@@ -542,20 +542,20 @@ pseudoElements =
         output =
             """
             #Page {
-                margin: 10px;
-                color: #aaa;
+                margin:10px;
+                color:#aaa;
             }
 
             #Page::before {
-                color: #fff;
+                color:#fff;
             }
 
             #Page::after {
-                color: #000;
+                color:#000;
             }
 
             #Page::-webkit-scrollbar {
-                display: none;
+                display:none;
             }
             """
     in
@@ -576,28 +576,28 @@ pseudoClasses =
         output =
             """
             #Page {
-                color: #fff;
-                background-color: #aaa;
+                color:#fff;
+                background-color:#aaa;
             }
 
             #Page:hover {
-                margin-top: 10px;
+                margin-top:10px;
             }
 
             #Page:hover:focus {
-                color: #000;
+                color:#000;
             }
 
             #Page:first {
-                font-size: 3em;
+                font-size:3em;
             }
 
             #Page:disabled {
-                margin-top: 20px;
+                margin-top:20px;
             }
 
             #Page:any-link {
-                color: #f00;
+                color:#f00;
             }
             """
     in
@@ -618,44 +618,44 @@ backgrounds =
         output =
             """
             div {
-                background-color: rgb(128, 127, 126);
-                background-repeat: repeat-x;
-                background-repeat: repeat-y;
-                background-repeat: repeat no-repeat;
-                background-repeat: space round;
-                background-attachment: local;
-                background-attachment: scroll;
-                background-attachment: fixed;
-                background-blend-mode: color;
-                background-blend-mode: screen;
-                background-blend-mode: multiply;
-                background-blend-mode: overlay;
-                background-blend-mode: darken;
-                background-blend-mode: lighten;
-                background-blend-mode: color-dodge;
-                background-blend-mode: color-burn;
-                background-blend-mode: hard-light;
-                background-blend-mode: soft-light;
-                background-blend-mode: difference;
-                background-blend-mode: exclusion;
-                background-blend-mode: hue;
-                background-blend-mode: saturation;
-                background-blend-mode: luminosity;
-                background-clip: border-box;
-                background-clip: padding-box;
-                background-clip: content-box;
-                background-image: url(http://example.com/elm.png);
-                background-image: linear-gradient(#111, rgb(16, 32, 64), #222 25px);
-                background-image: linear-gradient(to left, #111, #222);
-                background-origin: border-box;
-                background-origin: padding-box;
-                background-origin: content-box;
-                background-size: cover;
-                background-size: contain;
-                background-size: 50px;
-                background-size: auto 20px;
-                background-position: center;
-                background-position: 10% 0;
+                background-color:rgb(128, 127, 126);
+                background-repeat:repeat-x;
+                background-repeat:repeat-y;
+                background-repeat:repeat no-repeat;
+                background-repeat:space round;
+                background-attachment:local;
+                background-attachment:scroll;
+                background-attachment:fixed;
+                background-blend-mode:color;
+                background-blend-mode:screen;
+                background-blend-mode:multiply;
+                background-blend-mode:overlay;
+                background-blend-mode:darken;
+                background-blend-mode:lighten;
+                background-blend-mode:color-dodge;
+                background-blend-mode:color-burn;
+                background-blend-mode:hard-light;
+                background-blend-mode:soft-light;
+                background-blend-mode:difference;
+                background-blend-mode:exclusion;
+                background-blend-mode:hue;
+                background-blend-mode:saturation;
+                background-blend-mode:luminosity;
+                background-clip:border-box;
+                background-clip:padding-box;
+                background-clip:content-box;
+                background-image:url(http://example.com/elm.png);
+                background-image:linear-gradient(#111, rgb(16, 32, 64), #222 25px);
+                background-image:linear-gradient(to left, #111, #222);
+                background-origin:border-box;
+                background-origin:padding-box;
+                background-origin:content-box;
+                background-size:cover;
+                background-size:contain;
+                background-size:50px;
+                background-size:auto 20px;
+                background-position:center;
+                background-position:10% 0;
             }
         """
     in
@@ -674,7 +674,7 @@ bug280 =
             Fixtures.mediaQueryIndentation
 
         actual =
-            "@media (max-width: 515px) {\n    .mdl-layout__header > .mdl-layout-icon {\n        display: none;\n    }\n}"
+            "@media (max-width: 515px) {\n    .mdl-layout__header > .mdl-layout-icon {\n        display:none;\n    }\n}"
     in
     describe "bug280"
         [ test "pretty prints the expected output" <|
@@ -693,7 +693,7 @@ nestedEach =
         output =
             """
             span, span:focus, span:focus:hover, span  span:active {
-                color: #FF0000;
+                color:#FF0000;
             }
             """
     in


### PR DESCRIPTION
Removes the space after `:` in e.g. `display: none` (making it `display:none` instead) since we're doing things at runtime now and don't want to send all those whitespace bytes to critical CSS for the sake of pretty printing.

Depends on https://github.com/rtfeldman/elm-css/pull/368 - do not merge until that is merged!