### PR TITLE
Phantom Types: Add fill

### DIFF
--- a/src/Css.elm
+++ b/src/Css.elm
@@ -149,6 +149,7 @@ module Css
         , ex
         , exclusion
         , fantasy
+        , fill
         , firstBaseline
         , fixed
         , flexEnd
@@ -685,6 +686,11 @@ Multiple CSS properties use these values.
 
 @docs order
 
+
+# SVG
+
+@docs fill
+
 -}
 
 import Css.Preprocess as Preprocess exposing (Style(..))
@@ -847,8 +853,7 @@ revert =
 -- SHARED VALUES --
 
 
-{-| The `url` value for the [`cursor`](#cursor) and [`backgroundImage`](#backgroundImage)
-properties.
+{-| The `url` value for the [`cursor`](#cursor), [`fill`](#fill), and [`backgroundImage`](#backgroundImage) properties.
 -}
 url : String -> Value { provides | url : Supported }
 url str =
@@ -7915,3 +7920,31 @@ order :
     -> Style
 order (Value val) =
     AppendProperty ("order:" ++ val)
+
+
+{-| Sets [`fill`](https://css-tricks.com/almanac/properties/f/fill/)
+**Note:** `fill` also accepts the patterns of SVG shapes that are defined inside of a `defs` element.
+
+    fill (hex "#60b5cc")
+    fill (rgb 96 181 204)
+    fill (rgba 96 181 204 0.5)
+    fill (url "#pattern")
+
+-}
+fill :
+    Value
+        { rgb : Supported
+        , rgba : Supported
+        , hsl : Supported
+        , hsla : Supported
+        , hex : Supported
+        , currentColor : Supported
+        , transparent : Supported
+        , url : Supported
+        , inherit : Supported
+        , initial : Supported
+        , unset : Supported
+        }
+    -> Style
+fill (Value val) =
+    AppendProperty ("fill:" ++ val)


### PR DESCRIPTION
## Contribution Checklist

- [x] Each `Value` is an **open record** with a single field. The field's name is the value's name, and its type is `Supported`. For example `foo : Value { provides | foo : Supported }`
- [x] Each function returning `Style` accepts a **closed record** of `Supported` fields.
- [x] If a function returning `Style` takes a single `Value`, that `Value` should always support `inherit`, `initial`, and `unset` because all CSS properties support those three values! For example, `borderFoo : Value { foo : Supported, bar : Supported, inherit : Supported, initial : Supported, unset : Supported } -> Style`
- [x] If a function returning `Style` takes **more than one** `Value`, however, then **none** of its arguments should support `inherit`, `initial`, or `unset`, because these can never be used in conjunction with other values! For example, `border-radius: 5px 5px;` is valid CSS, `border-radius: inherit;` is valid CSS, but `border-radius: 5px inherit;` is invalid CSS. To reflect this, `borderRadius : Value { ... } -> Style` must have `inherit : Supported` in its record, but `borderRadius2 : Value { ... } -> Value { ... } -> Style` must **not** have `inherit : Supported` in *either* argument's record. If a user wants to get `border-radius: inherit`, they must call `borderRadius`, not `borderRadius2`! 
- [x] Every exposed value has documentation which includes at least 1 code sample.
- [x] Documentation links to to a [**CSS Tricks** article](https://css-tricks.com/) if available, and [MDN](https://developer.mozilla.org/en-US/docs/Web/CSS) if not.
- [x] Make a pull request against the `phantom-types` branch, not `master`!