### PR TITLE
fix docs typo form snake to kebap case

### DIFF
--- a/src/Css.elm
+++ b/src/Css.elm
@@ -794,7 +794,7 @@ Let's take a look at some of these declarations.
 
 This compiles to the CSS declaration `display: inline-block;` -
 
-_Snake-case_ CSS names become _camelCase_ names in elm-css.
+_Kebap-case_ CSS names become _camelCase_ names in elm-css.
 
 The [`Css.display`](#display) function only accepts values that are compatible
 with the CSS `display` property, such as [`inlineBlock`](#inlineBlock), [`flex`](#flex), [`none`](#none), [`inherit`](#inherit), etc.


### PR DESCRIPTION
The docs have a small error here
> Snake-case CSS names become camelCase names in elm-css.

because CSS names are kebap case (dashes) not snake case (underscores).