### PR TITLE
Add withAttribute

### DIFF
--- a/src/Css/Foreign.elm
+++ b/src/Css/Foreign.elm
@@ -83,6 +83,7 @@ module Css.Foreign
         , typeSelector
         , ul
         , video
+        , withAttribute
         , withClass
         )
 
@@ -107,7 +108,7 @@ third-party DOM nodes!
 
 # Combinators
 
-@docs children, descendants, adjacentSiblings, generalSiblings, each, withClass
+@docs children, descendants, adjacentSiblings, generalSiblings, each, withAttribute, withClass
 
 
 # Basic elements
@@ -362,6 +363,12 @@ children =
 withClass : class -> List Style -> Style
 withClass class =
     Preprocess.ExtendSelector (Structure.ClassSelector (identifierToString "" class))
+
+
+{-| -}
+withAttribute : String -> List Style -> Style
+withAttribute attribute =
+    Preprocess.ExtendSelector (Structure.AttributeSelector attribute)
 
 
 {-| -}

--- a/src/Css/Structure.elm
+++ b/src/Css/Structure.elm
@@ -125,6 +125,7 @@ type RepeatableSimpleSelector
     = ClassSelector String
     | IdSelector String
     | PseudoClassSelector String
+    | AttributeSelector String
 
 
 {-| A type selector. That's what the CSS spec calls them, but it could be

--- a/src/Css/Structure/Output.elm
+++ b/src/Css/Structure/Output.elm
@@ -182,6 +182,9 @@ repeatableSimpleSelectorToString repeatableSimpleSelector =
         PseudoClassSelector str ->
             ":" ++ str
 
+        AttributeSelector str ->
+            "[" ++ str ++ "]"
+
 
 selectorChainToString : ( SelectorCombinator, SimpleSelectorSequence ) -> String
 selectorChainToString ( combinator, sequence ) =

--- a/tests/Fixtures.elm
+++ b/tests/Fixtures.elm
@@ -181,6 +181,20 @@ multiSelector =
         ]
 
 
+attributeCombinator : Stylesheet
+attributeCombinator =
+    stylesheet
+        [ typeSelector "custom-element-one"
+            [ withAttribute "data-custom-attribute" [ display none ]
+            ]
+        , typeSelector "custom-element-two"
+            [ withAttribute "data-custom-attribute=value"
+                [ withAttribute "data-other-attribute" [ display none ]
+                ]
+            ]
+        ]
+
+
 keyValue : Stylesheet
 keyValue =
     stylesheet

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -377,6 +377,31 @@ multiSelector =
         ]
 
 
+attributeCombinator : Test
+attributeCombinator =
+    let
+        input =
+            Fixtures.attributeCombinator
+
+        output =
+            """
+          custom-element-one[data-custom-attribute] {
+            display:none;
+          }
+
+          custom-element-two[data-custom-attribute=value][data-other-attribute] {
+            display:none;
+          }
+            """
+    in
+    describe "withAttribute combinator"
+        [ test "pretty prints the expected output" <|
+            \_ ->
+                outdented (prettyPrint input)
+                    |> Expect.equal (outdented output)
+        ]
+
+
 keyValue : Test
 keyValue =
     let


### PR DESCRIPTION
This combinator allows for extending a selector with additional [attribute selectors](https://developer.mozilla.org/en-US/docs/Web/CSS/Attribute_selectors)

```elm
import Css exposing (display, none)
import Css.Foreign exposing (withAttribute, typeSelector)

typeSelector "custom-element"
  [ withAttribute "data-custom-attribute" [ display none ]
  , withAttribute "data-custom-attribute=true" [ display none ]
  ]
```

results in
```css
custom-element[data-custom-attribute] {
  display:none;
}

custom-element[data-custom-attribute=true] {
  display:none;
}
```

This is just meant as a primitive for building inline attribute selectors. Type-safe versions of the various attribute value comparison operators can be added later or separately.