### PR TITLE
Phantom types: background-size

### DIFF
--- a/src/Css.elm
+++ b/src/Css.elm
@@ -4348,9 +4348,6 @@ backgroundSize2 :
             , vmin : Supported
             , vmax : Supported
             , auto : Supported
-            , inherit : Supported
-            , initial : Supported
-            , unset : Supported
         }
     ->
         Value
@@ -4373,9 +4370,6 @@ backgroundSize2 :
                 , vmin : Supported
                 , vmax : Supported
                 , auto : Supported
-                , inherit : Supported
-                , initial : Supported
-                , unset : Supported
             }
     -> Style
 backgroundSize2 (Value width) (Value height) =

--- a/src/Css.elm
+++ b/src/Css.elm
@@ -4367,8 +4367,9 @@ backgroundSize2 (Value width) (Value height) =
     AppendProperty ("background-size:" ++ width ++ " " ++ height)
 
 
-{-| Used in [`backgroundSize`](#backgroundSize) to always show the whole
-background image, even if it leaves empty spaces on the sides.
+{-| Sets [`contain`](https://css-tricks.com/almanac/properties/b/background-size/)
+for [`backgroundSize`](#backgroundSize). It always show the whole background
+image, even if it leaves empty spaces on the sides.
 
     backgroundSize contain
 
@@ -4378,8 +4379,9 @@ contain =
     Value "contain"
 
 
-{-| Used in [`backgroundSize`](#backgroundSize) to always fill the whole
-background, even if it cuts off some of the image.
+{-| Sets [`contain`](https://css-tricks.com/almanac/properties/b/background-size/)
+for [`backgroundSize`](#backgroundSize). It fills the whole space available with
+the background image by scaling, even if it cuts off some of the image.
 
     backgroundSize cover
 

--- a/src/Css.elm
+++ b/src/Css.elm
@@ -4290,28 +4290,25 @@ need to set both width and height explicitly, use
 -}
 backgroundSize :
     Value
-        { provides
-            | contain : Supported
-            , cover : Supported
-            , px : Supported
-            , cm : Supported
-            , mm : Supported
-            , inches : Supported
-            , pc : Supported
-            , pct : Supported
-            , pt : Supported
-            , ch : Supported
-            , em : Supported
-            , ex : Supported
-            , rem : Supported
-            , vh : Supported
-            , vw : Supported
-            , vmin : Supported
-            , vmax : Supported
-            , auto : Supported
-            , inherit : Supported
-            , initial : Supported
-            , unset : Supported
+        { px : Supported
+        , cm : Supported
+        , mm : Supported
+        , inches : Supported
+        , pc : Supported
+        , pct : Supported
+        , pt : Supported
+        , ch : Supported
+        , em : Supported
+        , ex : Supported
+        , rem : Supported
+        , vh : Supported
+        , vw : Supported
+        , vmin : Supported
+        , vmax : Supported
+        , auto : Supported
+        , inherit : Supported
+        , initial : Supported
+        , unset : Supported
         }
     -> Style
 backgroundSize (Value size) =
@@ -4329,10 +4326,26 @@ If you only want to set the width, use [`backgroundImage`](#backgroundImage) ins
 -}
 backgroundSize2 :
     Value
-        { provides
-            | contain : Supported
-            , cover : Supported
-            , px : Supported
+        { px : Supported
+        , cm : Supported
+        , mm : Supported
+        , inches : Supported
+        , pc : Supported
+        , pct : Supported
+        , pt : Supported
+        , ch : Supported
+        , em : Supported
+        , ex : Supported
+        , rem : Supported
+        , vh : Supported
+        , vw : Supported
+        , vmin : Supported
+        , vmax : Supported
+        , auto : Supported
+        }
+    ->
+        Value
+            { px : Supported
             , cm : Supported
             , mm : Supported
             , inches : Supported
@@ -4348,28 +4361,6 @@ backgroundSize2 :
             , vmin : Supported
             , vmax : Supported
             , auto : Supported
-        }
-    ->
-        Value
-            { provides
-                | contain : Supported
-                , cover : Supported
-                , px : Supported
-                , cm : Supported
-                , mm : Supported
-                , inches : Supported
-                , pc : Supported
-                , pct : Supported
-                , pt : Supported
-                , ch : Supported
-                , em : Supported
-                , ex : Supported
-                , rem : Supported
-                , vh : Supported
-                , vw : Supported
-                , vmin : Supported
-                , vmax : Supported
-                , auto : Supported
             }
     -> Style
 backgroundSize2 (Value width) (Value height) =

--- a/src/Css.elm
+++ b/src/Css.elm
@@ -35,6 +35,7 @@ module Css
         , backgroundRepeat
         , backgroundRepeat2
         , backgroundSize
+        , backgroundSize2
         , baseline
         , batch
         , before
@@ -421,7 +422,7 @@ All CSS properties can have the values `unset`, `initial`, and `inherit`.
 
 ## Background Image
 
-@docs backgroundImage, backgroundImages, backgroundPosition, backgroundPosition2, backgroundPosition4, backgroundRepeat, backgroundRepeat2, backgroundSize
+@docs backgroundImage, backgroundImages, backgroundPosition, backgroundPosition2, backgroundPosition4, backgroundRepeat, backgroundRepeat2, backgroundSize, backgroundSize2
 
 @docs linearGradient, stop, stop2, toBottom, toBottomLeft, toBottomRight, toLeft, toRight, toTop, toTopLeft, toTopRight
 
@@ -4282,7 +4283,9 @@ round =
     backgroundSize (px 400)
 
 If you give a length value, it will be used for the width. The height will be set
-proportional to the size of the [`background-image`](#backgroundImage).
+proportional to the size of the [`background-image`](#backgroundImage). If you
+need to set both width and height explicitly, use
+[`backgroundImage2`](#backgroundImage2) instead.
 
 -}
 backgroundSize :
@@ -4313,6 +4316,70 @@ backgroundSize :
     -> Style
 backgroundSize (Value size) =
     AppendProperty ("background-size:" ++ size)
+
+
+{-| Sets [`background-size`](https://css-tricks.com/almanac/properties/b/background-size/) for both width and height (in that order.)
+
+    backgroundSize2 (px 300) (px 100)
+
+    backgroundSize2 auto (px 400)
+
+If you only want to set the width, use [`backgroundImage`](#backgroundImage) instead.
+
+-}
+backgroundSize2 :
+    Value
+        { provides
+            | contain : Supported
+            , cover : Supported
+            , px : Supported
+            , cm : Supported
+            , mm : Supported
+            , inches : Supported
+            , pc : Supported
+            , pct : Supported
+            , pt : Supported
+            , ch : Supported
+            , em : Supported
+            , ex : Supported
+            , rem : Supported
+            , vh : Supported
+            , vw : Supported
+            , vmin : Supported
+            , vmax : Supported
+            , auto : Supported
+            , inherit : Supported
+            , initial : Supported
+            , unset : Supported
+        }
+    ->
+        Value
+            { provides
+                | contain : Supported
+                , cover : Supported
+                , px : Supported
+                , cm : Supported
+                , mm : Supported
+                , inches : Supported
+                , pc : Supported
+                , pct : Supported
+                , pt : Supported
+                , ch : Supported
+                , em : Supported
+                , ex : Supported
+                , rem : Supported
+                , vh : Supported
+                , vw : Supported
+                , vmin : Supported
+                , vmax : Supported
+                , auto : Supported
+                , inherit : Supported
+                , initial : Supported
+                , unset : Supported
+            }
+    -> Style
+backgroundSize2 (Value width) (Value height) =
+    AppendProperty ("background-size:" ++ width ++ " " ++ height)
 
 
 {-| Used in [`backgroundSize`](#backgroundSize) to always show the whole

--- a/src/Css.elm
+++ b/src/Css.elm
@@ -34,6 +34,7 @@ module Css
         , backgroundPosition4
         , backgroundRepeat
         , backgroundRepeat2
+        , backgroundSize
         , baseline
         , batch
         , before
@@ -104,10 +105,12 @@ module Css
         , colorDodge
         , color_
         , commonLigatures
+        , contain
         , contentBox
         , contextMenu
         , contextual
         , copy
+        , cover
         , crosshair
         , cursive
         , cursor
@@ -418,11 +421,13 @@ All CSS properties can have the values `unset`, `initial`, and `inherit`.
 
 ## Background Image
 
-@docs backgroundImage, backgroundImages, backgroundPosition, backgroundPosition2, backgroundPosition4, backgroundRepeat, backgroundRepeat2
+@docs backgroundImage, backgroundImages, backgroundPosition, backgroundPosition2, backgroundPosition4, backgroundRepeat, backgroundRepeat2, backgroundSize
 
 @docs linearGradient, stop, stop2, toBottom, toBottomLeft, toBottomRight, toLeft, toRight, toTop, toTopLeft, toTopRight
 
 @docs repeat, noRepeat, repeatX, repeatY, space, round
+
+@docs cover, contain
 
 
 ## Box Shadow
@@ -4264,6 +4269,72 @@ space =
 round : Value { provides | round : Supported }
 round =
     Value "round"
+
+
+
+-- BACKGROUND SIZE --
+
+
+{-| Sets [`background-size`](https://css-tricks.com/almanac/properties/b/background-size/).
+
+    backgroundSize cover
+
+    backgroundSize (px 400)
+
+If you give a length value, it will be used for the width. The height will be set
+proportional to the size of the [`background-image`](#backgroundImage).
+
+-}
+backgroundSize :
+    Value
+        { provides
+            | contain : Supported
+            , cover : Supported
+            , px : Supported
+            , cm : Supported
+            , mm : Supported
+            , inches : Supported
+            , pc : Supported
+            , pct : Supported
+            , pt : Supported
+            , ch : Supported
+            , em : Supported
+            , ex : Supported
+            , rem : Supported
+            , vh : Supported
+            , vw : Supported
+            , vmin : Supported
+            , vmax : Supported
+            , auto : Supported
+            , inherit : Supported
+            , initial : Supported
+            , unset : Supported
+        }
+    -> Style
+backgroundSize (Value size) =
+    AppendProperty ("background-size:" ++ size)
+
+
+{-| Used in [`backgroundSize`](#backgroundSize) to always show the whole
+background image, even if it leaves empty spaces on the sides.
+
+    backgroundSize contain
+
+-}
+contain : Value { provides | contain : Supported }
+contain =
+    Value "contain"
+
+
+{-| Used in [`backgroundSize`](#backgroundSize) to always fill the whole
+background, even if it cuts off some of the image.
+
+    backgroundSize cover
+
+-}
+cover : Value { provides | cover : Supported }
+cover =
+    Value "cover"
 
 
 


### PR DESCRIPTION
This adds `backgroundSize` and `backgroundSize2` for #392. Commits for this start at 48733cd, and I'm happy to rebase onto phantom-types when/if #419 is merged.

I was going to add `backgroundSizes` to go along with `backgroundImages`, but I can't figure out a good way of doing the types. Essentially, we need to be able to have all these properties:

```css
/* valid */
background-size: cover;
background-size: 100px;
background-size: 100px, cover;
background-size: 100px 20px, cover;

/* invalid */
backgrouns-size: cover cover;
background-size: 100px 20px, cover cover;
```

---

- [x] Each `Value` is an **open record** with a single field. The field's name is the value's name, and its type is `Supported`. For example `foo : Value { provides | foo : Supported }`
- [x] Each function returning `Style` accepts a **closed record** of `Supported` fields.
- [x] If a function returning `Style` takes a single `Value`, that `Value` should always support `inherit`, `initial`, and `unset` because all CSS properties support those three values!
- [x] If a function returning `Style` takes **more than one** `Value`, however, then **none** of its arguments should support `inherit`, `initial`, or `unset`, because these can never be used in conjunction with other values!
- [x] Every exposed value has documentation which includes at least 1 code sample.
- [x] Documentation links to to a [**CSS Tricks** article](https://css-tricks.com/) if available, and [MDN](https://developer.mozilla.org/en-US/docs/Web/CSS) if not.
- [x] Make a pull request against the `phantom-types` branch, not `master`!