### PR TITLE
Add order

### DIFF
--- a/src/Css.elm
+++ b/src/Css.elm
@@ -226,6 +226,7 @@ module Css
         , oldstyleNums
         , optimizeLegibility
         , optimizeSpeed
+        , order
         , ordinal
         , oriya
         , outset
@@ -655,6 +656,11 @@ Multiple CSS properties use these values.
 # Visibility
 
 @docs visibility
+
+
+# Flexbox
+
+@docs order
 
 -}
 
@@ -1693,9 +1699,14 @@ pct value =
     Value (toString value ++ "%")
 
 
-{-| A unitless number. Useful with properties like [`flexGrow`](#flexGrow) which accept unitless numbers.
+{-| A unitless number. Useful with properties like
+[`flexGrow`](#flexGrow),
+[`z-index`](https://css-tricks.com/almanac/properties/z/z-index/),
+and [`order`](https://css-tricks.com/almanac/properties/o/order/)
+which accept unitless numbers.
 
     flexGrow (num 2)
+    order (num -2)
 
 -}
 num : Float -> Value { provides | num : Supported }
@@ -7163,3 +7174,25 @@ visibility :
     -> Style
 visibility (Value str) =
     AppendProperty ("visibility:" ++ str)
+
+
+
+-- ORDER --
+
+
+{-| Sets [`order`](https://css-tricks.com/almanac/properties/o/order/)
+
+    order (num 2)
+    order (num -2)
+
+-}
+order :
+    Value
+        { num : Supported
+        , inherit : Supported
+        , initial : Supported
+        , unset : Supported
+        }
+    -> Style
+order (Value val) =
+    AppendProperty ("order:" ++ val)


### PR DESCRIPTION
## Contribution Checklist

- [x] Each `Value` is an **open record** with a single field. The field's name is the value's name, and its type is `Supported`. For example `foo : Value { provides | foo : Supported }`
- [x] Each function returning `Style` accepts a **closed record** of `Supported` fields.
- [x] If a function returning `Style` takes a single `Value`, that `Value` should always support `inherit`, `initial`, and `unset` because all CSS properties support those three values! For example, `borderFoo : Value { foo : Supported, bar : Supported, inherit : Supported, initial : Supported, unset : Supported } -> Style`
- [x] If a function returning `Style` takes **more than one** `Value`, however, then **none** of its arguments should support `inherit`, `initial`, or `unset`, because these can never be used in conjunction with other values! For example, `border-radius: 5px 5px;` is valid CSS, `border-radius: inherit;` is valid CSS, but `border-radius: 5px inherit;` is invalid CSS. To reflect this, `borderRadius : Value { ... } -> Style` must have `inherit : Supported` in its record, but `borderRadius2 : Value { ... } -> Value { ... } -> Style` must **not** have `inherit : Supported` in *either* argument's record. If a user wants to get `border-radius: inherit`, they must call `borderRadius`, not `borderRadius2`! 
- [x] Every exposed value has documentation which includes at least 1 code sample.
- [x] Documentation links to to a [**CSS Tricks** article](https://css-tricks.com/) if available, and [MDN](https://developer.mozilla.org/en-US/docs/Web/CSS) if not.
- [x] Make a pull request against the `phantom-types` branch, not `master`!