### PR TITLE
Rewrite overflow and overflowWrap using phantom types approach

### DIFF
--- a/src/Css.elm
+++ b/src/Css.elm
@@ -2,6 +2,7 @@ module Css
     exposing
         ( BoxShadowConfig
         , Color
+        , Overflow
         , Style
         , Supported
         , Value
@@ -387,12 +388,13 @@ All CSS properties can have the values `unset`, `initial`, and `inherit`.
 Multiple CSS properties use these values.
 
 @docs auto, none
+@docs hidden, visible
 
 
 ## Overflow
 
+@docs Overflow
 @docs overflow, overflowX, overflowY
-@docs hidden, visible
 
 @docs overflowWrap
 @docs breakWord
@@ -585,21 +587,34 @@ none =
     Value "none"
 
 
-{-| -}
+{-| The `hidden` value used for properties such as [`visibility`](https://css-tricks.com/almanac/properties/v/visibility/), [`overflow`](https://css-tricks.com/almanac/properties/o/overflow/) and [`border style`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-style).
+
+    visibility hidden
+    overflow hidden
+    borderStyle hidden
+
+-}
 hidden : Value { provides | hidden : Supported }
 hidden =
     Value "hidden"
 
 
-{-| -}
+{-| The `visible` value used for properties such as [`visibility`](https://css-tricks.com/almanac/properties/v/visibility/), [`overflow`](https://css-tricks.com/almanac/properties/o/overflow/) and [`pointer-events`](https://developer.mozilla.org/en-US/docs/Web/CSS/pointer-events).
+
+    visibility visible
+    overflow visible
+    pointerEvents visible
+
+-}
 visible : Value { provides | visible : Supported }
 visible =
     Value "visible"
 
 
-{-| The `scroll` [`overflow`](https://developer.mozilla.org/en-US/docs/Web/CSS/overflow#Values) value.
+{-| The `scroll` value used for properties such as [`overflow`](https://developer.mozilla.org/en-US/docs/Web/CSS/overflow#Values) and [`background-attachment`](https://developer.mozilla.org/en-US/docs/Web/CSS/background-attachment).
 
-This can also represent a `scroll` [`background-attachment`](https://developer.mozilla.org/en-US/docs/Web/CSS/background-attachment) value.
+    overflow scroll
+    backgroundAttachment scroll
 
 -}
 scroll : Value { provides | scroll : Supported }
@@ -611,6 +626,7 @@ scroll =
 -- OVERFLOW --
 
 
+{-| -}
 type alias Overflow =
     Value
         { visible : Supported
@@ -623,25 +639,51 @@ type alias Overflow =
         }
 
 
-{-| -}
+{-| Sets [`overflow`](https://css-tricks.com/almanac/properties/o/overflow/).
+
+    overflow visible
+    overflow hidden
+    overflow scroll
+    overflow auto
+
+-}
 overflow : Overflow -> Style
 overflow (Value val) =
     AppendProperty ("overflow:" ++ val)
 
 
-{-| -}
+{-| Sets [`overflow-x`](https://css-tricks.com/almanac/properties/o/overflow/).
+
+    overflowX visible
+    overflowX hidden
+    overflowX scroll
+    overflowX auto
+
+-}
 overflowX : Overflow -> Style
 overflowX (Value val) =
     AppendProperty ("overflow-x:" ++ val)
 
 
-{-| -}
+{-| Sets [`overflow-y`](https://css-tricks.com/almanac/properties/o/overflow/).
+
+    overflowY visible
+    overflowY hidden
+    overflowY scroll
+    overflowY auto
+
+-}
 overflowY : Overflow -> Style
 overflowY (Value val) =
     AppendProperty ("overflow-y:" ++ val)
 
 
-{-| -}
+{-| Sets [`overflow-wrap`](https://css-tricks.com/almanac/properties/o/overflow-wrap/)
+
+    overflowWrap breakWord
+    overflowWrap normal
+
+-}
 overflowWrap :
     Value
         { breakWord : Supported
@@ -655,7 +697,8 @@ overflowWrap (Value val) =
     AppendProperty ("overflow-wrap:" ++ val)
 
 
-{-| -}
+{-| The `break-word` value for the [`overflow-wrap`](https://css-tricks.com/almanac/properties/o/overflow-wrap/) property.
+-}
 breakWord : Value { provides | breakWord : Supported }
 breakWord =
     Value "break-word"

--- a/src/Css.elm
+++ b/src/Css.elm
@@ -2,7 +2,6 @@ module Css
     exposing
         ( BoxShadowConfig
         , Color
-        , Overflow
         , Style
         , Supported
         , Value
@@ -393,7 +392,6 @@ Multiple CSS properties use these values.
 
 ## Overflow
 
-@docs Overflow
 @docs overflow, overflowX, overflowY
 
 @docs overflowWrap
@@ -626,8 +624,15 @@ scroll =
 -- OVERFLOW --
 
 
-{-| -}
-type alias Overflow =
+{-| Sets [`overflow`](https://css-tricks.com/almanac/properties/o/overflow/).
+
+    overflow visible
+    overflow hidden
+    overflow scroll
+    overflow auto
+
+-}
+overflow :
     Value
         { visible : Supported
         , hidden : Supported
@@ -637,17 +642,7 @@ type alias Overflow =
         , initial : Supported
         , unset : Supported
         }
-
-
-{-| Sets [`overflow`](https://css-tricks.com/almanac/properties/o/overflow/).
-
-    overflow visible
-    overflow hidden
-    overflow scroll
-    overflow auto
-
--}
-overflow : Overflow -> Style
+    -> Style
 overflow (Value val) =
     AppendProperty ("overflow:" ++ val)
 
@@ -660,7 +655,17 @@ overflow (Value val) =
     overflowX auto
 
 -}
-overflowX : Overflow -> Style
+overflowX :
+    Value
+        { visible : Supported
+        , hidden : Supported
+        , scroll : Supported
+        , auto : Supported
+        , inherit : Supported
+        , initial : Supported
+        , unset : Supported
+        }
+    -> Style
 overflowX (Value val) =
     AppendProperty ("overflow-x:" ++ val)
 
@@ -673,7 +678,17 @@ overflowX (Value val) =
     overflowY auto
 
 -}
-overflowY : Overflow -> Style
+overflowY :
+    Value
+        { visible : Supported
+        , hidden : Supported
+        , scroll : Supported
+        , auto : Supported
+        , inherit : Supported
+        , initial : Supported
+        , unset : Supported
+        }
+    -> Style
 overflowY (Value val) =
     AppendProperty ("overflow-y:" ++ val)
 

--- a/src/Css.elm
+++ b/src/Css.elm
@@ -36,6 +36,7 @@ module Css
         , bolder
         , borderBox
         , boxShadow
+        , breakWord
         , cell
         , center
         , ch
@@ -153,6 +154,7 @@ module Css
         , oriya
         , outset
         , overflow
+        , overflowWrap
         , overflowX
         , overflowY
         , overlay
@@ -391,6 +393,9 @@ Multiple CSS properties use these values.
 
 @docs overflow, overflowX, overflowY
 @docs hidden, visible
+
+@docs overflowWrap
+@docs breakWord
 
 -}
 
@@ -634,6 +639,26 @@ overflowX (Value val) =
 overflowY : Overflow -> Style
 overflowY (Value val) =
     AppendProperty ("overflow-y:" ++ val)
+
+
+{-| -}
+overflowWrap :
+    Value
+        { breakWord : Supported
+        , normal : Supported
+        , inherit : Supported
+        , initial : Supported
+        , unset : Supported
+        }
+    -> Style
+overflowWrap (Value val) =
+    AppendProperty ("overflow-wrap:" ++ val)
+
+
+{-| -}
+breakWord : Value { provides | breakWord : Supported }
+breakWord =
+    Value "break-word"
 
 
 

--- a/src/Css.elm
+++ b/src/Css.elm
@@ -96,6 +96,7 @@ module Css
         , hardLight
         , help
         , hex
+        , hidden
         , historicalLigatures
         , hsl
         , hsla
@@ -151,6 +152,9 @@ module Css
         , ordinal
         , oriya
         , outset
+        , overflow
+        , overflowX
+        , overflowY
         , overlay
         , paddingBox
         , pc
@@ -212,6 +216,7 @@ module Css
         , url
         , verticalText
         , vh
+        , visible
         , vmax
         , vmin
         , vw
@@ -380,6 +385,12 @@ All CSS properties can have the values `unset`, `initial`, and `inherit`.
 Multiple CSS properties use these values.
 
 @docs auto, none
+
+
+## Overflow
+
+@docs overflow, overflowX, overflowY
+@docs hidden, visible
 
 -}
 
@@ -567,6 +578,62 @@ auto =
 none : Value { provides | none : Supported }
 none =
     Value "none"
+
+
+{-| -}
+hidden : Value { provides | hidden : Supported }
+hidden =
+    Value "hidden"
+
+
+{-| -}
+visible : Value { provides | visible : Supported }
+visible =
+    Value "visible"
+
+
+{-| The `scroll` [`overflow`](https://developer.mozilla.org/en-US/docs/Web/CSS/overflow#Values) value.
+
+This can also represent a `scroll` [`background-attachment`](https://developer.mozilla.org/en-US/docs/Web/CSS/background-attachment) value.
+
+-}
+scroll : Value { provides | scroll : Supported }
+scroll =
+    Value "scroll"
+
+
+
+-- OVERFLOW --
+
+
+type alias Overflow =
+    Value
+        { visible : Supported
+        , hidden : Supported
+        , scroll : Supported
+        , auto : Supported
+        , inherit : Supported
+        , initial : Supported
+        , unset : Supported
+        }
+
+
+{-| -}
+overflow : Overflow -> Style
+overflow (Value val) =
+    AppendProperty ("overflow:" ++ val)
+
+
+{-| -}
+overflowX : Overflow -> Style
+overflowX (Value val) =
+    AppendProperty ("overflow-x:" ++ val)
+
+
+{-| -}
+overflowY : Overflow -> Style
+overflowY (Value val) =
+    AppendProperty ("overflow-y:" ++ val)
 
 
 
@@ -2729,16 +2796,6 @@ backgroundAttachments firstValue values =
 fixed : Value { provides | fixed : Supported }
 fixed =
     Value "fixed"
-
-
-{-| The `scroll` [`background-attachment` value](https://developer.mozilla.org/en-US/docs/Web/CSS/background-attachment#Values)
-
-    backgroundAttachment scroll
-
--}
-scroll : Value { provides | scroll : Supported }
-scroll =
-    Value "scroll"
 
 
 {-| The `local` [`background-attachment` value](https://developer.mozilla.org/en-US/docs/Web/CSS/background-attachment#Values)


### PR DESCRIPTION
Restored properties:
  - `overflow`
  - `overflowX`
  - `overflowY` 
  - `overflowWrap`