### PR TITLE
Add word-break

### DIFF
--- a/src/Css.elm
+++ b/src/Css.elm
@@ -87,6 +87,7 @@ module Css
         , bottom
         , bottom_
         , boxShadow
+        , breakAll
         , breakWord
         , capitalize
         , captionSide
@@ -174,6 +175,7 @@ module Css
         , italic
         , justify
         , kannada
+        , keepAll
         , khmer
         , lao
         , large
@@ -344,6 +346,7 @@ module Css
         , wait
         , wavy
         , whiteSpace
+        , wordBreak
         , xLarge
         , xSmall
         , xxLarge
@@ -634,6 +637,12 @@ Multiple CSS properties use these values.
 
 @docs whiteSpace
 @docs pre, preWrap, preLine, nowrap
+
+
+## Word break
+
+@docs wordBreak
+@docs breakAll, keepAll
 
 -}
 
@@ -953,7 +962,13 @@ overflowWrap (Value val) =
     AppendProperty ("overflow-wrap:" ++ val)
 
 
-{-| The `break-word` value for the [`overflow-wrap`](https://css-tricks.com/almanac/properties/o/overflow-wrap/) property.
+{-| The `break-word` value, which can be used with such properties as
+[`overflow-wrap`](https://css-tricks.com/almanac/properties/o/overflow-wrap/)
+and [`word-break`](https://css-tricks.com/almanac/properties/w/word-break/).
+
+    overflowWrap breakWord
+    wordBreak breakWord
+
 -}
 breakWord : Value { provides | breakWord : Supported }
 breakWord =
@@ -2604,9 +2619,12 @@ fontVariantCaps (Value str) =
 {-| The `normal` value, which can be used with such properties as
 [`font-variant-caps`](https://developer.mozilla.org/en-US/docs/Web/CSS/font-variant-caps#Values),
 [`white-space`](https://css-tricks.com/almanac/properties/w/whitespace/),
+[`word-break`](https://css-tricks.com/almanac/properties/w/word-break/),
 and [`align-items`](https://developer.mozilla.org/en-US/docs/Web/CSS/align-items#Values).
 
     fontVariantCaps normal
+    whiteSpace normal
+    wordBreak normal
     alignItems normal
 
 -}
@@ -7162,3 +7180,50 @@ preWrap =
 preLine : Value { provides | preLine : Supported }
 preLine =
     Value "pre-line"
+
+
+
+--- WORD-BREAK ---
+
+
+{-| Sets [`word-break`](https://css-tricks.com/almanac/properties/w/word-break/)
+
+      wordBreak normal
+      wordBreak breakAll
+      wordBreak keepAll
+      wordBreak breakWord
+
+-}
+wordBreak :
+    Value
+        { normal : Supported
+        , breakAll : Supported
+        , keepAll : Supported
+        , breakWord : Supported
+        , inherit : Supported
+        , initial : Supported
+        , unset : Supported
+        }
+    -> Style
+wordBreak (Value str) =
+    AppendProperty ("word-break:" ++ str)
+
+
+{-| A `breakAll` value for the [`word-break`](https://css-tricks.com/almanac/properties/w/word-break/) property.
+
+      wordBreak breakAll
+
+-}
+breakAll : Value { provides | breakAll : Supported }
+breakAll =
+    Value "break-all"
+
+
+{-| A `keepAll` value for the [`word-break`](https://css-tricks.com/almanac/properties/w/word-break/) property.
+
+      wordBreak keepAll
+
+-}
+keepAll : Value { provides | keepAll : Supported }
+keepAll =
+    Value "keep-all"


### PR DESCRIPTION
## Contribution Checklist

- [x] Each `Value` is an **open record** with a single field. The field's name is the value's name, and its type is `Supported`. For example `foo : Value { provides | foo : Supported }`
- [x] Each function returning `Style` accepts a **closed record** of `Supported` fields, which always includes `inherit`, `initial`, and `unset` because all CSS properties support those three values! For example, `borderFoo : Value { foo : Supported, bar : Supported, inherit : Supported, initial : Supported, unset : Supported } -> Style`
- [x] Every exposed value has documentation which includes at least 1 code sample.
- [x] Documentation links to to a [**CSS Tricks** article](https://css-tricks.com/) if available, and [MDN](https://developer.mozilla.org/en-US/docs/Web/CSS) if not.
- [x] Make a pull request against the `phantom-types` branch, not `master`!