### PR TITLE
Phantom types: add most missing flexbox functions/values

### DIFF
--- a/src/Css.elm
+++ b/src/Css.elm
@@ -197,6 +197,8 @@ module Css
         , flexBasis
         , flexDirection
         , flexEnd
+        , flexFlow
+        , flexFlow2
         , flexGrow
         , flexShrink
         , flexStart
@@ -709,6 +711,11 @@ See this [complete guide](https://css-tricks.com/snippets/css/a-guide-to-flexbox
 ### Flexbox Wrapping
 
 @docs flexWrap, nowrap, wrap, wrapReverse
+
+
+### Flexbox Shorthands
+
+@docs flexFlow, flexFlow2
 
 
 ## Font Size
@@ -3893,6 +3900,58 @@ wrap =
 wrapReverse : Value { provides | wrapReverse : Supported }
 wrapReverse =
     Value "wrap-reverse"
+
+
+{-| The [`flex-flow`](https://css-tricks.com/almanac/properties/f/flex-flow/) shorthand property.
+
+    flexFlow rowReverse
+    flexFlow wrap
+    flexFlow inherit
+    flexFlow2 column wrapReverse
+
+-}
+flexFlow :
+    Value
+        { row : Supported
+        , rowReverse : Supported
+        , column : Supported
+        , columnReverse : Supported
+        , nowrap : Supported
+        , wrap : Supported
+        , wrapReverse : Supported
+        , inherit : Supported
+        , initial : Supported
+        , unset : Supported
+        }
+    -> Style
+flexFlow (Value directionOrWrapping) =
+    AppendProperty ("flex-flow:" ++ directionOrWrapping)
+
+
+{-| The [`flex-flow`](https://css-tricks.com/almanac/properties/f/flex-flow/) shorthand property.
+
+    flexFlow rowReverse
+    flexFlow wrap
+    flexFlow inherit
+    flexFlow2 column wrapReverse
+
+-}
+flexFlow2 :
+    Value
+        { row : Supported
+        , rowReverse : Supported
+        , column : Supported
+        , columnReverse : Supported
+        }
+    ->
+        Value
+            { nowrap : Supported
+            , wrap : Supported
+            , wrapReverse : Supported
+            }
+    -> Style
+flexFlow2 (Value direction) (Value wrapping) =
+    AppendProperty ("flex-flow:" ++ direction ++ " " ++ wrapping)
 
 
 

--- a/src/Css.elm
+++ b/src/Css.elm
@@ -10,6 +10,7 @@ module Css
         , active
         , after
         , alias
+        , alignContent
         , alignItems
         , alignSelf
         , all
@@ -680,7 +681,7 @@ See this [complete guide](https://css-tricks.com/snippets/css/a-guide-to-flexbox
 
 ### Flexbox Alignment
 
-@docs alignItems, alignSelf, justifyContent
+@docs alignItems, alignSelf, justifyContent, alignContent
 
 
 ### Flexbox Direction
@@ -3434,10 +3435,11 @@ end =
     Value "end"
 
 
-{-| The `flex-start` value used by [`alignItems`](#alignItems) and [`justifyContent`](#justifyContent).
+{-| The `flex-start` value used by [`alignItems`](#alignItems), [`justifyContent`](#justifyContent) and [`alignContent`](#alignContent).
 
     alignItems flexStart
     justifyContent flexStart
+    alignContent flexStart
 
 -}
 flexStart : Value { provides | flexStart : Supported }
@@ -3445,10 +3447,11 @@ flexStart =
     Value "flex-start"
 
 
-{-| The `flex-end` value used by [`alignItems`](#alignItems) and [`justifyContent`](#justifyContent).
+{-| The `flex-end` value used by [`alignItems`](#alignItems), [`justifyContent`](#justifyContent) and [`alignContent`](#alignContent).
 
     alignItems flexEnd
     justifyContent flexEnd
+    alignContent flexEnd
 
 -}
 flexEnd : Value { provides | flexEnd : Supported }
@@ -3468,7 +3471,7 @@ selfEnd =
     Value "self-end"
 
 
-{-| The `space-between` value used by [`justifyContent`](#justifyContent).
+{-| The `space-between` value used by [`justifyContent`](#justifyContent) and [`alignContent`](#alignContent).
 
     justifyContent spaceBetween
 
@@ -3478,7 +3481,7 @@ spaceBetween =
     Value "space-between"
 
 
-{-| The `space-around` value used by [`justifyContent`](#justifyContent).
+{-| The `space-around` value used by [`justifyContent`](#justifyContent) and [`alignContent`](#alignContent).
 
     justifyContent spaceAround
 
@@ -3568,6 +3571,30 @@ unsafeCenter =
 
 
 -- FLEXBOX --
+
+
+{-| Sets [`align-content`](https://css-tricks.com/almanac/properties/a/align-content/).
+
+    alignContent flexStart
+
+**Note:** This property has no effect when the flexbox has only a single line.
+
+-}
+alignContent :
+    Value
+        { flexStart : Supported
+        , flexEnd : Supported
+        , center : Supported
+        , spaceBetween : Supported
+        , spaceAround : Supported
+        , stretch : Supported
+        , inherit : Supported
+        , initial : Supported
+        , unset : Supported
+        }
+    -> Style
+alignContent (Value val) =
+    AppendProperty ("align-content:" ++ val)
 
 
 {-| Sets [`align-items`](https://css-tricks.com/almanac/properties/a/align-items/).

--- a/src/Css.elm
+++ b/src/Css.elm
@@ -238,6 +238,7 @@ module Css
         , int
         , italic
         , justify
+        , justifyContent
         , kannada
         , keepAll
         , khmer
@@ -392,6 +393,8 @@ module Css
         , softLight
         , solid
         , space
+        , spaceAround
+        , spaceBetween
         , square
         , stackedFractions
         , start
@@ -677,7 +680,7 @@ See this [complete guide](https://css-tricks.com/snippets/css/a-guide-to-flexbox
 
 ### Flexbox Alignment
 
-@docs alignItems, alignSelf
+@docs alignItems, alignSelf, justifyContent
 
 
 ### Flexbox Direction
@@ -731,7 +734,7 @@ See this [complete guide](https://css-tricks.com/snippets/css/a-guide-to-flexbox
 
 # Align Items
 
-@docs normal, stretch, center, start, end, flexStart, flexEnd, selfStart, selfEnd, left_, right_, top_, bottom_, baseline, firstBaseline, lastBaseline, safeCenter, unsafeCenter
+@docs normal, stretch, center, start, end, flexStart, flexEnd, selfStart, selfEnd, spaceBetween, spaceAround, left_, right_, top_, bottom_, baseline, firstBaseline, lastBaseline, safeCenter, unsafeCenter
 
 
 # Url
@@ -3431,13 +3434,23 @@ end =
     Value "end"
 
 
-{-| -}
+{-| The `flex-start` value used by [`alignItems`](#alignItems) and [`justifyContent`](#justifyContent).
+
+    alignItems flexStart
+    justifyContent flexStart
+
+-}
 flexStart : Value { provides | flexStart : Supported }
 flexStart =
     Value "flex-start"
 
 
-{-| -}
+{-| The `flex-end` value used by [`alignItems`](#alignItems) and [`justifyContent`](#justifyContent).
+
+    alignItems flexEnd
+    justifyContent flexEnd
+
+-}
 flexEnd : Value { provides | flexEnd : Supported }
 flexEnd =
     Value "flex-end"
@@ -3453,6 +3466,26 @@ selfStart =
 selfEnd : Value { provides | selfEnd : Supported }
 selfEnd =
     Value "self-end"
+
+
+{-| The `space-between` value used by [`justifyContent`](#justifyContent).
+
+    justifyContent spaceBetween
+
+-}
+spaceBetween : Value { provides | spaceBetween : Supported }
+spaceBetween =
+    Value "space-between"
+
+
+{-| The `space-around` value used by [`justifyContent`](#justifyContent).
+
+    justifyContent spaceAround
+
+-}
+spaceAround : Value { provides | spaceAround : Supported }
+spaceAround =
+    Value "space-around"
 
 
 {-| The `left` value used for alignment.
@@ -3606,6 +3639,27 @@ alignSelf :
     -> Style
 alignSelf (Value val) =
     AppendProperty ("align-self:" ++ val)
+
+
+{-| Sets [`justify-content`](https://css-tricks.com/almanac/properties/j/justify-content/).
+
+    justifyContent flexStart
+
+-}
+justifyContent :
+    Value
+        { flexStart : Supported
+        , flexEnd : Supported
+        , center : Supported
+        , spaceBetween : Supported
+        , spaceAround : Supported
+        , inherit : Supported
+        , initial : Supported
+        , unset : Supported
+        }
+    -> Style
+justifyContent (Value val) =
+    AppendProperty ("justify-content:" ++ val)
 
 
 {-| Sets [`flex-direction`](https://css-tricks.com/almanac/properties/f/flex-direction/).

--- a/src/Css.elm
+++ b/src/Css.elm
@@ -1162,10 +1162,12 @@ url str =
 
 
 {-| The `auto` value used for properties such as [`width`](#width),
-and [`zoom`](#zoom).
+[`zoom`](#zoom),
+and [`flexBasis`](#flexBasis).
 
     width auto
     zoom auto
+    flexBasis auto
 
 -}
 auto : Value { provides | auto : Supported }
@@ -3459,7 +3461,9 @@ end =
     Value "end"
 
 
-{-| The `flex-start` value used by [`alignItems`](#alignItems), [`justifyContent`](#justifyContent) and [`alignContent`](#alignContent).
+{-| The `flex-start` value used by [`alignItems`](#alignItems),
+[`justifyContent`](#justifyContent),
+and [`alignContent`](#alignContent).
 
     alignItems flexStart
     justifyContent flexStart
@@ -3471,7 +3475,9 @@ flexStart =
     Value "flex-start"
 
 
-{-| The `flex-end` value used by [`alignItems`](#alignItems), [`justifyContent`](#justifyContent) and [`alignContent`](#alignContent).
+{-| The `flex-end` value used by [`alignItems`](#alignItems),
+[`justifyContent`](#justifyContent),
+and [`alignContent`](#alignContent).
 
     alignItems flexEnd
     justifyContent flexEnd
@@ -3495,9 +3501,11 @@ selfEnd =
     Value "self-end"
 
 
-{-| The `space-between` value used by [`justifyContent`](#justifyContent) and [`alignContent`](#alignContent).
+{-| The `space-between` value used by [`justifyContent`](#justifyContent)
+and [`alignContent`](#alignContent).
 
     justifyContent spaceBetween
+    alignContent spaceBetween
 
 -}
 spaceBetween : Value { provides | spaceBetween : Supported }
@@ -3505,9 +3513,11 @@ spaceBetween =
     Value "space-between"
 
 
-{-| The `space-around` value used by [`justifyContent`](#justifyContent) and [`alignContent`](#alignContent).
+{-| The `space-around` value used by [`justifyContent`](#justifyContent)
+and [`alignContent`](#alignContent).
 
     justifyContent spaceAround
+    alignContent spaceAround
 
 -}
 spaceAround : Value { provides | spaceAround : Supported }

--- a/src/Css.elm
+++ b/src/Css.elm
@@ -138,9 +138,11 @@ module Css
         , colorBurn
         , colorDodge
         , color_
+        , column
         , columnCount
         , columnFill
         , columnGap
+        , columnReverse
         , columnRule
         , columnRule2
         , columnRule3
@@ -190,6 +192,7 @@ module Css
         , fillBox
         , firstBaseline
         , fixed
+        , flexDirection
         , flexEnd
         , flexStart
         , flex_
@@ -354,7 +357,9 @@ module Css
         , rotateY
         , rotateZ
         , round
+        , row
         , rowResize
+        , rowReverse
         , rtl
         , sResize
         , safeCenter
@@ -666,7 +671,23 @@ All CSS properties can have the values `unset`, `initial`, and `inherit`.
 
 ## Flexbox
 
+The CSS Flexible Box Layout Module.
+See this [complete guide](https://css-tricks.com/snippets/css/a-guide-to-flexbox/).
+
+
+### Flexbox Alignment
+
 @docs alignItems, alignSelf
+
+
+### Flexbox Direction
+
+@docs flexDirection, row, rowReverse, column, columnReverse
+
+
+### Flexbox Order
+
+@docs order
 
 
 ## Font Size
@@ -847,11 +868,6 @@ Multiple CSS properties use these values.
 # Visibility
 
 @docs visibility
-
-
-# Flexbox
-
-@docs order
 
 
 # SVG
@@ -3590,6 +3606,66 @@ alignSelf :
     -> Style
 alignSelf (Value val) =
     AppendProperty ("align-self:" ++ val)
+
+
+{-| Sets [`flex-direction`](https://css-tricks.com/almanac/properties/f/flex-direction/).
+
+    flexDirection column
+
+-}
+flexDirection :
+    Value
+        { row : Supported
+        , rowReverse : Supported
+        , column : Supported
+        , columnReverse : Supported
+        , inherit : Supported
+        , initial : Supported
+        , unset : Supported
+        }
+    -> Style
+flexDirection (Value val) =
+    AppendProperty ("flex-direction:" ++ val)
+
+
+{-| The `row` [`flex-direction` value](https://developer.mozilla.org/en-US/docs/Web/CSS/flex-direction#Values).
+
+    flexDirection row
+
+-}
+row : Value { provides | row : Supported }
+row =
+    Value "row"
+
+
+{-| The `row-reverse` [`flex-direction` value](https://developer.mozilla.org/en-US/docs/Web/CSS/flex-direction#Values).
+
+    flexDirection rowReverse
+
+-}
+rowReverse : Value { provides | rowReverse : Supported }
+rowReverse =
+    Value "row-reverse"
+
+
+{-| The `column` [`flex-direction` value](https://developer.mozilla.org/en-US/docs/Web/CSS/flex-direction#Values).
+
+    flexDirection column
+
+-}
+column : Value { provides | column : Supported }
+column =
+    Value "column"
+
+
+{-| The `column-reverse` [`flex-direction` value](https://developer.mozilla.org/en-US/docs/Web/CSS/flex-direction#Values).
+
+    flexDirection columnReverse
+
+-}
+columnReverse : Value { provides | columnReverse : Supported }
+columnReverse =
+    Value "column-reverse"
 
 
 

--- a/src/Css.elm
+++ b/src/Css.elm
@@ -175,7 +175,6 @@ module Css
         , direction
         , discretionaryLigatures
         , display
-        , displayFlex
         , dividedBy
         , dotted
         , double
@@ -193,6 +192,7 @@ module Css
         , fixed
         , flexEnd
         , flexStart
+        , flex_
         , float
         , fontFamilies
         , fontFamily
@@ -637,9 +637,9 @@ All CSS properties can have the values `unset`, `initial`, and `inherit`.
 
 ## Display
 
-@docs display, displayFlex
+@docs display
 
-@docs block, grid, inline, inlineBlock, inlineFlex, table, tableCaption, tableCell, tableColumn, tableColumnGroup, tableFooterGroup, tableHeaderGroup, tableRow, tableRowGroup
+@docs block, flex_, grid, inline, inlineBlock, inlineFlex, table, tableCaption, tableCell, tableColumn, tableColumnGroup, tableFooterGroup, tableHeaderGroup, tableRow, tableRowGroup
 
 
 ## Positions
@@ -3266,12 +3266,13 @@ dividedBy (Value second) =
 
     display block
 
-For `display: flex`, use [`displayFlex`](#displayFlex).
+**Note:** This function accepts `flex_` rather than `flex` because [`flex` is already a function](#flex).
 
 -}
 display :
     Value
         { block : Supported
+        , flex_ : Supported
         , grid : Supported
         , inline : Supported
         , inlineBlock : Supported
@@ -3296,20 +3297,16 @@ display (Value val) =
     AppendProperty ("display:" ++ val)
 
 
-{-| [`display: flex`](https://css-tricks.com/snippets/css/a-guide-to-flexbox/). This works around the fact that [`flex` is already taken](#flex).
-
-    div [ displayFlex ]
-
--}
-displayFlex : Style
-displayFlex =
-    AppendProperty "display:flex"
-
-
 {-| -}
 block : Value { provides | block : Supported }
 block =
     Value "block"
+
+
+{-| -}
+flex_ : Value { provides | flex_ : Supported }
+flex_ =
+    Value "flex"
 
 
 {-| -}

--- a/src/Css.elm
+++ b/src/Css.elm
@@ -1083,11 +1083,10 @@ unset =
 -}
 all :
     Value
-        { accepts
-            | revert : Supported
-            , initial : Supported
-            , inherit : Supported
-            , unset : Supported
+        { revert : Supported
+        , initial : Supported
+        , inherit : Supported
+        , unset : Supported
         }
     -> Style
 all (Value val) =
@@ -3535,26 +3534,25 @@ because `Css.left` and `Css.right` are functions!
 -}
 alignItems :
     Value
-        { accepts
-            | normal : Supported
-            , stretch : Supported
-            , center : Supported
-            , start : Supported
-            , end : Supported
-            , flexStart : Supported
-            , flexEnd : Supported
-            , selfStart : Supported
-            , selfEnd : Supported
-            , left_ : Supported
-            , right_ : Supported
-            , baseline : Supported
-            , firstBaseline : Supported
-            , lastBaseline : Supported
-            , safeCenter : Supported
-            , unsafeCenter : Supported
-            , inherit : Supported
-            , initial : Supported
-            , unset : Supported
+        { normal : Supported
+        , stretch : Supported
+        , center : Supported
+        , start : Supported
+        , end : Supported
+        , flexStart : Supported
+        , flexEnd : Supported
+        , selfStart : Supported
+        , selfEnd : Supported
+        , left_ : Supported
+        , right_ : Supported
+        , baseline : Supported
+        , firstBaseline : Supported
+        , lastBaseline : Supported
+        , safeCenter : Supported
+        , unsafeCenter : Supported
+        , inherit : Supported
+        , initial : Supported
+        , unset : Supported
         }
     -> Style
 alignItems (Value val) =

--- a/src/Css.elm
+++ b/src/Css.elm
@@ -157,6 +157,7 @@ module Css
         , commonLigatures
         , compress
         , contain
+        , content
         , contentBox
         , contextMenu
         , contextual
@@ -193,8 +194,11 @@ module Css
         , fillBox
         , firstBaseline
         , fixed
+        , flexBasis
         , flexDirection
         , flexEnd
+        , flexGrow
+        , flexShrink
         , flexStart
         , flexWrap
         , flex_
@@ -695,6 +699,11 @@ See this [complete guide](https://css-tricks.com/snippets/css/a-guide-to-flexbox
 ### Flexbox Order
 
 @docs order
+
+
+### Flexbox Sizing
+
+@docs flexGrow, flexShrink, flexBasis, content
 
 
 ### Flexbox Wrapping
@@ -3695,6 +3704,94 @@ justifyContent :
     -> Style
 justifyContent (Value val) =
     AppendProperty ("justify-content:" ++ val)
+
+
+{-| Sets [`flex-basis`](https://css-tricks.com/almanac/properties/f/flex-basis/).
+
+    flexBasis (em 10)
+    flexBasis (px 3)
+    flexBasis (pct 100)
+    flexBasis auto
+
+-}
+flexBasis :
+    Value
+        { auto : Supported
+        , content : Supported
+        , ch : Supported
+        , cm : Supported
+        , em : Supported
+        , ex : Supported
+        , inches : Supported
+        , mm : Supported
+        , pc : Supported
+        , pct : Supported
+        , pt : Supported
+        , px : Supported
+        , rem : Supported
+        , vh : Supported
+        , vmax : Supported
+        , vmin : Supported
+        , vw : Supported
+        , zero : Supported
+        , calc : Supported
+        , inherit : Supported
+        , initial : Supported
+        , unset : Supported
+        }
+    -> Style
+flexBasis (Value val) =
+    AppendProperty ("flex-basis:" ++ val)
+
+
+{-| The `content` [`flex-basis` value](https://developer.mozilla.org/en-US/docs/Web/CSS/flex-basis#Values).
+
+    flexBasis content
+
+-}
+content : Value { provides | content : Supported }
+content =
+    Value "content"
+
+
+{-| Sets [`flex-grow`](https://css-tricks.com/almanac/properties/f/flex-grow/).
+
+    flexGrow (num 3)
+    flexGrow (num 0.6)
+
+-}
+flexGrow :
+    Value
+        { num : Supported
+        , zero : Supported
+        , calc : Supported
+        , inherit : Supported
+        , initial : Supported
+        , unset : Supported
+        }
+    -> Style
+flexGrow (Value val) =
+    AppendProperty ("flex-grow:" ++ val)
+
+
+{-| Sets [`flex-shrink`](https://css-tricks.com/almanac/properties/f/flex-shrink/).
+
+    flexShrink (num 2)
+    flexShrink (num 0.6)
+
+-}
+flexShrink :
+    Value
+        { num : Supported
+        , zero : Supported
+        , calc : Supported
+        , inherit : Supported
+        , initial : Supported
+        , unset : Supported
+        }
+    -> Style
+flexShrink (Value val) =
+    AppendProperty ("flex-shrink:" ++ val)
 
 
 {-| Sets [`flex-direction`](https://css-tricks.com/almanac/properties/f/flex-direction/).

--- a/src/Css.elm
+++ b/src/Css.elm
@@ -196,6 +196,7 @@ module Css
         , flexDirection
         , flexEnd
         , flexStart
+        , flexWrap
         , flex_
         , float
         , fontFamilies
@@ -503,6 +504,8 @@ module Css
         , wavy
         , whiteSpace
         , wordBreak
+        , wrap
+        , wrapReverse
         , xLarge
         , xSmall
         , xxLarge
@@ -692,6 +695,11 @@ See this [complete guide](https://css-tricks.com/snippets/css/a-guide-to-flexbox
 ### Flexbox Order
 
 @docs order
+
+
+### Flexbox Wrapping
+
+@docs flexWrap, nowrap, wrap, wrapReverse
 
 
 ## Font Size
@@ -3747,6 +3755,47 @@ column =
 columnReverse : Value { provides | columnReverse : Supported }
 columnReverse =
     Value "column-reverse"
+
+
+{-| Sets [`flex-wrap`](https://css-tricks.com/almanac/properties/f/flex-wrap/).
+
+    flexWrap wrap
+    flexWrap wrapReverse
+    flexWrap nowrap
+
+-}
+flexWrap :
+    Value
+        { nowrap : Supported
+        , wrap : Supported
+        , wrapReverse : Supported
+        , inherit : Supported
+        , initial : Supported
+        , unset : Supported
+        }
+    -> Style
+flexWrap (Value val) =
+    AppendProperty ("flex-wrap:" ++ val)
+
+
+{-| The `wrap` [`flex-wrap` value](https://developer.mozilla.org/en-US/docs/Web/CSS/flex-wrap#Values).
+
+    flexWrap wrap
+
+-}
+wrap : Value { provides | wrap : Supported }
+wrap =
+    Value "wrap"
+
+
+{-| The `wrap-reverse` [`flex-wrap` value](https://developer.mozilla.org/en-US/docs/Web/CSS/flex-wrap#Values).
+
+    flexWrap wrapReverse
+
+-}
+wrapReverse : Value { provides | wrapReverse : Supported }
+wrapReverse =
+    Value "wrap-reverse"
 
 
 
@@ -10128,9 +10177,11 @@ whiteSpace (Value str) =
     AppendProperty ("white-space:" ++ str)
 
 
-{-| A `nowrap` value for the [`white-space`](https://css-tricks.com/almanac/properties/w/whitespace/) property.
+{-| A `nowrap` value for the [`white-space`](https://css-tricks.com/almanac/properties/w/whitespace/)
+and [`flex-wrap`](https://css-tricks.com/almanac/properties/f/flex-wrap/) properties.
 
     whiteSpace nowrap
+    flexWrap nowrap
 
 -}
 nowrap : Value { provides | nowrap : Supported }

--- a/src/Css.elm
+++ b/src/Css.elm
@@ -194,6 +194,9 @@ module Css
         , fillBox
         , firstBaseline
         , fixed
+        , flex
+        , flex2
+        , flex3
         , flexBasis
         , flexDirection
         , flexEnd
@@ -715,7 +718,7 @@ See this [complete guide](https://css-tricks.com/snippets/css/a-guide-to-flexbox
 
 ### Flexbox Shorthands
 
-@docs flexFlow, flexFlow2
+@docs flex, flex2, flex3, flexFlow, flexFlow2
 
 
 ## Font Size
@@ -1178,11 +1181,13 @@ auto =
 {-| The `none` value used for properties such as [`display`](#display),
 [`borderStyle`](#borderStyle),
 [`clear`](#clear),
-and [`strokeDashJustify`](#strokeDashJustify).
+[`strokeDashJustify`](#strokeDashJustify),
+and [`flex`](#flex).
 
     display none
     borderStyle none
     strokeDashJustify none
+    flex none
 
 -}
 none : Value { provides | none : Supported }
@@ -3809,6 +3814,138 @@ flexShrink :
     -> Style
 flexShrink (Value val) =
     AppendProperty ("flex-shrink:" ++ val)
+
+
+{-| The [`flex`](https://css-tricks.com/almanac/properties/f/flex/) shorthand property.
+
+    flex none
+    flex auto
+    flex (num 1)
+    flex2 zero auto
+    flex3 (num 1) zero (pct 50)
+
+-}
+flex :
+    Value
+        { none : Supported
+        , auto : Supported
+        , content : Supported
+        , ch : Supported
+        , cm : Supported
+        , em : Supported
+        , ex : Supported
+        , inches : Supported
+        , mm : Supported
+        , pc : Supported
+        , pct : Supported
+        , pt : Supported
+        , px : Supported
+        , rem : Supported
+        , vh : Supported
+        , vmax : Supported
+        , vmin : Supported
+        , vw : Supported
+        , num : Supported
+        , zero : Supported
+        , calc : Supported
+        , inherit : Supported
+        , initial : Supported
+        , unset : Supported
+        }
+    -> Style
+flex (Value growOrBasis) =
+    AppendProperty ("flex:" ++ growOrBasis)
+
+
+{-| The [`flex`](https://css-tricks.com/almanac/properties/f/flex/) shorthand property.
+
+    flex none
+    flex auto
+    flex (num 1)
+    flex2 zero auto
+    flex3 (num 1) zero (pct 50)
+
+-}
+flex2 :
+    Value
+        { num : Supported
+        , zero : Supported
+        , calc : Supported
+        }
+    ->
+        Value
+            { auto : Supported
+            , content : Supported
+            , ch : Supported
+            , cm : Supported
+            , em : Supported
+            , ex : Supported
+            , inches : Supported
+            , mm : Supported
+            , pc : Supported
+            , pct : Supported
+            , pt : Supported
+            , px : Supported
+            , rem : Supported
+            , vh : Supported
+            , vmax : Supported
+            , vmin : Supported
+            , vw : Supported
+            , num : Supported
+            , zero : Supported
+            , calc : Supported
+            }
+    -> Style
+flex2 (Value grow) (Value shrinkOrBasis) =
+    AppendProperty ("flex:" ++ grow ++ " " ++ shrinkOrBasis)
+
+
+{-| The [`flex`](https://css-tricks.com/almanac/properties/f/flex/) shorthand property.
+
+    flex none
+    flex auto
+    flex (num 1)
+    flex2 zero auto
+    flex3 (num 1) zero (pct 50)
+
+-}
+flex3 :
+    Value
+        { num : Supported
+        , zero : Supported
+        , calc : Supported
+        }
+    ->
+        Value
+            { num : Supported
+            , zero : Supported
+            , calc : Supported
+            }
+    ->
+        Value
+            { auto : Supported
+            , content : Supported
+            , ch : Supported
+            , cm : Supported
+            , em : Supported
+            , ex : Supported
+            , inches : Supported
+            , mm : Supported
+            , pc : Supported
+            , pct : Supported
+            , pt : Supported
+            , px : Supported
+            , rem : Supported
+            , vh : Supported
+            , vmax : Supported
+            , vmin : Supported
+            , vw : Supported
+            , zero : Supported
+            , calc : Supported
+            }
+    -> Style
+flex3 (Value grow) (Value shrink) (Value basis) =
+    AppendProperty ("flex:" ++ grow ++ " " ++ shrink ++ " " ++ basis)
 
 
 {-| Sets [`flex-direction`](https://css-tricks.com/almanac/properties/f/flex-direction/).

--- a/src/Css.elm
+++ b/src/Css.elm
@@ -10122,6 +10122,7 @@ order :
     Value
         { num : Supported
         , zero : Supported
+        , calc : Supported
         , inherit : Supported
         , initial : Supported
         , unset : Supported


### PR DESCRIPTION
Hi, first PR here so feedback is welcome.

**Important notes / feedback likely needed**
1. I replaced `displayFlex` by `display flex_` as it seems that `underscore` won the namespace war for now. Tell me if I'm wrong.
2. I included a fix to "close" the "open" record parameter of `alignItems` and `all` (in passing) as they seemed wrong (their value record was parameterized on `accepts`). But I may have misunderstood something so tell me if I should remove this modification.
3. I did not  include yet overflow and baseline alignment for `justifyContent` and `alignContent` as they are still in a draft specification and are not well supported by all browsers. However `alignItems` already implements them partially (overflow alignment is limited to `safe center` or `unsafe center` but `center | start | end | self-start | self-end | flex-start | flex-end` should also be valid). So I need feedback to know what to do.
4. I also did not include intrinsic sizing (`min-content`, `max-content`, ...) for `flexBasis` for the same reasons. However they are listed in the [phantom-types issue](https://github.com/rtfeldman/elm-css/issues/392), so I'm not really sure what we want.

**Other less important notes**
* I added a 3rd level of documentation to try to have a nice flexbox section. If this is not wanted, I can flatten out the flexbox documentation to 2 levels as the rest of the document.
* I renamed `flexFlow1` (in the listed function to implement) to `flexFlow` as it seemed more consistent with other multiple values functions
* I struggled with the functions definition order. Maybe something should be added in the guidelines about that or a final pass done once all types are implemented.
* They are some inconsistency between comments about the use of values terminated by an `underscore` in the source. I choose what seemed the best but a pass to harmonize them is most likely needed at the end.

Thank you very much for this library.
Regards