### PR TITLE
Phantom border

### DIFF
--- a/src/Css.elm
+++ b/src/Css.elm
@@ -50,6 +50,10 @@ module Css
         , borderColor4
         , borderSpacing
         , borderSpacing2
+        , borderWidth
+        , borderWidth2
+        , borderWidth3
+        , borderWidth4
         , bottom
         , bottom_
         , boxShadow
@@ -379,7 +383,7 @@ All CSS properties can have the values `unset`, `initial`, and `inherit`.
 
 ## Border
 
-@docs border, border2, border3 ,borderColor ,borderColor2 ,borderColor3 ,borderColor4
+@docs border, border2, border3, borderColor, borderColor2, borderColor3, borderColor4, borderWidth, borderWidth2, borderWidth3, borderWidth4
 
 
 ## Border Width
@@ -4370,6 +4374,9 @@ border :
         , thin : Supported
         , medium : Supported
         , thick : Supported
+        , inherit : Supported
+        , initial : Supported
+        , unset : Supported
         }
     -> Style
 border (Value width) =
@@ -4403,6 +4410,9 @@ border2 :
         , thin : Supported
         , medium : Supported
         , thick : Supported
+        , inherit : Supported
+        , initial : Supported
+        , unset : Supported
         }
     ->
         Value
@@ -4452,6 +4462,9 @@ border3 :
         , thin : Supported
         , medium : Supported
         , thick : Supported
+        , inherit : Supported
+        , initial : Supported
+        , unset : Supported
         }
     ->
         Value
@@ -4485,6 +4498,298 @@ border3 :
     -> Style
 border3 (Value width) (Value style) (Value color) =
     AppendProperty ("border:" ++ width ++ " " ++ style ++ " " ++ color)
+
+
+{-| Sets [`border-width`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-width) property.
+
+    borderWidth (px 1)
+    borderWidth2 (px 1) thin
+    borderWidth3 (px 1) thin zero
+    borderWidth4 (px 1) thin zero (em 1)
+
+-}
+borderWidth :
+    Value
+        { ch : Supported
+        , cm : Supported
+        , em : Supported
+        , ex : Supported
+        , inches : Supported
+        , mm : Supported
+        , pc : Supported
+        , pt : Supported
+        , px : Supported
+        , rem : Supported
+        , vh : Supported
+        , vmax : Supported
+        , vmin : Supported
+        , vw : Supported
+        , zero : Supported
+        , thin : Supported
+        , medium : Supported
+        , thick : Supported
+        , inherit : Supported
+        , initial : Supported
+        , unset : Supported
+        }
+    -> Style
+borderWidth (Value width) =
+    AppendProperty ("border-width:" ++ width)
+
+
+{-| Sets [`border-width`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-width) property.
+
+    borderWidth (px 1)
+    borderWidth2 (px 1) thin
+    borderWidth3 (px 1) thin zero
+    borderWidth4 (px 1) thin zero (em 1)
+
+-}
+borderWidth2 :
+    Value
+        { ch : Supported
+        , cm : Supported
+        , em : Supported
+        , ex : Supported
+        , inches : Supported
+        , mm : Supported
+        , pc : Supported
+        , pt : Supported
+        , px : Supported
+        , rem : Supported
+        , vh : Supported
+        , vmax : Supported
+        , vmin : Supported
+        , vw : Supported
+        , zero : Supported
+        , thin : Supported
+        , medium : Supported
+        , thick : Supported
+        , inherit : Supported
+        , initial : Supported
+        , unset : Supported
+        }
+    ->
+        Value
+            { ch : Supported
+            , cm : Supported
+            , em : Supported
+            , ex : Supported
+            , inches : Supported
+            , mm : Supported
+            , pc : Supported
+            , pt : Supported
+            , px : Supported
+            , rem : Supported
+            , vh : Supported
+            , vmax : Supported
+            , vmin : Supported
+            , vw : Supported
+            , zero : Supported
+            , thin : Supported
+            , medium : Supported
+            , thick : Supported
+            , inherit : Supported
+            , initial : Supported
+            , unset : Supported
+            }
+    -> Style
+borderWidth2 (Value widthTopBottom) (Value widthRightLeft) =
+    AppendProperty ("border-width:" ++ widthTopBottom ++ " " ++ widthRightLeft)
+
+
+{-| Sets [`border-width`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-width) property.
+
+    borderWidth (px 1)
+    borderWidth2 (px 1) thin
+    borderWidth3 (px 1) thin zero
+    borderWidth4 (px 1) thin zero (em 1)
+
+-}
+borderWidth3 :
+    Value
+        { ch : Supported
+        , cm : Supported
+        , em : Supported
+        , ex : Supported
+        , inches : Supported
+        , mm : Supported
+        , pc : Supported
+        , pt : Supported
+        , px : Supported
+        , rem : Supported
+        , vh : Supported
+        , vmax : Supported
+        , vmin : Supported
+        , vw : Supported
+        , zero : Supported
+        , thin : Supported
+        , medium : Supported
+        , thick : Supported
+        , inherit : Supported
+        , initial : Supported
+        , unset : Supported
+        }
+    ->
+        Value
+            { ch : Supported
+            , cm : Supported
+            , em : Supported
+            , ex : Supported
+            , inches : Supported
+            , mm : Supported
+            , pc : Supported
+            , pt : Supported
+            , px : Supported
+            , rem : Supported
+            , vh : Supported
+            , vmax : Supported
+            , vmin : Supported
+            , vw : Supported
+            , zero : Supported
+            , thin : Supported
+            , medium : Supported
+            , thick : Supported
+            , inherit : Supported
+            , initial : Supported
+            , unset : Supported
+            }
+    ->
+        Value
+            { ch : Supported
+            , cm : Supported
+            , em : Supported
+            , ex : Supported
+            , inches : Supported
+            , mm : Supported
+            , pc : Supported
+            , pt : Supported
+            , px : Supported
+            , rem : Supported
+            , vh : Supported
+            , vmax : Supported
+            , vmin : Supported
+            , vw : Supported
+            , zero : Supported
+            , thin : Supported
+            , medium : Supported
+            , thick : Supported
+            , inherit : Supported
+            , initial : Supported
+            , unset : Supported
+            }
+    -> Style
+borderWidth3 (Value widthTop) (Value widthRightLeft) (Value widthBottom) =
+    AppendProperty ("border-width:" ++ widthTop ++ " " ++ widthRightLeft ++ " " ++ widthBottom)
+
+
+{-| Sets [`border-width`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-width) property.
+
+    borderWidth (px 1)
+    borderWidth2 (px 1) thin
+    borderWidth3 (px 1) thin zero
+    borderWidth4 (px 1) thin zero (em 1)
+
+-}
+borderWidth4 :
+    Value
+        { ch : Supported
+        , cm : Supported
+        , em : Supported
+        , ex : Supported
+        , inches : Supported
+        , mm : Supported
+        , pc : Supported
+        , pt : Supported
+        , px : Supported
+        , rem : Supported
+        , vh : Supported
+        , vmax : Supported
+        , vmin : Supported
+        , vw : Supported
+        , zero : Supported
+        , thin : Supported
+        , medium : Supported
+        , thick : Supported
+        , inherit : Supported
+        , initial : Supported
+        , unset : Supported
+        }
+    ->
+        Value
+            { ch : Supported
+            , cm : Supported
+            , em : Supported
+            , ex : Supported
+            , inches : Supported
+            , mm : Supported
+            , pc : Supported
+            , pt : Supported
+            , px : Supported
+            , rem : Supported
+            , vh : Supported
+            , vmax : Supported
+            , vmin : Supported
+            , vw : Supported
+            , zero : Supported
+            , thin : Supported
+            , medium : Supported
+            , thick : Supported
+            , inherit : Supported
+            , initial : Supported
+            , unset : Supported
+            }
+    ->
+        Value
+            { ch : Supported
+            , cm : Supported
+            , em : Supported
+            , ex : Supported
+            , inches : Supported
+            , mm : Supported
+            , pc : Supported
+            , pt : Supported
+            , px : Supported
+            , rem : Supported
+            , vh : Supported
+            , vmax : Supported
+            , vmin : Supported
+            , vw : Supported
+            , zero : Supported
+            , thin : Supported
+            , medium : Supported
+            , thick : Supported
+            , inherit : Supported
+            , initial : Supported
+            , unset : Supported
+            }
+    ->
+        Value
+            { ch : Supported
+            , cm : Supported
+            , em : Supported
+            , ex : Supported
+            , inches : Supported
+            , mm : Supported
+            , pc : Supported
+            , pt : Supported
+            , px : Supported
+            , rem : Supported
+            , vh : Supported
+            , vmax : Supported
+            , vmin : Supported
+            , vw : Supported
+            , zero : Supported
+            , thin : Supported
+            , medium : Supported
+            , thick : Supported
+            , inherit : Supported
+            , initial : Supported
+            , unset : Supported
+            }
+    -> Style
+borderWidth4 (Value widthTop) (Value widthRight) (Value widthBottom) (Value widthLeft) =
+    AppendProperty ("border-width:" ++ widthTop ++ " " ++ widthRight ++ " " ++ widthBottom ++ " " ++ widthLeft)
 
 
 {-| Sets [`border-color`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-color) property.

--- a/src/Css.elm
+++ b/src/Css.elm
@@ -289,7 +289,6 @@ module Css
         , vw
         , wResize
         , wait
-        , wavy
         , xLarge
         , xSmall
         , xxLarge
@@ -371,7 +370,7 @@ All CSS properties can have the values `unset`, `initial`, and `inherit`.
 
 ## Border Style
 
-@docs wavy, dotted, dashed, solid, double, groove, ridge, inset, outset
+@docs dotted, dashed, solid, double, groove, ridge, inset, outset
 
 
 ## Display
@@ -651,6 +650,7 @@ inherit =
 Any CSS property can be set to this value.
 
     display initial
+    borderStyle initial
 
 -}
 initial : Value { provides | initial : Supported }
