### PR TITLE
Add float

### DIFF
--- a/src/Css.elm
+++ b/src/Css.elm
@@ -136,6 +136,7 @@ module Css
         , fixed
         , flexEnd
         , flexStart
+        , float
         , fontFamilies
         , fontFamily
         , fontSize
@@ -634,6 +635,11 @@ Multiple CSS properties use these values.
 
 @docs whiteSpace
 @docs pre, preWrap, preLine, nowrap
+
+
+## Float
+
+@docs float
 
 -}
 
@@ -7162,3 +7168,28 @@ preWrap =
 preLine : Value { provides | preLine : Supported }
 preLine =
     Value "pre-line"
+
+
+
+-- FLOAT --
+
+
+{-| Sets [`float`](https://css-tricks.com/almanac/properties/f/float/).
+
+    float none
+    float left_
+    float right_
+
+-}
+float :
+    Value
+        { none : Supported
+        , left_ : Supported
+        , right_ : Supported
+        , inherit : Supported
+        , initial : Supported
+        , unset : Supported
+        }
+    -> Style
+float (Value str) =
+    AppendProperty ("float:" ++ str)


### PR DESCRIPTION
## Contribution Checklist

- [x] Each `Value` is an **open record** with a single field. The field's name is the value's name, and its type is `Supported`. For example `foo : Value { provides | foo : Supported }`
- [x] Each function returning `Style` accepts a **closed record** of `Supported` fields, which always includes `inherit`, `initial`, and `unset` because all CSS properties support those three values! For example, `borderFoo : Value { foo : Supported, bar : Supported, inherit : Supported, initial : Supported, unset : Supported } -> Style`
- [x] Every exposed value has documentation which includes at least 1 code sample.
- [x] Documentation links to to a [**CSS Tricks** article](https://css-tricks.com/) if available, and [MDN](https://developer.mozilla.org/en-US/docs/Web/CSS) if not.
- [x] Make a pull request against the `phantom-types` branch, not `master`!