### PR TITLE
Phantom types background image

### DIFF
--- a/src/Css.elm
+++ b/src/Css.elm
@@ -3222,7 +3222,7 @@ linearGradient :
     Value { colorStop : Supported }
     -> Value { colorStop : Supported }
     -> List (Value { colorStop : Supported })
-    -> Style
+    -> Value { provides | linearGradient : Supported }
 linearGradient (Value firstStop) (Value secondStop) moreStops =
     let
         peeledStops =
@@ -3231,7 +3231,7 @@ linearGradient (Value firstStop) (Value secondStop) moreStops =
         stops =
             String.join "," (firstStop :: secondStop :: peeledStops)
     in
-    AppendProperty ("linear-gradient(" ++ stops ++ ")")
+    Value ("linear-gradient(" ++ stops ++ ")")
 
 
 {-| Sets [`linear-gradient`](https://developer.mozilla.org/en-US/docs/Web/CSS/linear-gradient), providing an angle.
@@ -3254,7 +3254,7 @@ linearGradient2 :
     -> Value { colorStop : Supported }
     -> Value { colorStop : Supported }
     -> List (Value { colorStop : Supported })
-    -> Style
+    -> Value { provides | linearGradient : Supported }
 linearGradient2 (Value angle) (Value firstStop) (Value secondStop) moreStops =
     let
         peeledStops =
@@ -3263,7 +3263,7 @@ linearGradient2 (Value angle) (Value firstStop) (Value secondStop) moreStops =
         stops =
             String.join "," (firstStop :: secondStop :: peeledStops)
     in
-    AppendProperty ("linear-gradient(" ++ angle ++ "," ++ stops ++ ")")
+    Value ("linear-gradient(" ++ angle ++ "," ++ stops ++ ")")
 
 
 {-| Provides a stop for a [gradient](https://developer.mozilla.org/en-US/docs/Web/CSS/linear-gradient).

--- a/src/Css.elm
+++ b/src/Css.elm
@@ -37,7 +37,7 @@ module Css
         , bold
         , bolder
         , borderBox
-        , bottom
+        , bottom_
         , boxShadow
         , cell
         , center
@@ -218,7 +218,7 @@ module Css
         , titlingCaps
         , to
         , toCorner
-        , top
+        , top_
         , turn
         , unicase
         , unsafeCenter
@@ -373,7 +373,7 @@ All CSS properties can have the values `unset`, `initial`, and `inherit`.
 
 # Align Items
 
-@docs normal, stretch, center, start, end, flexStart, flexEnd, selfStart, selfEnd, left, right, top, bottom, baseline, firstBaseline, lastBaseline, safeCenter, unsafeCenter
+@docs normal, stretch, center, start, end, flexStart, flexEnd, selfStart, selfEnd, left, right, top_, bottom_, baseline, firstBaseline, lastBaseline, safeCenter, unsafeCenter
 
 
 # Url
@@ -1443,15 +1443,23 @@ right =
     Value "right"
 
 
-{-| -}
-top : Value { provides | top : Supported }
-top =
+{-| The `top` value used in [`color stops`](#stop).
+
+The value is called `top_` instead of `top` because [`top` is already a function](#top).
+
+-}
+top_ : Value { provides | top_ : Supported }
+top_ =
     Value "top"
 
 
-{-| -}
-bottom : Value { provides | bottom : Supported }
-bottom =
+{-| The `bottom` value value used in [`color stops`](#stop).
+
+The value is called `bottom_` instead of `bottom` because [`bottom` is already a function](#bottom).
+
+-}
+bottom_ : Value { provides | bottom_ : Supported }
+bottom_ =
     Value "bottom"
 
 
@@ -3295,7 +3303,7 @@ linearGradient (Value firstStop) (Value secondStop) moreStops =
 
     linearGradient2 (deg 90) (stop red) (stop blue) []
 
-    linearGradient2 (top left) (stop red) (stop blue) []
+    linearGradient2 (top_ left) (stop red) (stop blue) []
 
 See also [`linearGradient`](#linearGradient) if you don't need to set the angle.
 
@@ -3369,15 +3377,17 @@ stop2 (Value color) (Value position) =
 
 {-| Provides the special [`to` side angle](https://developer.mozilla.org/en-US/docs/Web/CSS/linear-gradient) for gradients.
 
-    to top
+    to top_
 
 See also [`toCorner`](#to) for a corner.
+
+**Note:** This function accepts `top_`, `bottom_`, `left_`, and `right_`, because the plain versions (e.g. [`top`](#top)) are position functions!
 
 -}
 to :
     Value
-        { top : Supported
-        , bottom : Supported
+        { top_ : Supported
+        , bottom_ : Supported
         , left : Supported
         , right : Supported
         }
@@ -3388,15 +3398,17 @@ to (Value direction) =
 
 {-| Provides the special [`to` corner angle](https://developer.mozilla.org/en-US/docs/Web/CSS/linear-gradient) for gradients.
 
-    toCorner top left
+    toCorner top_ left
 
-    toCorner bottom right
+    toCorner bottom_ right
 
 See also [`to`](#to) for a side.
 
+**Note:** This function accepts `top_`, `bottom_`, `left_`, and `right_`, because the plain versions (e.g. [`top`](#top)) are position functions!
+
 -}
 toCorner :
-    Value { top : Supported, bottom : Supported }
+    Value { top_ : Supported, bottom_ : Supported }
     -> Value { left : Supported, right : Supported }
     -> Value { supported | to : Supported }
 toCorner (Value topBottom) (Value leftRight) =

--- a/src/Css.elm
+++ b/src/Css.elm
@@ -118,6 +118,7 @@ module Css
         , left
         , lighten
         , lighter
+        , linearGradient
         , liningNums
         , listStyle
         , listStyle2
@@ -188,6 +189,8 @@ module Css
         , solid
         , stackedFractions
         , start
+        , stop
+        , stop2
         , stretch
         , swResize
         , systemUi
@@ -282,6 +285,11 @@ All CSS properties can have the values `unset`, `initial`, and `inherit`.
 ## Background Clip and Origin
 
 @docs backgroundClip, backgroundClips, backgroundOrigin, backgroundOrigins, borderBox, paddingBox, contentBox, text_
+
+
+## Background Image
+
+@docs linearGradient, stop, stop2
 
 
 ## Box Shadow
@@ -3169,6 +3177,71 @@ backgroundOrigins firstValue values =
                 |> String.join ","
     in
     AppendProperty ("background-origin:" ++ str)
+
+
+{-| Sets [`linear-gradient`](https://developer.mozilla.org/en-US/docs/Web/CSS/linear-gradient)
+
+    linearGradient (stop red) (stop blue) []
+
+-}
+linearGradient :
+    Value { colorStop : Supported }
+    -> Value { colorStop : Supported }
+    -> List (Value { colorStop : Supported })
+    -> Style
+linearGradient (Value firstStop) (Value secondStop) moreStops =
+    let
+        peeledStops =
+            List.map (\(Value stop) -> stop) moreStops
+
+        stops =
+            String.join "," (firstStop :: secondStop :: peeledStops)
+    in
+    AppendProperty ("linear-gradient(" ++ stops ++ ")")
+
+
+{-| Provides a stop for a [gradient](https://developer.mozilla.org/en-US/docs/Web/CSS/linear-gradient).
+
+    stop red
+
+See also [`stop2`](#stop2) for controlling stop positioning.
+
+-}
+stop : Color -> Value { provides | colorStop : Supported }
+stop (Value color) =
+    Value color
+
+
+{-| Provides a stop for a [gradient](https://developer.mozilla.org/en-US/docs/Web/CSS/linear-gradient).
+
+    stop2 red (px 20)
+
+See also [`stop`](#stop) if you don't need to control the stop position.
+
+-}
+stop2 :
+    Color
+    ->
+        Value
+            { px : Supported
+            , em : Supported
+            , ex : Supported
+            , ch : Supported
+            , rem : Supported
+            , vh : Supported
+            , vw : Supported
+            , vmin : Supported
+            , vmax : Supported
+            , mm : Supported
+            , cm : Supported
+            , inches : Supported
+            , pt : Supported
+            , pc : Supported
+            , pct : Supported
+            }
+    -> Value { supported | colorStop : Supported }
+stop2 (Value color) (Value position) =
+    Value (color ++ " " ++ position)
 
 
 

--- a/src/Css.elm
+++ b/src/Css.elm
@@ -59,6 +59,7 @@ module Css
         , dashed
         , default
         , defaultBoxShadow
+        , deg
         , devanagari
         , diagonalFractions
         , difference
@@ -89,6 +90,7 @@ module Css
         , georgian
         , grab
         , grabbing
+        , grad
         , grid
         , groove
         , gujarati
@@ -165,6 +167,7 @@ module Css
         , pseudoElement
         , pt
         , px
+        , rad
         , rem
         , revert
         , rgb
@@ -210,6 +213,7 @@ module Css
         , text_
         , thai
         , titlingCaps
+        , turn
         , unicase
         , unsafeCenter
         , unset
@@ -389,6 +393,11 @@ All CSS properties can have the values `unset`, `initial`, and `inherit`.
 Multiple CSS properties use these values.
 
 @docs auto, none
+
+
+## Angles
+
+@docs deg, grad, rad, turn
 
 -}
 
@@ -3479,3 +3488,55 @@ inset =
 outset : Value { provides | outset : Supported }
 outset =
     Value "outset"
+
+
+
+-- ANGLES --
+
+
+{-| A [`deg` angle](https://developer.mozilla.org/en-US/docs/Web/CSS/angle)
+
+    deg 360 -- one full circle
+
+    deg 14.23
+
+-}
+deg : Float -> Value { provides | deg : Supported }
+deg degrees =
+    Value (toString degrees ++ "deg")
+
+
+{-| A [`grad` angle](https://developer.mozilla.org/en-US/docs/Web/CSS/angle)
+
+    grad 400 -- one full circle
+
+    grad 38.8
+
+-}
+grad : Float -> Value { provides | grad : Supported }
+grad gradians =
+    Value (toString gradians ++ "grad")
+
+
+{-| A [`rad` angle](https://developer.mozilla.org/en-US/docs/Web/CSS/angle)
+
+    rad 6.2832 -- approximately one full circle
+
+    rad 1
+
+-}
+rad : Float -> Value { provides | rad : Supported }
+rad radians =
+    Value (toString radians ++ "rad")
+
+
+{-| A [`turn` angle](https://developer.mozilla.org/en-US/docs/Web/CSS/angle)
+
+    turn 1 -- one full circle
+
+    turn 0.25
+
+-}
+turn : Float -> Value { provides | turn : Supported }
+turn turns =
+    Value (toString turns ++ "turn")

--- a/src/Css.elm
+++ b/src/Css.elm
@@ -3341,7 +3341,7 @@ linearGradient2 (Value angle) (Value firstStop) (Value secondStop) moreStops =
 
 {-| Provides a stop for a [gradient](https://developer.mozilla.org/en-US/docs/Web/CSS/linear-gradient).
 
-    stop red
+    linearGradient (to top) (stop red) (stop blue) []
 
 See also [`stop2`](#stop2) for controlling stop positioning.
 
@@ -3353,7 +3353,7 @@ stop (Value color) =
 
 {-| Provides a stop for a [gradient](https://developer.mozilla.org/en-US/docs/Web/CSS/linear-gradient).
 
-    stop2 red (px 20)
+    linearGradient (to top) (stop2 red (px 20)) (stop blue) []
 
 See also [`stop`](#stop) if you don't need to control the stop position.
 

--- a/src/Css.elm
+++ b/src/Css.elm
@@ -119,6 +119,7 @@ module Css
         , lighten
         , lighter
         , linearGradient
+        , linearGradient2
         , liningNums
         , listStyle
         , listStyle2
@@ -289,7 +290,7 @@ All CSS properties can have the values `unset`, `initial`, and `inherit`.
 
 ## Background Image
 
-@docs linearGradient, stop, stop2
+@docs linearGradient, linearGradient2, stop, stop2
 
 
 ## Box Shadow
@@ -3183,6 +3184,10 @@ backgroundOrigins firstValue values =
 
     linearGradient (stop red) (stop blue) []
 
+    linearGradient (stop red) (stop blue) [ stop green ]
+
+See also [`linearGradient2`](#linearGradient2) if you don't need to set the angle.
+
 -}
 linearGradient :
     Value { colorStop : Supported }
@@ -3198,6 +3203,32 @@ linearGradient (Value firstStop) (Value secondStop) moreStops =
             String.join "," (firstStop :: secondStop :: peeledStops)
     in
     AppendProperty ("linear-gradient(" ++ stops ++ ")")
+
+
+{-| Sets [`linear-gradient`](https://developer.mozilla.org/en-US/docs/Web/CSS/linear-gradient), providing an angle.
+
+    linearGradient2 (deg 90) (stop red) (stop blue) []
+
+    linearGradient2 (top left) (stop red) (stop blue) []
+
+See also [`linearGradient`](#linearGradient) if you don't need to set the angle.
+
+-}
+linearGradient2 :
+    Value { deg : Supported }
+    -> Value { colorStop : Supported }
+    -> Value { colorStop : Supported }
+    -> List (Value { colorStop : Supported })
+    -> Style
+linearGradient2 (Value angle) (Value firstStop) (Value secondStop) moreStops =
+    let
+        peeledStops =
+            List.map (\(Value stop) -> stop) moreStops
+
+        stops =
+            String.join "," (firstStop :: secondStop :: peeledStops)
+    in
+    AppendProperty ("linear-gradient(" ++ angle ++ "," ++ stops ++ ")")
 
 
 {-| Provides a stop for a [gradient](https://developer.mozilla.org/en-US/docs/Web/CSS/linear-gradient).

--- a/src/Css.elm
+++ b/src/Css.elm
@@ -1433,7 +1433,7 @@ selfEnd =
 
 {-| The `left` value used for alignment.
 
-The value is called `left_` instead of `left` because [`left` is already a function](left).
+The value is called `left_` instead of `left` because [`left` is already a function](#left).
 
 -}
 left_ : Value { provides | left_ : Supported }
@@ -1443,7 +1443,7 @@ left_ =
 
 {-| The `right` value used for alignment.
 
-The value is called `right_` instead of `right` because [`right` is already a function](right).
+The value is called `right_` instead of `right` because [`right` is already a function](#right).
 
 -}
 right_ : Value { provides | right_ : Supported }

--- a/src/Css.elm
+++ b/src/Css.elm
@@ -3295,6 +3295,7 @@ linearGradient :
         , grad : Supported
         , rad : Supported
         , turn : Supported
+        , zero : Supported
         }
     -> Value { colorStop : Supported }
     -> Value { colorStop : Supported }
@@ -3334,21 +3335,22 @@ stop2 :
     Color
     ->
         Value
-            { px : Supported
+            { ch : Supported
+            , cm : Supported
             , em : Supported
             , ex : Supported
-            , ch : Supported
-            , rem : Supported
-            , vh : Supported
-            , vw : Supported
-            , vmin : Supported
-            , vmax : Supported
-            , mm : Supported
-            , cm : Supported
             , inches : Supported
-            , pt : Supported
+            , mm : Supported
             , pc : Supported
             , pct : Supported
+            , pt : Supported
+            , px : Supported
+            , rem : Supported
+            , vh : Supported
+            , vmax : Supported
+            , vmin : Supported
+            , vw : Supported
+            , zero : Supported
             }
     -> Value { supported | colorStop : Supported }
 stop2 (Value color) (Value position) =

--- a/src/Css.elm
+++ b/src/Css.elm
@@ -214,6 +214,8 @@ module Css
         , text_
         , thai
         , titlingCaps
+        , to
+        , toCorner
         , top
         , turn
         , unicase
@@ -296,7 +298,7 @@ All CSS properties can have the values `unset`, `initial`, and `inherit`.
 
 ## Background Image
 
-@docs linearGradient, linearGradient2, stop, stop2
+@docs linearGradient, linearGradient2, stop, stop2, to, toCorner
 
 
 ## Box Shadow
@@ -3300,6 +3302,42 @@ stop2 :
     -> Value { supported | colorStop : Supported }
 stop2 (Value color) (Value position) =
     Value (color ++ " " ++ position)
+
+
+{-| Provides the special [`to` side angle](https://developer.mozilla.org/en-US/docs/Web/CSS/linear-gradient) for gradients.
+
+    to top
+
+See also [`toCorner`](#to) for a corner.
+
+-}
+to :
+    Value
+        { top : Supported
+        , bottom : Supported
+        , left : Supported
+        , right : Supported
+        }
+    -> Value { supported | to : Supported }
+to (Value direction) =
+    Value ("to " ++ direction)
+
+
+{-| Provides the special [`to` corner angle](https://developer.mozilla.org/en-US/docs/Web/CSS/linear-gradient) for gradients.
+
+    toCorner top left
+
+    toCorner bottom right
+
+See also [`to`](#to) for a side.
+
+-}
+toCorner :
+    Value { top : Supported, bottom : Supported }
+    -> Value { left : Supported, right : Supported }
+    -> Value { supported | to : Supported }
+toCorner (Value topBottom) (Value leftRight) =
+    Value ("to " ++ topBottom ++ " " ++ leftRight)
 
 
 

--- a/src/Css.elm
+++ b/src/Css.elm
@@ -26,6 +26,7 @@ module Css
         , backgroundClips
         , backgroundColor
         , backgroundImage
+        , backgroundImages
         , backgroundOrigin
         , backgroundOrigins
         , baseline
@@ -299,7 +300,7 @@ All CSS properties can have the values `unset`, `initial`, and `inherit`.
 
 ## Background Image
 
-@docs backgroundImage
+@docs backgroundImage, backgroundImages
 
 @docs linearGradient, linearGradient2, stop, stop2, to, toCorner
 
@@ -3214,6 +3215,8 @@ backgroundOrigins firstValue values =
 
     backgroundImage (linearGradient (stop red) (stop blue))
 
+See also [`backgroundImage`](#backgroundImage) if you need multiple images.
+
 -}
 backgroundImage :
     Value
@@ -3224,6 +3227,39 @@ backgroundImage :
     -> Style
 backgroundImage (Value value) =
     AppendProperty ("background-image:" ++ value)
+
+
+{-| Sets [`background-image`](https://css-tricks.com/almanac/properties/b/background-image/) for multiple images.
+
+    backgroundImages
+        (linearGradient (stop red) (stop blue))
+        [ url "http://www.example.com/chicken.jpg" ]
+
+See also [`backgroundImage`](#backgroundImage) if you need only one.
+
+-}
+backgroundImages :
+    Value
+        { url : Supported
+        , linearGradient : Supported
+        }
+    ->
+        List
+            (Value
+                { url : Supported
+                , linearGradient : Supported
+                }
+            )
+    -> Style
+backgroundImages (Value first) rest =
+    let
+        peeled =
+            List.map (\(Value value) -> value) rest
+
+        values =
+            String.join "," (first :: peeled)
+    in
+    AppendProperty ("background-image:" ++ values)
 
 
 

--- a/src/Css.elm
+++ b/src/Css.elm
@@ -3189,6 +3189,10 @@ backgroundOrigins firstValue values =
     AppendProperty ("background-origin:" ++ str)
 
 
+
+{- GRADIENTS -}
+
+
 {-| Sets [`linear-gradient`](https://developer.mozilla.org/en-US/docs/Web/CSS/linear-gradient)
 
     linearGradient (stop red) (stop blue) []

--- a/src/Css.elm
+++ b/src/Css.elm
@@ -3244,7 +3244,13 @@ See also [`linearGradient`](#linearGradient) if you don't need to set the angle.
 
 -}
 linearGradient2 :
-    Value { deg : Supported }
+    Value
+        { to : Supported
+        , deg : Supported
+        , grad : Supported
+        , rad : Supported
+        , turn : Supported
+        }
     -> Value { colorStop : Supported }
     -> Value { colorStop : Supported }
     -> List (Value { colorStop : Supported })

--- a/src/Css.elm
+++ b/src/Css.elm
@@ -3385,9 +3385,11 @@ stop2 (Value color) (Value position) =
 
 {-| Provides the special [`to` side angle](https://developer.mozilla.org/en-US/docs/Web/CSS/linear-gradient) for gradients.
 
-    to top_
+    linearGradient (to top_) (stop red) (stop blue) []
 
-See also [`toCorner`](#to) for a corner.
+If you want your gradient to go to a corner, use [`toCorner`](#toCorner):
+
+    linearGradient (toCorner top_ left_) (stop red) (stop blue) []
 
 **Note:** This function accepts `top_`, `bottom_`, `left_`, and `right_`, because the plain versions (e.g. [`top`](#top)) are position functions!
 
@@ -3406,9 +3408,13 @@ to (Value direction) =
 
 {-| Provides the special [`to` corner angle](https://developer.mozilla.org/en-US/docs/Web/CSS/linear-gradient) for gradients.
 
-    toCorner top_ left_
+    linearGradient (toCorner top_ left_) (stop red) (stop blue) []
 
-    toCorner bottom_ right_
+    linearGradient (toCorner bottom_ right_) (stop red) (stop blue) []
+
+If you want your gradient to go to a side, use [`to`](#to):
+
+    linearGradient (to top_) (stop red) (stop blue) []
 
 See also [`to`](#to) for a side.
 

--- a/src/Css.elm
+++ b/src/Css.elm
@@ -120,7 +120,7 @@ module Css
         , large
         , larger
         , lastBaseline
-        , left
+        , left_
         , lighten
         , lighter
         , linearGradient
@@ -373,7 +373,7 @@ All CSS properties can have the values `unset`, `initial`, and `inherit`.
 
 # Align Items
 
-@docs normal, stretch, center, start, end, flexStart, flexEnd, selfStart, selfEnd, left, right, top_, bottom_, baseline, firstBaseline, lastBaseline, safeCenter, unsafeCenter
+@docs normal, stretch, center, start, end, flexStart, flexEnd, selfStart, selfEnd, left_, right, top_, bottom_, baseline, firstBaseline, lastBaseline, safeCenter, unsafeCenter
 
 
 # Url
@@ -1431,9 +1431,13 @@ selfEnd =
     Value "self-end"
 
 
-{-| -}
-left : Value { provides | left : Supported }
-left =
+{-| The `left` value used for alignment.
+
+The value is called `left_` instead of `left` because [`left` is already a funciton](left).
+
+-}
+left_ : Value { provides | left_ : Supported }
+left_ =
     Value "left"
 
 
@@ -3303,7 +3307,7 @@ linearGradient (Value firstStop) (Value secondStop) moreStops =
 
     linearGradient2 (deg 90) (stop red) (stop blue) []
 
-    linearGradient2 (top_ left) (stop red) (stop blue) []
+    linearGradient2 (toCorner top_ left_) (stop red) (stop blue) []
 
 See also [`linearGradient`](#linearGradient) if you don't need to set the angle.
 
@@ -3388,7 +3392,7 @@ to :
     Value
         { top_ : Supported
         , bottom_ : Supported
-        , left : Supported
+        , left_ : Supported
         , right : Supported
         }
     -> Value { supported | to : Supported }
@@ -3398,7 +3402,7 @@ to (Value direction) =
 
 {-| Provides the special [`to` corner angle](https://developer.mozilla.org/en-US/docs/Web/CSS/linear-gradient) for gradients.
 
-    toCorner top_ left
+    toCorner top_ left_
 
     toCorner bottom_ right
 
@@ -3409,7 +3413,7 @@ See also [`to`](#to) for a side.
 -}
 toCorner :
     Value { top_ : Supported, bottom_ : Supported }
-    -> Value { left : Supported, right : Supported }
+    -> Value { left_ : Supported, right : Supported }
     -> Value { supported | to : Supported }
 toCorner (Value topBottom) (Value leftRight) =
     Value ("to " ++ topBottom ++ " " ++ leftRight)

--- a/src/Css.elm
+++ b/src/Css.elm
@@ -25,6 +25,7 @@ module Css
         , backgroundClip
         , backgroundClips
         , backgroundColor
+        , backgroundImage
         , backgroundOrigin
         , backgroundOrigins
         , baseline
@@ -297,6 +298,8 @@ All CSS properties can have the values `unset`, `initial`, and `inherit`.
 
 
 ## Background Image
+
+@docs backgroundImage
 
 @docs linearGradient, linearGradient2, stop, stop2, to, toCorner
 
@@ -3203,6 +3206,24 @@ backgroundOrigins firstValue values =
                 |> String.join ","
     in
     AppendProperty ("background-origin:" ++ str)
+
+
+{-| Sets [`background-image`](https://css-tricks.com/almanac/properties/b/background-image/).
+
+    backgroundImage (url "http://www.example.com/chicken.jpg")
+
+    backgroundImage (linearGradient (stop red) (stop blue))
+
+-}
+backgroundImage :
+    Value
+        { url : Supported
+        , linearGradient : Supported
+        , none : Supported
+        }
+    -> Style
+backgroundImage (Value value) =
+    AppendProperty ("background-image:" ++ value)
 
 
 

--- a/src/Css.elm
+++ b/src/Css.elm
@@ -3281,7 +3281,7 @@ backgroundImages (Value first) rest =
 {- GRADIENTS -}
 
 
-{-| Sets [`linear-gradient`](https://developer.mozilla.org/en-US/docs/Web/CSS/linear-gradient)
+{-| Sets [`linear-gradient`](https://css-tricks.com/snippets/css/css-linear-gradient/)
 
     linearGradient (to top) (stop red) (stop blue) []
 
@@ -3312,7 +3312,7 @@ linearGradient (Value angle) (Value firstStop) (Value secondStop) moreStops =
     Value ("linear-gradient(" ++ angle ++ "," ++ stops ++ ")")
 
 
-{-| Provides a stop for a [gradient](https://developer.mozilla.org/en-US/docs/Web/CSS/linear-gradient).
+{-| Provides a stop for a [gradient](https://css-tricks.com/snippets/css/css-linear-gradient/).
 
     linearGradient (to top) (stop red) (stop blue) []
 
@@ -3324,7 +3324,7 @@ stop (Value color) =
     Value color
 
 
-{-| Provides a stop for a [gradient](https://developer.mozilla.org/en-US/docs/Web/CSS/linear-gradient).
+{-| Provides a stop for a [gradient](https://css-tricks.com/snippets/css/css-linear-gradient/).
 
     linearGradient (to top) (stop2 red (px 20)) (stop blue) []
 
@@ -3357,7 +3357,7 @@ stop2 (Value color) (Value position) =
     Value (color ++ " " ++ position)
 
 
-{-| Provides the special [`to` side angle](https://developer.mozilla.org/en-US/docs/Web/CSS/linear-gradient) for gradients.
+{-| Provides the special [`to` side angle](https://css-tricks.com/snippets/css/css-linear-gradient/) for gradients.
 
     linearGradient (to top_) (stop red) (stop blue) []
 
@@ -3380,7 +3380,7 @@ to (Value direction) =
     Value ("to " ++ direction)
 
 
-{-| Provides the special [`to` corner angle](https://developer.mozilla.org/en-US/docs/Web/CSS/linear-gradient) for gradients.
+{-| Provides the special [`to` corner angle](https://css-tricks.com/snippets/css/css-linear-gradient/) for gradients.
 
     linearGradient (toCorner top_ left_) (stop red) (stop blue) []
 

--- a/src/Css.elm
+++ b/src/Css.elm
@@ -35,6 +35,7 @@ module Css
         , bold
         , bolder
         , borderBox
+        , bottom
         , boxShadow
         , cell
         , center
@@ -213,6 +214,7 @@ module Css
         , text_
         , thai
         , titlingCaps
+        , top
         , turn
         , unicase
         , unsafeCenter
@@ -365,7 +367,7 @@ All CSS properties can have the values `unset`, `initial`, and `inherit`.
 
 # Align Items
 
-@docs normal, stretch, center, start, end, flexStart, flexEnd, selfStart, selfEnd, left, right, baseline, firstBaseline, lastBaseline, safeCenter, unsafeCenter
+@docs normal, stretch, center, start, end, flexStart, flexEnd, selfStart, selfEnd, left, right, top, bottom, baseline, firstBaseline, lastBaseline, safeCenter, unsafeCenter
 
 
 # Url
@@ -1433,6 +1435,18 @@ left =
 right : Value { provides | right : Supported }
 right =
     Value "right"
+
+
+{-| -}
+top : Value { provides | top : Supported }
+top =
+    Value "top"
+
+
+{-| -}
+bottom : Value { provides | bottom : Supported }
+bottom =
+    Value "bottom"
 
 
 {-| -}

--- a/src/Css.elm
+++ b/src/Css.elm
@@ -124,7 +124,6 @@ module Css
         , lighten
         , lighter
         , linearGradient
-        , linearGradient2
         , liningNums
         , listStyle
         , listStyle2
@@ -302,7 +301,7 @@ All CSS properties can have the values `unset`, `initial`, and `inherit`.
 
 @docs backgroundImage, backgroundImages
 
-@docs linearGradient, linearGradient2, stop, stop2, to, toCorner
+@docs linearGradient, stop, stop2, to, toCorner
 
 
 ## Box Shadow
@@ -3284,39 +3283,12 @@ backgroundImages (Value first) rest =
 
 {-| Sets [`linear-gradient`](https://developer.mozilla.org/en-US/docs/Web/CSS/linear-gradient)
 
-    linearGradient (stop red) (stop blue) []
+    linearGradient (to top) (stop red) (stop blue) []
 
-    linearGradient (stop red) (stop blue) [ stop green ]
-
-See also [`linearGradient2`](#linearGradient2) if you don't need to set the angle.
+    linearGradient (to top) (stop red) (stop blue) [ stop green ]
 
 -}
 linearGradient :
-    Value { colorStop : Supported }
-    -> Value { colorStop : Supported }
-    -> List (Value { colorStop : Supported })
-    -> Value { provides | linearGradient : Supported }
-linearGradient (Value firstStop) (Value secondStop) moreStops =
-    let
-        peeledStops =
-            List.map (\(Value stop) -> stop) moreStops
-
-        stops =
-            String.join "," (firstStop :: secondStop :: peeledStops)
-    in
-    Value ("linear-gradient(" ++ stops ++ ")")
-
-
-{-| Sets [`linear-gradient`](https://developer.mozilla.org/en-US/docs/Web/CSS/linear-gradient), providing an angle.
-
-    linearGradient2 (deg 90) (stop red) (stop blue) []
-
-    linearGradient2 (toCorner top_ left_) (stop red) (stop blue) []
-
-See also [`linearGradient`](#linearGradient) if you don't need to set the angle.
-
--}
-linearGradient2 :
     Value
         { to : Supported
         , deg : Supported
@@ -3328,7 +3300,7 @@ linearGradient2 :
     -> Value { colorStop : Supported }
     -> List (Value { colorStop : Supported })
     -> Value { provides | linearGradient : Supported }
-linearGradient2 (Value angle) (Value firstStop) (Value secondStop) moreStops =
+linearGradient (Value angle) (Value firstStop) (Value secondStop) moreStops =
     let
         peeledStops =
             List.map (\(Value stop) -> stop) moreStops

--- a/src/Css.elm
+++ b/src/Css.elm
@@ -3230,7 +3230,7 @@ backgroundOrigins firstValue values =
 
     backgroundImage (linearGradient (stop red) (stop blue))
 
-See also [`backgroundImage`](#backgroundImage) if you need multiple images.
+See also [`backgroundImages`](#backgroundImages) if you need multiple images.
 
 -}
 backgroundImage :

--- a/src/Css.elm
+++ b/src/Css.elm
@@ -176,7 +176,7 @@ module Css
         , rgb
         , rgba
         , ridge
-        , right
+        , right_
         , rowResize
         , sResize
         , safeCenter
@@ -373,7 +373,7 @@ All CSS properties can have the values `unset`, `initial`, and `inherit`.
 
 # Align Items
 
-@docs normal, stretch, center, start, end, flexStart, flexEnd, selfStart, selfEnd, left_, right, top_, bottom_, baseline, firstBaseline, lastBaseline, safeCenter, unsafeCenter
+@docs normal, stretch, center, start, end, flexStart, flexEnd, selfStart, selfEnd, left_, right_, top_, bottom_, baseline, firstBaseline, lastBaseline, safeCenter, unsafeCenter
 
 
 # Url
@@ -1433,7 +1433,7 @@ selfEnd =
 
 {-| The `left` value used for alignment.
 
-The value is called `left_` instead of `left` because [`left` is already a funciton](left).
+The value is called `left_` instead of `left` because [`left` is already a function](left).
 
 -}
 left_ : Value { provides | left_ : Supported }
@@ -1441,9 +1441,13 @@ left_ =
     Value "left"
 
 
-{-| -}
-right : Value { provides | right : Supported }
-right =
+{-| The `right` value used for alignment.
+
+The value is called `right_` instead of `right` because [`right` is already a function](right).
+
+-}
+right_ : Value { provides | right_ : Supported }
+right_ =
     Value "right"
 
 
@@ -3393,7 +3397,7 @@ to :
         { top_ : Supported
         , bottom_ : Supported
         , left_ : Supported
-        , right : Supported
+        , right_ : Supported
         }
     -> Value { supported | to : Supported }
 to (Value direction) =
@@ -3404,7 +3408,7 @@ to (Value direction) =
 
     toCorner top_ left_
 
-    toCorner bottom_ right
+    toCorner bottom_ right_
 
 See also [`to`](#to) for a side.
 
@@ -3413,7 +3417,7 @@ See also [`to`](#to) for a side.
 -}
 toCorner :
     Value { top_ : Supported, bottom_ : Supported }
-    -> Value { left_ : Supported, right : Supported }
+    -> Value { left_ : Supported, right_ : Supported }
     -> Value { supported | to : Supported }
 toCorner (Value topBottom) (Value leftRight) =
     Value ("to " ++ topBottom ++ " " ++ leftRight)


### PR DESCRIPTION
This builds on #395, adding `backgroundImage`. The commits for this depend on linear gradients to reach full coverage as is in master, and start at b7a4333.

8b1250d is new coverage of the CSS spec. I added it as I was thinking about it (since you can't have multiple `none`s) but feel free to cherry-pick/drop. 😄

progress for #392 