@@ -722,6 +722,7 @@ auto =
 {-| The `none` value used for properties such as [`display`](#display).
 
     display none
+    borderStyle none
 
 -}
 none : Value { provides | none : Supported }
@@ -2183,9 +2184,10 @@ small =
     Value "small"
 
 
-{-| The `medium` [`font-size` value](https://developer.mozilla.org/en-US/docs/Web/CSS/font-size#Values).
+{-| The `medium` [`font-size`](https://developer.mozilla.org/en-US/docs/Web/CSS/font-size#Values) or [`border-width`](https://css-tricks.com/almanac/properties/b/border/#article-header-id-0) (equivalent of 3px) value.
 
     fontSize medium
+    borderWidth medium
 
 -}
 medium : Value { provides | medium : Supported }
@@ -4317,66 +4319,258 @@ listStyle3 (Value val1) (Value val2) (Value val3) =
 
 
 
+{- BORDERS -}
+
+
+{-| Sets [`border`](https://css-tricks.com/almanac/properties/b/border/) property.
+
+    border (px 1)
+    border2 (px 1) solid
+    border3 (px 1) solid (hex "#f00")
+
+-}
+border :
+    Value
+        { ch : Supported
+        , cm : Supported
+        , em : Supported
+        , ex : Supported
+        , inches : Supported
+        , mm : Supported
+        , pc : Supported
+        , pt : Supported
+        , px : Supported
+        , rem : Supported
+        , vh : Supported
+        , vmax : Supported
+        , vmin : Supported
+        , vw : Supported
+        , zero : Supported
+        , thin : Supported
+        , medium : Supported
+        , thick : Supported
+        }
+    -> Style
+border (Value width) =
+    AppendProperty ("border:" ++ width)
+
+
+{-| Sets [`border`](https://css-tricks.com/almanac/properties/b/border/) property.
+
+    border (px 1)
+    border2 (px 1) solid
+    border3 (px 1) solid (hex "#f00")
+
+-}
+border2 :
+    Value
+        { ch : Supported
+        , cm : Supported
+        , em : Supported
+        , ex : Supported
+        , inches : Supported
+        , mm : Supported
+        , pc : Supported
+        , pt : Supported
+        , px : Supported
+        , rem : Supported
+        , vh : Supported
+        , vmax : Supported
+        , vmin : Supported
+        , vw : Supported
+        , zero : Supported
+        , thin : Supported
+        , medium : Supported
+        , thick : Supported
+        }
+    ->
+        Value
+            { solid : Supported
+            , none : Supported
+            , hidden : Supported
+            , dashed : Supported
+            , dotted : Supported
+            , double : Supported
+            , groove : Supported
+            , ridge : Supported
+            , inset : Supported
+            , outset : Supported
+            , inherit : Supported
+            , initial : Supported
+            , unset : Supported
+            }
+    -> Style
+border2 (Value width) (Value style) =
+    AppendProperty ("border:" ++ width ++ " " ++ style)
+
+
+{-| Sets [`border`](https://css-tricks.com/almanac/properties/b/border/) property.
+
+    border (px 1)
+    border2 (px 1) solid
+    border3 (px 1) solid (hex "#f00")
+
+-}
+border3 :
+    Value
+        { ch : Supported
+        , cm : Supported
+        , em : Supported
+        , ex : Supported
+        , inches : Supported
+        , mm : Supported
+        , pc : Supported
+        , pt : Supported
+        , px : Supported
+        , rem : Supported
+        , vh : Supported
+        , vmax : Supported
+        , vmin : Supported
+        , vw : Supported
+        , zero : Supported
+        , thin : Supported
+        , medium : Supported
+        , thick : Supported
+        }
+    ->
+        Value
+            { solid : Supported
+            , none : Supported
+            , hidden : Supported
+            , dashed : Supported
+            , dotted : Supported
+            , double : Supported
+            , groove : Supported
+            , ridge : Supported
+            , inset : Supported
+            , outset : Supported
+            , inherit : Supported
+            , initial : Supported
+            , unset : Supported
+            }
+    ->
+        Value
+            { rgb : Supported
+            , rgba : Supported
+            , hsl : Supported
+            , hsla : Supported
+            , hex : Supported
+            }
+    -> Style
+border3 (Value width) (Value style) (Value color) =
+    AppendProperty ("border:" ++ width ++ " " ++ style ++ " " ++ color)
+
+
+
+-- BORDER WIDTH --
+
+
+{-| The `thin` [`border-width`](https://css-tricks.com/almanac/properties/b/border/#article-header-id-0) (equivalent of 1px) value.
+
+    borderWidth thin
+
+-}
+thin : Value { provides | thin : Supported }
+thin =
+    Value "thin"
+
+
+{-| The `thick` [`border-width`](https://css-tricks.com/almanac/properties/b/border/#article-header-id-0) (equivalent of 5px) value.
+
+    borderWidth thick
+
+-}
+thick : Value { provides | thick : Supported }
+thick =
+    Value "thick"
+
+
+
 -- BORDER STYLE --
 
 
-{-| A `wavy` [text decoration style](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-style#Values).
--}
-wavy : Value { provides | wavy : Supported }
-wavy =
-    Value "wavy"
+{-| The `dotted` [`border-style`](<https://css-tricks.com/almanac/properties/b/border/#article-header-id-0> value.
+A line that consists of dots.
 
+    borderStyle dotted
 
-{-| A `dotted` [border style](https://developer.mozilla.org/en-US/docs/Web/CSS/border-style#Values).
 -}
 dotted : Value { provides | dotted : Supported }
 dotted =
     Value "dotted"
 
 
-{-| A `dashed` [border style](https://developer.mozilla.org/en-US/docs/Web/CSS/border-style#Values).
+{-| The `dashed` [`border-style`](<https://css-tricks.com/almanac/properties/b/border/#article-header-id-0> value.
+A line that consists of dashes.
+
+    borderStyle dashed
+
 -}
 dashed : Value { provides | dashed : Supported }
 dashed =
     Value "dashed"
 
 
-{-| A `solid` [border style](https://developer.mozilla.org/en-US/docs/Web/CSS/border-style#Values).
+{-| The `solid` [`border-style`](<https://css-tricks.com/almanac/properties/b/border/#article-header-id-0> value.
+A solid, continuous line.
+
+    borderStyle solid
+
 -}
 solid : Value { provides | solid : Supported }
 solid =
     Value "solid"
 
 
-{-| A `double` [border style](https://developer.mozilla.org/en-US/docs/Web/CSS/border-style#Values).
+{-| The `double` [`border-style`](<https://css-tricks.com/almanac/properties/b/border/#article-header-id-0> value.
+Two lines are drawn around the element.
+
+    borderStyle double
+
 -}
 double : Value { provides | double : Supported }
 double =
     Value "double"
 
 
-{-| A `groove` [border style](https://developer.mozilla.org/en-US/docs/Web/CSS/border-style#Values).
+{-| The `groove` [`border-style`](<https://css-tricks.com/almanac/properties/b/border/#article-header-id-0> value.
+Adds a bevel based on the color value in a way that makes the element appear pressed into the document.
+
+    borderStyle groove
+
 -}
 groove : Value { provides | groove : Supported }
 groove =
     Value "groove"
 
 
-{-| A `ridge` [border style](https://developer.mozilla.org/en-US/docs/Web/CSS/border-style#Values).
+{-| The `ridge` [`border-style`](<https://css-tricks.com/almanac/properties/b/border/#article-header-id-0> value.
+Similar to `groove`, but reverses the color values in a way that makes the element appear raised.
+
+    borderStyle ridge
+
 -}
 ridge : Value { provides | ridge : Supported }
 ridge =
     Value "ridge"
 
 
-{-| An `inset` [border style](https://developer.mozilla.org/en-US/docs/Web/CSS/border-style#Values).
+{-| The `inset` [`border-style`](<https://css-tricks.com/almanac/properties/b/border/#article-header-id-0> value.
+Adds a split tone to the line that makes the element appear slightly depressed.
+
+    borderStyle inset
+
 -}
 inset : Value { provides | inset : Supported }
 inset =
     Value "inset"
 
 
-{-| An `outset` [border style](https://developer.mozilla.org/en-US/docs/Web/CSS/border-style#Values).
+{-| The `outset` [`border-style`](<https://css-tricks.com/almanac/properties/b/border/#article-header-id-0> value.
+Similar to `inset`, but reverses the colors in a way that makes the element appear slightly raised.
+
+    borderStyle outset
+
 -}
 outset : Value { provides | outset : Supported }
 outset =

--- a/src/Css.elm
+++ b/src/Css.elm
@@ -330,6 +330,7 @@ module Css
         , vw
         , wResize
         , wait
+        , wavy
         , xLarge
         , xSmall
         , xxLarge
@@ -571,6 +572,11 @@ Multiple CSS properties use these values.
 
 @docs textTransform
 @docs capitalize, uppercase, lowercase, fullWidth
+
+
+## Text Decoration
+
+@docs wavy
 
 
 # Tables
@@ -6528,6 +6534,17 @@ rad radians =
 turn : Float -> Value { provides | turn : Supported }
 turn turns =
     Value (toString turns ++ "turn")
+
+
+
+-- TEXT DECORATION --
+
+
+{-| A `wavy` [text decoration style](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-style#Values).
+-}
+wavy : Value { provides | wavy : Supported }
+wavy =
+    Value "wavy"
 
 
 

--- a/src/Css.elm
+++ b/src/Css.elm
@@ -45,6 +45,7 @@ module Css
         , borderBottom
         , borderBottom2
         , borderBottom3
+        , borderBottomColor
         , borderBottomStyle
         , borderBottomWidth
         , borderBox
@@ -56,11 +57,13 @@ module Css
         , borderLeft
         , borderLeft2
         , borderLeft3
+        , borderLeftColor
         , borderLeftStyle
         , borderLeftWidth
         , borderRight
         , borderRight2
         , borderRight3
+        , borderRightColor
         , borderRightStyle
         , borderRightWidth
         , borderSpacing
@@ -72,6 +75,7 @@ module Css
         , borderTop
         , borderTop2
         , borderTop3
+        , borderTopColor
         , borderTopStyle
         , borderTopWidth
         , borderWidth
@@ -410,11 +414,6 @@ All CSS properties can have the values `unset`, `initial`, and `inherit`.
 @docs border, border2, border3, borderTop, borderTop2, borderTop3, borderRight, borderRight2, borderRight3, borderBottom, borderBottom2, borderBottom3, borderLeft, borderLeft2, borderLeft3
 
 
-## Border Color
-
-@docs borderColor, borderColor2, borderColor3, borderColor4
-
-
 ## Border Width
 
 @docs borderWidth, borderWidth2, borderWidth3, borderWidth4, borderTopWidth, borderRightWidth, borderBottomWidth, borderLeftWidth
@@ -427,6 +426,11 @@ All CSS properties can have the values `unset`, `initial`, and `inherit`.
 @docs borderStyle, borderStyle2, borderStyle3, borderStyle4, borderTopStyle, borderRightStyle, borderBottomStyle, borderLeftStyle
 
 @docs dotted, dashed, solid, double, groove, ridge, inset, outset
+
+
+## Border Color
+
+@docs borderColor, borderColor2, borderColor3, borderColor4, borderTopColor, borderRightColor, borderBottomColor, borderLeftColor
 
 
 ## Display
@@ -6069,6 +6073,98 @@ borderColor4 :
     -> Style
 borderColor4 (Value colorTop) (Value colorRight) (Value colorBottom) (Value colorLeft) =
     AppendProperty ("border-color:" ++ colorTop ++ " " ++ colorRight ++ " " ++ colorBottom ++ " " ++ colorLeft)
+
+
+{-| Sets [`border-top-color`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-top-color) property.
+
+    borderTopColor (rgb 0 0 0)
+
+-}
+borderTopColor :
+    Value
+        { rgb : Supported
+        , rgba : Supported
+        , hsl : Supported
+        , hsla : Supported
+        , hex : Supported
+        , transparent : Supported
+        , currentColor : Supported
+        , inherit : Supported
+        , initial : Supported
+        , unset : Supported
+        }
+    -> Style
+borderTopColor (Value color) =
+    AppendProperty ("border-top-color:" ++ color)
+
+
+{-| Sets [`border-right-color`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-right-color) property.
+
+    borderRightColor (rgb 0 0 0)
+
+-}
+borderRightColor :
+    Value
+        { rgb : Supported
+        , rgba : Supported
+        , hsl : Supported
+        , hsla : Supported
+        , hex : Supported
+        , transparent : Supported
+        , currentColor : Supported
+        , inherit : Supported
+        , initial : Supported
+        , unset : Supported
+        }
+    -> Style
+borderRightColor (Value color) =
+    AppendProperty ("border-right-color:" ++ color)
+
+
+{-| Sets [`border-bottom-color`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-bottom-color) property.
+
+    borderBottomColor (rgb 0 0 0)
+
+-}
+borderBottomColor :
+    Value
+        { rgb : Supported
+        , rgba : Supported
+        , hsl : Supported
+        , hsla : Supported
+        , hex : Supported
+        , transparent : Supported
+        , currentColor : Supported
+        , inherit : Supported
+        , initial : Supported
+        , unset : Supported
+        }
+    -> Style
+borderBottomColor (Value color) =
+    AppendProperty ("border-bottom-color:" ++ color)
+
+
+{-| Sets [`border-left-color`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-left-color) property.
+
+    borderLeftColor (rgb 0 0 0)
+
+-}
+borderLeftColor :
+    Value
+        { rgb : Supported
+        , rgba : Supported
+        , hsl : Supported
+        , hsla : Supported
+        , hex : Supported
+        , transparent : Supported
+        , currentColor : Supported
+        , inherit : Supported
+        , initial : Supported
+        , unset : Supported
+        }
+    -> Style
+borderLeftColor (Value color) =
+    AppendProperty ("border-left-color:" ++ color)
 
 
 

--- a/src/Css.elm
+++ b/src/Css.elm
@@ -50,6 +50,10 @@ module Css
         , borderColor4
         , borderSpacing
         , borderSpacing2
+        , borderStyle
+        , borderStyle2
+        , borderStyle3
+        , borderStyle4
         , borderWidth
         , borderWidth2
         , borderWidth3
@@ -383,7 +387,7 @@ All CSS properties can have the values `unset`, `initial`, and `inherit`.
 
 ## Border
 
-@docs border, border2, border3, borderColor, borderColor2, borderColor3, borderColor4, borderWidth, borderWidth2, borderWidth3, borderWidth4
+@docs border, border2, border3, borderColor, borderColor2, borderColor3, borderColor4, borderWidth, borderWidth2, borderWidth3, borderWidth4, borderStyle, borderStyle2, borderStyle3, borderStyle4
 
 
 ## Border Width
@@ -4790,6 +4794,218 @@ borderWidth4 :
     -> Style
 borderWidth4 (Value widthTop) (Value widthRight) (Value widthBottom) (Value widthLeft) =
     AppendProperty ("border-width:" ++ widthTop ++ " " ++ widthRight ++ " " ++ widthBottom ++ " " ++ widthLeft)
+
+
+{-| Sets [`border-style`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-style) property.
+
+    borderStyle solid
+    borderStyle2 solid none
+    borderStyle3 solid none dotted
+    borderStyle4 solid none dotted inherit
+
+-}
+borderStyle :
+    Value
+        { solid : Supported
+        , none : Supported
+        , hidden : Supported
+        , dashed : Supported
+        , dotted : Supported
+        , double : Supported
+        , groove : Supported
+        , ridge : Supported
+        , inset : Supported
+        , outset : Supported
+        , inherit : Supported
+        , initial : Supported
+        , unset : Supported
+        }
+    -> Style
+borderStyle (Value style) =
+    AppendProperty ("border-style:" ++ style)
+
+
+{-| Sets [`border-style`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-style) property.
+
+    borderStyle solid
+    borderStyle2 solid none
+    borderStyle3 solid none dotted
+    borderStyle4 solid none dotted inherit
+
+-}
+borderStyle2 :
+    Value
+        { solid : Supported
+        , none : Supported
+        , hidden : Supported
+        , dashed : Supported
+        , dotted : Supported
+        , double : Supported
+        , groove : Supported
+        , ridge : Supported
+        , inset : Supported
+        , outset : Supported
+        , inherit : Supported
+        , initial : Supported
+        , unset : Supported
+        }
+    ->
+        Value
+            { solid : Supported
+            , none : Supported
+            , hidden : Supported
+            , dashed : Supported
+            , dotted : Supported
+            , double : Supported
+            , groove : Supported
+            , ridge : Supported
+            , inset : Supported
+            , outset : Supported
+            , inherit : Supported
+            , initial : Supported
+            , unset : Supported
+            }
+    -> Style
+borderStyle2 (Value styleTopBottom) (Value styleRigthLeft) =
+    AppendProperty ("border-style:" ++ styleTopBottom ++ " " ++ styleRigthLeft)
+
+
+{-| Sets [`border-style`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-style) property.
+
+    borderStyle solid
+    borderStyle2 solid none
+    borderStyle3 solid none dotted
+    borderStyle4 solid none dotted inherit
+
+-}
+borderStyle3 :
+    Value
+        { solid : Supported
+        , none : Supported
+        , hidden : Supported
+        , dashed : Supported
+        , dotted : Supported
+        , double : Supported
+        , groove : Supported
+        , ridge : Supported
+        , inset : Supported
+        , outset : Supported
+        , inherit : Supported
+        , initial : Supported
+        , unset : Supported
+        }
+    ->
+        Value
+            { solid : Supported
+            , none : Supported
+            , hidden : Supported
+            , dashed : Supported
+            , dotted : Supported
+            , double : Supported
+            , groove : Supported
+            , ridge : Supported
+            , inset : Supported
+            , outset : Supported
+            , inherit : Supported
+            , initial : Supported
+            , unset : Supported
+            }
+    ->
+        Value
+            { solid : Supported
+            , none : Supported
+            , hidden : Supported
+            , dashed : Supported
+            , dotted : Supported
+            , double : Supported
+            , groove : Supported
+            , ridge : Supported
+            , inset : Supported
+            , outset : Supported
+            , inherit : Supported
+            , initial : Supported
+            , unset : Supported
+            }
+    -> Style
+borderStyle3 (Value styleTop) (Value styleRigthLeft) (Value styleBottom) =
+    AppendProperty ("border-style:" ++ styleTop ++ " " ++ styleRigthLeft ++ " " ++ styleBottom)
+
+
+{-| Sets [`border-style`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-style) property.
+
+    borderStyle solid
+    borderStyle2 solid none
+    borderStyle3 solid none dotted
+    borderStyle4 solid none dotted inherit
+
+-}
+borderStyle4 :
+    Value
+        { solid : Supported
+        , none : Supported
+        , hidden : Supported
+        , dashed : Supported
+        , dotted : Supported
+        , double : Supported
+        , groove : Supported
+        , ridge : Supported
+        , inset : Supported
+        , outset : Supported
+        , inherit : Supported
+        , initial : Supported
+        , unset : Supported
+        }
+    ->
+        Value
+            { solid : Supported
+            , none : Supported
+            , hidden : Supported
+            , dashed : Supported
+            , dotted : Supported
+            , double : Supported
+            , groove : Supported
+            , ridge : Supported
+            , inset : Supported
+            , outset : Supported
+            , inherit : Supported
+            , initial : Supported
+            , unset : Supported
+            }
+    ->
+        Value
+            { solid : Supported
+            , none : Supported
+            , hidden : Supported
+            , dashed : Supported
+            , dotted : Supported
+            , double : Supported
+            , groove : Supported
+            , ridge : Supported
+            , inset : Supported
+            , outset : Supported
+            , inherit : Supported
+            , initial : Supported
+            , unset : Supported
+            }
+    ->
+        Value
+            { solid : Supported
+            , none : Supported
+            , hidden : Supported
+            , dashed : Supported
+            , dotted : Supported
+            , double : Supported
+            , groove : Supported
+            , ridge : Supported
+            , inset : Supported
+            , outset : Supported
+            , inherit : Supported
+            , initial : Supported
+            , unset : Supported
+            }
+    -> Style
+borderStyle4 (Value styleTop) (Value styleRigt) (Value styleBottom) (Value styleLeft) =
+    AppendProperty ("border-style:" ++ styleTop ++ " " ++ styleRigt ++ " " ++ styleBottom ++ " " ++ styleLeft)
 
 
 {-| Sets [`border-color`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-color) property.

--- a/src/Css.elm
+++ b/src/Css.elm
@@ -39,6 +39,9 @@ module Css
         , block
         , bold
         , bolder
+        , border
+        , border2
+        , border3
         , borderBox
         , borderCollapse
         , borderSpacing
@@ -262,6 +265,8 @@ module Css
         , textTransform
         , text_
         , thai
+        , thick
+        , thin
         , titlingCaps
         , toBottom
         , toBottomLeft
@@ -368,9 +373,19 @@ All CSS properties can have the values `unset`, `initial`, and `inherit`.
 @docs BoxShadowConfig, boxShadow, defaultBoxShadow
 
 
+## Border
+
+@docs border, border2, border3
+
+
+## Border Width
+
+@docs thin ,thick
+
+
 ## Border Style
 
-@docs dotted, dashed, solid, double, groove, ridge, inset, outset
+@docs dotted ,dashed ,solid ,double ,groove ,ridge ,inset ,outset
 
 
 ## Display
@@ -2184,10 +2199,12 @@ small =
     Value "small"
 
 
-{-| The `medium` [`font-size`](https://developer.mozilla.org/en-US/docs/Web/CSS/font-size#Values) or [`border-width`](https://css-tricks.com/almanac/properties/b/border/#article-header-id-0) (equivalent of 3px) value.
+{-| The `medium` [`font-size`](https://developer.mozilla.org/en-US/docs/Web/CSS/font-size#Values) or [`border-width`](https://css-tricks.com/almanac/properties/b/border/#article-header-id-0) value.
 
     fontSize medium
     borderWidth medium
+
+The value is equivalent of 3px when using for `border-width`.
 
 -}
 medium : Value { provides | medium : Supported }
@@ -4465,9 +4482,11 @@ border3 (Value width) (Value style) (Value color) =
 -- BORDER WIDTH --
 
 
-{-| The `thin` [`border-width`](https://css-tricks.com/almanac/properties/b/border/#article-header-id-0) (equivalent of 1px) value.
+{-| The `thin` [`border-width`](https://css-tricks.com/almanac/properties/b/border/#article-header-id-0) value.
 
     borderWidth thin
+
+The value is equivalent of 1px.
 
 -}
 thin : Value { provides | thin : Supported }
@@ -4475,9 +4494,11 @@ thin =
     Value "thin"
 
 
-{-| The `thick` [`border-width`](https://css-tricks.com/almanac/properties/b/border/#article-header-id-0) (equivalent of 5px) value.
+{-| The `thick` [`border-width`](https://css-tricks.com/almanac/properties/b/border/#article-header-id-0) value.
 
     borderWidth thick
+
+The value is equivalent of 5px.
 
 -}
 thick : Value { provides | thick : Supported }
@@ -4490,9 +4511,10 @@ thick =
 
 
 {-| The `dotted` [`border-style`](<https://css-tricks.com/almanac/properties/b/border/#article-header-id-0> value.
-A line that consists of dots.
 
     borderStyle dotted
+
+A line that consists of dots.
 
 -}
 dotted : Value { provides | dotted : Supported }
@@ -4501,9 +4523,9 @@ dotted =
 
 
 {-| The `dashed` [`border-style`](<https://css-tricks.com/almanac/properties/b/border/#article-header-id-0> value.
-A line that consists of dashes.
+borderStyle dashed
 
-    borderStyle dashed
+A line that consists of dashes.
 
 -}
 dashed : Value { provides | dashed : Supported }
@@ -4512,9 +4534,10 @@ dashed =
 
 
 {-| The `solid` [`border-style`](<https://css-tricks.com/almanac/properties/b/border/#article-header-id-0> value.
-A solid, continuous line.
 
     borderStyle solid
+
+A solid, continuous line.
 
 -}
 solid : Value { provides | solid : Supported }
@@ -4523,9 +4546,10 @@ solid =
 
 
 {-| The `double` [`border-style`](<https://css-tricks.com/almanac/properties/b/border/#article-header-id-0> value.
-Two lines are drawn around the element.
 
     borderStyle double
+
+Two lines are drawn around the element.
 
 -}
 double : Value { provides | double : Supported }
@@ -4534,9 +4558,10 @@ double =
 
 
 {-| The `groove` [`border-style`](<https://css-tricks.com/almanac/properties/b/border/#article-header-id-0> value.
-Adds a bevel based on the color value in a way that makes the element appear pressed into the document.
 
     borderStyle groove
+
+Adds a bevel based on the color value in a way that makes the element appear pressed into the document.
 
 -}
 groove : Value { provides | groove : Supported }
@@ -4545,9 +4570,10 @@ groove =
 
 
 {-| The `ridge` [`border-style`](<https://css-tricks.com/almanac/properties/b/border/#article-header-id-0> value.
-Similar to `groove`, but reverses the color values in a way that makes the element appear raised.
 
     borderStyle ridge
+
+Similar to `groove`, but reverses the color values in a way that makes the element appear raised.
 
 -}
 ridge : Value { provides | ridge : Supported }
@@ -4556,9 +4582,10 @@ ridge =
 
 
 {-| The `inset` [`border-style`](<https://css-tricks.com/almanac/properties/b/border/#article-header-id-0> value.
-Adds a split tone to the line that makes the element appear slightly depressed.
 
     borderStyle inset
+
+Adds a split tone to the line that makes the element appear slightly depressed.
 
 -}
 inset : Value { provides | inset : Supported }
@@ -4567,9 +4594,10 @@ inset =
 
 
 {-| The `outset` [`border-style`](<https://css-tricks.com/almanac/properties/b/border/#article-header-id-0> value.
-Similar to `inset`, but reverses the colors in a way that makes the element appear slightly raised.
 
     borderStyle outset
+
+Similar to `inset`, but reverses the colors in a way that makes the element appear slightly raised.
 
 -}
 outset : Value { provides | outset : Supported }

--- a/src/Css.elm
+++ b/src/Css.elm
@@ -42,18 +42,30 @@ module Css
         , border
         , border2
         , border3
+        , borderBottom
+        , borderBottom2
+        , borderBottom3
         , borderBox
         , borderCollapse
         , borderColor
         , borderColor2
         , borderColor3
         , borderColor4
+        , borderLeft
+        , borderLeft2
+        , borderLeft3
+        , borderRight
+        , borderRight2
+        , borderRight3
         , borderSpacing
         , borderSpacing2
         , borderStyle
         , borderStyle2
         , borderStyle3
         , borderStyle4
+        , borderTop
+        , borderTop2
+        , borderTop3
         , borderWidth
         , borderWidth2
         , borderWidth3
@@ -387,16 +399,23 @@ All CSS properties can have the values `unset`, `initial`, and `inherit`.
 
 ## Border
 
-@docs border, border2, border3, borderColor, borderColor2, borderColor3, borderColor4, borderWidth, borderWidth2, borderWidth3, borderWidth4, borderStyle, borderStyle2, borderStyle3, borderStyle4
+@docs border, border2, border3, borderTop, borderTop2, borderTop3, borderRight, borderRight2, borderRight3, borderBottom, borderBottom2, borderBottom3, borderLeft, borderLeft2, borderLeft3
+
+
+## Border Color
+
+@docs borderColor, borderColor2, borderColor3, borderColor4
 
 
 ## Border Width
 
+@docs borderWidth, borderWidth2, borderWidth3, borderWidth4
 @docs thin ,thick
 
 
 ## Border Style
 
+@docs borderStyle, borderStyle2, borderStyle3, borderStyle4
 @docs dotted ,dashed ,solid ,double ,groove ,ridge ,inset ,outset
 
 
@@ -4502,6 +4521,618 @@ border3 :
     -> Style
 border3 (Value width) (Value style) (Value color) =
     AppendProperty ("border:" ++ width ++ " " ++ style ++ " " ++ color)
+
+
+{-| Sets [`border-top`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-top) property.
+
+    borderTop (px 1)
+    borderTop2 (px 1) solid
+    borderTop3 (px 1) solid (hex "#f00")
+
+-}
+borderTop :
+    Value
+        { ch : Supported
+        , cm : Supported
+        , em : Supported
+        , ex : Supported
+        , inches : Supported
+        , mm : Supported
+        , pc : Supported
+        , pt : Supported
+        , px : Supported
+        , rem : Supported
+        , vh : Supported
+        , vmax : Supported
+        , vmin : Supported
+        , vw : Supported
+        , zero : Supported
+        , thin : Supported
+        , medium : Supported
+        , thick : Supported
+        , inherit : Supported
+        , initial : Supported
+        , unset : Supported
+        }
+    -> Style
+borderTop (Value width) =
+    AppendProperty ("border-top:" ++ width)
+
+
+{-| Sets [`border-top`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-top) property.
+
+    borderTop (px 1)
+    borderTop2 (px 1) solid
+    borderTop3 (px 1) solid (hex "#f00")
+
+-}
+borderTop2 :
+    Value
+        { ch : Supported
+        , cm : Supported
+        , em : Supported
+        , ex : Supported
+        , inches : Supported
+        , mm : Supported
+        , pc : Supported
+        , pt : Supported
+        , px : Supported
+        , rem : Supported
+        , vh : Supported
+        , vmax : Supported
+        , vmin : Supported
+        , vw : Supported
+        , zero : Supported
+        , thin : Supported
+        , medium : Supported
+        , thick : Supported
+        , inherit : Supported
+        , initial : Supported
+        , unset : Supported
+        }
+    ->
+        Value
+            { solid : Supported
+            , none : Supported
+            , hidden : Supported
+            , dashed : Supported
+            , dotted : Supported
+            , double : Supported
+            , groove : Supported
+            , ridge : Supported
+            , inset : Supported
+            , outset : Supported
+            , inherit : Supported
+            , initial : Supported
+            , unset : Supported
+            }
+    -> Style
+borderTop2 (Value width) (Value style) =
+    AppendProperty ("border-top:" ++ width ++ " " ++ style)
+
+
+{-| Sets [`border-top`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-top) property.
+
+    borderTop (px 1)
+    borderTop2 (px 1) solid
+    borderTop3 (px 1) solid (hex "#f00")
+
+-}
+borderTop3 :
+    Value
+        { ch : Supported
+        , cm : Supported
+        , em : Supported
+        , ex : Supported
+        , inches : Supported
+        , mm : Supported
+        , pc : Supported
+        , pt : Supported
+        , px : Supported
+        , rem : Supported
+        , vh : Supported
+        , vmax : Supported
+        , vmin : Supported
+        , vw : Supported
+        , zero : Supported
+        , thin : Supported
+        , medium : Supported
+        , thick : Supported
+        , inherit : Supported
+        , initial : Supported
+        , unset : Supported
+        }
+    ->
+        Value
+            { solid : Supported
+            , none : Supported
+            , hidden : Supported
+            , dashed : Supported
+            , dotted : Supported
+            , double : Supported
+            , groove : Supported
+            , ridge : Supported
+            , inset : Supported
+            , outset : Supported
+            , inherit : Supported
+            , initial : Supported
+            , unset : Supported
+            }
+    ->
+        Value
+            { rgb : Supported
+            , rgba : Supported
+            , hsl : Supported
+            , hsla : Supported
+            , hex : Supported
+            , transparent : Supported
+            , currentColor : Supported
+            , inherit : Supported
+            , initial : Supported
+            , unset : Supported
+            }
+    -> Style
+borderTop3 (Value width) (Value style) (Value color) =
+    AppendProperty ("border-top:" ++ width ++ " " ++ style ++ " " ++ color)
+
+
+{-| Sets [`border-right`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-right) property.
+
+    borderRight (px 1)
+    borderRight2 (px 1) solid
+    borderRight3 (px 1) solid (hex "#f00")
+
+-}
+borderRight :
+    Value
+        { ch : Supported
+        , cm : Supported
+        , em : Supported
+        , ex : Supported
+        , inches : Supported
+        , mm : Supported
+        , pc : Supported
+        , pt : Supported
+        , px : Supported
+        , rem : Supported
+        , vh : Supported
+        , vmax : Supported
+        , vmin : Supported
+        , vw : Supported
+        , zero : Supported
+        , thin : Supported
+        , medium : Supported
+        , thick : Supported
+        , inherit : Supported
+        , initial : Supported
+        , unset : Supported
+        }
+    -> Style
+borderRight (Value width) =
+    AppendProperty ("border-right:" ++ width)
+
+
+{-| Sets [`border-right`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-right) property.
+
+    borderRight (px 1)
+    borderRight2 (px 1) solid
+    borderRight3 (px 1) solid (hex "#f00")
+
+-}
+borderRight2 :
+    Value
+        { ch : Supported
+        , cm : Supported
+        , em : Supported
+        , ex : Supported
+        , inches : Supported
+        , mm : Supported
+        , pc : Supported
+        , pt : Supported
+        , px : Supported
+        , rem : Supported
+        , vh : Supported
+        , vmax : Supported
+        , vmin : Supported
+        , vw : Supported
+        , zero : Supported
+        , thin : Supported
+        , medium : Supported
+        , thick : Supported
+        , inherit : Supported
+        , initial : Supported
+        , unset : Supported
+        }
+    ->
+        Value
+            { solid : Supported
+            , none : Supported
+            , hidden : Supported
+            , dashed : Supported
+            , dotted : Supported
+            , double : Supported
+            , groove : Supported
+            , ridge : Supported
+            , inset : Supported
+            , outset : Supported
+            , inherit : Supported
+            , initial : Supported
+            , unset : Supported
+            }
+    -> Style
+borderRight2 (Value width) (Value style) =
+    AppendProperty ("border-right:" ++ width ++ " " ++ style)
+
+
+{-| Sets [`border-right`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-right) property.
+
+    borderRight (px 1)
+    borderRight2 (px 1) solid
+    borderRight3 (px 1) solid (hex "#f00")
+
+-}
+borderRight3 :
+    Value
+        { ch : Supported
+        , cm : Supported
+        , em : Supported
+        , ex : Supported
+        , inches : Supported
+        , mm : Supported
+        , pc : Supported
+        , pt : Supported
+        , px : Supported
+        , rem : Supported
+        , vh : Supported
+        , vmax : Supported
+        , vmin : Supported
+        , vw : Supported
+        , zero : Supported
+        , thin : Supported
+        , medium : Supported
+        , thick : Supported
+        , inherit : Supported
+        , initial : Supported
+        , unset : Supported
+        }
+    ->
+        Value
+            { solid : Supported
+            , none : Supported
+            , hidden : Supported
+            , dashed : Supported
+            , dotted : Supported
+            , double : Supported
+            , groove : Supported
+            , ridge : Supported
+            , inset : Supported
+            , outset : Supported
+            , inherit : Supported
+            , initial : Supported
+            , unset : Supported
+            }
+    ->
+        Value
+            { rgb : Supported
+            , rgba : Supported
+            , hsl : Supported
+            , hsla : Supported
+            , hex : Supported
+            , transparent : Supported
+            , currentColor : Supported
+            , inherit : Supported
+            , initial : Supported
+            , unset : Supported
+            }
+    -> Style
+borderRight3 (Value width) (Value style) (Value color) =
+    AppendProperty ("border-right:" ++ width ++ " " ++ style ++ " " ++ color)
+
+
+{-| Sets [`border-bottom`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-bottom) property.
+
+    borderBottom (px 1)
+    borderBottom2 (px 1) solid
+    borderBottom3 (px 1) solid (hex "#f00")
+
+-}
+borderBottom :
+    Value
+        { ch : Supported
+        , cm : Supported
+        , em : Supported
+        , ex : Supported
+        , inches : Supported
+        , mm : Supported
+        , pc : Supported
+        , pt : Supported
+        , px : Supported
+        , rem : Supported
+        , vh : Supported
+        , vmax : Supported
+        , vmin : Supported
+        , vw : Supported
+        , zero : Supported
+        , thin : Supported
+        , medium : Supported
+        , thick : Supported
+        , inherit : Supported
+        , initial : Supported
+        , unset : Supported
+        }
+    -> Style
+borderBottom (Value width) =
+    AppendProperty ("border-bottom:" ++ width)
+
+
+{-| Sets [`border-bottom`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-bottom) property.
+
+    borderBottom (px 1)
+    borderBottom2 (px 1) solid
+    borderBottom3 (px 1) solid (hex "#f00")
+
+-}
+borderBottom2 :
+    Value
+        { ch : Supported
+        , cm : Supported
+        , em : Supported
+        , ex : Supported
+        , inches : Supported
+        , mm : Supported
+        , pc : Supported
+        , pt : Supported
+        , px : Supported
+        , rem : Supported
+        , vh : Supported
+        , vmax : Supported
+        , vmin : Supported
+        , vw : Supported
+        , zero : Supported
+        , thin : Supported
+        , medium : Supported
+        , thick : Supported
+        , inherit : Supported
+        , initial : Supported
+        , unset : Supported
+        }
+    ->
+        Value
+            { solid : Supported
+            , none : Supported
+            , hidden : Supported
+            , dashed : Supported
+            , dotted : Supported
+            , double : Supported
+            , groove : Supported
+            , ridge : Supported
+            , inset : Supported
+            , outset : Supported
+            , inherit : Supported
+            , initial : Supported
+            , unset : Supported
+            }
+    -> Style
+borderBottom2 (Value width) (Value style) =
+    AppendProperty ("border-bottom:" ++ width ++ " " ++ style)
+
+
+{-| Sets [`border-bottom`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-bottom) property.
+
+    borderBottom (px 1)
+    borderBottom2 (px 1) solid
+    borderBottom3 (px 1) solid (hex "#f00")
+
+-}
+borderBottom3 :
+    Value
+        { ch : Supported
+        , cm : Supported
+        , em : Supported
+        , ex : Supported
+        , inches : Supported
+        , mm : Supported
+        , pc : Supported
+        , pt : Supported
+        , px : Supported
+        , rem : Supported
+        , vh : Supported
+        , vmax : Supported
+        , vmin : Supported
+        , vw : Supported
+        , zero : Supported
+        , thin : Supported
+        , medium : Supported
+        , thick : Supported
+        , inherit : Supported
+        , initial : Supported
+        , unset : Supported
+        }
+    ->
+        Value
+            { solid : Supported
+            , none : Supported
+            , hidden : Supported
+            , dashed : Supported
+            , dotted : Supported
+            , double : Supported
+            , groove : Supported
+            , ridge : Supported
+            , inset : Supported
+            , outset : Supported
+            , inherit : Supported
+            , initial : Supported
+            , unset : Supported
+            }
+    ->
+        Value
+            { rgb : Supported
+            , rgba : Supported
+            , hsl : Supported
+            , hsla : Supported
+            , hex : Supported
+            , transparent : Supported
+            , currentColor : Supported
+            , inherit : Supported
+            , initial : Supported
+            , unset : Supported
+            }
+    -> Style
+borderBottom3 (Value width) (Value style) (Value color) =
+    AppendProperty ("border-bottom:" ++ width ++ " " ++ style ++ " " ++ color)
+
+
+{-| Sets [`border-left`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-left) property.
+
+    borderLeft (px 1)
+    borderLeft2 (px 1) solid
+    borderLeft3 (px 1) solid (hex "#f00")
+
+-}
+borderLeft :
+    Value
+        { ch : Supported
+        , cm : Supported
+        , em : Supported
+        , ex : Supported
+        , inches : Supported
+        , mm : Supported
+        , pc : Supported
+        , pt : Supported
+        , px : Supported
+        , rem : Supported
+        , vh : Supported
+        , vmax : Supported
+        , vmin : Supported
+        , vw : Supported
+        , zero : Supported
+        , thin : Supported
+        , medium : Supported
+        , thick : Supported
+        , inherit : Supported
+        , initial : Supported
+        , unset : Supported
+        }
+    -> Style
+borderLeft (Value width) =
+    AppendProperty ("border-left:" ++ width)
+
+
+{-| Sets [`border-left`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-left) property.
+
+    borderLeft (px 1)
+    borderLeft2 (px 1) solid
+    borderLeft3 (px 1) solid (hex "#f00")
+
+-}
+borderLeft2 :
+    Value
+        { ch : Supported
+        , cm : Supported
+        , em : Supported
+        , ex : Supported
+        , inches : Supported
+        , mm : Supported
+        , pc : Supported
+        , pt : Supported
+        , px : Supported
+        , rem : Supported
+        , vh : Supported
+        , vmax : Supported
+        , vmin : Supported
+        , vw : Supported
+        , zero : Supported
+        , thin : Supported
+        , medium : Supported
+        , thick : Supported
+        , inherit : Supported
+        , initial : Supported
+        , unset : Supported
+        }
+    ->
+        Value
+            { solid : Supported
+            , none : Supported
+            , hidden : Supported
+            , dashed : Supported
+            , dotted : Supported
+            , double : Supported
+            , groove : Supported
+            , ridge : Supported
+            , inset : Supported
+            , outset : Supported
+            , inherit : Supported
+            , initial : Supported
+            , unset : Supported
+            }
+    -> Style
+borderLeft2 (Value width) (Value style) =
+    AppendProperty ("border-left:" ++ width ++ " " ++ style)
+
+
+{-| Sets [`border-left`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-left) property.
+
+    borderLeft (px 1)
+    borderLeft2 (px 1) solid
+    borderLeft3 (px 1) solid (hex "#f00")
+
+-}
+borderLeft3 :
+    Value
+        { ch : Supported
+        , cm : Supported
+        , em : Supported
+        , ex : Supported
+        , inches : Supported
+        , mm : Supported
+        , pc : Supported
+        , pt : Supported
+        , px : Supported
+        , rem : Supported
+        , vh : Supported
+        , vmax : Supported
+        , vmin : Supported
+        , vw : Supported
+        , zero : Supported
+        , thin : Supported
+        , medium : Supported
+        , thick : Supported
+        , inherit : Supported
+        , initial : Supported
+        , unset : Supported
+        }
+    ->
+        Value
+            { solid : Supported
+            , none : Supported
+            , hidden : Supported
+            , dashed : Supported
+            , dotted : Supported
+            , double : Supported
+            , groove : Supported
+            , ridge : Supported
+            , inset : Supported
+            , outset : Supported
+            , inherit : Supported
+            , initial : Supported
+            , unset : Supported
+            }
+    ->
+        Value
+            { rgb : Supported
+            , rgba : Supported
+            , hsl : Supported
+            , hsla : Supported
+            , hex : Supported
+            , transparent : Supported
+            , currentColor : Supported
+            , inherit : Supported
+            , initial : Supported
+            , unset : Supported
+            }
+    -> Style
+borderLeft3 (Value width) (Value style) (Value color) =
+    AppendProperty ("border-left:" ++ width ++ " " ++ style ++ " " ++ color)
 
 
 {-| Sets [`border-width`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-width) property.

--- a/src/Css.elm
+++ b/src/Css.elm
@@ -722,6 +722,7 @@ initial =
 Any CSS property can be set to this value.
 
     display unset
+    borderStyle unset
 
 -}
 unset : Value { provides | unset : Supported }

--- a/src/Css.elm
+++ b/src/Css.elm
@@ -411,7 +411,15 @@ All CSS properties can have the values `unset`, `initial`, and `inherit`.
 
 ## Border
 
-@docs border, border2, border3, borderTop, borderTop2, borderTop3, borderRight, borderRight2, borderRight3, borderBottom, borderBottom2, borderBottom3, borderLeft, borderLeft2, borderLeft3
+@docs border, border2, border3
+
+@docs borderTop, borderTop2, borderTop3
+
+@docs borderRight, borderRight2, borderRight3
+
+@docs borderBottom, borderBottom2, borderBottom3
+
+@docs borderLeft, borderLeft2, borderLeft3
 
 
 ## Border Width

--- a/src/Css.elm
+++ b/src/Css.elm
@@ -45,6 +45,7 @@ module Css
         , borderBottom
         , borderBottom2
         , borderBottom3
+        , borderBottomStyle
         , borderBottomWidth
         , borderBox
         , borderCollapse
@@ -55,10 +56,12 @@ module Css
         , borderLeft
         , borderLeft2
         , borderLeft3
+        , borderLeftStyle
         , borderLeftWidth
         , borderRight
         , borderRight2
         , borderRight3
+        , borderRightStyle
         , borderRightWidth
         , borderSpacing
         , borderSpacing2
@@ -69,6 +72,7 @@ module Css
         , borderTop
         , borderTop2
         , borderTop3
+        , borderTopStyle
         , borderTopWidth
         , borderWidth
         , borderWidth2
@@ -414,14 +418,15 @@ All CSS properties can have the values `unset`, `initial`, and `inherit`.
 ## Border Width
 
 @docs borderWidth, borderWidth2, borderWidth3, borderWidth4, borderTopWidth, borderRightWidth, borderBottomWidth, borderLeftWidth
-@docs thin ,thick
+
+@docs thin, thick
 
 
 ## Border Style
 
-@docs borderStyle, borderStyle2, borderStyle3, borderStyle4
+@docs borderStyle, borderStyle2, borderStyle3, borderStyle4, borderTopStyle, borderRightStyle, borderBottomStyle, borderLeftStyle
 
-@docs dotted ,dashed ,solid ,double ,groove ,ridge ,inset ,outset
+@docs dotted, dashed, solid, double, groove, ridge, inset, outset
 
 
 ## Display
@@ -5778,6 +5783,110 @@ borderStyle4 :
     -> Style
 borderStyle4 (Value styleTop) (Value styleRigt) (Value styleBottom) (Value styleLeft) =
     AppendProperty ("border-style:" ++ styleTop ++ " " ++ styleRigt ++ " " ++ styleBottom ++ " " ++ styleLeft)
+
+
+{-| Sets [`border-top-style`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-top-style) property.
+
+    borderTopStyle solid
+
+-}
+borderTopStyle :
+    Value
+        { solid : Supported
+        , none : Supported
+        , hidden : Supported
+        , dashed : Supported
+        , dotted : Supported
+        , double : Supported
+        , groove : Supported
+        , ridge : Supported
+        , inset : Supported
+        , outset : Supported
+        , inherit : Supported
+        , initial : Supported
+        , unset : Supported
+        }
+    -> Style
+borderTopStyle (Value style) =
+    AppendProperty ("border-top-style:" ++ style)
+
+
+{-| Sets [`border-right-style`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-right-style) property.
+
+    borderRightStyle solid
+
+-}
+borderRightStyle :
+    Value
+        { solid : Supported
+        , none : Supported
+        , hidden : Supported
+        , dashed : Supported
+        , dotted : Supported
+        , double : Supported
+        , groove : Supported
+        , ridge : Supported
+        , inset : Supported
+        , outset : Supported
+        , inherit : Supported
+        , initial : Supported
+        , unset : Supported
+        }
+    -> Style
+borderRightStyle (Value style) =
+    AppendProperty ("border-right-style:" ++ style)
+
+
+{-| Sets [`border-bottom-style`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-bottom-style) property.
+
+    borderBottomStyle solid
+
+-}
+borderBottomStyle :
+    Value
+        { solid : Supported
+        , none : Supported
+        , hidden : Supported
+        , dashed : Supported
+        , dotted : Supported
+        , double : Supported
+        , groove : Supported
+        , ridge : Supported
+        , inset : Supported
+        , outset : Supported
+        , inherit : Supported
+        , initial : Supported
+        , unset : Supported
+        }
+    -> Style
+borderBottomStyle (Value style) =
+    AppendProperty ("border-bottom-style:" ++ style)
+
+
+{-| Sets [`border-left-style`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-left-style) property.
+
+    borderLeftStyle solid
+
+-}
+borderLeftStyle :
+    Value
+        { solid : Supported
+        , none : Supported
+        , hidden : Supported
+        , dashed : Supported
+        , dotted : Supported
+        , double : Supported
+        , groove : Supported
+        , ridge : Supported
+        , inset : Supported
+        , outset : Supported
+        , inherit : Supported
+        , initial : Supported
+        , unset : Supported
+        }
+    -> Style
+borderLeftStyle (Value style) =
+    AppendProperty ("border-left-style:" ++ style)
 
 
 {-| Sets [`border-color`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-color) property.

--- a/src/Css.elm
+++ b/src/Css.elm
@@ -45,6 +45,7 @@ module Css
         , borderBottom
         , borderBottom2
         , borderBottom3
+        , borderBottomWidth
         , borderBox
         , borderCollapse
         , borderColor
@@ -54,9 +55,11 @@ module Css
         , borderLeft
         , borderLeft2
         , borderLeft3
+        , borderLeftWidth
         , borderRight
         , borderRight2
         , borderRight3
+        , borderRightWidth
         , borderSpacing
         , borderSpacing2
         , borderStyle
@@ -66,6 +69,7 @@ module Css
         , borderTop
         , borderTop2
         , borderTop3
+        , borderTopWidth
         , borderWidth
         , borderWidth2
         , borderWidth3
@@ -409,13 +413,14 @@ All CSS properties can have the values `unset`, `initial`, and `inherit`.
 
 ## Border Width
 
-@docs borderWidth, borderWidth2, borderWidth3, borderWidth4
+@docs borderWidth, borderWidth2, borderWidth3, borderWidth4, borderTopWidth, borderRightWidth, borderBottomWidth, borderLeftWidth
 @docs thin ,thick
 
 
 ## Border Style
 
 @docs borderStyle, borderStyle2, borderStyle3, borderStyle4
+
 @docs dotted ,dashed ,solid ,double ,groove ,ridge ,inset ,outset
 
 
@@ -5425,6 +5430,142 @@ borderWidth4 :
     -> Style
 borderWidth4 (Value widthTop) (Value widthRight) (Value widthBottom) (Value widthLeft) =
     AppendProperty ("border-width:" ++ widthTop ++ " " ++ widthRight ++ " " ++ widthBottom ++ " " ++ widthLeft)
+
+
+{-| Sets [`border-top-width`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-top-width) property.
+
+    borderTopWidth (px 1)
+
+-}
+borderTopWidth :
+    Value
+        { ch : Supported
+        , cm : Supported
+        , em : Supported
+        , ex : Supported
+        , inches : Supported
+        , mm : Supported
+        , pc : Supported
+        , pt : Supported
+        , px : Supported
+        , rem : Supported
+        , vh : Supported
+        , vmax : Supported
+        , vmin : Supported
+        , vw : Supported
+        , zero : Supported
+        , thin : Supported
+        , medium : Supported
+        , thick : Supported
+        , inherit : Supported
+        , initial : Supported
+        , unset : Supported
+        }
+    -> Style
+borderTopWidth (Value width) =
+    AppendProperty ("border-top-width:" ++ width)
+
+
+{-| Sets [`border-right-width`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-right-width) property.
+
+    borderRightWidth (px 1)
+
+-}
+borderRightWidth :
+    Value
+        { ch : Supported
+        , cm : Supported
+        , em : Supported
+        , ex : Supported
+        , inches : Supported
+        , mm : Supported
+        , pc : Supported
+        , pt : Supported
+        , px : Supported
+        , rem : Supported
+        , vh : Supported
+        , vmax : Supported
+        , vmin : Supported
+        , vw : Supported
+        , zero : Supported
+        , thin : Supported
+        , medium : Supported
+        , thick : Supported
+        , inherit : Supported
+        , initial : Supported
+        , unset : Supported
+        }
+    -> Style
+borderRightWidth (Value width) =
+    AppendProperty ("border-right-width:" ++ width)
+
+
+{-| Sets [`border-bottom-width`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-bottom-width) property.
+
+    borderBottomWidth (px 1)
+
+-}
+borderBottomWidth :
+    Value
+        { ch : Supported
+        , cm : Supported
+        , em : Supported
+        , ex : Supported
+        , inches : Supported
+        , mm : Supported
+        , pc : Supported
+        , pt : Supported
+        , px : Supported
+        , rem : Supported
+        , vh : Supported
+        , vmax : Supported
+        , vmin : Supported
+        , vw : Supported
+        , zero : Supported
+        , thin : Supported
+        , medium : Supported
+        , thick : Supported
+        , inherit : Supported
+        , initial : Supported
+        , unset : Supported
+        }
+    -> Style
+borderBottomWidth (Value width) =
+    AppendProperty ("border-bottom-width:" ++ width)
+
+
+{-| Sets [`border-left-width`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-left-width) property.
+
+    borderLeftWidth (px 1)
+
+-}
+borderLeftWidth :
+    Value
+        { ch : Supported
+        , cm : Supported
+        , em : Supported
+        , ex : Supported
+        , inches : Supported
+        , mm : Supported
+        , pc : Supported
+        , pt : Supported
+        , px : Supported
+        , rem : Supported
+        , vh : Supported
+        , vmax : Supported
+        , vmin : Supported
+        , vw : Supported
+        , zero : Supported
+        , thin : Supported
+        , medium : Supported
+        , thick : Supported
+        , inherit : Supported
+        , initial : Supported
+        , unset : Supported
+        }
+    -> Style
+borderLeftWidth (Value width) =
+    AppendProperty ("border-left-width:" ++ width)
 
 
 {-| Sets [`border-style`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-style) property.

--- a/src/Css.elm
+++ b/src/Css.elm
@@ -44,6 +44,10 @@ module Css
         , border3
         , borderBox
         , borderCollapse
+        , borderColor
+        , borderColor2
+        , borderColor3
+        , borderColor4
         , borderSpacing
         , borderSpacing2
         , bottom
@@ -375,7 +379,7 @@ All CSS properties can have the values `unset`, `initial`, and `inherit`.
 
 ## Border
 
-@docs border, border2, border3
+@docs border, border2, border3 ,borderColor ,borderColor2 ,borderColor3 ,borderColor4
 
 
 ## Border Width
@@ -4476,6 +4480,138 @@ border3 :
     -> Style
 border3 (Value width) (Value style) (Value color) =
     AppendProperty ("border:" ++ width ++ " " ++ style ++ " " ++ color)
+
+
+{-| Sets [`border-color`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-color) property.
+
+    borderColor (rgb 0 0 0)
+    borderColor2 (rgb 0 0 0) (hsl 10 10 10)
+    borderColor3 (rgb 0 0 0) (hsl 10 10 10) (hex "#fff")
+    borderColor4 (rgb 0 0 0) (hsl 10 10 10) (hex "#fff") transparent
+
+-}
+borderColor :
+    Value
+        { rgb : Supported
+        , rgba : Supported
+        , hsl : Supported
+        , hsla : Supported
+        , hex : Supported
+        }
+    -> Style
+borderColor (Value color) =
+    AppendProperty ("border-color:" ++ color)
+
+
+{-| Sets [`border-color`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-color) property.
+
+    borderColor (rgb 0 0 0)
+    borderColor2 (rgb 0 0 0) (hsl 10 10 10)
+    borderColor3 (rgb 0 0 0) (hsl 10 10 10) (hex "#fff")
+    borderColor4 (rgb 0 0 0) (hsl 10 10 10) (hex "#fff") transparent
+
+-}
+borderColor2 :
+    Value
+        { rgb : Supported
+        , rgba : Supported
+        , hsl : Supported
+        , hsla : Supported
+        , hex : Supported
+        }
+    ->
+        Value
+            { rgb : Supported
+            , rgba : Supported
+            , hsl : Supported
+            , hsla : Supported
+            , hex : Supported
+            }
+    -> Style
+borderColor2 (Value colorTopBottom) (Value colorRightLeft) =
+    AppendProperty ("border-color:" ++ colorTopBottom ++ " " ++ colorRightLeft)
+
+
+{-| Sets [`border-color`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-color) property.
+
+    borderColor (rgb 0 0 0)
+    borderColor2 (rgb 0 0 0) (hsl 10 10 10)
+    borderColor3 (rgb 0 0 0) (hsl 10 10 10) (hex "#fff")
+    borderColor4 (rgb 0 0 0) (hsl 10 10 10) (hex "#fff") transparent
+
+-}
+borderColor3 :
+    Value
+        { rgb : Supported
+        , rgba : Supported
+        , hsl : Supported
+        , hsla : Supported
+        , hex : Supported
+        }
+    ->
+        Value
+            { rgb : Supported
+            , rgba : Supported
+            , hsl : Supported
+            , hsla : Supported
+            , hex : Supported
+            }
+    ->
+        Value
+            { rgb : Supported
+            , rgba : Supported
+            , hsl : Supported
+            , hsla : Supported
+            , hex : Supported
+            }
+    -> Style
+borderColor3 (Value colorTop) (Value colorRightLeft) (Value colorBottom) =
+    AppendProperty ("border-color:" ++ colorTop ++ " " ++ colorRightLeft ++ " " ++ colorBottom)
+
+
+{-| Sets [`border-color`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-color) property.
+
+    borderColor (rgb 0 0 0)
+    borderColor2 (rgb 0 0 0) (hsl 10 10 10)
+    borderColor3 (rgb 0 0 0) (hsl 10 10 10) (hex "#fff")
+    borderColor4 (rgb 0 0 0) (hsl 10 10 10) (hex "#fff") transparent
+
+-}
+borderColor4 :
+    Value
+        { rgb : Supported
+        , rgba : Supported
+        , hsl : Supported
+        , hsla : Supported
+        , hex : Supported
+        }
+    ->
+        Value
+            { rgb : Supported
+            , rgba : Supported
+            , hsl : Supported
+            , hsla : Supported
+            , hex : Supported
+            }
+    ->
+        Value
+            { rgb : Supported
+            , rgba : Supported
+            , hsl : Supported
+            , hsla : Supported
+            , hex : Supported
+            }
+    ->
+        Value
+            { rgb : Supported
+            , rgba : Supported
+            , hsl : Supported
+            , hsla : Supported
+            , hex : Supported
+            }
+    -> Style
+borderColor4 (Value colorTop) (Value colorRight) (Value colorBottom) (Value colorLeft) =
+    AppendProperty ("border-color:" ++ colorTop ++ " " ++ colorRight ++ " " ++ colorBottom ++ " " ++ colorLeft)
 
 
 

--- a/src/Css.elm
+++ b/src/Css.elm
@@ -4476,6 +4476,11 @@ border3 :
             , hsl : Supported
             , hsla : Supported
             , hex : Supported
+            , transparent : Supported
+            , currentColor : Supported
+            , inherit : Supported
+            , initial : Supported
+            , unset : Supported
             }
     -> Style
 border3 (Value width) (Value style) (Value color) =
@@ -4497,6 +4502,11 @@ borderColor :
         , hsl : Supported
         , hsla : Supported
         , hex : Supported
+        , transparent : Supported
+        , currentColor : Supported
+        , inherit : Supported
+        , initial : Supported
+        , unset : Supported
         }
     -> Style
 borderColor (Value color) =
@@ -4518,6 +4528,11 @@ borderColor2 :
         , hsl : Supported
         , hsla : Supported
         , hex : Supported
+        , transparent : Supported
+        , currentColor : Supported
+        , inherit : Supported
+        , initial : Supported
+        , unset : Supported
         }
     ->
         Value
@@ -4526,6 +4541,11 @@ borderColor2 :
             , hsl : Supported
             , hsla : Supported
             , hex : Supported
+            , transparent : Supported
+            , currentColor : Supported
+            , inherit : Supported
+            , initial : Supported
+            , unset : Supported
             }
     -> Style
 borderColor2 (Value colorTopBottom) (Value colorRightLeft) =
@@ -4547,6 +4567,11 @@ borderColor3 :
         , hsl : Supported
         , hsla : Supported
         , hex : Supported
+        , transparent : Supported
+        , currentColor : Supported
+        , inherit : Supported
+        , initial : Supported
+        , unset : Supported
         }
     ->
         Value
@@ -4555,6 +4580,11 @@ borderColor3 :
             , hsl : Supported
             , hsla : Supported
             , hex : Supported
+            , transparent : Supported
+            , currentColor : Supported
+            , inherit : Supported
+            , initial : Supported
+            , unset : Supported
             }
     ->
         Value
@@ -4563,6 +4593,11 @@ borderColor3 :
             , hsl : Supported
             , hsla : Supported
             , hex : Supported
+            , transparent : Supported
+            , currentColor : Supported
+            , inherit : Supported
+            , initial : Supported
+            , unset : Supported
             }
     -> Style
 borderColor3 (Value colorTop) (Value colorRightLeft) (Value colorBottom) =
@@ -4584,6 +4619,11 @@ borderColor4 :
         , hsl : Supported
         , hsla : Supported
         , hex : Supported
+        , transparent : Supported
+        , currentColor : Supported
+        , inherit : Supported
+        , initial : Supported
+        , unset : Supported
         }
     ->
         Value
@@ -4592,6 +4632,11 @@ borderColor4 :
             , hsl : Supported
             , hsla : Supported
             , hex : Supported
+            , transparent : Supported
+            , currentColor : Supported
+            , inherit : Supported
+            , initial : Supported
+            , unset : Supported
             }
     ->
         Value
@@ -4600,6 +4645,11 @@ borderColor4 :
             , hsl : Supported
             , hsla : Supported
             , hex : Supported
+            , transparent : Supported
+            , currentColor : Supported
+            , inherit : Supported
+            , initial : Supported
+            , unset : Supported
             }
     ->
         Value
@@ -4608,6 +4658,11 @@ borderColor4 :
             , hsl : Supported
             , hsla : Supported
             , hex : Supported
+            , transparent : Supported
+            , currentColor : Supported
+            , inherit : Supported
+            , initial : Supported
+            , unset : Supported
             }
     -> Style
 borderColor4 (Value colorTop) (Value colorRight) (Value colorBottom) (Value colorLeft) =


### PR DESCRIPTION
Hi @rtfeldman! I'm glad to show `border` properties as a part of #392 here. Please take a look.

## Checklist

- [x] Each `Value` is an **open record** with a single field. The field's name is the value's name, and its type is `Supported`. For example `foo : Value { provides | foo : Supported }`
- [x] Each function returning `Style` accepts a **closed record** of `Supported` fields, which always includes `inherit`, `initial`, and `unset` because all CSS properties support those three values! For example, `borderFoo : Value { foo : Supported, bar : Supported, inherit : Supported, initial : Supported, unset : Supported } -> Style`
- [x] Every exposed value has documentation which includes at least 1 code sample.
- [x] Documentation links to to a [**CSS Tricks** article](https://css-tricks.com/) if available, and [MDN](https://developer.mozilla.org/en-US/docs/Web/CSS) if not.
- [x] Make a pull request against the `phantom-types` branch, not `master`!