### PR TITLE
Phantom types: columns

### DIFF
--- a/src/Css.elm
+++ b/src/Css.elm
@@ -36,6 +36,8 @@ module Css
         , backgroundRepeat2
         , backgroundSize
         , backgroundSize2
+        , balance
+        , balanceAll
         , baseline
         , batch
         , before
@@ -118,6 +120,7 @@ module Css
         , colorDodge
         , color_
         , columnCount
+        , columnFill
         , columnWidth
         , columns
         , columns2
@@ -725,6 +728,7 @@ Multiple CSS properties use these values.
 # Columns
 
 @docs columns, columns2, columnWidth, columnCount
+@docs columnFill, balance, balanceAll
 
 -}
 
@@ -8887,3 +8891,44 @@ columnCount :
     -> Style
 columnCount (Value count) =
     AppendProperty ("column-count:" ++ count)
+
+
+{-| Sets [`column-fill`](https://css-tricks.com/almanac/properties/c/column-fill/)
+
+    columnFill auto
+    columnFill balance
+    columnFill balanceAll
+
+-}
+columnFill :
+    Value
+        { auto : Supported
+        , balance : Supported
+        , balanceAll : Supported
+        , initial : Supported
+        , inherit : Supported
+        , unset : Supported
+        }
+    -> Style
+columnFill (Value val) =
+    AppendProperty ("column-fill:" ++ val)
+
+
+{-| A `balance` value used in properties such as [`column-fill`](#columnFill)
+
+    columnFill balance
+
+-}
+balance : Value { provides | balance : Supported }
+balance =
+    Value "balance"
+
+
+{-| A `balance-all` value used in properties such as [`column-fill`](#columnFill)
+
+    columnFill balanceAll
+
+-}
+balanceAll : Value { provides | balanceAll : Supported }
+balanceAll =
+    Value "balance-all"

--- a/src/Css.elm
+++ b/src/Css.elm
@@ -117,6 +117,7 @@ module Css
         , colorBurn
         , colorDodge
         , color_
+        , columnWidth
         , columns
         , columns2
         , commonLigatures
@@ -722,7 +723,7 @@ Multiple CSS properties use these values.
 
 # Columns
 
-@docs columns, columns2
+@docs columns, columns2, columnWidth
 
 -}
 
@@ -8833,3 +8834,36 @@ columns2 :
     -> Style
 columns2 (Value width) (Value count) =
     AppendProperty ("columns:" ++ width ++ " " ++ count)
+
+
+{-| Sets [`column-width`](https://css-tricks.com/almanac/properties/c/column-width/)
+
+    columnWidth auto
+    columnWidth (px 200)
+
+-}
+columnWidth :
+    Value
+        { auto : Supported
+        , zero : Supported
+        , ch : Supported
+        , em : Supported
+        , ex : Supported
+        , rem : Supported
+        , vh : Supported
+        , vw : Supported
+        , vmin : Supported
+        , vmax : Supported
+        , px : Supported
+        , cm : Supported
+        , mm : Supported
+        , inches : Supported
+        , pc : Supported
+        , pt : Supported
+        , initial : Supported
+        , inherit : Supported
+        , unset : Supported
+        }
+    -> Style
+columnWidth (Value width) =
+    AppendProperty ("column-width:" ++ width)

--- a/src/Css.elm
+++ b/src/Css.elm
@@ -123,6 +123,7 @@ module Css
         , columnCount
         , columnFill
         , columnGap
+        , columnRuleStyle
         , columnRuleWidth
         , columnSpan
         , columnWidth
@@ -731,7 +732,7 @@ Multiple CSS properties use these values.
 
 # Columns
 
-@docs columns, columns2, columnWidth, columnCount, columnGap
+@docs columns, columns2, columnWidth, columnCount, columnGap, columnRuleWidth, columnRuleStyle
 @docs columnFill, balance, balanceAll
 @docs columnSpan, all_
 
@@ -7263,9 +7264,11 @@ thick =
 -- BORDER STYLE --
 
 
-{-| The `dotted` [`border-style`](<https://css-tricks.com/almanac/properties/b/border/#article-header-id-0> value.
+{-| The `dotted` value used by properties such as [`border-style`](#borderStyle),
+and [`column-rule-style`](#columnRuleStyle) value.
 
     borderStyle dotted
+    columnRuleStyle dotted
 
 A line that consists of dots.
 
@@ -7275,8 +7278,11 @@ dotted =
     Value "dotted"
 
 
-{-| The `dashed` [`border-style`](<https://css-tricks.com/almanac/properties/b/border/#article-header-id-0> value.
-borderStyle dashed
+{-| The `dashed` value used by properties such as [`border-style`](#borderStyle),
+and [`column-rule-style`](#columnRuleStyle) value.
+
+    borderStyle dashed
+    columnRuleStyle dashed
 
 A line that consists of dashes.
 
@@ -7286,9 +7292,11 @@ dashed =
     Value "dashed"
 
 
-{-| The `solid` [`border-style`](<https://css-tricks.com/almanac/properties/b/border/#article-header-id-0> value.
+{-| The `solid` value used by properties such as [`border-style`](#borderStyle),
+and [`column-rule-style`](#columnRuleStyle) value.
 
     borderStyle solid
+    columnRuleStyle solid
 
 A solid, continuous line.
 
@@ -7298,9 +7306,11 @@ solid =
     Value "solid"
 
 
-{-| The `double` [`border-style`](<https://css-tricks.com/almanac/properties/b/border/#article-header-id-0> value.
+{-| The `double` value used by properties such as [`border-style`](#borderStyle),
+and [`column-rule-style`](#columnRuleStyle) value.
 
     borderStyle double
+    columnRuleStyle double
 
 Two lines are drawn around the element.
 
@@ -7310,9 +7320,11 @@ double =
     Value "double"
 
 
-{-| The `groove` [`border-style`](<https://css-tricks.com/almanac/properties/b/border/#article-header-id-0> value.
+{-| The `groove` value used by properties such as [`border-style`](#borderStyle),
+and [`column-rule-style`](#columnRuleStyle) value.
 
     borderStyle groove
+    columnRuleStyle groove
 
 Adds a bevel based on the color value in a way that makes the element appear pressed into the document.
 
@@ -7322,9 +7334,11 @@ groove =
     Value "groove"
 
 
-{-| The `ridge` [`border-style`](<https://css-tricks.com/almanac/properties/b/border/#article-header-id-0> value.
+{-| The `ridge` value used by properties such as [`border-style`](#borderStyle),
+and [`column-rule-style`](#columnRuleStyle) value.
 
     borderStyle ridge
+    columnRuleStyle ridge
 
 Similar to `groove`, but reverses the color values in a way that makes the element appear raised.
 
@@ -7334,9 +7348,11 @@ ridge =
     Value "ridge"
 
 
-{-| The `inset` [`border-style`](<https://css-tricks.com/almanac/properties/b/border/#article-header-id-0> value.
+{-| The `inset` value used by properties such as [`border-style`](#borderStyle),
+and [`column-rule-style`](#columnRuleStyle) value.
 
     borderStyle inset
+    columnRuleStyle inset
 
 Adds a split tone to the line that makes the element appear slightly depressed.
 
@@ -7346,9 +7362,11 @@ inset =
     Value "inset"
 
 
-{-| The `outset` [`border-style`](<https://css-tricks.com/almanac/properties/b/border/#article-header-id-0> value.
+{-| The `outset` value used by properties such as [`border-style`](#borderStyle),
+and [`column-rule-style`](#columnRuleStyle) value.
 
     borderStyle outset
+    columnRuleStyle outset
 
 Similar to `inset`, but reverses the colors in a way that makes the element appear slightly raised.
 
@@ -9043,3 +9061,31 @@ columnRuleWidth :
     -> Style
 columnRuleWidth (Value width) =
     AppendProperty ("column-rule-width:" ++ width)
+
+
+{-| Sets [`column-rule-style`](https://www.w3.org/TR/css-multicol-1/#propdef-column-rule-style)
+
+    columnRuleStyle solid
+    columnRuleStyle dotted
+    columnRuleStyle dashed
+
+-}
+columnRuleStyle :
+    Value
+        { solid : Supported
+        , none : Supported
+        , hidden : Supported
+        , dashed : Supported
+        , dotted : Supported
+        , double : Supported
+        , groove : Supported
+        , ridge : Supported
+        , inset : Supported
+        , outset : Supported
+        , inherit : Supported
+        , initial : Supported
+        , unset : Supported
+        }
+    -> Style
+columnRuleStyle (Value style) =
+    AppendProperty ("column-rule-style:" ++ style)

--- a/src/Css.elm
+++ b/src/Css.elm
@@ -122,6 +122,7 @@ module Css
         , color_
         , columnCount
         , columnFill
+        , columnGap
         , columnSpan
         , columnWidth
         , columns
@@ -729,7 +730,7 @@ Multiple CSS properties use these values.
 
 # Columns
 
-@docs columns, columns2, columnWidth, columnCount
+@docs columns, columns2, columnWidth, columnCount, columnGap
 @docs columnFill, balance, balanceAll
 @docs columnSpan, all_
 
@@ -3523,12 +3524,14 @@ fontVariantCaps (Value str) =
 [`font-variant-caps`](https://developer.mozilla.org/en-US/docs/Web/CSS/font-variant-caps#Values),
 [`white-space`](https://css-tricks.com/almanac/properties/w/whitespace/),
 [`word-break`](https://css-tricks.com/almanac/properties/w/word-break/),
+[`column-gap`](#columnGap),
 and [`align-items`](https://developer.mozilla.org/en-US/docs/Web/CSS/align-items#Values).
 
     fontVariantCaps normal
     whiteSpace normal
     wordBreak normal
     alignItems normal
+    columnGap normal
 
 -}
 normal : Value { provides | normal : Supported }
@@ -8964,3 +8967,36 @@ columnSpan (Value span) =
 all_ : Value { provides | all_ : Supported }
 all_ =
     Value "all"
+
+
+{-| Sets [`column-gap`](https://css-tricks.com/almanac/properties/c/column-gap/)
+
+    columnGap normal
+    columnGap (px 20)
+
+-}
+columnGap :
+    Value
+        { normal : Supported
+        , zero : Supported
+        , ch : Supported
+        , em : Supported
+        , ex : Supported
+        , rem : Supported
+        , vh : Supported
+        , vw : Supported
+        , vmin : Supported
+        , vmax : Supported
+        , px : Supported
+        , cm : Supported
+        , mm : Supported
+        , inches : Supported
+        , pc : Supported
+        , pt : Supported
+        , initial : Supported
+        , inherit : Supported
+        , unset : Supported
+        }
+    -> Style
+columnGap (Value width) =
+    AppendProperty ("column-gap:" ++ width)

--- a/src/Css.elm
+++ b/src/Css.elm
@@ -117,6 +117,7 @@ module Css
         , colorBurn
         , colorDodge
         , color_
+        , columnCount
         , columnWidth
         , columns
         , columns2
@@ -723,7 +724,7 @@ Multiple CSS properties use these values.
 
 # Columns
 
-@docs columns, columns2, columnWidth
+@docs columns, columns2, columnWidth, columnCount
 
 -}
 
@@ -8867,3 +8868,22 @@ columnWidth :
     -> Style
 columnWidth (Value width) =
     AppendProperty ("column-width:" ++ width)
+
+
+{-| Sets [`column-count`](https://css-tricks.com/almanac/properties/c/column-count/)
+
+    columnCount auto
+    columnCount (num 3)
+
+-}
+columnCount :
+    Value
+        { auto : Supported
+        , num : Supported
+        , initial : Supported
+        , inherit : Supported
+        , unset : Supported
+        }
+    -> Style
+columnCount (Value count) =
+    AppendProperty ("column-count:" ++ count)

--- a/src/Css.elm
+++ b/src/Css.elm
@@ -123,6 +123,7 @@ module Css
         , columnCount
         , columnFill
         , columnGap
+        , columnRuleColor
         , columnRuleStyle
         , columnRuleWidth
         , columnSpan
@@ -9089,3 +9090,27 @@ columnRuleStyle :
     -> Style
 columnRuleStyle (Value style) =
     AppendProperty ("column-rule-style:" ++ style)
+
+
+{-| Sets [`column-rule-color`](https://www.w3.org/TR/css-multicol-1/#propdef-column-rule-color)
+
+    columnRuleColor (rgb 0 0 0)
+    columnRuleColor (hex "#fff")
+
+-}
+columnRuleColor :
+    Value
+        { rgb : Supported
+        , rgba : Supported
+        , hsl : Supported
+        , hsla : Supported
+        , hex : Supported
+        , transparent : Supported
+        , currentColor : Supported
+        , inherit : Supported
+        , initial : Supported
+        , unset : Supported
+        }
+    -> Style
+columnRuleColor (Value color) =
+    AppendProperty ("column-rule-color:" ++ color)

--- a/src/Css.elm
+++ b/src/Css.elm
@@ -117,6 +117,8 @@ module Css
         , colorBurn
         , colorDodge
         , color_
+        , columns
+        , columns2
         , commonLigatures
         , contain
         , contentBox
@@ -717,11 +719,15 @@ Multiple CSS properties use these values.
 
 @docs fill
 
+
+# Columns
+
+@docs columns, columns2
+
 -}
 
 import Css.Preprocess as Preprocess exposing (Style(..))
 import Css.Structure as Structure
-
 
 
 -- TYPES --
@@ -1218,7 +1224,6 @@ hex str =
     Value <|
         if String.startsWith "#" str then
             String.dropLeft 1 str
-
         else
             str
 
@@ -2753,7 +2758,6 @@ boxShadowConfigToString config =
         insetStr =
             if config.inset then
                 "inset "
-
             else
                 ""
     in
@@ -8757,3 +8761,75 @@ fill :
     -> Style
 fill (Value val) =
     AppendProperty ("fill:" ++ val)
+
+
+
+-- COLUMNS --
+
+
+{-| Sets [`columns`](https://css-tricks.com/almanac/properties/c/columns/)
+
+    columns (px 300)
+    columns2 (px 300) (num 2)
+
+-}
+columns :
+    Value
+        { auto : Supported
+        , zero : Supported
+        , ch : Supported
+        , em : Supported
+        , ex : Supported
+        , rem : Supported
+        , vh : Supported
+        , vw : Supported
+        , vmin : Supported
+        , vmax : Supported
+        , px : Supported
+        , cm : Supported
+        , mm : Supported
+        , inches : Supported
+        , pc : Supported
+        , pt : Supported
+        , initial : Supported
+        , inherit : Supported
+        , unset : Supported
+        }
+    -> Style
+columns (Value width) =
+    AppendProperty ("columns:" ++ width)
+
+
+{-| Sets [`columns`](https://css-tricks.com/almanac/properties/c/columns/)
+
+    columns (px 300)
+    columns2 (px 300) (num 2)
+
+-}
+columns2 :
+    Value
+        { auto : Supported
+        , zero : Supported
+        , ch : Supported
+        , em : Supported
+        , ex : Supported
+        , rem : Supported
+        , vh : Supported
+        , vw : Supported
+        , vmin : Supported
+        , vmax : Supported
+        , px : Supported
+        , cm : Supported
+        , mm : Supported
+        , inches : Supported
+        , pc : Supported
+        , pt : Supported
+        }
+    ->
+        Value
+            { auto : Supported
+            , num : Supported
+            }
+    -> Style
+columns2 (Value width) (Value count) =
+    AppendProperty ("columns:" ++ width ++ " " ++ count)

--- a/src/Css.elm
+++ b/src/Css.elm
@@ -123,6 +123,9 @@ module Css
         , columnCount
         , columnFill
         , columnGap
+        , columnRule
+        , columnRule2
+        , columnRule3
         , columnRuleColor
         , columnRuleStyle
         , columnRuleWidth
@@ -733,7 +736,7 @@ Multiple CSS properties use these values.
 
 # Columns
 
-@docs columns, columns2, columnWidth, columnCount, columnGap, columnRuleWidth, columnRuleStyle
+@docs columns, columns2, columnWidth, columnCount, columnGap, columnRuleWidth, columnRuleStyle, columnRuleColor, columnRule, columnRule2, columnRule3
 @docs columnFill, balance, balanceAll
 @docs columnSpan, all_
 
@@ -9114,3 +9117,150 @@ columnRuleColor :
     -> Style
 columnRuleColor (Value color) =
     AppendProperty ("column-rule-color:" ++ color)
+
+
+{-| Sets [`column-rule`](https://css-tricks.com/almanac/properties/c/column-rule/).
+This is a shorthand for the [`column-rule-width`](#columnRuleWidth),
+[`column-rule-style`](#columnRuleStyle), and [`column-rule-color`](#columnRuleColor)
+properties.
+
+    columnRule thin
+    columnRule2 thin solid
+    columnRule3 thin solid (hex "#000000")
+
+-}
+columnRule :
+    Value
+        { thin : Supported
+        , medium : Supported
+        , thick : Supported
+        , zero : Supported
+        , ch : Supported
+        , em : Supported
+        , ex : Supported
+        , rem : Supported
+        , vh : Supported
+        , vw : Supported
+        , vmin : Supported
+        , vmax : Supported
+        , px : Supported
+        , cm : Supported
+        , mm : Supported
+        , inches : Supported
+        , pc : Supported
+        , pt : Supported
+        , initial : Supported
+        , inherit : Supported
+        , unset : Supported
+        }
+    -> Style
+columnRule (Value width) =
+    AppendProperty ("column-rule:" ++ width)
+
+
+{-| Sets [`column-rule`](https://css-tricks.com/almanac/properties/c/column-rule/).
+This is a shorthand for the [`column-rule-width`](#columnRuleWidth),
+[`column-rule-style`](#columnRuleStyle), and [`column-rule-color`](#columnRuleColor)
+properties.
+
+    columnRule thin
+    columnRule2 thin solid
+    columnRule3 thin solid (hex "#000000")
+
+-}
+columnRule2 :
+    Value
+        { thin : Supported
+        , medium : Supported
+        , thick : Supported
+        , zero : Supported
+        , ch : Supported
+        , em : Supported
+        , ex : Supported
+        , rem : Supported
+        , vh : Supported
+        , vw : Supported
+        , vmin : Supported
+        , vmax : Supported
+        , px : Supported
+        , cm : Supported
+        , mm : Supported
+        , inches : Supported
+        , pc : Supported
+        , pt : Supported
+        }
+    ->
+        Value
+            { solid : Supported
+            , none : Supported
+            , hidden : Supported
+            , dashed : Supported
+            , dotted : Supported
+            , double : Supported
+            , groove : Supported
+            , ridge : Supported
+            , inset : Supported
+            , outset : Supported
+            }
+    -> Style
+columnRule2 (Value width) (Value style) =
+    AppendProperty ("column-rule:" ++ width ++ " " ++ style)
+
+
+{-| Sets [`column-rule`](https://css-tricks.com/almanac/properties/c/column-rule/).
+This is a shorthand for the [`column-rule-width`](#columnRuleWidth),
+[`column-rule-style`](#columnRuleStyle), and [`column-rule-color`](#columnRuleColor)
+properties.
+
+    columnRule thin
+    columnRule2 thin solid
+    columnRule3 thin solid (hex "#000000")
+
+-}
+columnRule3 :
+    Value
+        { thin : Supported
+        , medium : Supported
+        , thick : Supported
+        , zero : Supported
+        , ch : Supported
+        , em : Supported
+        , ex : Supported
+        , rem : Supported
+        , vh : Supported
+        , vw : Supported
+        , vmin : Supported
+        , vmax : Supported
+        , px : Supported
+        , cm : Supported
+        , mm : Supported
+        , inches : Supported
+        , pc : Supported
+        , pt : Supported
+        }
+    ->
+        Value
+            { solid : Supported
+            , none : Supported
+            , hidden : Supported
+            , dashed : Supported
+            , dotted : Supported
+            , double : Supported
+            , groove : Supported
+            , ridge : Supported
+            , inset : Supported
+            , outset : Supported
+            }
+    ->
+        Value
+            { rgb : Supported
+            , rgba : Supported
+            , hsl : Supported
+            , hsla : Supported
+            , hex : Supported
+            , transparent : Supported
+            , currentColor : Supported
+            }
+    -> Style
+columnRule3 (Value width) (Value style) (Value color) =
+    AppendProperty ("column-rule:" ++ width ++ " " ++ style ++ " " ++ color)

--- a/src/Css.elm
+++ b/src/Css.elm
@@ -15,6 +15,7 @@ module Css
         , allPetiteCaps
         , allScroll
         , allSmallCaps
+        , all_
         , arabicIndic
         , armenian
         , auto
@@ -121,6 +122,7 @@ module Css
         , color_
         , columnCount
         , columnFill
+        , columnSpan
         , columnWidth
         , columns
         , columns2
@@ -729,6 +731,7 @@ Multiple CSS properties use these values.
 
 @docs columns, columns2, columnWidth, columnCount
 @docs columnFill, balance, balanceAll
+@docs columnSpan, all_
 
 -}
 
@@ -8932,3 +8935,32 @@ balance =
 balanceAll : Value { provides | balanceAll : Supported }
 balanceAll =
     Value "balance-all"
+
+
+{-| Sets [`column-span`](https://css-tricks.com/almanac/properties/c/column-span/)
+
+    columnSpan all_
+    columnSpan none
+
+-}
+columnSpan :
+    Value
+        { none : Supported
+        , all_ : Supported
+        , initial : Supported
+        , inherit : Supported
+        , unset : Supported
+        }
+    -> Style
+columnSpan (Value span) =
+    AppendProperty ("column-span:" ++ span)
+
+
+{-| A `all` value used in properties such as [`column-span`](#columnSpan).
+
+    columnSpan all_
+
+-}
+all_ : Value { provides | all_ : Supported }
+all_ =
+    Value "all"

--- a/src/Css.elm
+++ b/src/Css.elm
@@ -3195,8 +3195,8 @@ small =
     Value "small"
 
 
-{-| The `medium` value used by properties such as [`font-size`](#fontSize),
-[`border-width`](#borderWidth),
+{-| The `medium` value used by properties such as [`fontSize`](#fontSize),
+[`borderWidth`](#borderWidth),
 [`columnRuleWidth`](#columnRuleWidth).
 
     fontSize medium
@@ -3530,11 +3530,11 @@ fontVariantCaps (Value str) =
 
 
 {-| The `normal` value, which can be used with such properties as
-[`font-variant-caps`](https://developer.mozilla.org/en-US/docs/Web/CSS/font-variant-caps#Values),
-[`white-space`](https://css-tricks.com/almanac/properties/w/whitespace/),
-[`word-break`](https://css-tricks.com/almanac/properties/w/word-break/),
-[`column-gap`](#columnGap),
-and [`align-items`](https://developer.mozilla.org/en-US/docs/Web/CSS/align-items#Values).
+[`fontVariantCaps`](#fontVariantCaps),
+[`whiteSpace`](#whiteSpace),
+[`wordBreak`](#wordBreak),
+[`columnGap`](#columnGap),
+and [`alignItems`](#alignItems).
 
     fontVariantCaps normal
     whiteSpace normal
@@ -7236,8 +7236,8 @@ borderLeftColor (Value color) =
 -- BORDER WIDTH --
 
 
-{-| The `thin` value used by properties such as [`border-width`](#borderWidth),
-and [`column-rule-width`](#columnRuleWidth).
+{-| The `thin` value used by properties such as [`borderWidth`](#borderWidth),
+and [`columnRuleWidth`](#columnRuleWidth).
 
     borderWidth thin
     columnRuleWidth thin
@@ -7250,8 +7250,8 @@ thin =
     Value "thin"
 
 
-{-| The `thick` value used by properties such as [`border-width`](#borderWidth),
-and [`column-rule-width`](#columnRuleWidth).
+{-| The `thick` value used by properties such as [`borderWidth`](#borderWidth),
+and [`columnRuleWidth`](#columnRuleWidth).
 
     borderWidth thick
     columnRuleWidth thick
@@ -7268,8 +7268,8 @@ thick =
 -- BORDER STYLE --
 
 
-{-| The `dotted` value used by properties such as [`border-style`](#borderStyle),
-and [`column-rule-style`](#columnRuleStyle) value.
+{-| The `dotted` value used by properties such as [`borderStyle`](#borderStyle),
+and [`columnRuleStyle`](#columnRuleStyle) value.
 
     borderStyle dotted
     columnRuleStyle dotted
@@ -7282,8 +7282,8 @@ dotted =
     Value "dotted"
 
 
-{-| The `dashed` value used by properties such as [`border-style`](#borderStyle),
-and [`column-rule-style`](#columnRuleStyle) value.
+{-| The `dashed` value used by properties such as [`borderStyle`](#borderStyle),
+and [`columnRuleStyle`](#columnRuleStyle) value.
 
     borderStyle dashed
     columnRuleStyle dashed
@@ -7296,8 +7296,8 @@ dashed =
     Value "dashed"
 
 
-{-| The `solid` value used by properties such as [`border-style`](#borderStyle),
-and [`column-rule-style`](#columnRuleStyle) value.
+{-| The `solid` value used by properties such as [`borderStyle`](#borderStyle),
+and [`columnRuleStyle`](#columnRuleStyle) value.
 
     borderStyle solid
     columnRuleStyle solid
@@ -7310,8 +7310,8 @@ solid =
     Value "solid"
 
 
-{-| The `double` value used by properties such as [`border-style`](#borderStyle),
-and [`column-rule-style`](#columnRuleStyle) value.
+{-| The `double` value used by properties such as [`borderStyle`](#borderStyle),
+and [`columnRuleStyle`](#columnRuleStyle) value.
 
     borderStyle double
     columnRuleStyle double
@@ -7324,8 +7324,8 @@ double =
     Value "double"
 
 
-{-| The `groove` value used by properties such as [`border-style`](#borderStyle),
-and [`column-rule-style`](#columnRuleStyle) value.
+{-| The `groove` value used by properties such as [`borderStyle`](#borderStyle),
+and [`columnRuleStyle`](#columnRuleStyle) value.
 
     borderStyle groove
     columnRuleStyle groove
@@ -7338,8 +7338,8 @@ groove =
     Value "groove"
 
 
-{-| The `ridge` value used by properties such as [`border-style`](#borderStyle),
-and [`column-rule-style`](#columnRuleStyle) value.
+{-| The `ridge` value used by properties such as [`borderStyle`](#borderStyle),
+and [`columnRuleStyle`](#columnRuleStyle) value.
 
     borderStyle ridge
     columnRuleStyle ridge
@@ -7352,8 +7352,8 @@ ridge =
     Value "ridge"
 
 
-{-| The `inset` value used by properties such as [`border-style`](#borderStyle),
-and [`column-rule-style`](#columnRuleStyle) value.
+{-| The `inset` value used by properties such as [`borderStyle`](#borderStyle),
+and [`columnRuleStyle`](#columnRuleStyle) value.
 
     borderStyle inset
     columnRuleStyle inset
@@ -7366,8 +7366,8 @@ inset =
     Value "inset"
 
 
-{-| The `outset` value used by properties such as [`border-style`](#borderStyle),
-and [`column-rule-style`](#columnRuleStyle) value.
+{-| The `outset` value used by properties such as [`borderStyle`](#borderStyle),
+and [`columnRuleStyle`](#columnRuleStyle) value.
 
     borderStyle outset
     columnRuleStyle outset
@@ -8950,7 +8950,7 @@ columnFill (Value val) =
     AppendProperty ("column-fill:" ++ val)
 
 
-{-| A `balance` value used in properties such as [`column-fill`](#columnFill)
+{-| A `balance` value used in properties such as [`columnFill`](#columnFill)
 
     columnFill balance
 
@@ -8960,7 +8960,7 @@ balance =
     Value "balance"
 
 
-{-| A `balance-all` value used in properties such as [`column-fill`](#columnFill)
+{-| A `balance-all` value used in properties such as [`columnFill`](#columnFill)
 
     columnFill balanceAll
 
@@ -8989,7 +8989,7 @@ columnSpan (Value span) =
     AppendProperty ("column-span:" ++ span)
 
 
-{-| A `all` value used in properties such as [`column-span`](#columnSpan).
+{-| A `all` value used in properties such as [`columnSpan`](#columnSpan).
 
     columnSpan all_
 
@@ -9120,8 +9120,8 @@ columnRuleColor (Value color) =
 
 
 {-| Sets [`column-rule`](https://css-tricks.com/almanac/properties/c/column-rule/).
-This is a shorthand for the [`column-rule-width`](#columnRuleWidth),
-[`column-rule-style`](#columnRuleStyle), and [`column-rule-color`](#columnRuleColor)
+This is a shorthand for the [`columnRuleWidth`](#columnRuleWidth),
+[`columnRuleStyle`](#columnRuleStyle), and [`columnRuleColor`](#columnRuleColor)
 properties.
 
     columnRule thin
@@ -9159,8 +9159,8 @@ columnRule (Value width) =
 
 
 {-| Sets [`column-rule`](https://css-tricks.com/almanac/properties/c/column-rule/).
-This is a shorthand for the [`column-rule-width`](#columnRuleWidth),
-[`column-rule-style`](#columnRuleStyle), and [`column-rule-color`](#columnRuleColor)
+This is a shorthand for the [`columnRuleWidth`](#columnRuleWidth),
+[`columnRuleStyle`](#columnRuleStyle), and [`columnRuleColor`](#columnRuleColor)
 properties.
 
     columnRule thin
@@ -9208,8 +9208,8 @@ columnRule2 (Value width) (Value style) =
 
 
 {-| Sets [`column-rule`](https://css-tricks.com/almanac/properties/c/column-rule/).
-This is a shorthand for the [`column-rule-width`](#columnRuleWidth),
-[`column-rule-style`](#columnRuleStyle), and [`column-rule-color`](#columnRuleColor)
+This is a shorthand for the [`columnRuleWidth`](#columnRuleWidth),
+[`columnRuleStyle`](#columnRuleStyle), and [`columnRuleColor`](#columnRuleColor)
 properties.
 
     columnRule thin

--- a/src/Css.elm
+++ b/src/Css.elm
@@ -123,6 +123,7 @@ module Css
         , columnCount
         , columnFill
         , columnGap
+        , columnRuleWidth
         , columnSpan
         , columnWidth
         , columns
@@ -3189,10 +3190,13 @@ small =
     Value "small"
 
 
-{-| The `medium` [`font-size`](https://developer.mozilla.org/en-US/docs/Web/CSS/font-size#Values) or [`border-width`](https://css-tricks.com/almanac/properties/b/border/#article-header-id-0) value.
+{-| The `medium` value used by properties such as [`font-size`](#fontSize),
+[`border-width`](#borderWidth),
+[`columnRuleWidth`](#columnRuleWidth).
 
     fontSize medium
     borderWidth medium
+    columnRuleWidth medium
 
 The value is equivalent of 3px when using for `border-width`.
 
@@ -7227,9 +7231,11 @@ borderLeftColor (Value color) =
 -- BORDER WIDTH --
 
 
-{-| The `thin` [`border-width`](https://css-tricks.com/almanac/properties/b/border/#article-header-id-0) value.
+{-| The `thin` value used by properties such as [`border-width`](#borderWidth),
+and [`column-rule-width`](#columnRuleWidth).
 
     borderWidth thin
+    columnRuleWidth thin
 
 The value is equivalent of 1px.
 
@@ -7239,9 +7245,11 @@ thin =
     Value "thin"
 
 
-{-| The `thick` [`border-width`](https://css-tricks.com/almanac/properties/b/border/#article-header-id-0) value.
+{-| The `thick` value used by properties such as [`border-width`](#borderWidth),
+and [`column-rule-width`](#columnRuleWidth).
 
     borderWidth thick
+    columnRuleWidth thick
 
 The value is equivalent of 5px.
 
@@ -9000,3 +9008,38 @@ columnGap :
     -> Style
 columnGap (Value width) =
     AppendProperty ("column-gap:" ++ width)
+
+
+{-| Sets [`column-rule-width`](https://www.w3.org/TR/css-multicol-1/#propdef-column-rule-width)
+
+    columnRuleWidth thin
+    columnRuleWidth (px 2)
+
+-}
+columnRuleWidth :
+    Value
+        { thin : Supported
+        , medium : Supported
+        , thick : Supported
+        , zero : Supported
+        , ch : Supported
+        , em : Supported
+        , ex : Supported
+        , rem : Supported
+        , vh : Supported
+        , vw : Supported
+        , vmin : Supported
+        , vmax : Supported
+        , px : Supported
+        , cm : Supported
+        , mm : Supported
+        , inches : Supported
+        , pc : Supported
+        , pt : Supported
+        , initial : Supported
+        , inherit : Supported
+        , unset : Supported
+        }
+    -> Style
+columnRuleWidth (Value width) =
+    AppendProperty ("column-rule-width:" ++ width)


### PR DESCRIPTION
This adds the following properties with values:
- [x] `column-count`
- [x] `column-fill`
- [x] `column-gap`
- [x] `column-rule`
- [x] `column-rule-style`
- [x] `column-rule-color`
- [x] `column-rule-width`
- [x] `column-span`
- [x] `column-width`
- [x] `columns`

## Contribution Checklist

- [x] Each `Value` is an **open record** with a single field. The field's name is the value's name, and its type is `Supported`. For example `foo : Value { provides | foo : Supported }`
- [x] Each function returning `Style` accepts a **closed record** of `Supported` fields.
- [x] If a function returning `Style` takes a single `Value`, that `Value` should always support `inherit`, `initial`, and `unset` because all CSS properties support those three values! For example, `borderFoo : Value { foo : Supported, bar : Supported, inherit : Supported, initial : Supported, unset : Supported } -> Style`
- [x] If a function returning `Style` takes **more than one** `Value`, however, then **none** of its arguments should support `inherit`, `initial`, or `unset`, because these can never be used in conjunction with other values! For example, `border-radius: 5px 5px;` is valid CSS, `border-radius: inherit;` is valid CSS, but `border-radius: 5px inherit;` is invalid CSS. To reflect this, `borderRadius : Value { ... } -> Style` must have `inherit : Supported` in its record, but `borderRadius2 : Value { ... } -> Value { ... } -> Style` must **not** have `inherit : Supported` in *either* argument's record. If a user wants to get `border-radius: inherit`, they must call `borderRadius`, not `borderRadius2`! 
- [x] Every exposed value has documentation which includes at least 1 code sample.
- [x] Documentation links to to a [**CSS Tricks** article](https://css-tricks.com/) if available, and [MDN](https://developer.mozilla.org/en-US/docs/Web/CSS) if not.
- [x] Make a pull request against the `phantom-types` branch, not `master`!