### PR TITLE
Add visibility

### DIFF
--- a/src/Css.elm
+++ b/src/Css.elm
@@ -339,6 +339,7 @@ module Css
         , verticalAlign
         , verticalText
         , vh
+        , visibility
         , visible
         , vmax
         , vmin
@@ -638,7 +639,6 @@ Multiple CSS properties use these values.
 
 @docs whiteSpace
 @docs pre, preWrap, preLine, nowrap
-
 
 
 ## Word break
@@ -6746,9 +6746,11 @@ borderCollapse (Value str) =
     AppendProperty ("border-collapse:" ++ str)
 
 
-{-| A `collapse` value for the [`border-collapse`](https://css-tricks.com/almanac/properties/b/border-collapse/) property.
+{-| A `collapse` value for the [`border-collapse`](https://css-tricks.com/almanac/properties/b/border-collapse/) and
+[`visibility`](https://css-tricks.com/almanac/properties/v/visibility/) property.
 
     borderCollapse collapse
+    visibility collapse
 
 -}
 collapse : Value { provides | collapse : Supported }
@@ -7258,3 +7260,28 @@ float :
     -> Style
 float (Value str) =
     AppendProperty ("float:" ++ str)
+
+
+
+-- VISIBILITY --
+
+
+{-| Sets [`visibility`](https://css-tricks.com/almanac/properties/v/visibility/)
+
+      visibility visible
+      visibility hidden
+      visibility collapse
+
+-}
+visibility :
+    Value
+        { visible : Supported
+        , hidden : Supported
+        , collapse : Supported
+        , inherit : Supported
+        , initial : Supported
+        , unset : Supported
+        }
+    -> Style
+visibility (Value str) =
+    AppendProperty ("visibility:" ++ str)


### PR DESCRIPTION
## Contribution Checklist

- [x] Each `Value` is an **open record** with a single field. The field's name is the value's name, and its type is `Supported`. For example `foo : Value { provides | foo : Supported }`
- [x] Each function returning `Style` accepts a **closed record** of `Supported` fields.
- [x] If a function returning `Style` takes a single `Value`, that `Value` should always support `inherit`, `initial`, and `unset` because all CSS properties support those three values! For example, `borderFoo : Value { foo : Supported, bar : Supported, inherit : Supported, initial : Supported, unset : Supported } -> Style`
- [x] If a function returning `Style` takes **more than one** `Value`, however, then **none** of its arguments should support `inherit`, `initial`, or `unset`, because these can never be used in conjunction with other values! For example, `border-radius: 5px 5px;` is valid CSS, `border-radius: inherit;` is valid CSS, but `border-radius: 5px inherit;` is invalid CSS. To reflect this, `borderRadius : Value { ... } -> Style` must have `inherit : Supported` in its record, but `borderRadius2 : Value { ... } -> Value { ... } -> Style` must **not** have `inherit : Supported` in *either* argument's record. If a user wants to get `border-radius: inherit`, they must call `borderRadius`, not `borderRadius2`! 
- [x] Every exposed value has documentation which includes at least 1 code sample.
- [x] Documentation links to to a [**CSS Tricks** article](https://css-tricks.com/) if available, and [MDN](https://developer.mozilla.org/en-US/docs/Web/CSS) if not.
- [x] Make a pull request against the `phantom-types` branch, not `master`!