### PR TITLE
Phantom Type: Add missing color to box-shadow output

### DIFF
--- a/src/Css.elm
+++ b/src/Css.elm
@@ -3072,8 +3072,13 @@ boxShadowConfigToString config =
 
             else
                 ""
+
+        color =
+            config.color
+                |> Maybe.map (unpackValue >> (++) " ")
+                |> Maybe.withDefault ""
     in
-    insetStr ++ offsetX ++ " " ++ offsetY ++ blurRadius ++ spreadRadius
+    insetStr ++ offsetX ++ " " ++ offsetY ++ blurRadius ++ spreadRadius ++ color
 
 
 


### PR DESCRIPTION
Found this little bug when I was working on the `textShadow` implementation. Color was not present in the output.