### PR TITLE
Styled.styled supports tesk9/accessible-html-with-css by being more general

### DIFF
--- a/src/Html/Styled.elm
+++ b/src/Html/Styled.elm
@@ -293,10 +293,10 @@ attributes). They will be applied after the pre-applied styles.
 
 -}
 styled :
-    (List (Attribute msg) -> List (Html msg) -> Html msg)
+    (List (Attribute a) -> List (Html b) -> Html msg)
     -> List Style
-    -> List (Attribute msg)
-    -> List (Html msg)
+    -> List (Attribute a)
+    -> List (Html b)
     -> Html msg
 styled fn styles attrs children =
     fn (Internal.css styles :: attrs) children


### PR DESCRIPTION
(paired with @avh4)

Previously:

when using `Html.Styled.styled`, with `tesk9/accessible-html-with-css`, `styled` would coerce all subtypes into `Html Never`

This PR generalizes `Html.Styled.styled` such that it can still return `Html msg`