### PR TITLE
Phantom types: add boxSizing

### DIFF
--- a/src/Css.elm
+++ b/src/Css.elm
@@ -116,6 +116,7 @@ module Css
         , bottom_
         , boundingBox
         , boxShadow
+        , boxSizing
         , breakAll
         , breakWord
         , butt
@@ -539,7 +540,7 @@ All CSS properties can have the values `unset`, `initial`, and `inherit`.
 
 ## Background Clip and Origin
 
-@docs backgroundClip, backgroundClips, backgroundOrigin, backgroundOrigins, borderBox, paddingBox, contentBox, text_
+@docs backgroundClip, backgroundClips, backgroundOrigin, backgroundOrigins, paddingBox, text_
 
 
 ## Background Image
@@ -626,6 +627,11 @@ All CSS properties can have the values `unset`, `initial`, and `inherit`.
 @docs margin, margin2, margin3, margin4, marginTop, marginRight, marginBottom, marginLeft
 
 
+## Box Sizing
+
+@docs boxSizing
+
+
 ## Flexbox
 
 @docs alignItems, alignSelf
@@ -701,6 +707,7 @@ Multiple CSS properties use these values.
 
 @docs auto, none
 @docs hidden, visible
+@docs contentBox, borderBox
 
 
 ## Overflow
@@ -1090,6 +1097,36 @@ visible =
 scroll : Value { provides | scroll : Supported }
 scroll =
     Value "scroll"
+
+
+{-| The `content-box` value, used with [`boxSizing`](#boxSizing),
+[`backgroundClip`](#backgroundClip), [`backgroundOrigin`](#backgroundOrigin),
+and [`strokeOrigin`](#strokeOrigin).
+
+    boxSizing contentBox
+    backgroundClip contentBox
+    backgroundOrigin contentBox
+    strokeOrigin contentBox
+
+-}
+contentBox : Value { provides | contentBox : Supported }
+contentBox =
+    Value "content-box"
+
+
+{-| The `border-box` value, used with [`boxSizing`](#boxSizing),
+[`backgroundClip`](#backgroundClip), [`backgroundOrigin`](backgroundOrigin),
+and [`strokeOrigin`](#strokeOrigin).
+
+    boxSizing borderBox
+    backgroundClip borderBox
+    backgroundOrigin borderBox
+    strokeOrigin borderBox
+
+-}
+borderBox : Value { provides | borderBox : Supported }
+borderBox =
+    Value "border-box"
 
 
 
@@ -2449,6 +2486,29 @@ marginLeft :
     -> Style
 marginLeft (Value value) =
     AppendProperty ("margin-left:" ++ value)
+
+
+
+-- BOX SIZING --
+
+
+{-| Sets [`box-sizing`](https://css-tricks.com/almanac/properties/b/box-sizing/) property.
+
+    boxSizing contentBox
+    boxSizing borderBox
+
+-}
+boxSizing :
+    Value
+        { contentBox : Supported
+        , borderBox : Supported
+        , inherit : Supported
+        , initial : Supported
+        , unset : Supported
+        }
+    -> Style
+boxSizing (Value value) =
+    AppendProperty ("box-sizing:" ++ value)
 
 
 
@@ -5023,34 +5083,6 @@ and [`strokeOrigin`](#strokeOrigin).
 paddingBox : Value { provides | paddingBox : Supported }
 paddingBox =
     Value "padding-box"
-
-
-{-| The `content-box` value, used with [`backgroundClip`](#backgroundClip),
-[`backgroundOrigin`](#backgroundOrigin),
-and [`strokeOrigin`](#strokeOrigin).
-
-    backgroundClip contentBox
-    backgroundOrigin contentBox
-    strokeOrigin contentBox
-
--}
-contentBox : Value { provides | contentBox : Supported }
-contentBox =
-    Value "content-box"
-
-
-{-| The `border-box` value, used with [`backgroundClip`](#backgroundClip),
-[`backgroundOrigin`](backgroundOrigin),
-and [`strokeOrigin`](#strokeOrigin).
-
-    backgroundClip borderBox
-    backgroundOrigin borderBox
-    strokeOrigin borderBox
-
--}
-borderBox : Value { provides | borderBox : Supported }
-borderBox =
-    Value "border-box"
 
 
 


### PR DESCRIPTION
Convert `boxSizing` to use phantom types #392.

- [x] Each `Value` is an **open record** with a single field. The field's name is the value's name, and its type is `Supported`. For example `foo : Value { provides | foo : Supported }`
- [x] Each function returning `Style` accepts a **closed record** of `Supported` fields.
- [x] If a function returning `Style` takes a single `Value`, that `Value` should always support `inherit`, `initial`, and `unset` because all CSS properties support those three values! For example, `borderFoo : Value { foo : Supported, bar : Supported, inherit : Supported, initial : Supported, unset : Supported } -> Style`
- [x] If a function returning `Style` takes **more than one** `Value`, however, then **none** of its arguments should support `inherit`, `initial`, or `unset`, because these can never be used in conjunction with other values! For example, `border-radius: 5px 5px;` is valid CSS, `border-radius: inherit;` is valid CSS, but `border-radius: 5px inherit;` is invalid CSS. To reflect this, `borderRadius : Value { ... } -> Style` must have `inherit : Supported` in its record, but `borderRadius2 : Value { ... } -> Value { ... } -> Style` must **not** have `inherit : Supported` in *either* argument's record. If a user wants to get `border-radius: inherit`, they must call `borderRadius`, not `borderRadius2`! 
- [x] When accepting a numeric `Value` (e.g. a length like `px`, an angle like `deg`, or a unitless number like `int` or `num`), *always* include `zero : Supported` as well as `calc : Supported`!
- [x] Every exposed value has documentation which includes at least 1 code sample.
- [x] Documentation links to to a [**CSS Tricks** article](https://css-tricks.com/) if available, and [MDN](https://developer.mozilla.org/en-US/docs/Web/CSS) if not.
- [x] Make a pull request against the `phantom-types` branch, not `master`!