### PR TITLE
Phantom types: fix wordbreak

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,5 +38,8 @@ script:
   - elm-make --output=/dev/null --yes
   - cd ../readme-example
   - elm-make --output=/dev/null --yes
-  # - cd ..
+  - cd ..
+  # this line is here to catch type errors until phantom-types is merged into
+  # master, at which point it can be replaced by the test script again. :)
+  - elm-make --docs=/dev/null --yes
   # - npm test

--- a/src/Css.elm
+++ b/src/Css.elm
@@ -7202,14 +7202,13 @@ preLine =
 -}
 wordBreak :
     Value
-        { provides
-            | normal : Supported
-            , breakAll : Supported
-            , keepAll : Supported
-            , breakWord : Supported
-            , inherit : Supported
-            , initial : Supported
-            , unset : Supported
+        { normal : Supported
+        , breakAll : Supported
+        , keepAll : Supported
+        , breakWord : Supported
+        , inherit : Supported
+        , initial : Supported
+        , unset : Supported
         }
     -> Style
 wordBreak (Value str) =

--- a/src/Css.elm
+++ b/src/Css.elm
@@ -7202,14 +7202,16 @@ preLine =
 -}
 wordBreak :
     Value
-        { normal : Supported
-        , breakAll : Supported
-        , keepAll : Supported
-        , breakWord : Supported
-        , inherit : Supported
-        , initial : Supported
-        , unset : Supported
+        { provides
+            | normal : Supported
+            , breakAll : Supported
+            , keepAll : Supported
+            , breakWord : Supported
+            , inherit : Supported
+            , initial : Supported
+            , unset : Supported
         }
+    -> Style
 wordBreak (Value str) =
     AppendProperty ("word-break:" ++ str)
 


### PR DESCRIPTION
`wordBreak` currently has the wrong signature in phantom-types :cry: This fixes it. I *think* it's right! But always good to have a second set of eyes on it 😄

Also adds a Travis check for type signatures so future issues on phantom-types should fail the build.