### PR TITLE
Phantom types new properties

### DIFF
--- a/src/Css.elm
+++ b/src/Css.elm
@@ -10050,6 +10050,7 @@ visibility (Value str) =
 order :
     Value
         { num : Supported
+        , zero : Supported
         , inherit : Supported
         , initial : Supported
         , unset : Supported

--- a/src/Css.elm
+++ b/src/Css.elm
@@ -475,6 +475,7 @@ module Css
         , xxSmall
         , zIndex
         , zero
+        , zoom
         , zoomIn
         , zoomOut
         )
@@ -857,6 +858,11 @@ Multiple CSS properties use these values.
 
 @docs opacity
 
+
+# Viewport
+
+@docs zoom
+
 -}
 
 import Css.Preprocess as Preprocess exposing (Style(..))
@@ -1052,9 +1058,11 @@ url str =
     Value ("url(" ++ str ++ ")")
 
 
-{-| The `auto` value used for properties such as [`width`](#width).
+{-| The `auto` value used for properties such as [`width`](#width),
+and [`zoom`](#zoom).
 
     width auto
+    zoom auto
 
 -}
 auto : Value { provides | auto : Supported }
@@ -3947,13 +3955,15 @@ fontVariantCaps (Value str) =
 [`whiteSpace`](#whiteSpace),
 [`wordBreak`](#wordBreak),
 [`columnGap`](#columnGap),
+[`zoom`](#zoom),
 and [`alignItems`](#alignItems).
 
+    alignItems normal
+    columnGap normal
     fontVariantCaps normal
     whiteSpace normal
     wordBreak normal
-    alignItems normal
-    columnGap normal
+    zoom normal
 
 -}
 normal : Value { provides | normal : Supported }
@@ -11507,3 +11517,26 @@ opacity :
     -> Style
 opacity (Value val) =
     AppendProperty ("stroke-opacity:" ++ val)
+
+
+{-| Sets [`zoom`](https://css-tricks.com/almanac/properties/z/zoom/)
+
+    zoom (pct 150)
+    zoom (num 1.5)
+    zoom normal
+
+-}
+zoom :
+    Value
+        { pct : Supported
+        , zero : Supported
+        , num : Supported
+        , normal : Supported
+        , auto : Supported
+        , inherit : Supported
+        , initial : Supported
+        , unset : Supported
+        }
+    -> Style
+zoom (Value val) =
+    AppendProperty ("zoom:" ++ val)

--- a/src/Css.elm
+++ b/src/Css.elm
@@ -11510,6 +11510,7 @@ opacity :
     Value
         { num : Supported
         , zero : Supported
+        , calc : Supported
         , inherit : Supported
         , initial : Supported
         , unset : Supported
@@ -11532,6 +11533,7 @@ zoom :
         , zero : Supported
         , num : Supported
         , normal : Supported
+        , calc : Supported
         , auto : Supported
         , inherit : Supported
         , initial : Supported

--- a/src/Css.elm
+++ b/src/Css.elm
@@ -295,6 +295,7 @@ module Css
         , nwseResize
         , oblique
         , oldstyleNums
+        , opacity
         , optimizeLegibility
         , optimizeSpeed
         , order
@@ -850,6 +851,11 @@ Multiple CSS properties use these values.
 @docs columns, columns2, columnWidth, columnCount, columnGap, columnRuleWidth, columnRuleStyle, columnRuleColor, columnRule, columnRule2, columnRule3
 @docs columnFill, balance, balanceAll
 @docs columnSpan, all_
+
+
+# Opacity
+
+@docs opacity
 
 -}
 
@@ -11481,3 +11487,23 @@ inlineStart =
 inlineEnd : Value { provides | inlineEnd : Supported }
 inlineEnd =
     Value "inline-end"
+
+
+{-| Sets [`opacity`](https://css-tricks.com/almanac/properties/o/opacity/)
+
+    opacity (num 0.5)
+    opacity (num 1.0)
+    opacity zero
+
+-}
+opacity :
+    Value
+        { num : Supported
+        , zero : Supported
+        , inherit : Supported
+        , initial : Supported
+        , unset : Supported
+        }
+    -> Style
+opacity (Value val) =
+    AppendProperty ("stroke-opacity:" ++ val)

--- a/src/Css.elm
+++ b/src/Css.elm
@@ -112,6 +112,7 @@ module Css
         , borderWidth2
         , borderWidth3
         , borderWidth4
+        , both
         , bottom
         , bottom_
         , boundingBox
@@ -128,6 +129,7 @@ module Css
         , ch
         , cjkEarthlyBranch
         , cjkHeavenlyStem
+        , clear
         , clone
         , cm
         , colResize
@@ -226,7 +228,9 @@ module Css
         , initial
         , inline
         , inlineBlock
+        , inlineEnd
         , inlineFlex
+        , inlineStart
         , inset
         , int
         , italic
@@ -810,6 +814,7 @@ Multiple CSS properties use these values.
 ## Float
 
 @docs float
+@docs clear, both, inlineStart, inlineEnd
 
 
 # Visibility
@@ -1053,6 +1058,7 @@ auto =
 
 {-| The `none` value used for properties such as [`display`](#display),
 [`borderStyle`](#borderStyle),
+[`clear`](#clear),
 and [`strokeDashJustify`](#strokeDashJustify).
 
     display none
@@ -11417,3 +11423,60 @@ columnRule3 :
     -> Style
 columnRule3 (Value width) (Value style) (Value color) =
     AppendProperty ("column-rule:" ++ width ++ " " ++ style ++ " " ++ color)
+
+
+{-| Sets [`clear`](https://css-tricks.com/almanac/properties/c/clear/) property.
+
+    clear none
+    clear both
+    clear left_
+    clear right_
+    clear inlineStart
+    clear inlineEnd
+
+-}
+clear :
+    Value
+        { none : Supported
+        , left_ : Supported
+        , right_ : Supported
+        , both : Supported
+        , inlineStart : Supported
+        , inlineEnd : Supported
+        , inherit : Supported
+        , initial : Supported
+        , unset : Supported
+        }
+    -> Style
+clear (Value val) =
+    AppendProperty ("clear:" ++ val)
+
+
+{-| Sets `both` value for usage with [`clear`](#clear).
+
+      clear both
+
+-}
+both : Value { provides | both : Supported }
+both =
+    Value "both"
+
+
+{-| Sets `inline-start` value for usage with [`clear`](#clear).
+
+      clear inlineStart
+
+-}
+inlineStart : Value { provides | inlineStart : Supported }
+inlineStart =
+    Value "inline-start"
+
+
+{-| Sets `inline-end` value for usage with [`clear`](#clear).
+
+      clear inlineEnd
+
+-}
+inlineEnd : Value { provides | inlineEnd : Supported }
+inlineEnd =
+    Value "inline-end"


### PR DESCRIPTION
- [x] Each `Value` is an **open record** with a single field. The field's name is the value's name, and its type is `Supported`. For example `foo : Value { provides | foo : Supported }`
- [x] Each function returning `Style` accepts a **closed record** of `Supported` fields.
- [x] If a function returning `Style` takes a single `Value`, that `Value` should always support `inherit`, `initial`, and `unset` because all CSS properties support those three values! For example, `borderFoo : Value { foo : Supported, bar : Supported, inherit : Supported, initial : Supported, unset : Supported } -> Style`
- [x] If a function returning `Style` takes **more than one** `Value`, however, then **none** of its arguments should support `inherit`, `initial`, or `unset`, because these can never be used in conjunction with other values! For example, `border-radius: 5px 5px;` is valid CSS, `border-radius: inherit;` is valid CSS, but `border-radius: 5px inherit;` is invalid CSS. To reflect this, `borderRadius : Value { ... } -> Style` must have `inherit : Supported` in its record, but `borderRadius2 : Value { ... } -> Value { ... } -> Style` must **not** have `inherit : Supported` in *either* argument's record. If a user wants to get `border-radius: inherit`, they must call `borderRadius`, not `borderRadius2`! 
- [x] When accepting a numeric `Value` (e.g. a length like `px`, an angle like `deg`, or a unitless number like `int` or `num`), *always* include `zero : Supported` as well as `calc : Supported`!
- [x] Every exposed value has documentation which includes at least 1 code sample.
- [x] Documentation links to to a [**CSS Tricks** article](https://css-tricks.com/) if available, and [MDN](https://developer.mozilla.org/en-US/docs/Web/CSS) if not.
- [x] Make a pull request against the `phantom-types` branch, not `master`!