### PR TITLE
Use `type alias` for `Property`

### DIFF
--- a/src/Css.elm
+++ b/src/Css.elm
@@ -1082,7 +1082,7 @@ Other notes:
 getOverloadedProperty : String -> String -> Style -> Style
 getOverloadedProperty functionName desiredKey style =
     case style of
-        Preprocess.AppendProperty (Property str) ->
+        Preprocess.AppendProperty str ->
             let
                 key =
                     String.split ":" str
@@ -1775,15 +1775,15 @@ declaration.
 -}
 important : Style -> Style
 important =
-    Preprocess.mapLastProperty (\(Property str) -> Property (makeImportant str))
+    Preprocess.mapLastProperty makeImportant
 
 
-makeImportant : String -> String
-makeImportant value =
-    if String.endsWith " !important" (String.toLower value) then
-        value
+makeImportant : Property -> Property
+makeImportant str =
+    if String.endsWith " !important" (String.toLower str) then
+        str
     else
-        value ++ " !important"
+        str ++ " !important"
 
 
 {-| A [`ColorValue`](#ColorValue) that does not have `red`, `green`, or `blue`
@@ -7758,7 +7758,7 @@ batch =
 -}
 property : String -> String -> Style
 property key value =
-    Property (key ++ ":" ++ value)
+    (key ++ ":" ++ value)
         |> Preprocess.AppendProperty
 
 

--- a/src/Css/Preprocess.elm
+++ b/src/Css/Preprocess.elm
@@ -4,7 +4,7 @@ module Css.Preprocess exposing (..)
 the data structures found in this module.
 -}
 
-import Css.Structure as Structure exposing (MediaQuery, Property(Property), concatMapLast, mapLast)
+import Css.Structure as Structure exposing (MediaQuery, Property, concatMapLast, mapLast)
 
 
 stylesheet : List Snippet -> Stylesheet
@@ -135,7 +135,7 @@ toPropertyStrings styles =
         [] ->
             []
 
-        (AppendProperty (Property str)) :: rest ->
+        (AppendProperty str) :: rest ->
             str :: toPropertyStrings rest
 
         (ApplyStyles styles) :: rest ->

--- a/src/Css/Structure.elm
+++ b/src/Css/Structure.elm
@@ -17,9 +17,14 @@ type alias Number compatible =
 
 
 {-| A property consisting of a key:value string.
+
+Ideally, this would be `type Property = Property String` - but in order to
+reduce allocations, we're doing it as a `type alias` until union types with
+one constructor get unboxed automatically.
+
 -}
-type Property
-    = Property String
+type alias Property =
+    String
 
 
 {-| A stylesheet. Since they follow such specific rules, the following at-rules

--- a/src/Css/Structure/Output.elm
+++ b/src/Css/Structure/Output.elm
@@ -229,7 +229,7 @@ combinatorToString combinator =
 
 
 emitProperty : Property -> String
-emitProperty (Property str) =
+emitProperty str =
     str ++ ";"
 
 


### PR DESCRIPTION
This will reduce allocations until we have automatic unboxing of single-constructor union types. At that point, this can be reverted with no runtime downside!