### PR TITLE
Phantom types aliases proposal

### DIFF
--- a/src/Css.elm
+++ b/src/Css.elm
@@ -1,8 +1,19 @@
 module Css
     exposing
-        ( BoxShadowConfig
+        ( Angle
+        , AngleSupported
+        , BorderStyle
+        , BorderStyleSupported
+        , BorderWidth
+        , BorderWidthSupported
+        , BoxShadowConfig
         , CalcOperation
         , Color
+        , ColorSupported
+        , Length
+        , LengthSupported
+        , ListStyle
+        , ListStyleSupported
         , Style
         , Supported
         , Value
@@ -534,6 +545,8 @@ All CSS properties can have the values `unset`, `initial`, and `inherit`.
 
 @docs all, revert
 
+@docs Length, LengthSupported, Angle, AngleSupported
+
 
 ## Numeric Units
 
@@ -547,7 +560,7 @@ All CSS properties can have the values `unset`, `initial`, and `inherit`.
 
 ## Color
 
-@docs Color, color, backgroundColor, hex, rgb, rgba, hsl, hsla
+@docs Color, ColorSupported, color, backgroundColor, hex, rgb, rgba, hsl, hsla
 
 
 ## Pseudo-Classes
@@ -592,6 +605,8 @@ All CSS properties can have the values `unset`, `initial`, and `inherit`.
 
 
 ## Border
+
+@docs BorderWidth, BorderWidthSupported, BorderStyle, BorderStyleSupported
 
 @docs border, border2, border3
 
@@ -729,6 +744,7 @@ All CSS properties can have the values `unset`, `initial`, and `inherit`.
 
 ## List Style Type
 
+@docs ListStyle, ListStyleSupported
 @docs listStyle, listStyle2, listStyle3
 @docs arabicIndic, armenian, bengali, cjkEarthlyBranch, cjkHeavenlyStem, devanagari, georgian, gujarati, gurmukhi, kannada, khmer, lao, malayalam, myanmar, oriya, telugu, thai
 
@@ -983,6 +999,119 @@ type Value supports
 -}
 type Supported
     = Supported
+
+
+{-| A type alias used to accept a [length](https://developer.mozilla.org/en-US/docs/Web/CSS/length)
+among other values.
+-}
+type alias LengthSupported v =
+    { v
+        | ch : Supported
+        , em : Supported
+        , ex : Supported
+        , rem : Supported
+        , vh : Supported
+        , vw : Supported
+        , vmin : Supported
+        , vmax : Supported
+        , px : Supported
+        , cm : Supported
+        , mm : Supported
+        , inches : Supported
+        , pc : Supported
+        , pt : Supported
+        , zero : Supported
+        , calc : Supported
+    }
+
+
+{-| A type alias used to accept a [length](https://developer.mozilla.org/en-US/docs/Web/CSS/length).
+-}
+type alias Length =
+    LengthSupported {}
+
+
+{-| A type alias used to accept a [color](https://developer.mozilla.org/en-US/docs/Web/CSS/color)
+among other values.
+-}
+type alias ColorSupported v =
+    { v
+        | rgb : Supported
+        , rgba : Supported
+        , hsl : Supported
+        , hsla : Supported
+        , hex : Supported
+        , transparent : Supported
+        , currentColor : Supported
+    }
+
+
+{-| A type alias used to accept a [color](https://developer.mozilla.org/en-US/docs/Web/CSS/color).
+-}
+type alias Color =
+    ColorSupported {}
+
+
+{-| A type alias used to accept a [border-style](https://developer.mozilla.org/en-US/docs/Web/CSS/border-style#Values)
+among other values.
+-}
+type alias BorderStyleSupported v =
+    { v
+        | none : Supported
+        , hidden : Supported
+        , dotted : Supported
+        , dashed : Supported
+        , solid : Supported
+        , double : Supported
+        , groove : Supported
+        , ridge : Supported
+        , inset : Supported
+        , outset : Supported
+    }
+
+
+{-| A type alias used to accept a [border-style](https://developer.mozilla.org/en-US/docs/Web/CSS/border-style#Values).
+-}
+type alias BorderStyle =
+    BorderStyleSupported {}
+
+
+{-| A type alias used to accept a [border-width](https://developer.mozilla.org/en-US/docs/Web/CSS/border-width#Values)
+among other values.
+-}
+type alias BorderWidthSupported v =
+    LengthSupported
+        { v
+            | thin : Supported
+            , medium : Supported
+            , thick : Supported
+        }
+
+
+{-| A type alias used to accept a [border-width](https://developer.mozilla.org/en-US/docs/Web/CSS/border-width#Values).
+-}
+type alias BorderWidth =
+    BorderWidthSupported {}
+
+
+{-| A type alias used to accept an [angle](https://developer.mozilla.org/en-US/docs/Web/CSS/angle)
+among other values.
+-}
+type alias AngleSupported v =
+    { v
+        | deg : Supported
+        , grad : Supported
+        , rad : Supported
+        , turn : Supported
+        , zero : Supported
+        , calc : Supported
+    }
+
+
+{-| A type alias used to accept an [angle](https://developer.mozilla.org/en-US/docs/Web/CSS/angle).
+-}
+type alias Angle =
+    AngleSupported {}
 
 
 
@@ -1319,31 +1448,6 @@ breakWord =
 -- COLORS --
 
 
-{-| A color created with [`hex`](#hex), [`rgb`](#rgb), [`rgba`](#rgba),
-[`hsl`](#hsl), or [`hsla`](#hsla). `Color` can be used to annotate values
-returned by any of those functions.
-
-    limeGreen : Css.Color
-    limeGreen =
-        rgb 0 100 44
-
-    rebeccaPurple : Css.Color
-    rebeccaPurple =
-        hex "#663399"
-
--}
-type alias Color =
-    Value
-        { rgb : Supported
-        , rgba : Supported
-        , hsl : Supported
-        , hsla : Supported
-        , hex : Supported
-        , transparent : Supported
-        , currentColor : Supported
-        }
-
-
 {-| Sets [`color`](https://css-tricks.com/almanac/properties/c/color/).
 
     color (hex "#60b5cc")
@@ -1353,17 +1457,12 @@ type alias Color =
 -}
 color :
     Value
-        { rgb : Supported
-        , rgba : Supported
-        , hsl : Supported
-        , hsla : Supported
-        , hex : Supported
-        , transparent : Supported
-        , currentColor : Supported
-        , inherit : Supported
-        , initial : Supported
-        , unset : Supported
-        }
+        (ColorSupported
+            { inherit : Supported
+            , initial : Supported
+            , unset : Supported
+            }
+        )
     -> Style
 color (Value val) =
     AppendProperty ("color:" ++ val)
@@ -1378,17 +1477,12 @@ color (Value val) =
 -}
 backgroundColor :
     Value
-        { rgb : Supported
-        , rgba : Supported
-        , hsl : Supported
-        , hsla : Supported
-        , hex : Supported
-        , transparent : Supported
-        , currentColor : Supported
-        , inherit : Supported
-        , initial : Supported
-        , unset : Supported
-        }
+        (ColorSupported
+            { inherit : Supported
+            , initial : Supported
+            , unset : Supported
+            }
+        )
     -> Style
 backgroundColor (Value val) =
     AppendProperty ("background-color:" ++ val)
@@ -1529,28 +1623,14 @@ for example in `vertical-align: top`, use [`top_`](#top_) instead of this.
 -}
 top :
     Value
-        { px : Supported
-        , cm : Supported
-        , mm : Supported
-        , inches : Supported
-        , pc : Supported
-        , pct : Supported
-        , pt : Supported
-        , ch : Supported
-        , em : Supported
-        , ex : Supported
-        , rem : Supported
-        , vh : Supported
-        , vw : Supported
-        , vmin : Supported
-        , vmax : Supported
-        , auto : Supported
-        , zero : Supported
-        , calc : Supported
-        , inherit : Supported
-        , initial : Supported
-        , unset : Supported
-        }
+        (LengthSupported
+            { pct : Supported
+            , auto : Supported
+            , inherit : Supported
+            , initial : Supported
+            , unset : Supported
+            }
+        )
     -> Style
 top (Value val) =
     AppendProperty ("top:" ++ val)
@@ -1569,28 +1649,14 @@ for example in `vertical-align: bottom`, use [`bottom_`](#bottom_) instead of th
 -}
 bottom :
     Value
-        { px : Supported
-        , cm : Supported
-        , mm : Supported
-        , inches : Supported
-        , pc : Supported
-        , pct : Supported
-        , pt : Supported
-        , ch : Supported
-        , em : Supported
-        , ex : Supported
-        , rem : Supported
-        , vh : Supported
-        , vw : Supported
-        , vmin : Supported
-        , vmax : Supported
-        , auto : Supported
-        , zero : Supported
-        , calc : Supported
-        , inherit : Supported
-        , initial : Supported
-        , unset : Supported
-        }
+        (LengthSupported
+            { pct : Supported
+            , auto : Supported
+            , inherit : Supported
+            , initial : Supported
+            , unset : Supported
+            }
+        )
     -> Style
 bottom (Value val) =
     AppendProperty ("bottom:" ++ val)
@@ -1609,28 +1675,14 @@ for example in `float: left`, use [`left_`](#left_) instead of this.
 -}
 left :
     Value
-        { px : Supported
-        , cm : Supported
-        , mm : Supported
-        , inches : Supported
-        , pc : Supported
-        , pct : Supported
-        , pt : Supported
-        , ch : Supported
-        , em : Supported
-        , ex : Supported
-        , rem : Supported
-        , vh : Supported
-        , vw : Supported
-        , vmin : Supported
-        , vmax : Supported
-        , auto : Supported
-        , zero : Supported
-        , calc : Supported
-        , inherit : Supported
-        , initial : Supported
-        , unset : Supported
-        }
+        (LengthSupported
+            { pct : Supported
+            , auto : Supported
+            , inherit : Supported
+            , initial : Supported
+            , unset : Supported
+            }
+        )
     -> Style
 left (Value val) =
     AppendProperty ("left:" ++ val)
@@ -1649,28 +1701,14 @@ for example in `float: right`, use [`right_`](#right_) instead of this.
 -}
 right :
     Value
-        { px : Supported
-        , cm : Supported
-        , mm : Supported
-        , inches : Supported
-        , pc : Supported
-        , pct : Supported
-        , pt : Supported
-        , ch : Supported
-        , em : Supported
-        , ex : Supported
-        , rem : Supported
-        , vh : Supported
-        , vw : Supported
-        , vmin : Supported
-        , vmax : Supported
-        , auto : Supported
-        , zero : Supported
-        , calc : Supported
-        , inherit : Supported
-        , initial : Supported
-        , unset : Supported
-        }
+        (LengthSupported
+            { pct : Supported
+            , auto : Supported
+            , inherit : Supported
+            , initial : Supported
+            , unset : Supported
+            }
+        )
     -> Style
 right (Value val) =
     AppendProperty ("right:" ++ val)
@@ -1775,27 +1813,13 @@ zIndex (Value val) =
 -}
 padding :
     Value
-        { ch : Supported
-        , cm : Supported
-        , em : Supported
-        , ex : Supported
-        , inches : Supported
-        , mm : Supported
-        , pc : Supported
-        , pt : Supported
-        , pct : Supported
-        , px : Supported
-        , rem : Supported
-        , vh : Supported
-        , vmax : Supported
-        , vmin : Supported
-        , vw : Supported
-        , zero : Supported
-        , calc : Supported
-        , inherit : Supported
-        , initial : Supported
-        , unset : Supported
-        }
+        (LengthSupported
+            { pct : Supported
+            , inherit : Supported
+            , initial : Supported
+            , unset : Supported
+            }
+        )
     -> Style
 padding (Value value) =
     AppendProperty ("padding:" ++ value)
@@ -1811,44 +1835,16 @@ padding (Value value) =
 -}
 padding2 :
     Value
-        { ch : Supported
-        , cm : Supported
-        , em : Supported
-        , ex : Supported
-        , inches : Supported
-        , mm : Supported
-        , pc : Supported
-        , pt : Supported
-        , pct : Supported
-        , px : Supported
-        , rem : Supported
-        , vh : Supported
-        , vmax : Supported
-        , vmin : Supported
-        , vw : Supported
-        , zero : Supported
-        , calc : Supported
-        }
+        (LengthSupported
+            { pct : Supported
+            }
+        )
     ->
         Value
-            { ch : Supported
-            , cm : Supported
-            , em : Supported
-            , ex : Supported
-            , inches : Supported
-            , mm : Supported
-            , pc : Supported
-            , pt : Supported
-            , pct : Supported
-            , px : Supported
-            , rem : Supported
-            , vh : Supported
-            , vmax : Supported
-            , vmin : Supported
-            , vw : Supported
-            , zero : Supported
-            , calc : Supported
-            }
+            (LengthSupported
+                { pct : Supported
+                }
+            )
     -> Style
 padding2 (Value valueTopBottom) (Value valueRightLeft) =
     AppendProperty ("padding:" ++ valueTopBottom ++ " " ++ valueRightLeft)
@@ -1864,64 +1860,22 @@ padding2 (Value valueTopBottom) (Value valueRightLeft) =
 -}
 padding3 :
     Value
-        { ch : Supported
-        , cm : Supported
-        , em : Supported
-        , ex : Supported
-        , inches : Supported
-        , mm : Supported
-        , pc : Supported
-        , pt : Supported
-        , pct : Supported
-        , px : Supported
-        , rem : Supported
-        , vh : Supported
-        , vmax : Supported
-        , vmin : Supported
-        , vw : Supported
-        , zero : Supported
-        , calc : Supported
-        }
+        (LengthSupported
+            { pct : Supported
+            }
+        )
     ->
         Value
-            { ch : Supported
-            , cm : Supported
-            , em : Supported
-            , ex : Supported
-            , inches : Supported
-            , mm : Supported
-            , pc : Supported
-            , pt : Supported
-            , pct : Supported
-            , px : Supported
-            , rem : Supported
-            , vh : Supported
-            , vmax : Supported
-            , vmin : Supported
-            , vw : Supported
-            , zero : Supported
-            , calc : Supported
-            }
+            (LengthSupported
+                { pct : Supported
+                }
+            )
     ->
         Value
-            { ch : Supported
-            , cm : Supported
-            , em : Supported
-            , ex : Supported
-            , inches : Supported
-            , mm : Supported
-            , pc : Supported
-            , pt : Supported
-            , pct : Supported
-            , px : Supported
-            , rem : Supported
-            , vh : Supported
-            , vmax : Supported
-            , vmin : Supported
-            , vw : Supported
-            , zero : Supported
-            , calc : Supported
-            }
+            (LengthSupported
+                { pct : Supported
+                }
+            )
     -> Style
 padding3 (Value valueTop) (Value valueRightLeft) (Value valueBottom) =
     AppendProperty ("padding:" ++ valueTop ++ " " ++ valueRightLeft ++ " " ++ valueBottom)
@@ -1937,84 +1891,28 @@ padding3 (Value valueTop) (Value valueRightLeft) (Value valueBottom) =
 -}
 padding4 :
     Value
-        { ch : Supported
-        , cm : Supported
-        , em : Supported
-        , ex : Supported
-        , inches : Supported
-        , mm : Supported
-        , pc : Supported
-        , pt : Supported
-        , pct : Supported
-        , px : Supported
-        , rem : Supported
-        , vh : Supported
-        , vmax : Supported
-        , vmin : Supported
-        , vw : Supported
-        , zero : Supported
-        , calc : Supported
-        }
+        (LengthSupported
+            { pct : Supported
+            }
+        )
     ->
         Value
-            { ch : Supported
-            , cm : Supported
-            , em : Supported
-            , ex : Supported
-            , inches : Supported
-            , mm : Supported
-            , pc : Supported
-            , pt : Supported
-            , pct : Supported
-            , px : Supported
-            , rem : Supported
-            , vh : Supported
-            , vmax : Supported
-            , vmin : Supported
-            , vw : Supported
-            , zero : Supported
-            , calc : Supported
-            }
+            (LengthSupported
+                { pct : Supported
+                }
+            )
     ->
         Value
-            { ch : Supported
-            , cm : Supported
-            , em : Supported
-            , ex : Supported
-            , inches : Supported
-            , mm : Supported
-            , pc : Supported
-            , pt : Supported
-            , pct : Supported
-            , px : Supported
-            , rem : Supported
-            , vh : Supported
-            , vmax : Supported
-            , vmin : Supported
-            , vw : Supported
-            , zero : Supported
-            , calc : Supported
-            }
+            (LengthSupported
+                { pct : Supported
+                }
+            )
     ->
         Value
-            { ch : Supported
-            , cm : Supported
-            , em : Supported
-            , ex : Supported
-            , inches : Supported
-            , mm : Supported
-            , pc : Supported
-            , pt : Supported
-            , pct : Supported
-            , px : Supported
-            , rem : Supported
-            , vh : Supported
-            , vmax : Supported
-            , vmin : Supported
-            , vw : Supported
-            , zero : Supported
-            , calc : Supported
-            }
+            (LengthSupported
+                { pct : Supported
+                }
+            )
     -> Style
 padding4 (Value valueTop) (Value valueRight) (Value valueBottom) (Value valueLeft) =
     AppendProperty ("padding:" ++ valueTop ++ " " ++ valueRight ++ " " ++ valueBottom ++ " " ++ valueLeft)
@@ -2027,27 +1925,13 @@ padding4 (Value valueTop) (Value valueRight) (Value valueBottom) (Value valueLef
 -}
 paddingTop :
     Value
-        { ch : Supported
-        , cm : Supported
-        , em : Supported
-        , ex : Supported
-        , inches : Supported
-        , mm : Supported
-        , pc : Supported
-        , pt : Supported
-        , pct : Supported
-        , px : Supported
-        , rem : Supported
-        , vh : Supported
-        , vmax : Supported
-        , vmin : Supported
-        , vw : Supported
-        , zero : Supported
-        , calc : Supported
-        , inherit : Supported
-        , initial : Supported
-        , unset : Supported
-        }
+        (LengthSupported
+            { pct : Supported
+            , inherit : Supported
+            , initial : Supported
+            , unset : Supported
+            }
+        )
     -> Style
 paddingTop (Value value) =
     AppendProperty ("padding-top:" ++ value)
@@ -2060,27 +1944,13 @@ paddingTop (Value value) =
 -}
 paddingRight :
     Value
-        { ch : Supported
-        , cm : Supported
-        , em : Supported
-        , ex : Supported
-        , inches : Supported
-        , mm : Supported
-        , pc : Supported
-        , pt : Supported
-        , pct : Supported
-        , px : Supported
-        , rem : Supported
-        , vh : Supported
-        , vmax : Supported
-        , vmin : Supported
-        , vw : Supported
-        , zero : Supported
-        , calc : Supported
-        , inherit : Supported
-        , initial : Supported
-        , unset : Supported
-        }
+        (LengthSupported
+            { pct : Supported
+            , inherit : Supported
+            , initial : Supported
+            , unset : Supported
+            }
+        )
     -> Style
 paddingRight (Value value) =
     AppendProperty ("padding-right:" ++ value)
@@ -2093,27 +1963,13 @@ paddingRight (Value value) =
 -}
 paddingBottom :
     Value
-        { ch : Supported
-        , cm : Supported
-        , em : Supported
-        , ex : Supported
-        , inches : Supported
-        , mm : Supported
-        , pc : Supported
-        , pt : Supported
-        , pct : Supported
-        , px : Supported
-        , rem : Supported
-        , vh : Supported
-        , vmax : Supported
-        , vmin : Supported
-        , vw : Supported
-        , zero : Supported
-        , calc : Supported
-        , inherit : Supported
-        , initial : Supported
-        , unset : Supported
-        }
+        (LengthSupported
+            { pct : Supported
+            , inherit : Supported
+            , initial : Supported
+            , unset : Supported
+            }
+        )
     -> Style
 paddingBottom (Value value) =
     AppendProperty ("padding-bottom:" ++ value)
@@ -2126,27 +1982,13 @@ paddingBottom (Value value) =
 -}
 paddingLeft :
     Value
-        { ch : Supported
-        , cm : Supported
-        , em : Supported
-        , ex : Supported
-        , inches : Supported
-        , mm : Supported
-        , pc : Supported
-        , pt : Supported
-        , pct : Supported
-        , px : Supported
-        , rem : Supported
-        , vh : Supported
-        , vmax : Supported
-        , vmin : Supported
-        , vw : Supported
-        , zero : Supported
-        , calc : Supported
-        , inherit : Supported
-        , initial : Supported
-        , unset : Supported
-        }
+        (LengthSupported
+            { pct : Supported
+            , inherit : Supported
+            , initial : Supported
+            , unset : Supported
+            }
+        )
     -> Style
 paddingLeft (Value value) =
     AppendProperty ("padding-left:" ++ value)
@@ -2168,28 +2010,14 @@ You may want to check out [this article on collapsing margins](https://css-trick
 -}
 margin :
     Value
-        { ch : Supported
-        , cm : Supported
-        , em : Supported
-        , ex : Supported
-        , inches : Supported
-        , mm : Supported
-        , pc : Supported
-        , pt : Supported
-        , pct : Supported
-        , px : Supported
-        , rem : Supported
-        , vh : Supported
-        , vmax : Supported
-        , vmin : Supported
-        , vw : Supported
-        , zero : Supported
-        , calc : Supported
-        , auto : Supported
-        , inherit : Supported
-        , initial : Supported
-        , unset : Supported
-        }
+        (LengthSupported
+            { pct : Supported
+            , auto : Supported
+            , inherit : Supported
+            , initial : Supported
+            , unset : Supported
+            }
+        )
     -> Style
 margin (Value value) =
     AppendProperty ("margin:" ++ value)
@@ -2207,46 +2035,18 @@ You may want to check out [this article on collapsing margins](https://css-trick
 -}
 margin2 :
     Value
-        { ch : Supported
-        , cm : Supported
-        , em : Supported
-        , ex : Supported
-        , inches : Supported
-        , mm : Supported
-        , pc : Supported
-        , pt : Supported
-        , pct : Supported
-        , px : Supported
-        , rem : Supported
-        , vh : Supported
-        , vmax : Supported
-        , vmin : Supported
-        , vw : Supported
-        , zero : Supported
-        , calc : Supported
-        , auto : Supported
-        }
-    ->
-        Value
-            { ch : Supported
-            , cm : Supported
-            , em : Supported
-            , ex : Supported
-            , inches : Supported
-            , mm : Supported
-            , pc : Supported
-            , pt : Supported
-            , pct : Supported
-            , px : Supported
-            , rem : Supported
-            , vh : Supported
-            , vmax : Supported
-            , vmin : Supported
-            , vw : Supported
-            , zero : Supported
-            , calc : Supported
+        (LengthSupported
+            { pct : Supported
             , auto : Supported
             }
+        )
+    ->
+        Value
+            (LengthSupported
+                { pct : Supported
+                , auto : Supported
+                }
+            )
     -> Style
 margin2 (Value valueTopBottom) (Value valueRightLeft) =
     AppendProperty ("margin:" ++ valueTopBottom ++ " " ++ valueRightLeft)
@@ -2264,67 +2064,25 @@ You may want to check out [this article on collapsing margins](https://css-trick
 -}
 margin3 :
     Value
-        { ch : Supported
-        , cm : Supported
-        , em : Supported
-        , ex : Supported
-        , inches : Supported
-        , mm : Supported
-        , pc : Supported
-        , pt : Supported
-        , pct : Supported
-        , px : Supported
-        , rem : Supported
-        , vh : Supported
-        , vmax : Supported
-        , vmin : Supported
-        , vw : Supported
-        , zero : Supported
-        , calc : Supported
-        , auto : Supported
-        }
-    ->
-        Value
-            { ch : Supported
-            , cm : Supported
-            , em : Supported
-            , ex : Supported
-            , inches : Supported
-            , mm : Supported
-            , pc : Supported
-            , pt : Supported
-            , pct : Supported
-            , px : Supported
-            , rem : Supported
-            , vh : Supported
-            , vmax : Supported
-            , vmin : Supported
-            , vw : Supported
-            , zero : Supported
-            , calc : Supported
+        (LengthSupported
+            { pct : Supported
             , auto : Supported
             }
+        )
     ->
         Value
-            { ch : Supported
-            , cm : Supported
-            , em : Supported
-            , ex : Supported
-            , inches : Supported
-            , mm : Supported
-            , pc : Supported
-            , pt : Supported
-            , pct : Supported
-            , px : Supported
-            , rem : Supported
-            , vh : Supported
-            , vmax : Supported
-            , vmin : Supported
-            , vw : Supported
-            , zero : Supported
-            , calc : Supported
-            , auto : Supported
-            }
+            (LengthSupported
+                { pct : Supported
+                , auto : Supported
+                }
+            )
+    ->
+        Value
+            (LengthSupported
+                { pct : Supported
+                , auto : Supported
+                }
+            )
     -> Style
 margin3 (Value valueTop) (Value valueRightLeft) (Value valueBottom) =
     AppendProperty ("margin:" ++ valueTop ++ " " ++ valueRightLeft ++ " " ++ valueBottom)
@@ -2342,88 +2100,32 @@ You may want to check out [this article on collapsing margins](https://css-trick
 -}
 margin4 :
     Value
-        { ch : Supported
-        , cm : Supported
-        , em : Supported
-        , ex : Supported
-        , inches : Supported
-        , mm : Supported
-        , pc : Supported
-        , pt : Supported
-        , pct : Supported
-        , px : Supported
-        , rem : Supported
-        , vh : Supported
-        , vmax : Supported
-        , vmin : Supported
-        , vw : Supported
-        , zero : Supported
-        , calc : Supported
-        , auto : Supported
-        }
-    ->
-        Value
-            { ch : Supported
-            , cm : Supported
-            , em : Supported
-            , ex : Supported
-            , inches : Supported
-            , mm : Supported
-            , pc : Supported
-            , pt : Supported
-            , pct : Supported
-            , px : Supported
-            , rem : Supported
-            , vh : Supported
-            , vmax : Supported
-            , vmin : Supported
-            , vw : Supported
-            , zero : Supported
-            , calc : Supported
+        (LengthSupported
+            { pct : Supported
             , auto : Supported
             }
+        )
     ->
         Value
-            { ch : Supported
-            , cm : Supported
-            , em : Supported
-            , ex : Supported
-            , inches : Supported
-            , mm : Supported
-            , pc : Supported
-            , pt : Supported
-            , pct : Supported
-            , px : Supported
-            , rem : Supported
-            , vh : Supported
-            , vmax : Supported
-            , vmin : Supported
-            , vw : Supported
-            , zero : Supported
-            , calc : Supported
-            , auto : Supported
-            }
+            (LengthSupported
+                { pct : Supported
+                , auto : Supported
+                }
+            )
     ->
         Value
-            { ch : Supported
-            , cm : Supported
-            , em : Supported
-            , ex : Supported
-            , inches : Supported
-            , mm : Supported
-            , pc : Supported
-            , pt : Supported
-            , pct : Supported
-            , px : Supported
-            , rem : Supported
-            , vh : Supported
-            , vmax : Supported
-            , vmin : Supported
-            , vw : Supported
-            , zero : Supported
-            , calc : Supported
-            , auto : Supported
-            }
+            (LengthSupported
+                { pct : Supported
+                , auto : Supported
+                }
+            )
+    ->
+        Value
+            (LengthSupported
+                { pct : Supported
+                , auto : Supported
+                }
+            )
     -> Style
 margin4 (Value valueTop) (Value valueRight) (Value valueBottom) (Value valueLeft) =
     AppendProperty ("margin:" ++ valueTop ++ " " ++ valueRight ++ " " ++ valueBottom ++ " " ++ valueLeft)
@@ -2438,28 +2140,14 @@ This article on [`margin-top` versus `margin-bottom`](https://css-tricks.com/mar
 -}
 marginTop :
     Value
-        { ch : Supported
-        , cm : Supported
-        , em : Supported
-        , ex : Supported
-        , inches : Supported
-        , mm : Supported
-        , pc : Supported
-        , pt : Supported
-        , pct : Supported
-        , px : Supported
-        , rem : Supported
-        , vh : Supported
-        , vmax : Supported
-        , vmin : Supported
-        , vw : Supported
-        , zero : Supported
-        , calc : Supported
-        , inherit : Supported
-        , initial : Supported
-        , unset : Supported
-        , auto : Supported
-        }
+        (LengthSupported
+            { pct : Supported
+            , inherit : Supported
+            , initial : Supported
+            , unset : Supported
+            , auto : Supported
+            }
+        )
     -> Style
 marginTop (Value value) =
     AppendProperty ("margin-top:" ++ value)
@@ -2472,28 +2160,14 @@ marginTop (Value value) =
 -}
 marginRight :
     Value
-        { ch : Supported
-        , cm : Supported
-        , em : Supported
-        , ex : Supported
-        , inches : Supported
-        , mm : Supported
-        , pc : Supported
-        , pt : Supported
-        , pct : Supported
-        , px : Supported
-        , rem : Supported
-        , vh : Supported
-        , vmax : Supported
-        , vmin : Supported
-        , vw : Supported
-        , zero : Supported
-        , calc : Supported
-        , inherit : Supported
-        , initial : Supported
-        , unset : Supported
-        , auto : Supported
-        }
+        (LengthSupported
+            { pct : Supported
+            , inherit : Supported
+            , initial : Supported
+            , unset : Supported
+            , auto : Supported
+            }
+        )
     -> Style
 marginRight (Value value) =
     AppendProperty ("margin-right:" ++ value)
@@ -2508,28 +2182,14 @@ This article on [`margin-top` versus `margin-bottom`](https://css-tricks.com/mar
 -}
 marginBottom :
     Value
-        { ch : Supported
-        , cm : Supported
-        , em : Supported
-        , ex : Supported
-        , inches : Supported
-        , mm : Supported
-        , pc : Supported
-        , pt : Supported
-        , pct : Supported
-        , px : Supported
-        , rem : Supported
-        , vh : Supported
-        , vmax : Supported
-        , vmin : Supported
-        , vw : Supported
-        , zero : Supported
-        , calc : Supported
-        , inherit : Supported
-        , initial : Supported
-        , unset : Supported
-        , auto : Supported
-        }
+        (LengthSupported
+            { pct : Supported
+            , inherit : Supported
+            , initial : Supported
+            , unset : Supported
+            , auto : Supported
+            }
+        )
     -> Style
 marginBottom (Value value) =
     AppendProperty ("margin-bottom:" ++ value)
@@ -2542,28 +2202,14 @@ marginBottom (Value value) =
 -}
 marginLeft :
     Value
-        { ch : Supported
-        , cm : Supported
-        , em : Supported
-        , ex : Supported
-        , inches : Supported
-        , mm : Supported
-        , pc : Supported
-        , pt : Supported
-        , pct : Supported
-        , px : Supported
-        , rem : Supported
-        , vh : Supported
-        , vmax : Supported
-        , vmin : Supported
-        , vw : Supported
-        , zero : Supported
-        , calc : Supported
-        , inherit : Supported
-        , initial : Supported
-        , unset : Supported
-        , auto : Supported
-        }
+        (LengthSupported
+            { pct : Supported
+            , inherit : Supported
+            , initial : Supported
+            , unset : Supported
+            , auto : Supported
+            }
+        )
     -> Style
 marginLeft (Value value) =
     AppendProperty ("margin-left:" ++ value)
@@ -2890,100 +2536,34 @@ int value =
 type alias BoxShadowConfig =
     { offsetX :
         Value
-            { px : Supported
-            , em : Supported
-            , ex : Supported
-            , ch : Supported
-            , rem : Supported
-            , vh : Supported
-            , vw : Supported
-            , vmin : Supported
-            , vmax : Supported
-            , mm : Supported
-            , cm : Supported
-            , inches : Supported
-            , pt : Supported
-            , pc : Supported
-            , pct : Supported
-            , zero : Supported
-            , calc : Supported
-            }
+            (LengthSupported
+                { pct : Supported
+                }
+            )
     , offsetY :
         Value
-            { px : Supported
-            , em : Supported
-            , ex : Supported
-            , ch : Supported
-            , rem : Supported
-            , vh : Supported
-            , vw : Supported
-            , vmin : Supported
-            , vmax : Supported
-            , mm : Supported
-            , cm : Supported
-            , inches : Supported
-            , pt : Supported
-            , pc : Supported
-            , pct : Supported
-            , zero : Supported
-            , calc : Supported
-            }
+            (LengthSupported
+                { pct : Supported
+                }
+            )
     , blurRadius :
         Maybe
             (Value
-                { px : Supported
-                , em : Supported
-                , ex : Supported
-                , ch : Supported
-                , rem : Supported
-                , vh : Supported
-                , vw : Supported
-                , vmin : Supported
-                , vmax : Supported
-                , mm : Supported
-                , cm : Supported
-                , inches : Supported
-                , pt : Supported
-                , pc : Supported
-                , pct : Supported
-                , zero : Supported
-                , calc : Supported
-                }
+                (LengthSupported
+                    { pct : Supported
+                    }
+                )
             )
     , spreadRadius :
         Maybe
             (Value
-                { px : Supported
-                , em : Supported
-                , ex : Supported
-                , ch : Supported
-                , rem : Supported
-                , vh : Supported
-                , vw : Supported
-                , vmin : Supported
-                , vmax : Supported
-                , mm : Supported
-                , cm : Supported
-                , inches : Supported
-                , pt : Supported
-                , pc : Supported
-                , pct : Supported
-                , zero : Supported
-                , calc : Supported
-                }
+                (LengthSupported
+                    { pct : Supported
+                    }
+                )
             )
     , color :
-        Maybe
-            (Value
-                { rgb : Supported
-                , rgba : Supported
-                , hsl : Supported
-                , hsla : Supported
-                , hex : Supported
-                , transparent : Supported
-                , currentColor : Supported
-                }
-            )
+        Maybe (Value Color)
     , inset : Bool
     }
 
@@ -3106,26 +2686,12 @@ to make `calc` more reliable. Use with caution!
 -}
 calc :
     Value
-        { px : Supported
-        , cm : Supported
-        , mm : Supported
-        , inches : Supported
-        , pc : Supported
-        , pct : Supported
-        , pt : Supported
-        , ch : Supported
-        , em : Supported
-        , ex : Supported
-        , rem : Supported
-        , vh : Supported
-        , vw : Supported
-        , vmin : Supported
-        , vmax : Supported
-        , num : Supported
-        , int : Supported
-        , zero : Supported
-        , calc : Supported
-        }
+        (LengthSupported
+            { pct : Supported
+            , num : Supported
+            , int : Supported
+            }
+        )
     -> CalcOperation
     -> Value { provides | calc : Supported }
 calc (Value first) (CalcOperation operation) =
@@ -3163,26 +2729,12 @@ getCalcExpression str =
 -}
 minus :
     Value
-        { px : Supported
-        , cm : Supported
-        , mm : Supported
-        , inches : Supported
-        , pc : Supported
-        , pct : Supported
-        , pt : Supported
-        , ch : Supported
-        , em : Supported
-        , ex : Supported
-        , rem : Supported
-        , vh : Supported
-        , vw : Supported
-        , vmin : Supported
-        , vmax : Supported
-        , num : Supported
-        , int : Supported
-        , zero : Supported
-        , calc : Supported
-        }
+        (LengthSupported
+            { pct : Supported
+            , num : Supported
+            , int : Supported
+            }
+        )
     -> CalcOperation
 minus (Value second) =
     -- The calc `-` operator MUST be surrounded by whitespace.
@@ -3197,26 +2749,12 @@ minus (Value second) =
 -}
 plus :
     Value
-        { px : Supported
-        , cm : Supported
-        , mm : Supported
-        , inches : Supported
-        , pc : Supported
-        , pct : Supported
-        , pt : Supported
-        , ch : Supported
-        , em : Supported
-        , ex : Supported
-        , rem : Supported
-        , vh : Supported
-        , vw : Supported
-        , vmin : Supported
-        , vmax : Supported
-        , num : Supported
-        , int : Supported
-        , zero : Supported
-        , calc : Supported
-        }
+        (LengthSupported
+            { pct : Supported
+            , num : Supported
+            , int : Supported
+            }
+        )
     -> CalcOperation
 plus (Value second) =
     -- The calc `+` operator MUST be surrounded by whitespace.
@@ -3611,36 +3149,22 @@ Check out [fluid typography](https://css-tricks.com/snippets/css/fluid-typograph
 -}
 fontSize :
     Value
-        { xxSmall : Supported
-        , xSmall : Supported
-        , small : Supported
-        , medium : Supported
-        , large : Supported
-        , xLarge : Supported
-        , xxLarge : Supported
-        , smaller : Supported
-        , larger : Supported
-        , px : Supported
-        , em : Supported
-        , ex : Supported
-        , ch : Supported
-        , rem : Supported
-        , vh : Supported
-        , vw : Supported
-        , vmin : Supported
-        , vmax : Supported
-        , mm : Supported
-        , cm : Supported
-        , inches : Supported
-        , pt : Supported
-        , pc : Supported
-        , pct : Supported
-        , zero : Supported
-        , calc : Supported
-        , inherit : Supported
-        , initial : Supported
-        , unset : Supported
-        }
+        (LengthSupported
+            { xxSmall : Supported
+            , xSmall : Supported
+            , small : Supported
+            , medium : Supported
+            , large : Supported
+            , xLarge : Supported
+            , xxLarge : Supported
+            , smaller : Supported
+            , larger : Supported
+            , pct : Supported
+            , inherit : Supported
+            , initial : Supported
+            , unset : Supported
+            }
+        )
     -> Style
 fontSize (Value val) =
     AppendProperty ("font-size:" ++ val)
@@ -5300,30 +4824,16 @@ If you need to set the offsets from the right or bottom, use
 -}
 backgroundPosition :
     Value
-        { ch : Supported
-        , cm : Supported
-        , em : Supported
-        , ex : Supported
-        , inches : Supported
-        , mm : Supported
-        , pc : Supported
-        , pct : Supported
-        , pt : Supported
-        , px : Supported
-        , rem : Supported
-        , vh : Supported
-        , vmax : Supported
-        , vmin : Supported
-        , vw : Supported
-        , zero : Supported
-        , calc : Supported
-        , left_ : Supported
-        , right_ : Supported
-        , center : Supported
-        , inherit : Supported
-        , unset : Supported
-        , initial : Supported
-        }
+        (LengthSupported
+            { pct : Supported
+            , left_ : Supported
+            , right_ : Supported
+            , center : Supported
+            , inherit : Supported
+            , unset : Supported
+            , initial : Supported
+            }
+        )
     -> Style
 backgroundPosition (Value horiz) =
     AppendProperty ("background-position:" ++ horiz)
@@ -5349,50 +4859,22 @@ If you need to set the offsets from the right or bottom, use
 -}
 backgroundPosition2 :
     Value
-        { ch : Supported
-        , cm : Supported
-        , em : Supported
-        , ex : Supported
-        , inches : Supported
-        , mm : Supported
-        , pc : Supported
-        , pct : Supported
-        , pt : Supported
-        , px : Supported
-        , rem : Supported
-        , vh : Supported
-        , vmax : Supported
-        , vmin : Supported
-        , vw : Supported
-        , zero : Supported
-        , calc : Supported
-        , left_ : Supported
-        , right_ : Supported
-        , center : Supported
-        }
-    ->
-        Value
-            { ch : Supported
-            , cm : Supported
-            , em : Supported
-            , ex : Supported
-            , inches : Supported
-            , mm : Supported
-            , pc : Supported
-            , pct : Supported
-            , pt : Supported
-            , px : Supported
-            , rem : Supported
-            , vh : Supported
-            , vmax : Supported
-            , vmin : Supported
-            , vw : Supported
-            , zero : Supported
-            , calc : Supported
-            , top_ : Supported
-            , bottom_ : Supported
+        (LengthSupported
+            { pct : Supported
+            , left_ : Supported
+            , right_ : Supported
             , center : Supported
             }
+        )
+    ->
+        Value
+            (LengthSupported
+                { pct : Supported
+                , top_ : Supported
+                , bottom_ : Supported
+                , center : Supported
+                }
+            )
     -> Style
 backgroundPosition2 (Value horiz) (Value vert) =
     AppendProperty ("background-position:" ++ horiz ++ " " ++ vert)
@@ -5418,24 +4900,10 @@ backgroundPosition4 :
         }
     ->
         Value
-            { ch : Supported
-            , cm : Supported
-            , em : Supported
-            , ex : Supported
-            , inches : Supported
-            , mm : Supported
-            , pc : Supported
-            , pct : Supported
-            , pt : Supported
-            , px : Supported
-            , rem : Supported
-            , vh : Supported
-            , vmax : Supported
-            , vmin : Supported
-            , vw : Supported
-            , zero : Supported
-            , calc : Supported
-            }
+            (LengthSupported
+                { pct : Supported
+                }
+            )
     ->
         Value
             { top_ : Supported
@@ -5443,24 +4911,10 @@ backgroundPosition4 :
             }
     ->
         Value
-            { ch : Supported
-            , cm : Supported
-            , em : Supported
-            , ex : Supported
-            , inches : Supported
-            , mm : Supported
-            , pc : Supported
-            , pct : Supported
-            , pt : Supported
-            , px : Supported
-            , rem : Supported
-            , vh : Supported
-            , vmax : Supported
-            , vmin : Supported
-            , vw : Supported
-            , zero : Supported
-            , calc : Supported
-            }
+            (LengthSupported
+                { pct : Supported
+                }
+            )
     -> Style
 backgroundPosition4 (Value horiz) (Value horizAmount) (Value vert) (Value vertAmount) =
     AppendProperty
@@ -5628,27 +5082,15 @@ need to set both width and height explicitly, use
 -}
 backgroundSize :
     Value
-        { px : Supported
-        , cm : Supported
-        , mm : Supported
-        , inches : Supported
-        , pc : Supported
-        , pct : Supported
-        , pt : Supported
-        , ch : Supported
-        , em : Supported
-        , ex : Supported
-        , rem : Supported
-        , vh : Supported
-        , vw : Supported
-        , vmin : Supported
-        , vmax : Supported
-        , auto : Supported
-        , cover : Supported
-        , inherit : Supported
-        , initial : Supported
-        , unset : Supported
-        }
+        (LengthSupported
+            { pct : Supported
+            , auto : Supported
+            , cover : Supported
+            , inherit : Supported
+            , initial : Supported
+            , unset : Supported
+            }
+        )
     -> Style
 backgroundSize (Value size) =
     AppendProperty ("background-size:" ++ size)
@@ -5665,42 +5107,18 @@ If you only want to set the width, use [`backgroundImage`](#backgroundImage) ins
 -}
 backgroundSize2 :
     Value
-        { px : Supported
-        , cm : Supported
-        , mm : Supported
-        , inches : Supported
-        , pc : Supported
-        , pct : Supported
-        , pt : Supported
-        , ch : Supported
-        , em : Supported
-        , ex : Supported
-        , rem : Supported
-        , vh : Supported
-        , vw : Supported
-        , vmin : Supported
-        , vmax : Supported
-        , auto : Supported
-        }
-    ->
-        Value
-            { px : Supported
-            , cm : Supported
-            , mm : Supported
-            , inches : Supported
-            , pc : Supported
-            , pct : Supported
-            , pt : Supported
-            , ch : Supported
-            , em : Supported
-            , ex : Supported
-            , rem : Supported
-            , vh : Supported
-            , vw : Supported
-            , vmin : Supported
-            , vmax : Supported
+        (LengthSupported
+            { pct : Supported
             , auto : Supported
             }
+        )
+    ->
+        Value
+            (LengthSupported
+                { pct : Supported
+                , auto : Supported
+                }
+            )
     -> Style
 backgroundSize2 (Value width) (Value height) =
     AppendProperty ("background-size:" ++ width ++ " " ++ height)
@@ -5744,14 +5162,10 @@ cover =
 -}
 linearGradient :
     Value
-        { to : Supported
-        , deg : Supported
-        , grad : Supported
-        , rad : Supported
-        , turn : Supported
-        , zero : Supported
-        , calc : Supported
-        }
+        (AngleSupported
+            { to : Supported
+            }
+        )
     -> Value { colorStop : Supported }
     -> Value { colorStop : Supported }
     -> List (Value { colorStop : Supported })
@@ -5774,7 +5188,7 @@ linearGradient (Value angle) (Value firstStop) (Value secondStop) moreStops =
 See also [`stop2`](#stop2) for controlling stop positioning.
 
 -}
-stop : Color -> Value { provides | colorStop : Supported }
+stop : Value Color -> Value { provides | colorStop : Supported }
 stop (Value color) =
     Value color
 
@@ -5787,27 +5201,13 @@ See also [`stop`](#stop) if you don't need to control the stop position.
 
 -}
 stop2 :
-    Color
+    Value Color
     ->
         Value
-            { ch : Supported
-            , cm : Supported
-            , em : Supported
-            , ex : Supported
-            , inches : Supported
-            , mm : Supported
-            , pc : Supported
-            , pct : Supported
-            , pt : Supported
-            , px : Supported
-            , rem : Supported
-            , vh : Supported
-            , vmax : Supported
-            , vmin : Supported
-            , vw : Supported
-            , zero : Supported
-            , calc : Supported
-            }
+            (LengthSupported
+                { pct : Supported
+                }
+            )
     -> Value { supported | colorStop : Supported }
 stop2 (Value color) (Value position) =
     Value (color ++ " " ++ position)
@@ -5941,36 +5341,23 @@ toTopRight =
 -}
 listStyle :
     Value
-        { armenian : Supported
-        , bengali : Supported
-        , cjkEarthlyBranch : Supported
-        , cjkHeavenlyStem : Supported
-        , devanagari : Supported
-        , georgian : Supported
-        , gujarati : Supported
-        , gurmukhi : Supported
-        , kannada : Supported
-        , khmer : Supported
-        , lao : Supported
-        , malayalam : Supported
-        , myanmar : Supported
-        , oriya : Supported
-        , telugu : Supported
-        , thai : Supported
-        , inherit : Supported
-        , initial : Supported
-        , unset : Supported
-        }
+        (ListStyleSupported
+            { inherit : Supported
+            , initial : Supported
+            , unset : Supported
+            }
+        )
     -> Style
 listStyle (Value val) =
     AppendProperty ("list-style:" ++ val)
 
 
-{-| The [`list-style`](https://css-tricks.com/almanac/properties/l/list-style/) shorthand property.
+{-| A type alias used to accept a [list-style-type](https://developer.mozilla.org/fr/docs/Web/CSS/list-style-type)
+among other values.
 -}
-listStyle2 :
-    Value
-        { armenian : Supported
+type alias ListStyleSupported v =
+    { v
+        | armenian : Supported
         , bengali : Supported
         , cjkEarthlyBranch : Supported
         , cjkHeavenlyStem : Supported
@@ -5986,26 +5373,20 @@ listStyle2 :
         , oriya : Supported
         , telugu : Supported
         , thai : Supported
-        }
-    ->
-        Value
-            { armenian : Supported
-            , bengali : Supported
-            , cjkEarthlyBranch : Supported
-            , cjkHeavenlyStem : Supported
-            , devanagari : Supported
-            , georgian : Supported
-            , gujarati : Supported
-            , gurmukhi : Supported
-            , kannada : Supported
-            , khmer : Supported
-            , lao : Supported
-            , malayalam : Supported
-            , myanmar : Supported
-            , oriya : Supported
-            , telugu : Supported
-            , thai : Supported
-            }
+    }
+
+
+{-| A type alias used to accept a [list-style-type](https://developer.mozilla.org/fr/docs/Web/CSS/list-style-type)
+-}
+type alias ListStyle =
+    ListStyleSupported {}
+
+
+{-| The [`list-style`](https://css-tricks.com/almanac/properties/l/list-style/) shorthand property.
+-}
+listStyle2 :
+    Value ListStyle
+    -> Value ListStyle
     -> Style
 listStyle2 (Value val1) (Value val2) =
     AppendProperty ("list-style:" ++ val1 ++ " " ++ val2)
@@ -6014,62 +5395,9 @@ listStyle2 (Value val1) (Value val2) =
 {-| The [`list-style`](https://css-tricks.com/almanac/properties/l/list-style/) shorthand property.
 -}
 listStyle3 :
-    Value
-        { armenian : Supported
-        , bengali : Supported
-        , cjkEarthlyBranch : Supported
-        , cjkHeavenlyStem : Supported
-        , devanagari : Supported
-        , georgian : Supported
-        , gujarati : Supported
-        , gurmukhi : Supported
-        , kannada : Supported
-        , khmer : Supported
-        , lao : Supported
-        , malayalam : Supported
-        , myanmar : Supported
-        , oriya : Supported
-        , telugu : Supported
-        , thai : Supported
-        }
-    ->
-        Value
-            { armenian : Supported
-            , bengali : Supported
-            , cjkEarthlyBranch : Supported
-            , cjkHeavenlyStem : Supported
-            , devanagari : Supported
-            , georgian : Supported
-            , gujarati : Supported
-            , gurmukhi : Supported
-            , kannada : Supported
-            , khmer : Supported
-            , lao : Supported
-            , malayalam : Supported
-            , myanmar : Supported
-            , oriya : Supported
-            , telugu : Supported
-            , thai : Supported
-            }
-    ->
-        Value
-            { armenian : Supported
-            , bengali : Supported
-            , cjkEarthlyBranch : Supported
-            , cjkHeavenlyStem : Supported
-            , devanagari : Supported
-            , georgian : Supported
-            , gujarati : Supported
-            , gurmukhi : Supported
-            , kannada : Supported
-            , khmer : Supported
-            , lao : Supported
-            , malayalam : Supported
-            , myanmar : Supported
-            , oriya : Supported
-            , telugu : Supported
-            , thai : Supported
-            }
+    Value ListStyle
+    -> Value ListStyle
+    -> Value ListStyle
     -> Style
 listStyle3 (Value val1) (Value val2) (Value val3) =
     AppendProperty ("list-style:" ++ val1 ++ " " ++ val2 ++ " " ++ val3)
@@ -6088,29 +5416,12 @@ listStyle3 (Value val1) (Value val2) (Value val3) =
 -}
 border :
     Value
-        { ch : Supported
-        , cm : Supported
-        , em : Supported
-        , ex : Supported
-        , inches : Supported
-        , mm : Supported
-        , pc : Supported
-        , pt : Supported
-        , px : Supported
-        , rem : Supported
-        , vh : Supported
-        , vmax : Supported
-        , vmin : Supported
-        , vw : Supported
-        , zero : Supported
-        , calc : Supported
-        , thin : Supported
-        , medium : Supported
-        , thick : Supported
-        , inherit : Supported
-        , initial : Supported
-        , unset : Supported
-        }
+        (BorderWidthSupported
+            { inherit : Supported
+            , initial : Supported
+            , unset : Supported
+            }
+        )
     -> Style
 border (Value width) =
     AppendProperty ("border:" ++ width)
@@ -6124,40 +5435,8 @@ border (Value width) =
 
 -}
 border2 :
-    Value
-        { ch : Supported
-        , cm : Supported
-        , em : Supported
-        , ex : Supported
-        , inches : Supported
-        , mm : Supported
-        , pc : Supported
-        , pt : Supported
-        , px : Supported
-        , rem : Supported
-        , vh : Supported
-        , vmax : Supported
-        , vmin : Supported
-        , vw : Supported
-        , zero : Supported
-        , calc : Supported
-        , thin : Supported
-        , medium : Supported
-        , thick : Supported
-        }
-    ->
-        Value
-            { solid : Supported
-            , none : Supported
-            , hidden : Supported
-            , dashed : Supported
-            , dotted : Supported
-            , double : Supported
-            , groove : Supported
-            , ridge : Supported
-            , inset : Supported
-            , outset : Supported
-            }
+    Value BorderWidth
+    -> Value BorderStyle
     -> Style
 border2 (Value width) (Value style) =
     AppendProperty ("border:" ++ width ++ " " ++ style)
@@ -6171,50 +5450,9 @@ border2 (Value width) (Value style) =
 
 -}
 border3 :
-    Value
-        { ch : Supported
-        , cm : Supported
-        , em : Supported
-        , ex : Supported
-        , inches : Supported
-        , mm : Supported
-        , pc : Supported
-        , pt : Supported
-        , px : Supported
-        , rem : Supported
-        , vh : Supported
-        , vmax : Supported
-        , vmin : Supported
-        , vw : Supported
-        , zero : Supported
-        , calc : Supported
-        , thin : Supported
-        , medium : Supported
-        , thick : Supported
-        }
-    ->
-        Value
-            { solid : Supported
-            , none : Supported
-            , hidden : Supported
-            , dashed : Supported
-            , dotted : Supported
-            , double : Supported
-            , groove : Supported
-            , ridge : Supported
-            , inset : Supported
-            , outset : Supported
-            }
-    ->
-        Value
-            { rgb : Supported
-            , rgba : Supported
-            , hsl : Supported
-            , hsla : Supported
-            , hex : Supported
-            , transparent : Supported
-            , currentColor : Supported
-            }
+    Value BorderWidth
+    -> Value BorderStyle
+    -> Value Color
     -> Style
 border3 (Value width) (Value style) (Value color) =
     AppendProperty ("border:" ++ width ++ " " ++ style ++ " " ++ color)
@@ -6229,29 +5467,12 @@ border3 (Value width) (Value style) (Value color) =
 -}
 borderTop :
     Value
-        { ch : Supported
-        , cm : Supported
-        , em : Supported
-        , ex : Supported
-        , inches : Supported
-        , mm : Supported
-        , pc : Supported
-        , pt : Supported
-        , px : Supported
-        , rem : Supported
-        , vh : Supported
-        , vmax : Supported
-        , vmin : Supported
-        , vw : Supported
-        , zero : Supported
-        , calc : Supported
-        , thin : Supported
-        , medium : Supported
-        , thick : Supported
-        , inherit : Supported
-        , initial : Supported
-        , unset : Supported
-        }
+        (BorderWidthSupported
+            { inherit : Supported
+            , initial : Supported
+            , unset : Supported
+            }
+        )
     -> Style
 borderTop (Value width) =
     AppendProperty ("border-top:" ++ width)
@@ -6265,40 +5486,8 @@ borderTop (Value width) =
 
 -}
 borderTop2 :
-    Value
-        { ch : Supported
-        , cm : Supported
-        , em : Supported
-        , ex : Supported
-        , inches : Supported
-        , mm : Supported
-        , pc : Supported
-        , pt : Supported
-        , px : Supported
-        , rem : Supported
-        , vh : Supported
-        , vmax : Supported
-        , vmin : Supported
-        , vw : Supported
-        , zero : Supported
-        , calc : Supported
-        , thin : Supported
-        , medium : Supported
-        , thick : Supported
-        }
-    ->
-        Value
-            { solid : Supported
-            , none : Supported
-            , hidden : Supported
-            , dashed : Supported
-            , dotted : Supported
-            , double : Supported
-            , groove : Supported
-            , ridge : Supported
-            , inset : Supported
-            , outset : Supported
-            }
+    Value BorderWidth
+    -> Value BorderStyle
     -> Style
 borderTop2 (Value width) (Value style) =
     AppendProperty ("border-top:" ++ width ++ " " ++ style)
@@ -6312,50 +5501,9 @@ borderTop2 (Value width) (Value style) =
 
 -}
 borderTop3 :
-    Value
-        { ch : Supported
-        , cm : Supported
-        , em : Supported
-        , ex : Supported
-        , inches : Supported
-        , mm : Supported
-        , pc : Supported
-        , pt : Supported
-        , px : Supported
-        , rem : Supported
-        , vh : Supported
-        , vmax : Supported
-        , vmin : Supported
-        , vw : Supported
-        , zero : Supported
-        , calc : Supported
-        , thin : Supported
-        , medium : Supported
-        , thick : Supported
-        }
-    ->
-        Value
-            { solid : Supported
-            , none : Supported
-            , hidden : Supported
-            , dashed : Supported
-            , dotted : Supported
-            , double : Supported
-            , groove : Supported
-            , ridge : Supported
-            , inset : Supported
-            , outset : Supported
-            }
-    ->
-        Value
-            { rgb : Supported
-            , rgba : Supported
-            , hsl : Supported
-            , hsla : Supported
-            , hex : Supported
-            , transparent : Supported
-            , currentColor : Supported
-            }
+    Value BorderWidth
+    -> Value BorderStyle
+    -> Value Color
     -> Style
 borderTop3 (Value width) (Value style) (Value color) =
     AppendProperty ("border-top:" ++ width ++ " " ++ style ++ " " ++ color)
@@ -6370,29 +5518,12 @@ borderTop3 (Value width) (Value style) (Value color) =
 -}
 borderRight :
     Value
-        { ch : Supported
-        , cm : Supported
-        , em : Supported
-        , ex : Supported
-        , inches : Supported
-        , mm : Supported
-        , pc : Supported
-        , pt : Supported
-        , px : Supported
-        , rem : Supported
-        , vh : Supported
-        , vmax : Supported
-        , vmin : Supported
-        , vw : Supported
-        , zero : Supported
-        , calc : Supported
-        , thin : Supported
-        , medium : Supported
-        , thick : Supported
-        , inherit : Supported
-        , initial : Supported
-        , unset : Supported
-        }
+        (BorderWidthSupported
+            { inherit : Supported
+            , initial : Supported
+            , unset : Supported
+            }
+        )
     -> Style
 borderRight (Value width) =
     AppendProperty ("border-right:" ++ width)
@@ -6406,40 +5537,8 @@ borderRight (Value width) =
 
 -}
 borderRight2 :
-    Value
-        { ch : Supported
-        , cm : Supported
-        , em : Supported
-        , ex : Supported
-        , inches : Supported
-        , mm : Supported
-        , pc : Supported
-        , pt : Supported
-        , px : Supported
-        , rem : Supported
-        , vh : Supported
-        , vmax : Supported
-        , vmin : Supported
-        , vw : Supported
-        , zero : Supported
-        , calc : Supported
-        , thin : Supported
-        , medium : Supported
-        , thick : Supported
-        }
-    ->
-        Value
-            { solid : Supported
-            , none : Supported
-            , hidden : Supported
-            , dashed : Supported
-            , dotted : Supported
-            , double : Supported
-            , groove : Supported
-            , ridge : Supported
-            , inset : Supported
-            , outset : Supported
-            }
+    Value BorderWidth
+    -> Value BorderStyle
     -> Style
 borderRight2 (Value width) (Value style) =
     AppendProperty ("border-right:" ++ width ++ " " ++ style)
@@ -6453,50 +5552,9 @@ borderRight2 (Value width) (Value style) =
 
 -}
 borderRight3 :
-    Value
-        { ch : Supported
-        , cm : Supported
-        , em : Supported
-        , ex : Supported
-        , inches : Supported
-        , mm : Supported
-        , pc : Supported
-        , pt : Supported
-        , px : Supported
-        , rem : Supported
-        , vh : Supported
-        , vmax : Supported
-        , vmin : Supported
-        , vw : Supported
-        , zero : Supported
-        , calc : Supported
-        , thin : Supported
-        , medium : Supported
-        , thick : Supported
-        }
-    ->
-        Value
-            { solid : Supported
-            , none : Supported
-            , hidden : Supported
-            , dashed : Supported
-            , dotted : Supported
-            , double : Supported
-            , groove : Supported
-            , ridge : Supported
-            , inset : Supported
-            , outset : Supported
-            }
-    ->
-        Value
-            { rgb : Supported
-            , rgba : Supported
-            , hsl : Supported
-            , hsla : Supported
-            , hex : Supported
-            , transparent : Supported
-            , currentColor : Supported
-            }
+    Value BorderWidth
+    -> Value BorderStyle
+    -> Value Color
     -> Style
 borderRight3 (Value width) (Value style) (Value color) =
     AppendProperty ("border-right:" ++ width ++ " " ++ style ++ " " ++ color)
@@ -6511,29 +5569,12 @@ borderRight3 (Value width) (Value style) (Value color) =
 -}
 borderBottom :
     Value
-        { ch : Supported
-        , cm : Supported
-        , em : Supported
-        , ex : Supported
-        , inches : Supported
-        , mm : Supported
-        , pc : Supported
-        , pt : Supported
-        , px : Supported
-        , rem : Supported
-        , vh : Supported
-        , vmax : Supported
-        , vmin : Supported
-        , vw : Supported
-        , zero : Supported
-        , calc : Supported
-        , thin : Supported
-        , medium : Supported
-        , thick : Supported
-        , inherit : Supported
-        , initial : Supported
-        , unset : Supported
-        }
+        (BorderWidthSupported
+            { inherit : Supported
+            , initial : Supported
+            , unset : Supported
+            }
+        )
     -> Style
 borderBottom (Value width) =
     AppendProperty ("border-bottom:" ++ width)
@@ -6547,40 +5588,8 @@ borderBottom (Value width) =
 
 -}
 borderBottom2 :
-    Value
-        { ch : Supported
-        , cm : Supported
-        , em : Supported
-        , ex : Supported
-        , inches : Supported
-        , mm : Supported
-        , pc : Supported
-        , pt : Supported
-        , px : Supported
-        , rem : Supported
-        , vh : Supported
-        , vmax : Supported
-        , vmin : Supported
-        , vw : Supported
-        , zero : Supported
-        , calc : Supported
-        , thin : Supported
-        , medium : Supported
-        , thick : Supported
-        }
-    ->
-        Value
-            { solid : Supported
-            , none : Supported
-            , hidden : Supported
-            , dashed : Supported
-            , dotted : Supported
-            , double : Supported
-            , groove : Supported
-            , ridge : Supported
-            , inset : Supported
-            , outset : Supported
-            }
+    Value BorderWidth
+    -> Value BorderStyle
     -> Style
 borderBottom2 (Value width) (Value style) =
     AppendProperty ("border-bottom:" ++ width ++ " " ++ style)
@@ -6594,50 +5603,9 @@ borderBottom2 (Value width) (Value style) =
 
 -}
 borderBottom3 :
-    Value
-        { ch : Supported
-        , cm : Supported
-        , em : Supported
-        , ex : Supported
-        , inches : Supported
-        , mm : Supported
-        , pc : Supported
-        , pt : Supported
-        , px : Supported
-        , rem : Supported
-        , vh : Supported
-        , vmax : Supported
-        , vmin : Supported
-        , vw : Supported
-        , zero : Supported
-        , calc : Supported
-        , thin : Supported
-        , medium : Supported
-        , thick : Supported
-        }
-    ->
-        Value
-            { solid : Supported
-            , none : Supported
-            , hidden : Supported
-            , dashed : Supported
-            , dotted : Supported
-            , double : Supported
-            , groove : Supported
-            , ridge : Supported
-            , inset : Supported
-            , outset : Supported
-            }
-    ->
-        Value
-            { rgb : Supported
-            , rgba : Supported
-            , hsl : Supported
-            , hsla : Supported
-            , hex : Supported
-            , transparent : Supported
-            , currentColor : Supported
-            }
+    Value BorderWidth
+    -> Value BorderStyle
+    -> Value Color
     -> Style
 borderBottom3 (Value width) (Value style) (Value color) =
     AppendProperty ("border-bottom:" ++ width ++ " " ++ style ++ " " ++ color)
@@ -6652,29 +5620,12 @@ borderBottom3 (Value width) (Value style) (Value color) =
 -}
 borderLeft :
     Value
-        { ch : Supported
-        , cm : Supported
-        , em : Supported
-        , ex : Supported
-        , inches : Supported
-        , mm : Supported
-        , pc : Supported
-        , pt : Supported
-        , px : Supported
-        , rem : Supported
-        , vh : Supported
-        , vmax : Supported
-        , vmin : Supported
-        , vw : Supported
-        , zero : Supported
-        , calc : Supported
-        , thin : Supported
-        , medium : Supported
-        , thick : Supported
-        , inherit : Supported
-        , initial : Supported
-        , unset : Supported
-        }
+        (BorderWidthSupported
+            { inherit : Supported
+            , initial : Supported
+            , unset : Supported
+            }
+        )
     -> Style
 borderLeft (Value width) =
     AppendProperty ("border-left:" ++ width)
@@ -6688,40 +5639,8 @@ borderLeft (Value width) =
 
 -}
 borderLeft2 :
-    Value
-        { ch : Supported
-        , cm : Supported
-        , em : Supported
-        , ex : Supported
-        , inches : Supported
-        , mm : Supported
-        , pc : Supported
-        , pt : Supported
-        , px : Supported
-        , rem : Supported
-        , vh : Supported
-        , vmax : Supported
-        , vmin : Supported
-        , vw : Supported
-        , zero : Supported
-        , calc : Supported
-        , thin : Supported
-        , medium : Supported
-        , thick : Supported
-        }
-    ->
-        Value
-            { solid : Supported
-            , none : Supported
-            , hidden : Supported
-            , dashed : Supported
-            , dotted : Supported
-            , double : Supported
-            , groove : Supported
-            , ridge : Supported
-            , inset : Supported
-            , outset : Supported
-            }
+    Value BorderWidth
+    -> Value BorderStyle
     -> Style
 borderLeft2 (Value width) (Value style) =
     AppendProperty ("border-left:" ++ width ++ " " ++ style)
@@ -6735,50 +5654,9 @@ borderLeft2 (Value width) (Value style) =
 
 -}
 borderLeft3 :
-    Value
-        { ch : Supported
-        , cm : Supported
-        , em : Supported
-        , ex : Supported
-        , inches : Supported
-        , mm : Supported
-        , pc : Supported
-        , pt : Supported
-        , px : Supported
-        , rem : Supported
-        , vh : Supported
-        , vmax : Supported
-        , vmin : Supported
-        , vw : Supported
-        , zero : Supported
-        , calc : Supported
-        , thin : Supported
-        , medium : Supported
-        , thick : Supported
-        }
-    ->
-        Value
-            { solid : Supported
-            , none : Supported
-            , hidden : Supported
-            , dashed : Supported
-            , dotted : Supported
-            , double : Supported
-            , groove : Supported
-            , ridge : Supported
-            , inset : Supported
-            , outset : Supported
-            }
-    ->
-        Value
-            { rgb : Supported
-            , rgba : Supported
-            , hsl : Supported
-            , hsla : Supported
-            , hex : Supported
-            , transparent : Supported
-            , currentColor : Supported
-            }
+    Value BorderWidth
+    -> Value BorderStyle
+    -> Value Color
     -> Style
 borderLeft3 (Value width) (Value style) (Value color) =
     AppendProperty ("border-left:" ++ width ++ " " ++ style ++ " " ++ color)
@@ -6794,29 +5672,12 @@ borderLeft3 (Value width) (Value style) (Value color) =
 -}
 borderWidth :
     Value
-        { ch : Supported
-        , cm : Supported
-        , em : Supported
-        , ex : Supported
-        , inches : Supported
-        , mm : Supported
-        , pc : Supported
-        , pt : Supported
-        , px : Supported
-        , rem : Supported
-        , vh : Supported
-        , vmax : Supported
-        , vmin : Supported
-        , vw : Supported
-        , zero : Supported
-        , calc : Supported
-        , thin : Supported
-        , medium : Supported
-        , thick : Supported
-        , inherit : Supported
-        , initial : Supported
-        , unset : Supported
-        }
+        (BorderWidthSupported
+            { inherit : Supported
+            , initial : Supported
+            , unset : Supported
+            }
+        )
     -> Style
 borderWidth (Value width) =
     AppendProperty ("border-width:" ++ width)
@@ -6831,49 +5692,8 @@ borderWidth (Value width) =
 
 -}
 borderWidth2 :
-    Value
-        { ch : Supported
-        , cm : Supported
-        , em : Supported
-        , ex : Supported
-        , inches : Supported
-        , mm : Supported
-        , pc : Supported
-        , pt : Supported
-        , px : Supported
-        , rem : Supported
-        , vh : Supported
-        , vmax : Supported
-        , vmin : Supported
-        , vw : Supported
-        , zero : Supported
-        , calc : Supported
-        , thin : Supported
-        , medium : Supported
-        , thick : Supported
-        }
-    ->
-        Value
-            { ch : Supported
-            , cm : Supported
-            , em : Supported
-            , ex : Supported
-            , inches : Supported
-            , mm : Supported
-            , pc : Supported
-            , pt : Supported
-            , px : Supported
-            , rem : Supported
-            , vh : Supported
-            , vmax : Supported
-            , vmin : Supported
-            , vw : Supported
-            , zero : Supported
-            , calc : Supported
-            , thin : Supported
-            , medium : Supported
-            , thick : Supported
-            }
+    Value BorderWidth
+    -> Value BorderWidth
     -> Style
 borderWidth2 (Value widthTopBottom) (Value widthRightLeft) =
     AppendProperty ("border-width:" ++ widthTopBottom ++ " " ++ widthRightLeft)
@@ -6888,72 +5708,9 @@ borderWidth2 (Value widthTopBottom) (Value widthRightLeft) =
 
 -}
 borderWidth3 :
-    Value
-        { ch : Supported
-        , cm : Supported
-        , em : Supported
-        , ex : Supported
-        , inches : Supported
-        , mm : Supported
-        , pc : Supported
-        , pt : Supported
-        , px : Supported
-        , rem : Supported
-        , vh : Supported
-        , vmax : Supported
-        , vmin : Supported
-        , vw : Supported
-        , zero : Supported
-        , calc : Supported
-        , thin : Supported
-        , medium : Supported
-        , thick : Supported
-        }
-    ->
-        Value
-            { ch : Supported
-            , cm : Supported
-            , em : Supported
-            , ex : Supported
-            , inches : Supported
-            , mm : Supported
-            , pc : Supported
-            , pt : Supported
-            , px : Supported
-            , rem : Supported
-            , vh : Supported
-            , vmax : Supported
-            , vmin : Supported
-            , vw : Supported
-            , zero : Supported
-            , calc : Supported
-            , thin : Supported
-            , medium : Supported
-            , thick : Supported
-            }
-    ->
-        Value
-            { ch : Supported
-            , cm : Supported
-            , em : Supported
-            , ex : Supported
-            , inches : Supported
-            , mm : Supported
-            , pc : Supported
-            , pt : Supported
-            , px : Supported
-            , rem : Supported
-            , vh : Supported
-            , vmax : Supported
-            , vmin : Supported
-            , vw : Supported
-            , zero : Supported
-            , calc : Supported
-            , thin : Supported
-            , medium : Supported
-            , thick : Supported
-            , inherit : Supported
-            }
+    Value BorderWidth
+    -> Value BorderWidth
+    -> Value BorderWidth
     -> Style
 borderWidth3 (Value widthTop) (Value widthRightLeft) (Value widthBottom) =
     AppendProperty ("border-width:" ++ widthTop ++ " " ++ widthRightLeft ++ " " ++ widthBottom)
@@ -6968,93 +5725,10 @@ borderWidth3 (Value widthTop) (Value widthRightLeft) (Value widthBottom) =
 
 -}
 borderWidth4 :
-    Value
-        { ch : Supported
-        , cm : Supported
-        , em : Supported
-        , ex : Supported
-        , inches : Supported
-        , mm : Supported
-        , pc : Supported
-        , pt : Supported
-        , px : Supported
-        , rem : Supported
-        , vh : Supported
-        , vmax : Supported
-        , vmin : Supported
-        , vw : Supported
-        , zero : Supported
-        , calc : Supported
-        , thin : Supported
-        , medium : Supported
-        , thick : Supported
-        }
-    ->
-        Value
-            { ch : Supported
-            , cm : Supported
-            , em : Supported
-            , ex : Supported
-            , inches : Supported
-            , mm : Supported
-            , pc : Supported
-            , pt : Supported
-            , px : Supported
-            , rem : Supported
-            , vh : Supported
-            , vmax : Supported
-            , vmin : Supported
-            , vw : Supported
-            , zero : Supported
-            , calc : Supported
-            , thin : Supported
-            , medium : Supported
-            , thick : Supported
-            }
-    ->
-        Value
-            { ch : Supported
-            , cm : Supported
-            , em : Supported
-            , ex : Supported
-            , inches : Supported
-            , mm : Supported
-            , pc : Supported
-            , pt : Supported
-            , px : Supported
-            , rem : Supported
-            , vh : Supported
-            , vmax : Supported
-            , vmin : Supported
-            , vw : Supported
-            , zero : Supported
-            , calc : Supported
-            , thin : Supported
-            , medium : Supported
-            , thick : Supported
-            }
-    ->
-        Value
-            { ch : Supported
-            , cm : Supported
-            , em : Supported
-            , ex : Supported
-            , inches : Supported
-            , mm : Supported
-            , pc : Supported
-            , pt : Supported
-            , px : Supported
-            , rem : Supported
-            , vh : Supported
-            , vmax : Supported
-            , vmin : Supported
-            , vw : Supported
-            , zero : Supported
-            , calc : Supported
-            , thin : Supported
-            , medium : Supported
-            , thick : Supported
-            }
+    Value BorderWidth
+    -> Value BorderWidth
+    -> Value BorderWidth
+    -> Value BorderWidth
     -> Style
 borderWidth4 (Value widthTop) (Value widthRight) (Value widthBottom) (Value widthLeft) =
     AppendProperty ("border-width:" ++ widthTop ++ " " ++ widthRight ++ " " ++ widthBottom ++ " " ++ widthLeft)
@@ -7067,29 +5741,12 @@ borderWidth4 (Value widthTop) (Value widthRight) (Value widthBottom) (Value widt
 -}
 borderTopWidth :
     Value
-        { ch : Supported
-        , cm : Supported
-        , em : Supported
-        , ex : Supported
-        , inches : Supported
-        , mm : Supported
-        , pc : Supported
-        , pt : Supported
-        , px : Supported
-        , rem : Supported
-        , vh : Supported
-        , vmax : Supported
-        , vmin : Supported
-        , vw : Supported
-        , zero : Supported
-        , calc : Supported
-        , thin : Supported
-        , medium : Supported
-        , thick : Supported
-        , inherit : Supported
-        , initial : Supported
-        , unset : Supported
-        }
+        (BorderWidthSupported
+            { inherit : Supported
+            , initial : Supported
+            , unset : Supported
+            }
+        )
     -> Style
 borderTopWidth (Value width) =
     AppendProperty ("border-top-width:" ++ width)
@@ -7102,29 +5759,12 @@ borderTopWidth (Value width) =
 -}
 borderRightWidth :
     Value
-        { ch : Supported
-        , cm : Supported
-        , em : Supported
-        , ex : Supported
-        , inches : Supported
-        , mm : Supported
-        , pc : Supported
-        , pt : Supported
-        , px : Supported
-        , rem : Supported
-        , vh : Supported
-        , vmax : Supported
-        , vmin : Supported
-        , vw : Supported
-        , zero : Supported
-        , calc : Supported
-        , thin : Supported
-        , medium : Supported
-        , thick : Supported
-        , inherit : Supported
-        , initial : Supported
-        , unset : Supported
-        }
+        (BorderWidthSupported
+            { inherit : Supported
+            , initial : Supported
+            , unset : Supported
+            }
+        )
     -> Style
 borderRightWidth (Value width) =
     AppendProperty ("border-right-width:" ++ width)
@@ -7137,29 +5777,12 @@ borderRightWidth (Value width) =
 -}
 borderBottomWidth :
     Value
-        { ch : Supported
-        , cm : Supported
-        , em : Supported
-        , ex : Supported
-        , inches : Supported
-        , mm : Supported
-        , pc : Supported
-        , pt : Supported
-        , px : Supported
-        , rem : Supported
-        , vh : Supported
-        , vmax : Supported
-        , vmin : Supported
-        , vw : Supported
-        , zero : Supported
-        , calc : Supported
-        , thin : Supported
-        , medium : Supported
-        , thick : Supported
-        , inherit : Supported
-        , initial : Supported
-        , unset : Supported
-        }
+        (BorderWidthSupported
+            { inherit : Supported
+            , initial : Supported
+            , unset : Supported
+            }
+        )
     -> Style
 borderBottomWidth (Value width) =
     AppendProperty ("border-bottom-width:" ++ width)
@@ -7172,29 +5795,12 @@ borderBottomWidth (Value width) =
 -}
 borderLeftWidth :
     Value
-        { ch : Supported
-        , cm : Supported
-        , em : Supported
-        , ex : Supported
-        , inches : Supported
-        , mm : Supported
-        , pc : Supported
-        , pt : Supported
-        , px : Supported
-        , rem : Supported
-        , vh : Supported
-        , vmax : Supported
-        , vmin : Supported
-        , vw : Supported
-        , zero : Supported
-        , calc : Supported
-        , thin : Supported
-        , medium : Supported
-        , thick : Supported
-        , inherit : Supported
-        , initial : Supported
-        , unset : Supported
-        }
+        (BorderWidthSupported
+            { inherit : Supported
+            , initial : Supported
+            , unset : Supported
+            }
+        )
     -> Style
 borderLeftWidth (Value width) =
     AppendProperty ("border-left-width:" ++ width)
@@ -7210,20 +5816,12 @@ borderLeftWidth (Value width) =
 -}
 borderStyle :
     Value
-        { solid : Supported
-        , none : Supported
-        , hidden : Supported
-        , dashed : Supported
-        , dotted : Supported
-        , double : Supported
-        , groove : Supported
-        , ridge : Supported
-        , inset : Supported
-        , outset : Supported
-        , inherit : Supported
-        , initial : Supported
-        , unset : Supported
-        }
+        (BorderStyleSupported
+            { inherit : Supported
+            , initial : Supported
+            , unset : Supported
+            }
+        )
     -> Style
 borderStyle (Value style) =
     AppendProperty ("border-style:" ++ style)
@@ -7238,31 +5836,8 @@ borderStyle (Value style) =
 
 -}
 borderStyle2 :
-    Value
-        { solid : Supported
-        , none : Supported
-        , hidden : Supported
-        , dashed : Supported
-        , dotted : Supported
-        , double : Supported
-        , groove : Supported
-        , ridge : Supported
-        , inset : Supported
-        , outset : Supported
-        }
-    ->
-        Value
-            { solid : Supported
-            , none : Supported
-            , hidden : Supported
-            , dashed : Supported
-            , dotted : Supported
-            , double : Supported
-            , groove : Supported
-            , ridge : Supported
-            , inset : Supported
-            , outset : Supported
-            }
+    Value BorderStyle
+    -> Value BorderStyle
     -> Style
 borderStyle2 (Value styleTopBottom) (Value styleRigthLeft) =
     AppendProperty ("border-style:" ++ styleTopBottom ++ " " ++ styleRigthLeft)
@@ -7277,44 +5852,9 @@ borderStyle2 (Value styleTopBottom) (Value styleRigthLeft) =
 
 -}
 borderStyle3 :
-    Value
-        { solid : Supported
-        , none : Supported
-        , hidden : Supported
-        , dashed : Supported
-        , dotted : Supported
-        , double : Supported
-        , groove : Supported
-        , ridge : Supported
-        , inset : Supported
-        , outset : Supported
-        }
-    ->
-        Value
-            { solid : Supported
-            , none : Supported
-            , hidden : Supported
-            , dashed : Supported
-            , dotted : Supported
-            , double : Supported
-            , groove : Supported
-            , ridge : Supported
-            , inset : Supported
-            , outset : Supported
-            }
-    ->
-        Value
-            { solid : Supported
-            , none : Supported
-            , hidden : Supported
-            , dashed : Supported
-            , dotted : Supported
-            , double : Supported
-            , groove : Supported
-            , ridge : Supported
-            , inset : Supported
-            , outset : Supported
-            }
+    Value BorderStyle
+    -> Value BorderStyle
+    -> Value BorderStyle
     -> Style
 borderStyle3 (Value styleTop) (Value styleRigthLeft) (Value styleBottom) =
     AppendProperty ("border-style:" ++ styleTop ++ " " ++ styleRigthLeft ++ " " ++ styleBottom)
@@ -7329,57 +5869,10 @@ borderStyle3 (Value styleTop) (Value styleRigthLeft) (Value styleBottom) =
 
 -}
 borderStyle4 :
-    Value
-        { solid : Supported
-        , none : Supported
-        , hidden : Supported
-        , dashed : Supported
-        , dotted : Supported
-        , double : Supported
-        , groove : Supported
-        , ridge : Supported
-        , inset : Supported
-        , outset : Supported
-        }
-    ->
-        Value
-            { solid : Supported
-            , none : Supported
-            , hidden : Supported
-            , dashed : Supported
-            , dotted : Supported
-            , double : Supported
-            , groove : Supported
-            , ridge : Supported
-            , inset : Supported
-            , outset : Supported
-            }
-    ->
-        Value
-            { solid : Supported
-            , none : Supported
-            , hidden : Supported
-            , dashed : Supported
-            , dotted : Supported
-            , double : Supported
-            , groove : Supported
-            , ridge : Supported
-            , inset : Supported
-            , outset : Supported
-            }
-    ->
-        Value
-            { solid : Supported
-            , none : Supported
-            , hidden : Supported
-            , dashed : Supported
-            , dotted : Supported
-            , double : Supported
-            , groove : Supported
-            , ridge : Supported
-            , inset : Supported
-            , outset : Supported
-            }
+    Value BorderStyle
+    -> Value BorderStyle
+    -> Value BorderStyle
+    -> Value BorderStyle
     -> Style
 borderStyle4 (Value styleTop) (Value styleRigt) (Value styleBottom) (Value styleLeft) =
     AppendProperty ("border-style:" ++ styleTop ++ " " ++ styleRigt ++ " " ++ styleBottom ++ " " ++ styleLeft)
@@ -7392,20 +5885,12 @@ borderStyle4 (Value styleTop) (Value styleRigt) (Value styleBottom) (Value style
 -}
 borderTopStyle :
     Value
-        { solid : Supported
-        , none : Supported
-        , hidden : Supported
-        , dashed : Supported
-        , dotted : Supported
-        , double : Supported
-        , groove : Supported
-        , ridge : Supported
-        , inset : Supported
-        , outset : Supported
-        , inherit : Supported
-        , initial : Supported
-        , unset : Supported
-        }
+        (BorderStyleSupported
+            { inherit : Supported
+            , initial : Supported
+            , unset : Supported
+            }
+        )
     -> Style
 borderTopStyle (Value style) =
     AppendProperty ("border-top-style:" ++ style)
@@ -7418,20 +5903,12 @@ borderTopStyle (Value style) =
 -}
 borderRightStyle :
     Value
-        { solid : Supported
-        , none : Supported
-        , hidden : Supported
-        , dashed : Supported
-        , dotted : Supported
-        , double : Supported
-        , groove : Supported
-        , ridge : Supported
-        , inset : Supported
-        , outset : Supported
-        , inherit : Supported
-        , initial : Supported
-        , unset : Supported
-        }
+        (BorderStyleSupported
+            { inherit : Supported
+            , initial : Supported
+            , unset : Supported
+            }
+        )
     -> Style
 borderRightStyle (Value style) =
     AppendProperty ("border-right-style:" ++ style)
@@ -7444,20 +5921,12 @@ borderRightStyle (Value style) =
 -}
 borderBottomStyle :
     Value
-        { solid : Supported
-        , none : Supported
-        , hidden : Supported
-        , dashed : Supported
-        , dotted : Supported
-        , double : Supported
-        , groove : Supported
-        , ridge : Supported
-        , inset : Supported
-        , outset : Supported
-        , inherit : Supported
-        , initial : Supported
-        , unset : Supported
-        }
+        (BorderStyleSupported
+            { inherit : Supported
+            , initial : Supported
+            , unset : Supported
+            }
+        )
     -> Style
 borderBottomStyle (Value style) =
     AppendProperty ("border-bottom-style:" ++ style)
@@ -7470,20 +5939,12 @@ borderBottomStyle (Value style) =
 -}
 borderLeftStyle :
     Value
-        { solid : Supported
-        , none : Supported
-        , hidden : Supported
-        , dashed : Supported
-        , dotted : Supported
-        , double : Supported
-        , groove : Supported
-        , ridge : Supported
-        , inset : Supported
-        , outset : Supported
-        , inherit : Supported
-        , initial : Supported
-        , unset : Supported
-        }
+        (BorderStyleSupported
+            { inherit : Supported
+            , initial : Supported
+            , unset : Supported
+            }
+        )
     -> Style
 borderLeftStyle (Value style) =
     AppendProperty ("border-left-style:" ++ style)
@@ -7499,17 +5960,12 @@ borderLeftStyle (Value style) =
 -}
 borderColor :
     Value
-        { rgb : Supported
-        , rgba : Supported
-        , hsl : Supported
-        , hsla : Supported
-        , hex : Supported
-        , transparent : Supported
-        , currentColor : Supported
-        , inherit : Supported
-        , initial : Supported
-        , unset : Supported
-        }
+        (ColorSupported
+            { inherit : Supported
+            , initial : Supported
+            , unset : Supported
+            }
+        )
     -> Style
 borderColor (Value color) =
     AppendProperty ("border-color:" ++ color)
@@ -7524,25 +5980,8 @@ borderColor (Value color) =
 
 -}
 borderColor2 :
-    Value
-        { rgb : Supported
-        , rgba : Supported
-        , hsl : Supported
-        , hsla : Supported
-        , hex : Supported
-        , transparent : Supported
-        , currentColor : Supported
-        }
-    ->
-        Value
-            { rgb : Supported
-            , rgba : Supported
-            , hsl : Supported
-            , hsla : Supported
-            , hex : Supported
-            , transparent : Supported
-            , currentColor : Supported
-            }
+    Value Color
+    -> Value Color
     -> Style
 borderColor2 (Value colorTopBottom) (Value colorRightLeft) =
     AppendProperty ("border-color:" ++ colorTopBottom ++ " " ++ colorRightLeft)
@@ -7557,35 +5996,9 @@ borderColor2 (Value colorTopBottom) (Value colorRightLeft) =
 
 -}
 borderColor3 :
-    Value
-        { rgb : Supported
-        , rgba : Supported
-        , hsl : Supported
-        , hsla : Supported
-        , hex : Supported
-        , transparent : Supported
-        , currentColor : Supported
-        }
-    ->
-        Value
-            { rgb : Supported
-            , rgba : Supported
-            , hsl : Supported
-            , hsla : Supported
-            , hex : Supported
-            , transparent : Supported
-            , currentColor : Supported
-            }
-    ->
-        Value
-            { rgb : Supported
-            , rgba : Supported
-            , hsl : Supported
-            , hsla : Supported
-            , hex : Supported
-            , transparent : Supported
-            , currentColor : Supported
-            }
+    Value Color
+    -> Value Color
+    -> Value Color
     -> Style
 borderColor3 (Value colorTop) (Value colorRightLeft) (Value colorBottom) =
     AppendProperty ("border-color:" ++ colorTop ++ " " ++ colorRightLeft ++ " " ++ colorBottom)
@@ -7600,45 +6013,10 @@ borderColor3 (Value colorTop) (Value colorRightLeft) (Value colorBottom) =
 
 -}
 borderColor4 :
-    Value
-        { rgb : Supported
-        , rgba : Supported
-        , hsl : Supported
-        , hsla : Supported
-        , hex : Supported
-        , transparent : Supported
-        , currentColor : Supported
-        }
-    ->
-        Value
-            { rgb : Supported
-            , rgba : Supported
-            , hsl : Supported
-            , hsla : Supported
-            , hex : Supported
-            , transparent : Supported
-            , currentColor : Supported
-            }
-    ->
-        Value
-            { rgb : Supported
-            , rgba : Supported
-            , hsl : Supported
-            , hsla : Supported
-            , hex : Supported
-            , transparent : Supported
-            , currentColor : Supported
-            }
-    ->
-        Value
-            { rgb : Supported
-            , rgba : Supported
-            , hsl : Supported
-            , hsla : Supported
-            , hex : Supported
-            , transparent : Supported
-            , currentColor : Supported
-            }
+    Value Color
+    -> Value Color
+    -> Value Color
+    -> Value Color
     -> Style
 borderColor4 (Value colorTop) (Value colorRight) (Value colorBottom) (Value colorLeft) =
     AppendProperty ("border-color:" ++ colorTop ++ " " ++ colorRight ++ " " ++ colorBottom ++ " " ++ colorLeft)
@@ -7651,17 +6029,12 @@ borderColor4 (Value colorTop) (Value colorRight) (Value colorBottom) (Value colo
 -}
 borderTopColor :
     Value
-        { rgb : Supported
-        , rgba : Supported
-        , hsl : Supported
-        , hsla : Supported
-        , hex : Supported
-        , transparent : Supported
-        , currentColor : Supported
-        , inherit : Supported
-        , initial : Supported
-        , unset : Supported
-        }
+        (ColorSupported
+            { inherit : Supported
+            , initial : Supported
+            , unset : Supported
+            }
+        )
     -> Style
 borderTopColor (Value color) =
     AppendProperty ("border-top-color:" ++ color)
@@ -7674,17 +6047,12 @@ borderTopColor (Value color) =
 -}
 borderRightColor :
     Value
-        { rgb : Supported
-        , rgba : Supported
-        , hsl : Supported
-        , hsla : Supported
-        , hex : Supported
-        , transparent : Supported
-        , currentColor : Supported
-        , inherit : Supported
-        , initial : Supported
-        , unset : Supported
-        }
+        (ColorSupported
+            { inherit : Supported
+            , initial : Supported
+            , unset : Supported
+            }
+        )
     -> Style
 borderRightColor (Value color) =
     AppendProperty ("border-right-color:" ++ color)
@@ -7697,17 +6065,12 @@ borderRightColor (Value color) =
 -}
 borderBottomColor :
     Value
-        { rgb : Supported
-        , rgba : Supported
-        , hsl : Supported
-        , hsla : Supported
-        , hex : Supported
-        , transparent : Supported
-        , currentColor : Supported
-        , inherit : Supported
-        , initial : Supported
-        , unset : Supported
-        }
+        (ColorSupported
+            { inherit : Supported
+            , initial : Supported
+            , unset : Supported
+            }
+        )
     -> Style
 borderBottomColor (Value color) =
     AppendProperty ("border-bottom-color:" ++ color)
@@ -7720,17 +6083,12 @@ borderBottomColor (Value color) =
 -}
 borderLeftColor :
     Value
-        { rgb : Supported
-        , rgba : Supported
-        , hsl : Supported
-        , hsla : Supported
-        , hex : Supported
-        , transparent : Supported
-        , currentColor : Supported
-        , inherit : Supported
-        , initial : Supported
-        , unset : Supported
-        }
+        (ColorSupported
+            { inherit : Supported
+            , initial : Supported
+            , unset : Supported
+            }
+        )
     -> Style
 borderLeftColor (Value color) =
     AppendProperty ("border-left-color:" ++ color)
@@ -7911,27 +6269,13 @@ outset =
 -}
 borderRadius :
     Value
-        { ch : Supported
-        , cm : Supported
-        , em : Supported
-        , ex : Supported
-        , inches : Supported
-        , mm : Supported
-        , pc : Supported
-        , pt : Supported
-        , pct : Supported
-        , px : Supported
-        , rem : Supported
-        , vh : Supported
-        , vmax : Supported
-        , vmin : Supported
-        , vw : Supported
-        , zero : Supported
-        , calc : Supported
-        , inherit : Supported
-        , initial : Supported
-        , unset : Supported
-        }
+        (LengthSupported
+            { pct : Supported
+            , inherit : Supported
+            , initial : Supported
+            , unset : Supported
+            }
+        )
     -> Style
 borderRadius (Value radius) =
     AppendProperty ("border-radius:" ++ radius)
@@ -7947,44 +6291,16 @@ borderRadius (Value radius) =
 -}
 borderRadius2 :
     Value
-        { ch : Supported
-        , cm : Supported
-        , em : Supported
-        , ex : Supported
-        , inches : Supported
-        , mm : Supported
-        , pc : Supported
-        , pt : Supported
-        , pct : Supported
-        , px : Supported
-        , rem : Supported
-        , vh : Supported
-        , vmax : Supported
-        , vmin : Supported
-        , vw : Supported
-        , zero : Supported
-        , calc : Supported
-        }
+        (LengthSupported
+            { pct : Supported
+            }
+        )
     ->
         Value
-            { ch : Supported
-            , cm : Supported
-            , em : Supported
-            , ex : Supported
-            , inches : Supported
-            , mm : Supported
-            , pc : Supported
-            , pt : Supported
-            , pct : Supported
-            , px : Supported
-            , rem : Supported
-            , vh : Supported
-            , vmax : Supported
-            , vmin : Supported
-            , vw : Supported
-            , zero : Supported
-            , calc : Supported
-            }
+            (LengthSupported
+                { pct : Supported
+                }
+            )
     -> Style
 borderRadius2 (Value radiusTopLeftAndBottomRight) (Value radiusTopRightAndBottomLeft) =
     AppendProperty ("border-radius:" ++ radiusTopLeftAndBottomRight ++ " " ++ radiusTopRightAndBottomLeft)
@@ -8000,64 +6316,22 @@ borderRadius2 (Value radiusTopLeftAndBottomRight) (Value radiusTopRightAndBottom
 -}
 borderRadius3 :
     Value
-        { ch : Supported
-        , cm : Supported
-        , em : Supported
-        , ex : Supported
-        , inches : Supported
-        , mm : Supported
-        , pc : Supported
-        , pt : Supported
-        , pct : Supported
-        , px : Supported
-        , rem : Supported
-        , vh : Supported
-        , vmax : Supported
-        , vmin : Supported
-        , vw : Supported
-        , zero : Supported
-        , calc : Supported
-        }
+        (LengthSupported
+            { pct : Supported
+            }
+        )
     ->
         Value
-            { ch : Supported
-            , cm : Supported
-            , em : Supported
-            , ex : Supported
-            , inches : Supported
-            , mm : Supported
-            , pc : Supported
-            , pt : Supported
-            , pct : Supported
-            , px : Supported
-            , rem : Supported
-            , vh : Supported
-            , vmax : Supported
-            , vmin : Supported
-            , vw : Supported
-            , zero : Supported
-            , calc : Supported
-            }
+            (LengthSupported
+                { pct : Supported
+                }
+            )
     ->
         Value
-            { ch : Supported
-            , cm : Supported
-            , em : Supported
-            , ex : Supported
-            , inches : Supported
-            , mm : Supported
-            , pc : Supported
-            , pt : Supported
-            , pct : Supported
-            , px : Supported
-            , rem : Supported
-            , vh : Supported
-            , vmax : Supported
-            , vmin : Supported
-            , vw : Supported
-            , zero : Supported
-            , calc : Supported
-            }
+            (LengthSupported
+                { pct : Supported
+                }
+            )
     -> Style
 borderRadius3 (Value radiusTopLeft) (Value radiusTopRightAndBottomLeft) (Value radiusBottomRight) =
     AppendProperty ("border-radius:" ++ radiusTopLeft ++ " " ++ radiusTopRightAndBottomLeft ++ " " ++ radiusBottomRight)
@@ -8073,84 +6347,28 @@ borderRadius3 (Value radiusTopLeft) (Value radiusTopRightAndBottomLeft) (Value r
 -}
 borderRadius4 :
     Value
-        { ch : Supported
-        , cm : Supported
-        , em : Supported
-        , ex : Supported
-        , inches : Supported
-        , mm : Supported
-        , pc : Supported
-        , pt : Supported
-        , pct : Supported
-        , px : Supported
-        , rem : Supported
-        , vh : Supported
-        , vmax : Supported
-        , vmin : Supported
-        , vw : Supported
-        , zero : Supported
-        , calc : Supported
-        }
+        (LengthSupported
+            { pct : Supported
+            }
+        )
     ->
         Value
-            { ch : Supported
-            , cm : Supported
-            , em : Supported
-            , ex : Supported
-            , inches : Supported
-            , mm : Supported
-            , pc : Supported
-            , pt : Supported
-            , pct : Supported
-            , px : Supported
-            , rem : Supported
-            , vh : Supported
-            , vmax : Supported
-            , vmin : Supported
-            , vw : Supported
-            , zero : Supported
-            , calc : Supported
-            }
+            (LengthSupported
+                { pct : Supported
+                }
+            )
     ->
         Value
-            { ch : Supported
-            , cm : Supported
-            , em : Supported
-            , ex : Supported
-            , inches : Supported
-            , mm : Supported
-            , pc : Supported
-            , pt : Supported
-            , pct : Supported
-            , px : Supported
-            , rem : Supported
-            , vh : Supported
-            , vmax : Supported
-            , vmin : Supported
-            , vw : Supported
-            , zero : Supported
-            , calc : Supported
-            }
+            (LengthSupported
+                { pct : Supported
+                }
+            )
     ->
         Value
-            { ch : Supported
-            , cm : Supported
-            , em : Supported
-            , ex : Supported
-            , inches : Supported
-            , mm : Supported
-            , pc : Supported
-            , pt : Supported
-            , pct : Supported
-            , px : Supported
-            , rem : Supported
-            , vh : Supported
-            , vmax : Supported
-            , vmin : Supported
-            , vw : Supported
-            , zero : Supported
-            , calc : Supported
-            }
+            (LengthSupported
+                { pct : Supported
+                }
+            )
     -> Style
 borderRadius4 (Value radiusTopLeft) (Value radiusTopRight) (Value radiusBottomRight) (Value radiusBottomLeft) =
     AppendProperty ("border-radius:" ++ radiusTopLeft ++ " " ++ radiusTopRight ++ " " ++ radiusBottomRight ++ " " ++ radiusBottomLeft)
@@ -8164,27 +6382,13 @@ borderRadius4 (Value radiusTopLeft) (Value radiusTopRight) (Value radiusBottomRi
 -}
 borderTopLeftRadius :
     Value
-        { ch : Supported
-        , cm : Supported
-        , em : Supported
-        , ex : Supported
-        , inches : Supported
-        , mm : Supported
-        , pc : Supported
-        , pt : Supported
-        , pct : Supported
-        , px : Supported
-        , rem : Supported
-        , vh : Supported
-        , vmax : Supported
-        , vmin : Supported
-        , vw : Supported
-        , zero : Supported
-        , calc : Supported
-        , inherit : Supported
-        , initial : Supported
-        , unset : Supported
-        }
+        (LengthSupported
+            { pct : Supported
+            , inherit : Supported
+            , initial : Supported
+            , unset : Supported
+            }
+        )
     -> Style
 borderTopLeftRadius (Value radius) =
     AppendProperty ("border-top-left-radius:" ++ radius)
@@ -8198,44 +6402,16 @@ borderTopLeftRadius (Value radius) =
 -}
 borderTopLeftRadius2 :
     Value
-        { ch : Supported
-        , cm : Supported
-        , em : Supported
-        , ex : Supported
-        , inches : Supported
-        , mm : Supported
-        , pc : Supported
-        , pt : Supported
-        , pct : Supported
-        , px : Supported
-        , rem : Supported
-        , vh : Supported
-        , vmax : Supported
-        , vmin : Supported
-        , vw : Supported
-        , zero : Supported
-        , calc : Supported
-        }
+        (LengthSupported
+            { pct : Supported
+            }
+        )
     ->
         Value
-            { ch : Supported
-            , cm : Supported
-            , em : Supported
-            , ex : Supported
-            , inches : Supported
-            , mm : Supported
-            , pc : Supported
-            , pt : Supported
-            , pct : Supported
-            , px : Supported
-            , rem : Supported
-            , vh : Supported
-            , vmax : Supported
-            , vmin : Supported
-            , vw : Supported
-            , zero : Supported
-            , calc : Supported
-            }
+            (LengthSupported
+                { pct : Supported
+                }
+            )
     -> Style
 borderTopLeftRadius2 (Value horizontal) (Value vertical) =
     AppendProperty ("border-top-left-radius:" ++ horizontal ++ " " ++ vertical)
@@ -8249,27 +6425,13 @@ borderTopLeftRadius2 (Value horizontal) (Value vertical) =
 -}
 borderTopRightRadius :
     Value
-        { ch : Supported
-        , cm : Supported
-        , em : Supported
-        , ex : Supported
-        , inches : Supported
-        , mm : Supported
-        , pc : Supported
-        , pt : Supported
-        , pct : Supported
-        , px : Supported
-        , rem : Supported
-        , vh : Supported
-        , vmax : Supported
-        , vmin : Supported
-        , vw : Supported
-        , zero : Supported
-        , calc : Supported
-        , inherit : Supported
-        , initial : Supported
-        , unset : Supported
-        }
+        (LengthSupported
+            { pct : Supported
+            , inherit : Supported
+            , initial : Supported
+            , unset : Supported
+            }
+        )
     -> Style
 borderTopRightRadius (Value radius) =
     AppendProperty ("border-top-right-radius:" ++ radius)
@@ -8283,44 +6445,16 @@ borderTopRightRadius (Value radius) =
 -}
 borderTopRightRadius2 :
     Value
-        { ch : Supported
-        , cm : Supported
-        , em : Supported
-        , ex : Supported
-        , inches : Supported
-        , mm : Supported
-        , pc : Supported
-        , pt : Supported
-        , pct : Supported
-        , px : Supported
-        , rem : Supported
-        , vh : Supported
-        , vmax : Supported
-        , vmin : Supported
-        , vw : Supported
-        , zero : Supported
-        , calc : Supported
-        }
+        (LengthSupported
+            { pct : Supported
+            }
+        )
     ->
         Value
-            { ch : Supported
-            , cm : Supported
-            , em : Supported
-            , ex : Supported
-            , inches : Supported
-            , mm : Supported
-            , pc : Supported
-            , pt : Supported
-            , pct : Supported
-            , px : Supported
-            , rem : Supported
-            , vh : Supported
-            , vmax : Supported
-            , vmin : Supported
-            , vw : Supported
-            , zero : Supported
-            , calc : Supported
-            }
+            (LengthSupported
+                { pct : Supported
+                }
+            )
     -> Style
 borderTopRightRadius2 (Value horizontal) (Value vertical) =
     AppendProperty ("border-top-right-radius:" ++ horizontal ++ " " ++ vertical)
@@ -8334,27 +6468,13 @@ borderTopRightRadius2 (Value horizontal) (Value vertical) =
 -}
 borderBottomRightRadius :
     Value
-        { ch : Supported
-        , cm : Supported
-        , em : Supported
-        , ex : Supported
-        , inches : Supported
-        , mm : Supported
-        , pc : Supported
-        , pt : Supported
-        , pct : Supported
-        , px : Supported
-        , rem : Supported
-        , vh : Supported
-        , vmax : Supported
-        , vmin : Supported
-        , vw : Supported
-        , zero : Supported
-        , calc : Supported
-        , inherit : Supported
-        , initial : Supported
-        , unset : Supported
-        }
+        (LengthSupported
+            { pct : Supported
+            , inherit : Supported
+            , initial : Supported
+            , unset : Supported
+            }
+        )
     -> Style
 borderBottomRightRadius (Value radius) =
     AppendProperty ("border-bottom-right-radius:" ++ radius)
@@ -8368,44 +6488,16 @@ borderBottomRightRadius (Value radius) =
 -}
 borderBottomRightRadius2 :
     Value
-        { ch : Supported
-        , cm : Supported
-        , em : Supported
-        , ex : Supported
-        , inches : Supported
-        , mm : Supported
-        , pc : Supported
-        , pt : Supported
-        , pct : Supported
-        , px : Supported
-        , rem : Supported
-        , vh : Supported
-        , vmax : Supported
-        , vmin : Supported
-        , vw : Supported
-        , zero : Supported
-        , calc : Supported
-        }
+        (LengthSupported
+            { pct : Supported
+            }
+        )
     ->
         Value
-            { ch : Supported
-            , cm : Supported
-            , em : Supported
-            , ex : Supported
-            , inches : Supported
-            , mm : Supported
-            , pc : Supported
-            , pt : Supported
-            , pct : Supported
-            , px : Supported
-            , rem : Supported
-            , vh : Supported
-            , vmax : Supported
-            , vmin : Supported
-            , vw : Supported
-            , zero : Supported
-            , calc : Supported
-            }
+            (LengthSupported
+                { pct : Supported
+                }
+            )
     -> Style
 borderBottomRightRadius2 (Value horizontal) (Value vertical) =
     AppendProperty ("border-bottom-right-radius:" ++ horizontal ++ " " ++ vertical)
@@ -8419,27 +6511,13 @@ borderBottomRightRadius2 (Value horizontal) (Value vertical) =
 -}
 borderBottomLeftRadius :
     Value
-        { ch : Supported
-        , cm : Supported
-        , em : Supported
-        , ex : Supported
-        , inches : Supported
-        , mm : Supported
-        , pc : Supported
-        , pt : Supported
-        , pct : Supported
-        , px : Supported
-        , rem : Supported
-        , vh : Supported
-        , vmax : Supported
-        , vmin : Supported
-        , vw : Supported
-        , zero : Supported
-        , calc : Supported
-        , inherit : Supported
-        , initial : Supported
-        , unset : Supported
-        }
+        (LengthSupported
+            { pct : Supported
+            , inherit : Supported
+            , initial : Supported
+            , unset : Supported
+            }
+        )
     -> Style
 borderBottomLeftRadius (Value radius) =
     AppendProperty ("border-bottom-left-radius:" ++ radius)
@@ -8453,44 +6531,16 @@ borderBottomLeftRadius (Value radius) =
 -}
 borderBottomLeftRadius2 :
     Value
-        { ch : Supported
-        , cm : Supported
-        , em : Supported
-        , ex : Supported
-        , inches : Supported
-        , mm : Supported
-        , pc : Supported
-        , pt : Supported
-        , pct : Supported
-        , px : Supported
-        , rem : Supported
-        , vh : Supported
-        , vmax : Supported
-        , vmin : Supported
-        , vw : Supported
-        , zero : Supported
-        , calc : Supported
-        }
+        (LengthSupported
+            { pct : Supported
+            }
+        )
     ->
         Value
-            { ch : Supported
-            , cm : Supported
-            , em : Supported
-            , ex : Supported
-            , inches : Supported
-            , mm : Supported
-            , pc : Supported
-            , pt : Supported
-            , pct : Supported
-            , px : Supported
-            , rem : Supported
-            , vh : Supported
-            , vmax : Supported
-            , vmin : Supported
-            , vw : Supported
-            , zero : Supported
-            , calc : Supported
-            }
+            (LengthSupported
+                { pct : Supported
+                }
+            )
     -> Style
 borderBottomLeftRadius2 (Value horizontal) (Value vertical) =
     AppendProperty ("border-bottom-left-radius:" ++ horizontal ++ " " ++ vertical)
@@ -8508,27 +6558,13 @@ Specifies the distance by which an element's border image is set out from its bo
 -}
 borderImageOutset :
     Value
-        { ch : Supported
-        , cm : Supported
-        , em : Supported
-        , ex : Supported
-        , inches : Supported
-        , mm : Supported
-        , pc : Supported
-        , pt : Supported
-        , px : Supported
-        , rem : Supported
-        , vh : Supported
-        , vmax : Supported
-        , vmin : Supported
-        , vw : Supported
-        , zero : Supported
-        , calc : Supported
-        , num : Supported
-        , inherit : Supported
-        , initial : Supported
-        , unset : Supported
-        }
+        (LengthSupported
+            { num : Supported
+            , inherit : Supported
+            , initial : Supported
+            , unset : Supported
+            }
+        )
     -> Style
 borderImageOutset (Value width) =
     AppendProperty ("border-image-outset:" ++ width)
@@ -8546,44 +6582,16 @@ Specifies the distance by which an element's border image is set out from its bo
 -}
 borderImageOutset2 :
     Value
-        { ch : Supported
-        , cm : Supported
-        , em : Supported
-        , ex : Supported
-        , inches : Supported
-        , mm : Supported
-        , pc : Supported
-        , pt : Supported
-        , px : Supported
-        , rem : Supported
-        , vh : Supported
-        , vmax : Supported
-        , vmin : Supported
-        , vw : Supported
-        , zero : Supported
-        , calc : Supported
-        , num : Supported
-        }
+        (LengthSupported
+            { num : Supported
+            }
+        )
     ->
         Value
-            { ch : Supported
-            , cm : Supported
-            , em : Supported
-            , ex : Supported
-            , inches : Supported
-            , mm : Supported
-            , pc : Supported
-            , pt : Supported
-            , px : Supported
-            , rem : Supported
-            , vh : Supported
-            , vmax : Supported
-            , vmin : Supported
-            , vw : Supported
-            , zero : Supported
-            , calc : Supported
-            , num : Supported
-            }
+            (LengthSupported
+                { num : Supported
+                }
+            )
     -> Style
 borderImageOutset2 (Value valueTopBottom) (Value valueRightLeft) =
     AppendProperty ("border-image-outset:" ++ valueTopBottom ++ " " ++ valueRightLeft)
@@ -8601,64 +6609,22 @@ Specifies the distance by which an element's border image is set out from its bo
 -}
 borderImageOutset3 :
     Value
-        { ch : Supported
-        , cm : Supported
-        , em : Supported
-        , ex : Supported
-        , inches : Supported
-        , mm : Supported
-        , pc : Supported
-        , pt : Supported
-        , px : Supported
-        , rem : Supported
-        , vh : Supported
-        , vmax : Supported
-        , vmin : Supported
-        , vw : Supported
-        , zero : Supported
-        , calc : Supported
-        , num : Supported
-        }
+        (LengthSupported
+            { num : Supported
+            }
+        )
     ->
         Value
-            { ch : Supported
-            , cm : Supported
-            , em : Supported
-            , ex : Supported
-            , inches : Supported
-            , mm : Supported
-            , pc : Supported
-            , pt : Supported
-            , px : Supported
-            , rem : Supported
-            , vh : Supported
-            , vmax : Supported
-            , vmin : Supported
-            , vw : Supported
-            , zero : Supported
-            , calc : Supported
-            , num : Supported
-            }
+            (LengthSupported
+                { num : Supported
+                }
+            )
     ->
         Value
-            { ch : Supported
-            , cm : Supported
-            , em : Supported
-            , ex : Supported
-            , inches : Supported
-            , mm : Supported
-            , pc : Supported
-            , pt : Supported
-            , px : Supported
-            , rem : Supported
-            , vh : Supported
-            , vmax : Supported
-            , vmin : Supported
-            , vw : Supported
-            , zero : Supported
-            , calc : Supported
-            , num : Supported
-            }
+            (LengthSupported
+                { num : Supported
+                }
+            )
     -> Style
 borderImageOutset3 (Value valueTop) (Value valueRightLeft) (Value valueBottom) =
     AppendProperty ("border-image-outset:" ++ valueTop ++ " " ++ valueRightLeft ++ " " ++ valueBottom)
@@ -8676,84 +6642,28 @@ Specifies the distance by which an element's border image is set out from its bo
 -}
 borderImageOutset4 :
     Value
-        { ch : Supported
-        , cm : Supported
-        , em : Supported
-        , ex : Supported
-        , inches : Supported
-        , mm : Supported
-        , pc : Supported
-        , pt : Supported
-        , px : Supported
-        , rem : Supported
-        , vh : Supported
-        , vmax : Supported
-        , vmin : Supported
-        , vw : Supported
-        , zero : Supported
-        , calc : Supported
-        , num : Supported
-        }
+        (LengthSupported
+            { num : Supported
+            }
+        )
     ->
         Value
-            { ch : Supported
-            , cm : Supported
-            , em : Supported
-            , ex : Supported
-            , inches : Supported
-            , mm : Supported
-            , pc : Supported
-            , pt : Supported
-            , px : Supported
-            , rem : Supported
-            , vh : Supported
-            , vmax : Supported
-            , vmin : Supported
-            , vw : Supported
-            , zero : Supported
-            , calc : Supported
-            , num : Supported
-            }
+            (LengthSupported
+                { num : Supported
+                }
+            )
     ->
         Value
-            { ch : Supported
-            , cm : Supported
-            , em : Supported
-            , ex : Supported
-            , inches : Supported
-            , mm : Supported
-            , pc : Supported
-            , pt : Supported
-            , px : Supported
-            , rem : Supported
-            , vh : Supported
-            , vmax : Supported
-            , vmin : Supported
-            , vw : Supported
-            , zero : Supported
-            , calc : Supported
-            , num : Supported
-            }
+            (LengthSupported
+                { num : Supported
+                }
+            )
     ->
         Value
-            { ch : Supported
-            , cm : Supported
-            , em : Supported
-            , ex : Supported
-            , inches : Supported
-            , mm : Supported
-            , pc : Supported
-            , pt : Supported
-            , px : Supported
-            , rem : Supported
-            , vh : Supported
-            , vmax : Supported
-            , vmin : Supported
-            , vw : Supported
-            , zero : Supported
-            , calc : Supported
-            , num : Supported
-            }
+            (LengthSupported
+                { num : Supported
+                }
+            )
     -> Style
 borderImageOutset4 (Value valueTop) (Value valueRight) (Value valueBottom) (Value valueLeft) =
     AppendProperty ("border-image-outset:" ++ valueTop ++ " " ++ valueRight ++ " " ++ valueBottom ++ " " ++ valueLeft)
@@ -8771,29 +6681,15 @@ Specifies the width of an element's border image. Supports values specified as l
 -}
 borderImageWidth :
     Value
-        { ch : Supported
-        , cm : Supported
-        , em : Supported
-        , ex : Supported
-        , inches : Supported
-        , mm : Supported
-        , pc : Supported
-        , pct : Supported
-        , pt : Supported
-        , px : Supported
-        , rem : Supported
-        , vh : Supported
-        , vmax : Supported
-        , vmin : Supported
-        , vw : Supported
-        , zero : Supported
-        , calc : Supported
-        , num : Supported
-        , auto : Supported
-        , inherit : Supported
-        , initial : Supported
-        , unset : Supported
-        }
+        (LengthSupported
+            { pct : Supported
+            , num : Supported
+            , auto : Supported
+            , inherit : Supported
+            , initial : Supported
+            , unset : Supported
+            }
+        )
     -> Style
 borderImageWidth (Value width) =
     AppendProperty ("border-image-width:" ++ width)
@@ -8811,48 +6707,20 @@ Specifies the width of an element's border image. Supports values specified as l
 -}
 borderImageWidth2 :
     Value
-        { ch : Supported
-        , cm : Supported
-        , em : Supported
-        , ex : Supported
-        , inches : Supported
-        , mm : Supported
-        , pc : Supported
-        , pct : Supported
-        , pt : Supported
-        , px : Supported
-        , rem : Supported
-        , vh : Supported
-        , vmax : Supported
-        , vmin : Supported
-        , vw : Supported
-        , zero : Supported
-        , calc : Supported
-        , num : Supported
-        , auto : Supported
-        }
-    ->
-        Value
-            { ch : Supported
-            , cm : Supported
-            , em : Supported
-            , ex : Supported
-            , inches : Supported
-            , mm : Supported
-            , pc : Supported
-            , pct : Supported
-            , pt : Supported
-            , px : Supported
-            , rem : Supported
-            , vh : Supported
-            , vmax : Supported
-            , vmin : Supported
-            , vw : Supported
-            , zero : Supported
-            , calc : Supported
+        (LengthSupported
+            { pct : Supported
             , num : Supported
             , auto : Supported
             }
+        )
+    ->
+        Value
+            (LengthSupported
+                { pct : Supported
+                , num : Supported
+                , auto : Supported
+                }
+            )
     -> Style
 borderImageWidth2 (Value valueTopBottom) (Value valueRightLeft) =
     AppendProperty ("border-image-width:" ++ valueTopBottom ++ " " ++ valueRightLeft)
@@ -8870,70 +6738,28 @@ Specifies the width of an element's border image. Supports values specified as l
 -}
 borderImageWidth3 :
     Value
-        { ch : Supported
-        , cm : Supported
-        , em : Supported
-        , ex : Supported
-        , inches : Supported
-        , mm : Supported
-        , pc : Supported
-        , pct : Supported
-        , pt : Supported
-        , px : Supported
-        , rem : Supported
-        , vh : Supported
-        , vmax : Supported
-        , vmin : Supported
-        , vw : Supported
-        , zero : Supported
-        , calc : Supported
-        , num : Supported
-        , auto : Supported
-        }
-    ->
-        Value
-            { ch : Supported
-            , cm : Supported
-            , em : Supported
-            , ex : Supported
-            , inches : Supported
-            , mm : Supported
-            , pc : Supported
-            , pct : Supported
-            , pt : Supported
-            , px : Supported
-            , rem : Supported
-            , vh : Supported
-            , vmax : Supported
-            , vmin : Supported
-            , vw : Supported
-            , zero : Supported
-            , calc : Supported
+        (LengthSupported
+            { pct : Supported
             , num : Supported
             , auto : Supported
             }
+        )
     ->
         Value
-            { ch : Supported
-            , cm : Supported
-            , em : Supported
-            , ex : Supported
-            , inches : Supported
-            , mm : Supported
-            , pc : Supported
-            , pct : Supported
-            , pt : Supported
-            , px : Supported
-            , rem : Supported
-            , vh : Supported
-            , vmax : Supported
-            , vmin : Supported
-            , vw : Supported
-            , zero : Supported
-            , calc : Supported
-            , num : Supported
-            , auto : Supported
-            }
+            (LengthSupported
+                { pct : Supported
+                , num : Supported
+                , auto : Supported
+                }
+            )
+    ->
+        Value
+            (LengthSupported
+                { pct : Supported
+                , num : Supported
+                , auto : Supported
+                }
+            )
     -> Style
 borderImageWidth3 (Value valueTop) (Value valueRightLeft) (Value valueBottom) =
     AppendProperty ("border-image-width:" ++ valueTop ++ " " ++ valueRightLeft ++ " " ++ valueBottom)
@@ -8951,92 +6777,36 @@ Specifies the width of an element's border image. Supports values specified as l
 -}
 borderImageWidth4 :
     Value
-        { ch : Supported
-        , cm : Supported
-        , em : Supported
-        , ex : Supported
-        , inches : Supported
-        , mm : Supported
-        , pc : Supported
-        , pct : Supported
-        , pt : Supported
-        , px : Supported
-        , rem : Supported
-        , vh : Supported
-        , vmax : Supported
-        , vmin : Supported
-        , vw : Supported
-        , zero : Supported
-        , calc : Supported
-        , num : Supported
-        , auto : Supported
-        }
-    ->
-        Value
-            { ch : Supported
-            , cm : Supported
-            , em : Supported
-            , ex : Supported
-            , inches : Supported
-            , mm : Supported
-            , pc : Supported
-            , pct : Supported
-            , pt : Supported
-            , px : Supported
-            , rem : Supported
-            , vh : Supported
-            , vmax : Supported
-            , vmin : Supported
-            , vw : Supported
-            , zero : Supported
-            , calc : Supported
+        (LengthSupported
+            { pct : Supported
             , num : Supported
             , auto : Supported
             }
+        )
     ->
         Value
-            { ch : Supported
-            , cm : Supported
-            , em : Supported
-            , ex : Supported
-            , inches : Supported
-            , mm : Supported
-            , pc : Supported
-            , pct : Supported
-            , pt : Supported
-            , px : Supported
-            , rem : Supported
-            , vh : Supported
-            , vmax : Supported
-            , vmin : Supported
-            , vw : Supported
-            , zero : Supported
-            , calc : Supported
-            , num : Supported
-            , auto : Supported
-            }
+            (LengthSupported
+                { pct : Supported
+                , num : Supported
+                , auto : Supported
+                }
+            )
     ->
         Value
-            { ch : Supported
-            , cm : Supported
-            , em : Supported
-            , ex : Supported
-            , inches : Supported
-            , mm : Supported
-            , pc : Supported
-            , pct : Supported
-            , pt : Supported
-            , px : Supported
-            , rem : Supported
-            , vh : Supported
-            , vmax : Supported
-            , vmin : Supported
-            , vw : Supported
-            , zero : Supported
-            , calc : Supported
-            , num : Supported
-            , auto : Supported
-            }
+            (LengthSupported
+                { pct : Supported
+                , num : Supported
+                , auto : Supported
+                }
+            )
+    ->
+        Value
+            (LengthSupported
+                { pct : Supported
+                , num : Supported
+                , auto : Supported
+                }
+            )
     -> Style
 borderImageWidth4 (Value valueTop) (Value valueRight) (Value valueBottom) (Value valueLeft) =
     AppendProperty ("border-image-width:" ++ valueTop ++ " " ++ valueRight ++ " " ++ valueBottom ++ " " ++ valueLeft)
@@ -9298,16 +7068,7 @@ textDecoration3 :
             , dashed : Supported
             , wavy : Supported
             }
-    ->
-        Value
-            { rgb : Supported
-            , rgba : Supported
-            , hsl : Supported
-            , hsla : Supported
-            , hex : Supported
-            , transparent : Supported
-            , currentColor : Supported
-            }
+    -> Value Color
     -> Style
 textDecoration3 (Value line) (Value style) (Value color) =
     AppendProperty ("text-decoration:" ++ line ++ " " ++ style ++ " " ++ color)
@@ -9427,17 +7188,12 @@ textDecorationStyle (Value style) =
 -}
 textDecorationColor :
     Value
-        { rgb : Supported
-        , rgba : Supported
-        , hsl : Supported
-        , hsla : Supported
-        , hex : Supported
-        , transparent : Supported
-        , currentColor : Supported
-        , inherit : Supported
-        , initial : Supported
-        , unset : Supported
-        }
+        (ColorSupported
+            { inherit : Supported
+            , initial : Supported
+            , unset : Supported
+            }
+        )
     -> Style
 textDecorationColor (Value color) =
     AppendProperty ("text-decoration-color:" ++ color)
@@ -9605,26 +7361,12 @@ separate =
 -}
 borderSpacing :
     Value
-        { zero : Supported
-        , calc : Supported
-        , ch : Supported
-        , em : Supported
-        , ex : Supported
-        , rem : Supported
-        , vh : Supported
-        , vw : Supported
-        , vmin : Supported
-        , vmax : Supported
-        , px : Supported
-        , cm : Supported
-        , mm : Supported
-        , inches : Supported
-        , pc : Supported
-        , pt : Supported
-        , initial : Supported
-        , inherit : Supported
-        , unset : Supported
-        }
+        (LengthSupported
+            { initial : Supported
+            , inherit : Supported
+            , unset : Supported
+            }
+        )
     -> Style
 borderSpacing (Value str) =
     AppendProperty ("border-spacing:" ++ str)
@@ -9636,43 +7378,8 @@ borderSpacing (Value str) =
 
 -}
 borderSpacing2 :
-    Value
-        { zero : Supported
-        , calc : Supported
-        , ch : Supported
-        , em : Supported
-        , ex : Supported
-        , rem : Supported
-        , vh : Supported
-        , vw : Supported
-        , vmin : Supported
-        , vmax : Supported
-        , px : Supported
-        , cm : Supported
-        , mm : Supported
-        , inches : Supported
-        , pc : Supported
-        , pt : Supported
-        }
-    ->
-        Value
-            { zero : Supported
-            , calc : Supported
-            , ch : Supported
-            , em : Supported
-            , ex : Supported
-            , rem : Supported
-            , vh : Supported
-            , vw : Supported
-            , vmin : Supported
-            , vmax : Supported
-            , px : Supported
-            , cm : Supported
-            , mm : Supported
-            , inches : Supported
-            , pc : Supported
-            , pt : Supported
-            }
+    Value Length
+    -> Value Length
     -> Style
 borderSpacing2 (Value horizontal) (Value vertical) =
     AppendProperty ("border-spacing:" ++ horizontal ++ " " ++ vertical)
@@ -9779,35 +7486,21 @@ tableLayout (Value str) =
 -}
 verticalAlign :
     Value
-        { baseline : Supported
-        , sub : Supported
-        , super : Supported
-        , textTop : Supported
-        , textBottom : Supported
-        , middle : Supported
-        , top_ : Supported
-        , bottom_ : Supported
-        , pct : Supported
-        , zero : Supported
-        , calc : Supported
-        , ch : Supported
-        , em : Supported
-        , ex : Supported
-        , rem : Supported
-        , vh : Supported
-        , vw : Supported
-        , vmin : Supported
-        , vmax : Supported
-        , px : Supported
-        , cm : Supported
-        , mm : Supported
-        , inches : Supported
-        , pc : Supported
-        , pt : Supported
-        , initial : Supported
-        , inherit : Supported
-        , unset : Supported
-        }
+        (LengthSupported
+            { baseline : Supported
+            , sub : Supported
+            , super : Supported
+            , textTop : Supported
+            , textBottom : Supported
+            , middle : Supported
+            , top_ : Supported
+            , bottom_ : Supported
+            , pct : Supported
+            , initial : Supported
+            , inherit : Supported
+            , unset : Supported
+            }
+        )
     -> Style
 verticalAlign (Value str) =
     AppendProperty ("vertical-align:" ++ str)
@@ -10147,18 +7840,13 @@ order (Value val) =
 -}
 fill :
     Value
-        { rgb : Supported
-        , rgba : Supported
-        , hsl : Supported
-        , hsla : Supported
-        , hex : Supported
-        , currentColor : Supported
-        , transparent : Supported
-        , url : Supported
-        , inherit : Supported
-        , initial : Supported
-        , unset : Supported
-        }
+        (ColorSupported
+            { url : Supported
+            , inherit : Supported
+            , initial : Supported
+            , unset : Supported
+            }
+        )
     -> Style
 fill (Value val) =
     AppendProperty ("fill:" ++ val)
@@ -10176,27 +7864,13 @@ fill (Value val) =
 -}
 columns :
     Value
-        { auto : Supported
-        , zero : Supported
-        , calc : Supported
-        , ch : Supported
-        , em : Supported
-        , ex : Supported
-        , rem : Supported
-        , vh : Supported
-        , vw : Supported
-        , vmin : Supported
-        , vmax : Supported
-        , px : Supported
-        , cm : Supported
-        , mm : Supported
-        , inches : Supported
-        , pc : Supported
-        , pt : Supported
-        , initial : Supported
-        , inherit : Supported
-        , unset : Supported
-        }
+        (LengthSupported
+            { auto : Supported
+            , initial : Supported
+            , inherit : Supported
+            , unset : Supported
+            }
+        )
     -> Style
 columns (Value width) =
     AppendProperty ("columns:" ++ width)
@@ -10210,24 +7884,10 @@ columns (Value width) =
 -}
 columns2 :
     Value
-        { auto : Supported
-        , zero : Supported
-        , calc : Supported
-        , ch : Supported
-        , em : Supported
-        , ex : Supported
-        , rem : Supported
-        , vh : Supported
-        , vw : Supported
-        , vmin : Supported
-        , vmax : Supported
-        , px : Supported
-        , cm : Supported
-        , mm : Supported
-        , inches : Supported
-        , pc : Supported
-        , pt : Supported
-        }
+        (LengthSupported
+            { auto : Supported
+            }
+        )
     ->
         Value
             { auto : Supported
@@ -10246,27 +7906,13 @@ columns2 (Value width) (Value count) =
 -}
 columnWidth :
     Value
-        { auto : Supported
-        , zero : Supported
-        , calc : Supported
-        , ch : Supported
-        , em : Supported
-        , ex : Supported
-        , rem : Supported
-        , vh : Supported
-        , vw : Supported
-        , vmin : Supported
-        , vmax : Supported
-        , px : Supported
-        , cm : Supported
-        , mm : Supported
-        , inches : Supported
-        , pc : Supported
-        , pt : Supported
-        , initial : Supported
-        , inherit : Supported
-        , unset : Supported
-        }
+        (LengthSupported
+            { auto : Supported
+            , initial : Supported
+            , inherit : Supported
+            , unset : Supported
+            }
+        )
     -> Style
 columnWidth (Value width) =
     AppendProperty ("column-width:" ++ width)
@@ -10369,27 +8015,13 @@ all_ =
 -}
 columnGap :
     Value
-        { normal : Supported
-        , zero : Supported
-        , calc : Supported
-        , ch : Supported
-        , em : Supported
-        , ex : Supported
-        , rem : Supported
-        , vh : Supported
-        , vw : Supported
-        , vmin : Supported
-        , vmax : Supported
-        , px : Supported
-        , cm : Supported
-        , mm : Supported
-        , inches : Supported
-        , pc : Supported
-        , pt : Supported
-        , initial : Supported
-        , inherit : Supported
-        , unset : Supported
-        }
+        (LengthSupported
+            { normal : Supported
+            , initial : Supported
+            , inherit : Supported
+            , unset : Supported
+            }
+        )
     -> Style
 columnGap (Value width) =
     AppendProperty ("column-gap:" ++ width)
@@ -10403,29 +8035,12 @@ columnGap (Value width) =
 -}
 columnRuleWidth :
     Value
-        { thin : Supported
-        , medium : Supported
-        , thick : Supported
-        , zero : Supported
-        , calc : Supported
-        , ch : Supported
-        , em : Supported
-        , ex : Supported
-        , rem : Supported
-        , vh : Supported
-        , vw : Supported
-        , vmin : Supported
-        , vmax : Supported
-        , px : Supported
-        , cm : Supported
-        , mm : Supported
-        , inches : Supported
-        , pc : Supported
-        , pt : Supported
-        , initial : Supported
-        , inherit : Supported
-        , unset : Supported
-        }
+        (BorderWidthSupported
+            { initial : Supported
+            , inherit : Supported
+            , unset : Supported
+            }
+        )
     -> Style
 columnRuleWidth (Value width) =
     AppendProperty ("column-rule-width:" ++ width)
@@ -10440,20 +8055,12 @@ columnRuleWidth (Value width) =
 -}
 columnRuleStyle :
     Value
-        { solid : Supported
-        , none : Supported
-        , hidden : Supported
-        , dashed : Supported
-        , dotted : Supported
-        , double : Supported
-        , groove : Supported
-        , ridge : Supported
-        , inset : Supported
-        , outset : Supported
-        , inherit : Supported
-        , initial : Supported
-        , unset : Supported
-        }
+        (BorderStyleSupported
+            { inherit : Supported
+            , initial : Supported
+            , unset : Supported
+            }
+        )
     -> Style
 columnRuleStyle (Value style) =
     AppendProperty ("column-rule-style:" ++ style)
@@ -10467,17 +8074,12 @@ columnRuleStyle (Value style) =
 -}
 columnRuleColor :
     Value
-        { rgb : Supported
-        , rgba : Supported
-        , hsl : Supported
-        , hsla : Supported
-        , hex : Supported
-        , transparent : Supported
-        , currentColor : Supported
-        , inherit : Supported
-        , initial : Supported
-        , unset : Supported
-        }
+        (ColorSupported
+            { inherit : Supported
+            , initial : Supported
+            , unset : Supported
+            }
+        )
     -> Style
 columnRuleColor (Value color) =
     AppendProperty ("column-rule-color:" ++ color)
@@ -10497,28 +8099,14 @@ columnRuleColor (Value color) =
 -}
 strokeDasharray :
     Value
-        { zero : Supported
-        , calc : Supported
-        , num : Supported
-        , ch : Supported
-        , em : Supported
-        , ex : Supported
-        , rem : Supported
-        , vh : Supported
-        , vw : Supported
-        , vmin : Supported
-        , vmax : Supported
-        , px : Supported
-        , cm : Supported
-        , mm : Supported
-        , inches : Supported
-        , pc : Supported
-        , pct : Supported
-        , pt : Supported
-        , inherit : Supported
-        , initial : Supported
-        , unset : Supported
-        }
+        (LengthSupported
+            { num : Supported
+            , pct : Supported
+            , inherit : Supported
+            , initial : Supported
+            , unset : Supported
+            }
+        )
     -> Style
 strokeDasharray (Value val) =
     AppendProperty ("stroke-dasharray:" ++ val)
@@ -10599,28 +8187,14 @@ square =
 -}
 strokeWidth :
     Value
-        { zero : Supported
-        , calc : Supported
-        , num : Supported
-        , ch : Supported
-        , em : Supported
-        , ex : Supported
-        , rem : Supported
-        , vh : Supported
-        , vw : Supported
-        , vmin : Supported
-        , vmax : Supported
-        , px : Supported
-        , cm : Supported
-        , mm : Supported
-        , inches : Supported
-        , pc : Supported
-        , pct : Supported
-        , pt : Supported
-        , inherit : Supported
-        , initial : Supported
-        , unset : Supported
-        }
+        (LengthSupported
+            { num : Supported
+            , pct : Supported
+            , inherit : Supported
+            , initial : Supported
+            , unset : Supported
+            }
+        )
     -> Style
 strokeWidth (Value val) =
     AppendProperty ("stroke-width:" ++ val)
@@ -10706,17 +8280,12 @@ clone =
 -}
 strokeColor :
     Value
-        { rgb : Supported
-        , rgba : Supported
-        , hsl : Supported
-        , hsla : Supported
-        , hex : Supported
-        , currentColor : Supported
-        , transparent : Supported
-        , inherit : Supported
-        , initial : Supported
-        , unset : Supported
-        }
+        (ColorSupported
+            { inherit : Supported
+            , initial : Supported
+            , unset : Supported
+            }
+        )
     -> Style
 strokeColor (Value val) =
     AppendProperty ("stroke-color:" ++ val)
@@ -10841,30 +8410,16 @@ If you need to set the offsets from the right or bottom, use
 -}
 strokePosition :
     Value
-        { ch : Supported
-        , cm : Supported
-        , em : Supported
-        , ex : Supported
-        , inches : Supported
-        , mm : Supported
-        , pc : Supported
-        , pct : Supported
-        , pt : Supported
-        , px : Supported
-        , rem : Supported
-        , vh : Supported
-        , vmax : Supported
-        , vmin : Supported
-        , vw : Supported
-        , zero : Supported
-        , calc : Supported
-        , left_ : Supported
-        , right_ : Supported
-        , center : Supported
-        , inherit : Supported
-        , unset : Supported
-        , initial : Supported
-        }
+        (LengthSupported
+            { pct : Supported
+            , left_ : Supported
+            , right_ : Supported
+            , center : Supported
+            , inherit : Supported
+            , unset : Supported
+            , initial : Supported
+            }
+        )
     -> Style
 strokePosition (Value horiz) =
     AppendProperty ("stroke-position:" ++ horiz)
@@ -10890,50 +8445,22 @@ If you need to set the offsets from the right or bottom, use
 -}
 strokePosition2 :
     Value
-        { ch : Supported
-        , cm : Supported
-        , em : Supported
-        , ex : Supported
-        , inches : Supported
-        , mm : Supported
-        , pc : Supported
-        , pct : Supported
-        , pt : Supported
-        , px : Supported
-        , rem : Supported
-        , vh : Supported
-        , vmax : Supported
-        , vmin : Supported
-        , vw : Supported
-        , zero : Supported
-        , calc : Supported
-        , left_ : Supported
-        , right_ : Supported
-        , center : Supported
-        }
-    ->
-        Value
-            { ch : Supported
-            , cm : Supported
-            , em : Supported
-            , ex : Supported
-            , inches : Supported
-            , mm : Supported
-            , pc : Supported
-            , pct : Supported
-            , pt : Supported
-            , px : Supported
-            , rem : Supported
-            , vh : Supported
-            , vmax : Supported
-            , vmin : Supported
-            , vw : Supported
-            , zero : Supported
-            , calc : Supported
-            , top_ : Supported
-            , bottom_ : Supported
+        (LengthSupported
+            { pct : Supported
+            , left_ : Supported
+            , right_ : Supported
             , center : Supported
             }
+        )
+    ->
+        Value
+            (LengthSupported
+                { pct : Supported
+                , top_ : Supported
+                , bottom_ : Supported
+                , center : Supported
+                }
+            )
     -> Style
 strokePosition2 (Value horiz) (Value vert) =
     AppendProperty ("stroke-position:" ++ horiz ++ " " ++ vert)
@@ -10959,24 +8486,10 @@ strokePosition4 :
         }
     ->
         Value
-            { ch : Supported
-            , cm : Supported
-            , em : Supported
-            , ex : Supported
-            , inches : Supported
-            , mm : Supported
-            , pc : Supported
-            , pct : Supported
-            , pt : Supported
-            , px : Supported
-            , rem : Supported
-            , vh : Supported
-            , vmax : Supported
-            , vmin : Supported
-            , vw : Supported
-            , zero : Supported
-            , calc : Supported
-            }
+            (LengthSupported
+                { pct : Supported
+                }
+            )
     ->
         Value
             { top_ : Supported
@@ -10984,24 +8497,10 @@ strokePosition4 :
             }
     ->
         Value
-            { ch : Supported
-            , cm : Supported
-            , em : Supported
-            , ex : Supported
-            , inches : Supported
-            , mm : Supported
-            , pc : Supported
-            , pct : Supported
-            , pt : Supported
-            , px : Supported
-            , rem : Supported
-            , vh : Supported
-            , vmax : Supported
-            , vmin : Supported
-            , vw : Supported
-            , zero : Supported
-            , calc : Supported
-            }
+            (LengthSupported
+                { pct : Supported
+                }
+            )
     -> Style
 strokePosition4 (Value horiz) (Value horizAmount) (Value vert) (Value vertAmount) =
     AppendProperty
@@ -11086,27 +8585,15 @@ need to set both width and height explicitly, use
 -}
 strokeSize :
     Value
-        { px : Supported
-        , cm : Supported
-        , mm : Supported
-        , inches : Supported
-        , pc : Supported
-        , pct : Supported
-        , pt : Supported
-        , ch : Supported
-        , em : Supported
-        , ex : Supported
-        , rem : Supported
-        , vh : Supported
-        , vw : Supported
-        , vmin : Supported
-        , vmax : Supported
-        , auto : Supported
-        , cover : Supported
-        , inherit : Supported
-        , initial : Supported
-        , unset : Supported
-        }
+        (LengthSupported
+            { pct : Supported
+            , auto : Supported
+            , cover : Supported
+            , inherit : Supported
+            , initial : Supported
+            , unset : Supported
+            }
+        )
     -> Style
 strokeSize (Value size) =
     AppendProperty ("stroke-size:" ++ size)
@@ -11123,42 +8610,18 @@ If you only want to set the width, use [`strokeImage`](#strokeImage) instead.
 -}
 strokeSize2 :
     Value
-        { px : Supported
-        , cm : Supported
-        , mm : Supported
-        , inches : Supported
-        , pc : Supported
-        , pct : Supported
-        , pt : Supported
-        , ch : Supported
-        , em : Supported
-        , ex : Supported
-        , rem : Supported
-        , vh : Supported
-        , vw : Supported
-        , vmin : Supported
-        , vmax : Supported
-        , auto : Supported
-        }
-    ->
-        Value
-            { px : Supported
-            , cm : Supported
-            , mm : Supported
-            , inches : Supported
-            , pc : Supported
-            , pct : Supported
-            , pt : Supported
-            , ch : Supported
-            , em : Supported
-            , ex : Supported
-            , rem : Supported
-            , vh : Supported
-            , vw : Supported
-            , vmin : Supported
-            , vmax : Supported
+        (LengthSupported
+            { pct : Supported
             , auto : Supported
             }
+        )
+    ->
+        Value
+            (LengthSupported
+                { pct : Supported
+                , auto : Supported
+                }
+            )
     -> Style
 strokeSize2 (Value width) (Value height) =
     AppendProperty ("stroke-size:" ++ width ++ " " ++ height)
@@ -11173,28 +8636,16 @@ strokeSize2 (Value width) (Value height) =
 -}
 strokeDashCorner :
     Value
-        { none : Supported
-        , px : Supported
-        , cm : Supported
-        , mm : Supported
-        , inches : Supported
-        , pc : Supported
-        , pct : Supported
-        , pt : Supported
-        , ch : Supported
-        , em : Supported
-        , ex : Supported
-        , rem : Supported
-        , vh : Supported
-        , vw : Supported
-        , vmin : Supported
-        , vmax : Supported
-        , auto : Supported
-        , cover : Supported
-        , inherit : Supported
-        , initial : Supported
-        , unset : Supported
-        }
+        (LengthSupported
+            { none : Supported
+            , pct : Supported
+            , auto : Supported
+            , cover : Supported
+            , inherit : Supported
+            , initial : Supported
+            , unset : Supported
+            }
+        )
     -> Style
 strokeDashCorner (Value size) =
     AppendProperty ("stroke-dash-corner:" ++ size)
@@ -11365,29 +8816,12 @@ properties.
 -}
 columnRule :
     Value
-        { thin : Supported
-        , medium : Supported
-        , thick : Supported
-        , zero : Supported
-        , calc : Supported
-        , ch : Supported
-        , em : Supported
-        , ex : Supported
-        , rem : Supported
-        , vh : Supported
-        , vw : Supported
-        , vmin : Supported
-        , vmax : Supported
-        , px : Supported
-        , cm : Supported
-        , mm : Supported
-        , inches : Supported
-        , pc : Supported
-        , pt : Supported
-        , initial : Supported
-        , inherit : Supported
-        , unset : Supported
-        }
+        (BorderWidthSupported
+            { initial : Supported
+            , inherit : Supported
+            , unset : Supported
+            }
+        )
     -> Style
 columnRule (Value width) =
     AppendProperty ("column-rule:" ++ width)
@@ -11404,40 +8838,8 @@ properties.
 
 -}
 columnRule2 :
-    Value
-        { thin : Supported
-        , medium : Supported
-        , thick : Supported
-        , zero : Supported
-        , calc : Supported
-        , ch : Supported
-        , em : Supported
-        , ex : Supported
-        , rem : Supported
-        , vh : Supported
-        , vw : Supported
-        , vmin : Supported
-        , vmax : Supported
-        , px : Supported
-        , cm : Supported
-        , mm : Supported
-        , inches : Supported
-        , pc : Supported
-        , pt : Supported
-        }
-    ->
-        Value
-            { solid : Supported
-            , none : Supported
-            , hidden : Supported
-            , dashed : Supported
-            , dotted : Supported
-            , double : Supported
-            , groove : Supported
-            , ridge : Supported
-            , inset : Supported
-            , outset : Supported
-            }
+    Value BorderWidth
+    -> Value BorderStyle
     -> Style
 columnRule2 (Value width) (Value style) =
     AppendProperty ("column-rule:" ++ width ++ " " ++ style)
@@ -11454,49 +8856,9 @@ properties.
 
 -}
 columnRule3 :
-    Value
-        { thin : Supported
-        , medium : Supported
-        , thick : Supported
-        , zero : Supported
-        , ch : Supported
-        , em : Supported
-        , ex : Supported
-        , rem : Supported
-        , vh : Supported
-        , vw : Supported
-        , vmin : Supported
-        , vmax : Supported
-        , px : Supported
-        , cm : Supported
-        , mm : Supported
-        , inches : Supported
-        , pc : Supported
-        , pt : Supported
-        }
-    ->
-        Value
-            { solid : Supported
-            , none : Supported
-            , hidden : Supported
-            , dashed : Supported
-            , dotted : Supported
-            , double : Supported
-            , groove : Supported
-            , ridge : Supported
-            , inset : Supported
-            , outset : Supported
-            }
-    ->
-        Value
-            { rgb : Supported
-            , rgba : Supported
-            , hsl : Supported
-            , hsla : Supported
-            , hex : Supported
-            , transparent : Supported
-            , currentColor : Supported
-            }
+    Value BorderWidth
+    -> Value BorderStyle
+    -> Value Color
     -> Style
 columnRule3 (Value width) (Value style) (Value color) =
     AppendProperty ("column-rule:" ++ width ++ " " ++ style ++ " " ++ color)
@@ -11700,24 +9062,7 @@ matrix3d a1 b1 c1 d1 a2 b2 c2 d2 a3 b3 c3 d3 a4 b4 c4 d4 =
 
 -}
 translate :
-    Value
-        { zero : Supported
-        , calc : Supported
-        , ch : Supported
-        , em : Supported
-        , ex : Supported
-        , rem : Supported
-        , vh : Supported
-        , vw : Supported
-        , vmin : Supported
-        , vmax : Supported
-        , px : Supported
-        , cm : Supported
-        , mm : Supported
-        , inches : Supported
-        , pc : Supported
-        , pt : Supported
-        }
+    Value Length
     -> Value { provides | translate : Supported }
 translate (Value x) =
     Value ("translate(" ++ x ++ ")")
@@ -11729,43 +9074,8 @@ translate (Value x) =
 
 -}
 translate2 :
-    Value
-        { zero : Supported
-        , calc : Supported
-        , ch : Supported
-        , em : Supported
-        , ex : Supported
-        , rem : Supported
-        , vh : Supported
-        , vw : Supported
-        , vmin : Supported
-        , vmax : Supported
-        , px : Supported
-        , cm : Supported
-        , mm : Supported
-        , inches : Supported
-        , pc : Supported
-        , pt : Supported
-        }
-    ->
-        Value
-            { zero : Supported
-            , calc : Supported
-            , ch : Supported
-            , em : Supported
-            , ex : Supported
-            , rem : Supported
-            , vh : Supported
-            , vw : Supported
-            , vmin : Supported
-            , vmax : Supported
-            , px : Supported
-            , cm : Supported
-            , mm : Supported
-            , inches : Supported
-            , pc : Supported
-            , pt : Supported
-            }
+    Value Length
+    -> Value Length
     -> Value { provides | translate2 : Supported }
 translate2 (Value x) (Value y) =
     Value ("translate(" ++ x ++ "," ++ y ++ ")")
@@ -11777,24 +9087,7 @@ translate2 (Value x) (Value y) =
 
 -}
 translateX :
-    Value
-        { zero : Supported
-        , calc : Supported
-        , ch : Supported
-        , em : Supported
-        , ex : Supported
-        , rem : Supported
-        , vh : Supported
-        , vw : Supported
-        , vmin : Supported
-        , vmax : Supported
-        , px : Supported
-        , cm : Supported
-        , mm : Supported
-        , inches : Supported
-        , pc : Supported
-        , pt : Supported
-        }
+    Value Length
     -> Value { provides | translateX : Supported }
 translateX (Value x) =
     Value ("translateX(" ++ x ++ ")")
@@ -11806,24 +9099,7 @@ translateX (Value x) =
 
 -}
 translateY :
-    Value
-        { zero : Supported
-        , calc : Supported
-        , ch : Supported
-        , em : Supported
-        , ex : Supported
-        , rem : Supported
-        , vh : Supported
-        , vw : Supported
-        , vmin : Supported
-        , vmax : Supported
-        , px : Supported
-        , cm : Supported
-        , mm : Supported
-        , inches : Supported
-        , pc : Supported
-        , pt : Supported
-        }
+    Value Length
     -> Value { provides | translateY : Supported }
 translateY (Value y) =
     Value ("translateY(" ++ y ++ ")")
@@ -11835,24 +9111,7 @@ translateY (Value y) =
 
 -}
 translateZ :
-    Value
-        { zero : Supported
-        , calc : Supported
-        , ch : Supported
-        , em : Supported
-        , ex : Supported
-        , rem : Supported
-        , vh : Supported
-        , vw : Supported
-        , vmin : Supported
-        , vmax : Supported
-        , px : Supported
-        , cm : Supported
-        , mm : Supported
-        , inches : Supported
-        , pc : Supported
-        , pt : Supported
-        }
+    Value Length
     -> Value { provides | translateZ : Supported }
 translateZ (Value z) =
     Value ("translateZ(" ++ z ++ ")")
@@ -11865,64 +9124,22 @@ translateZ (Value z) =
 -}
 translate3d :
     Value
-        { zero : Supported
-        , calc : Supported
-        , ch : Supported
-        , em : Supported
-        , ex : Supported
-        , rem : Supported
-        , vh : Supported
-        , vw : Supported
-        , vmin : Supported
-        , vmax : Supported
-        , px : Supported
-        , cm : Supported
-        , mm : Supported
-        , inches : Supported
-        , pc : Supported
-        , pt : Supported
-        , pct : Supported
-        }
+        (LengthSupported
+            { pct : Supported
+            }
+        )
     ->
         Value
-            { zero : Supported
-            , calc : Supported
-            , ch : Supported
-            , em : Supported
-            , ex : Supported
-            , rem : Supported
-            , vh : Supported
-            , vw : Supported
-            , vmin : Supported
-            , vmax : Supported
-            , px : Supported
-            , cm : Supported
-            , mm : Supported
-            , inches : Supported
-            , pc : Supported
-            , pt : Supported
-            , pct : Supported
-            }
+            (LengthSupported
+                { pct : Supported
+                }
+            )
     ->
         Value
-            { zero : Supported
-            , calc : Supported
-            , ch : Supported
-            , em : Supported
-            , ex : Supported
-            , rem : Supported
-            , vh : Supported
-            , vw : Supported
-            , vmin : Supported
-            , vmax : Supported
-            , px : Supported
-            , cm : Supported
-            , mm : Supported
-            , inches : Supported
-            , pc : Supported
-            , pt : Supported
-            , pct : Supported
-            }
+            (LengthSupported
+                { pct : Supported
+                }
+            )
     -> Value { provides | translate3d : Supported }
 translate3d (Value x) (Value y) (Value z) =
     Value ("translate3d(" ++ x ++ "," ++ y ++ "," ++ z ++ ")")
@@ -12006,12 +9223,7 @@ scale3d x y z =
 
 -}
 skew :
-    Value
-        { deg : Supported
-        , grad : Supported
-        , rad : Supported
-        , turn : Supported
-        }
+    Value Angle
     -> Value { provides | skew : Supported }
 skew (Value angle) =
     Value ("skew(" ++ angle ++ ")")
@@ -12023,19 +9235,8 @@ skew (Value angle) =
 
 -}
 skew2 :
-    Value
-        { deg : Supported
-        , grad : Supported
-        , rad : Supported
-        , turn : Supported
-        }
-    ->
-        Value
-            { deg : Supported
-            , grad : Supported
-            , rad : Supported
-            , turn : Supported
-            }
+    Value Angle
+    -> Value Angle
     -> Value { provides | skew2 : Supported }
 skew2 (Value angle1) (Value angle2) =
     Value ("skew(" ++ angle1 ++ "," ++ angle2 ++ ")")
@@ -12047,12 +9248,7 @@ skew2 (Value angle1) (Value angle2) =
 
 -}
 skewX :
-    Value
-        { deg : Supported
-        , grad : Supported
-        , rad : Supported
-        , turn : Supported
-        }
+    Value Angle
     -> Value { provides | skewX : Supported }
 skewX (Value angle) =
     Value ("skewX(" ++ angle ++ ")")
@@ -12064,12 +9260,7 @@ skewX (Value angle) =
 
 -}
 skewY :
-    Value
-        { deg : Supported
-        , grad : Supported
-        , rad : Supported
-        , turn : Supported
-        }
+    Value Angle
     -> Value { provides | skewY : Supported }
 skewY (Value angle) =
     Value ("skewY(" ++ angle ++ ")")
@@ -12085,12 +9276,7 @@ skewY (Value angle) =
 
 -}
 rotate :
-    Value
-        { deg : Supported
-        , grad : Supported
-        , rad : Supported
-        , turn : Supported
-        }
+    Value Angle
     -> Value { provides | rotate : Supported }
 rotate (Value angle) =
     Value ("rotate(" ++ angle ++ ")")
@@ -12102,12 +9288,7 @@ rotate (Value angle) =
 
 -}
 rotateX :
-    Value
-        { deg : Supported
-        , grad : Supported
-        , rad : Supported
-        , turn : Supported
-        }
+    Value Angle
     -> Value { provides | rotateX : Supported }
 rotateX (Value angle) =
     Value ("rotateX(" ++ angle ++ ")")
@@ -12119,12 +9300,7 @@ rotateX (Value angle) =
 
 -}
 rotateY :
-    Value
-        { deg : Supported
-        , grad : Supported
-        , rad : Supported
-        , turn : Supported
-        }
+    Value Angle
     -> Value { provides | rotateY : Supported }
 rotateY (Value angle) =
     Value ("rotateY(" ++ angle ++ ")")
@@ -12136,12 +9312,7 @@ rotateY (Value angle) =
 
 -}
 rotateZ :
-    Value
-        { deg : Supported
-        , grad : Supported
-        , rad : Supported
-        , turn : Supported
-        }
+    Value Angle
     -> Value { provides | rotateZ : Supported }
 rotateZ (Value angle) =
     Value ("rotateZ(" ++ angle ++ ")")
@@ -12156,13 +9327,7 @@ rotate3d :
     Float
     -> Float
     -> Float
-    ->
-        Value
-            { deg : Supported
-            , grad : Supported
-            , rad : Supported
-            , turn : Supported
-            }
+    -> Value Angle
     -> Value { provides | rotate3d : Supported }
 rotate3d x y z (Value angle) =
     Value
@@ -12188,24 +9353,7 @@ rotate3d x y z (Value angle) =
 
 -}
 perspective :
-    Value
-        { zero : Supported
-        , calc : Supported
-        , ch : Supported
-        , em : Supported
-        , ex : Supported
-        , rem : Supported
-        , vh : Supported
-        , vw : Supported
-        , vmin : Supported
-        , vmax : Supported
-        , px : Supported
-        , cm : Supported
-        , mm : Supported
-        , inches : Supported
-        , pc : Supported
-        , pt : Supported
-        }
+    Value Length
     -> Value { provides | perspective : Supported }
 perspective (Value length) =
     Value ("perspective(" ++ length ++ ")")

--- a/src/Css.elm
+++ b/src/Css.elm
@@ -15,6 +15,10 @@ module Css
         , ListStyle
         , ListStyleSupported
         , Style
+        , Stylist
+        , Stylist2
+        , Stylist3
+        , Stylist4
         , Supported
         , Value
         , absolute
@@ -532,6 +536,11 @@ functions let you define custom properties and selectors, respectively.
 @docs Style, batch
 
 
+## Style functions types
+
+@docs Stylist, Stylist2, Stylist3, Stylist4
+
+
 ## Custom Properties
 
 @docs property
@@ -1001,6 +1010,37 @@ type Supported
     = Supported
 
 
+{-| A type alias for functions returning a `Style` from one `Value`. This alias
+will make the `Value` support the `initial`, `inherit` and `unset` global values.
+-}
+type alias Stylist v =
+    Value
+        { v
+            | initial : Supported
+            , inherit : Supported
+            , unset : Supported
+        }
+    -> Style
+
+
+{-| A type alias for functions returning a `Style` from two `Value`.
+-}
+type alias Stylist2 v1 v2 =
+    Value v1 -> Value v2 -> Style
+
+
+{-| A type alias for functions returning a `Style` from three `Value`.
+-}
+type alias Stylist3 v1 v2 v3 =
+    Value v1 -> Value v2 -> Value v3 -> Style
+
+
+{-| A type alias for functions returning a `Style` from four `Value`.
+-}
+type alias Stylist4 v1 v2 v3 v4 =
+    Value v1 -> Value v2 -> Value v3 -> Value v4 -> Style
+
+
 {-| A type alias used to accept a [length](https://developer.mozilla.org/en-US/docs/Web/CSS/length)
 among other values.
 -}
@@ -1352,16 +1392,12 @@ borderBox =
 
 -}
 overflow :
-    Value
+    Stylist
         { visible : Supported
         , hidden : Supported
         , scroll : Supported
         , auto : Supported
-        , inherit : Supported
-        , initial : Supported
-        , unset : Supported
         }
-    -> Style
 overflow (Value val) =
     AppendProperty ("overflow:" ++ val)
 
@@ -1375,16 +1411,12 @@ overflow (Value val) =
 
 -}
 overflowX :
-    Value
+    Stylist
         { visible : Supported
         , hidden : Supported
         , scroll : Supported
         , auto : Supported
-        , inherit : Supported
-        , initial : Supported
-        , unset : Supported
         }
-    -> Style
 overflowX (Value val) =
     AppendProperty ("overflow-x:" ++ val)
 
@@ -1398,16 +1430,12 @@ overflowX (Value val) =
 
 -}
 overflowY :
-    Value
+    Stylist
         { visible : Supported
         , hidden : Supported
         , scroll : Supported
         , auto : Supported
-        , inherit : Supported
-        , initial : Supported
-        , unset : Supported
         }
-    -> Style
 overflowY (Value val) =
     AppendProperty ("overflow-y:" ++ val)
 
@@ -1419,14 +1447,10 @@ overflowY (Value val) =
 
 -}
 overflowWrap :
-    Value
+    Stylist
         { breakWord : Supported
         , normal : Supported
-        , inherit : Supported
-        , initial : Supported
-        , unset : Supported
         }
-    -> Style
 overflowWrap (Value val) =
     AppendProperty ("overflow-wrap:" ++ val)
 
@@ -1455,15 +1479,7 @@ breakWord =
     color (rgba 96 181 204 0.5)
 
 -}
-color :
-    Value
-        (ColorSupported
-            { inherit : Supported
-            , initial : Supported
-            , unset : Supported
-            }
-        )
-    -> Style
+color : Stylist Color
 color (Value val) =
     AppendProperty ("color:" ++ val)
 
@@ -1475,15 +1491,7 @@ color (Value val) =
     backgroundColor (rgba 96 181 204 0.5)
 
 -}
-backgroundColor :
-    Value
-        (ColorSupported
-            { inherit : Supported
-            , initial : Supported
-            , unset : Supported
-            }
-        )
-    -> Style
+backgroundColor : Stylist Color
 backgroundColor (Value val) =
     AppendProperty ("background-color:" ++ val)
 
@@ -1595,17 +1603,13 @@ hex str =
 
 -}
 position :
-    Value
+    Stylist
         { absolute : Supported
         , fixed : Supported
         , relative : Supported
         , static : Supported
         , sticky : Supported
-        , inherit : Supported
-        , initial : Supported
-        , unset : Supported
         }
-    -> Style
 position (Value val) =
     AppendProperty ("position:" ++ val)
 
@@ -1622,16 +1626,12 @@ for example in `vertical-align: top`, use [`top_`](#top_) instead of this.
 
 -}
 top :
-    Value
+    Stylist
         (LengthSupported
             { pct : Supported
             , auto : Supported
-            , inherit : Supported
-            , initial : Supported
-            , unset : Supported
             }
         )
-    -> Style
 top (Value val) =
     AppendProperty ("top:" ++ val)
 
@@ -1648,16 +1648,12 @@ for example in `vertical-align: bottom`, use [`bottom_`](#bottom_) instead of th
 
 -}
 bottom :
-    Value
+    Stylist
         (LengthSupported
             { pct : Supported
             , auto : Supported
-            , inherit : Supported
-            , initial : Supported
-            , unset : Supported
             }
         )
-    -> Style
 bottom (Value val) =
     AppendProperty ("bottom:" ++ val)
 
@@ -1674,16 +1670,12 @@ for example in `float: left`, use [`left_`](#left_) instead of this.
 
 -}
 left :
-    Value
+    Stylist
         (LengthSupported
             { pct : Supported
             , auto : Supported
-            , inherit : Supported
-            , initial : Supported
-            , unset : Supported
             }
         )
-    -> Style
 left (Value val) =
     AppendProperty ("left:" ++ val)
 
@@ -1700,16 +1692,12 @@ for example in `float: right`, use [`right_`](#right_) instead of this.
 
 -}
 right :
-    Value
+    Stylist
         (LengthSupported
             { pct : Supported
             , auto : Supported
-            , inherit : Supported
-            , initial : Supported
-            , unset : Supported
             }
         )
-    -> Style
 right (Value val) =
     AppendProperty ("right:" ++ val)
 
@@ -1787,14 +1775,10 @@ sticky =
 
 -}
 zIndex :
-    Value
+    Stylist
         { int : Supported
         , auto : Supported
-        , inherit : Supported
-        , initial : Supported
-        , unset : Supported
         }
-    -> Style
 zIndex (Value val) =
     AppendProperty ("z-index:" ++ val)
 
@@ -1812,15 +1796,11 @@ zIndex (Value val) =
 
 -}
 padding :
-    Value
+    Stylist
         (LengthSupported
             { pct : Supported
-            , inherit : Supported
-            , initial : Supported
-            , unset : Supported
             }
         )
-    -> Style
 padding (Value value) =
     AppendProperty ("padding:" ++ value)
 
@@ -1834,18 +1814,15 @@ padding (Value value) =
 
 -}
 padding2 :
-    Value
+    Stylist2
         (LengthSupported
             { pct : Supported
             }
         )
-    ->
-        Value
-            (LengthSupported
-                { pct : Supported
-                }
-            )
-    -> Style
+        (LengthSupported
+            { pct : Supported
+            }
+        )
 padding2 (Value valueTopBottom) (Value valueRightLeft) =
     AppendProperty ("padding:" ++ valueTopBottom ++ " " ++ valueRightLeft)
 
@@ -1859,24 +1836,19 @@ padding2 (Value valueTopBottom) (Value valueRightLeft) =
 
 -}
 padding3 :
-    Value
+    Stylist3
         (LengthSupported
             { pct : Supported
             }
         )
-    ->
-        Value
-            (LengthSupported
-                { pct : Supported
-                }
-            )
-    ->
-        Value
-            (LengthSupported
-                { pct : Supported
-                }
-            )
-    -> Style
+        (LengthSupported
+            { pct : Supported
+            }
+        )
+        (LengthSupported
+            { pct : Supported
+            }
+        )
 padding3 (Value valueTop) (Value valueRightLeft) (Value valueBottom) =
     AppendProperty ("padding:" ++ valueTop ++ " " ++ valueRightLeft ++ " " ++ valueBottom)
 
@@ -1890,30 +1862,23 @@ padding3 (Value valueTop) (Value valueRightLeft) (Value valueBottom) =
 
 -}
 padding4 :
-    Value
+    Stylist4
         (LengthSupported
             { pct : Supported
             }
         )
-    ->
-        Value
-            (LengthSupported
-                { pct : Supported
-                }
-            )
-    ->
-        Value
-            (LengthSupported
-                { pct : Supported
-                }
-            )
-    ->
-        Value
-            (LengthSupported
-                { pct : Supported
-                }
-            )
-    -> Style
+        (LengthSupported
+            { pct : Supported
+            }
+        )
+        (LengthSupported
+            { pct : Supported
+            }
+        )
+        (LengthSupported
+            { pct : Supported
+            }
+        )
 padding4 (Value valueTop) (Value valueRight) (Value valueBottom) (Value valueLeft) =
     AppendProperty ("padding:" ++ valueTop ++ " " ++ valueRight ++ " " ++ valueBottom ++ " " ++ valueLeft)
 
@@ -1924,15 +1889,11 @@ padding4 (Value valueTop) (Value valueRight) (Value valueBottom) (Value valueLef
 
 -}
 paddingTop :
-    Value
+    Stylist
         (LengthSupported
             { pct : Supported
-            , inherit : Supported
-            , initial : Supported
-            , unset : Supported
             }
         )
-    -> Style
 paddingTop (Value value) =
     AppendProperty ("padding-top:" ++ value)
 
@@ -1943,15 +1904,11 @@ paddingTop (Value value) =
 
 -}
 paddingRight :
-    Value
+    Stylist
         (LengthSupported
             { pct : Supported
-            , inherit : Supported
-            , initial : Supported
-            , unset : Supported
             }
         )
-    -> Style
 paddingRight (Value value) =
     AppendProperty ("padding-right:" ++ value)
 
@@ -1962,15 +1919,11 @@ paddingRight (Value value) =
 
 -}
 paddingBottom :
-    Value
+    Stylist
         (LengthSupported
             { pct : Supported
-            , inherit : Supported
-            , initial : Supported
-            , unset : Supported
             }
         )
-    -> Style
 paddingBottom (Value value) =
     AppendProperty ("padding-bottom:" ++ value)
 
@@ -1981,15 +1934,11 @@ paddingBottom (Value value) =
 
 -}
 paddingLeft :
-    Value
+    Stylist
         (LengthSupported
             { pct : Supported
-            , inherit : Supported
-            , initial : Supported
-            , unset : Supported
             }
         )
-    -> Style
 paddingLeft (Value value) =
     AppendProperty ("padding-left:" ++ value)
 
@@ -2009,16 +1958,12 @@ You may want to check out [this article on collapsing margins](https://css-trick
 
 -}
 margin :
-    Value
+    Stylist
         (LengthSupported
             { pct : Supported
             , auto : Supported
-            , inherit : Supported
-            , initial : Supported
-            , unset : Supported
             }
         )
-    -> Style
 margin (Value value) =
     AppendProperty ("margin:" ++ value)
 
@@ -2034,20 +1979,17 @@ You may want to check out [this article on collapsing margins](https://css-trick
 
 -}
 margin2 :
-    Value
+    Stylist2
         (LengthSupported
             { pct : Supported
             , auto : Supported
             }
         )
-    ->
-        Value
-            (LengthSupported
-                { pct : Supported
-                , auto : Supported
-                }
-            )
-    -> Style
+        (LengthSupported
+            { pct : Supported
+            , auto : Supported
+            }
+        )
 margin2 (Value valueTopBottom) (Value valueRightLeft) =
     AppendProperty ("margin:" ++ valueTopBottom ++ " " ++ valueRightLeft)
 
@@ -2063,27 +2005,22 @@ You may want to check out [this article on collapsing margins](https://css-trick
 
 -}
 margin3 :
-    Value
+    Stylist3
         (LengthSupported
             { pct : Supported
             , auto : Supported
             }
         )
-    ->
-        Value
-            (LengthSupported
-                { pct : Supported
-                , auto : Supported
-                }
-            )
-    ->
-        Value
-            (LengthSupported
-                { pct : Supported
-                , auto : Supported
-                }
-            )
-    -> Style
+        (LengthSupported
+            { pct : Supported
+            , auto : Supported
+            }
+        )
+        (LengthSupported
+            { pct : Supported
+            , auto : Supported
+            }
+        )
 margin3 (Value valueTop) (Value valueRightLeft) (Value valueBottom) =
     AppendProperty ("margin:" ++ valueTop ++ " " ++ valueRightLeft ++ " " ++ valueBottom)
 
@@ -2099,34 +2036,27 @@ You may want to check out [this article on collapsing margins](https://css-trick
 
 -}
 margin4 :
-    Value
+    Stylist4
         (LengthSupported
             { pct : Supported
             , auto : Supported
             }
         )
-    ->
-        Value
-            (LengthSupported
-                { pct : Supported
-                , auto : Supported
-                }
-            )
-    ->
-        Value
-            (LengthSupported
-                { pct : Supported
-                , auto : Supported
-                }
-            )
-    ->
-        Value
-            (LengthSupported
-                { pct : Supported
-                , auto : Supported
-                }
-            )
-    -> Style
+        (LengthSupported
+            { pct : Supported
+            , auto : Supported
+            }
+        )
+        (LengthSupported
+            { pct : Supported
+            , auto : Supported
+            }
+        )
+        (LengthSupported
+            { pct : Supported
+            , auto : Supported
+            }
+        )
 margin4 (Value valueTop) (Value valueRight) (Value valueBottom) (Value valueLeft) =
     AppendProperty ("margin:" ++ valueTop ++ " " ++ valueRight ++ " " ++ valueBottom ++ " " ++ valueLeft)
 
@@ -2139,16 +2069,12 @@ This article on [`margin-top` versus `margin-bottom`](https://css-tricks.com/mar
 
 -}
 marginTop :
-    Value
+    Stylist
         (LengthSupported
             { pct : Supported
-            , inherit : Supported
-            , initial : Supported
-            , unset : Supported
             , auto : Supported
             }
         )
-    -> Style
 marginTop (Value value) =
     AppendProperty ("margin-top:" ++ value)
 
@@ -2159,16 +2085,12 @@ marginTop (Value value) =
 
 -}
 marginRight :
-    Value
+    Stylist
         (LengthSupported
             { pct : Supported
-            , inherit : Supported
-            , initial : Supported
-            , unset : Supported
             , auto : Supported
             }
         )
-    -> Style
 marginRight (Value value) =
     AppendProperty ("margin-right:" ++ value)
 
@@ -2181,16 +2103,12 @@ This article on [`margin-top` versus `margin-bottom`](https://css-tricks.com/mar
 
 -}
 marginBottom :
-    Value
+    Stylist
         (LengthSupported
             { pct : Supported
-            , inherit : Supported
-            , initial : Supported
-            , unset : Supported
             , auto : Supported
             }
         )
-    -> Style
 marginBottom (Value value) =
     AppendProperty ("margin-bottom:" ++ value)
 
@@ -2201,16 +2119,12 @@ marginBottom (Value value) =
 
 -}
 marginLeft :
-    Value
+    Stylist
         (LengthSupported
             { pct : Supported
-            , inherit : Supported
-            , initial : Supported
-            , unset : Supported
             , auto : Supported
             }
         )
-    -> Style
 marginLeft (Value value) =
     AppendProperty ("margin-left:" ++ value)
 
@@ -2226,14 +2140,10 @@ marginLeft (Value value) =
 
 -}
 boxSizing :
-    Value
+    Stylist
         { contentBox : Supported
         , borderBox : Supported
-        , inherit : Supported
-        , initial : Supported
-        , unset : Supported
         }
-    -> Style
 boxSizing (Value value) =
     AppendProperty ("box-sizing:" ++ value)
 
@@ -2809,7 +2719,7 @@ For `display: flex`, use [`displayFlex`](#displayFlex).
 
 -}
 display :
-    Value
+    Stylist
         { block : Supported
         , grid : Supported
         , inline : Supported
@@ -2826,11 +2736,7 @@ display :
         , tableRow : Supported
         , tableRowGroup : Supported
         , for_display_flex_see_docs_for_displayFlex : Supported
-        , inherit : Supported
-        , initial : Supported
-        , unset : Supported
         }
-    -> Style
 display (Value val) =
     AppendProperty ("display:" ++ val)
 
@@ -3108,7 +3014,7 @@ because `Css.left` and `Css.right` are functions!
 
 -}
 alignSelf :
-    Value
+    Stylist
         { auto : Supported
         , normal : Supported
         , stretch : Supported
@@ -3126,11 +3032,7 @@ alignSelf :
         , lastBaseline : Supported
         , safeCenter : Supported
         , unsafeCenter : Supported
-        , inherit : Supported
-        , initial : Supported
-        , unset : Supported
         }
-    -> Style
 alignSelf (Value val) =
     AppendProperty ("align-self:" ++ val)
 
@@ -3148,7 +3050,7 @@ Check out [fluid typography](https://css-tricks.com/snippets/css/fluid-typograph
 
 -}
 fontSize :
-    Value
+    Stylist
         (LengthSupported
             { xxSmall : Supported
             , xSmall : Supported
@@ -3160,12 +3062,8 @@ fontSize :
             , smaller : Supported
             , larger : Supported
             , pct : Supported
-            , inherit : Supported
-            , initial : Supported
-            , unset : Supported
             }
         )
-    -> Style
 fontSize (Value val) =
     AppendProperty ("font-size:" ++ val)
 
@@ -3276,18 +3174,14 @@ If you want to refer to a font by its name (like Helvetica or Arial), use [`font
 
 -}
 fontFamily :
-    Value
+    Stylist
         { serif : Supported
         , sansSerif : Supported
         , monospace : Supported
         , cursive : Supported
         , fantasy : Supported
         , systemUi : Supported
-        , inherit : Supported
-        , initial : Supported
-        , unset : Supported
         }
-    -> Style
 fontFamily (Value genericFont) =
     AppendProperty ("font-family:" ++ genericFont)
 
@@ -3442,16 +3336,12 @@ enquoteIfNotGeneric fontName =
 
 -}
 fontStyle :
-    Value
+    Stylist
         { normal : Supported
         , bold : Supported
         , bolder : Supported
         , lighter : Supported
-        , inherit : Supported
-        , initial : Supported
-        , unset : Supported
         }
-    -> Style
 fontStyle (Value val) =
     AppendProperty ("font-style:" ++ val)
 
@@ -3517,7 +3407,7 @@ bolder =
 
 -}
 fontVariantCaps :
-    Value
+    Stylist
         { normal : Supported
         , smallCaps : Supported
         , smallCaps : Supported
@@ -3525,11 +3415,7 @@ fontVariantCaps :
         , allPetiteCaps : Supported
         , unicase : Supported
         , titlingCaps : Supported
-        , inherit : Supported
-        , initial : Supported
-        , unset : Supported
         }
-    -> Style
 fontVariantCaps (Value str) =
     AppendProperty ("font-variant-caps:" ++ str)
 
@@ -3626,7 +3512,7 @@ titlingCaps =
 
 -}
 fontVariantLigatures :
-    Value
+    Stylist
         { normal : Supported
         , none : Supported
         , commonLigatures : Supported
@@ -3637,11 +3523,7 @@ fontVariantLigatures :
         , noHistoricalLigatures : Supported
         , contextual : Supported
         , noContextual : Supported
-        , inherit : Supported
-        , initial : Supported
-        , unset : Supported
         }
-    -> Style
 fontVariantLigatures (Value str) =
     AppendProperty ("font-variant-ligatures:" ++ str)
 
@@ -3738,7 +3620,7 @@ See [`fontVariantNumeric4`](#fontVariantNumeric4) for a more advanced version.
 
 -}
 fontVariantNumeric :
-    Value
+    Stylist
         { normal : Supported
         , ordinal : Supported
         , slashedZero : Supported
@@ -3748,11 +3630,7 @@ fontVariantNumeric :
         , tabularNums : Supported
         , diagonalFractions : Supported
         , stackedFractions : Supported
-        , inherit : Supported
-        , initial : Supported
-        , unset : Supported
         }
-    -> Style
 fontVariantNumeric (Value str) =
     AppendProperty ("font-variant-numeric:" ++ str)
 
@@ -3896,7 +3774,7 @@ stackedFractions =
 property.
 -}
 cursor :
-    Value
+    Stylist
         { pointer : Supported
         , auto : Supported
         , default : Supported
@@ -3934,11 +3812,7 @@ cursor :
         , grab : Supported
         , grabbing : Supported
         , url : Supported
-        , inherit : Supported
-        , initial : Supported
-        , unset : Supported
         }
-    -> Style
 cursor (Value val) =
     AppendProperty ("cursor:" ++ val)
 
@@ -4295,15 +4169,11 @@ See [`backgroundAttachments`](#backgroundAttachments) to set more than one `back
 
 -}
 backgroundAttachment :
-    Value
+    Stylist
         { fixed : Supported
         , scroll : Supported
         , local : Supported
-        , inherit : Supported
-        , initial : Supported
-        , unset : Supported
         }
-    -> Style
 backgroundAttachment (Value str) =
     AppendProperty ("background-attachment:" ++ str)
 
@@ -4371,7 +4241,7 @@ See [`backgroundBlendModes`](#backgroundBlendModes) to set more than one `backgr
 
 -}
 backgroundBlendMode :
-    Value
+    Stylist
         { normal : Supported
         , multiply : Supported
         , screen : Supported
@@ -4388,11 +4258,7 @@ backgroundBlendMode :
         , saturation : Supported
         , color : Supported
         , luminosity : Supported
-        , initial : Supported
-        , inherit : Supported
-        , unset : Supported
         }
-    -> Style
 backgroundBlendMode (Value str) =
     AppendProperty ("background-blend-mode:" ++ str)
 
@@ -4624,16 +4490,12 @@ See [`backgroundClips`](#backgroundClips) to set more than one `background-clip`
 
 -}
 backgroundClip :
-    Value
+    Stylist
         { borderBox : Supported
         , paddingBox : Supported
         , contentBox : Supported
         , text_ : Supported
-        , initial : Supported
-        , inherit : Supported
-        , unset : Supported
         }
-    -> Style
 backgroundClip (Value str) =
     AppendProperty ("background-clip:" ++ str)
 
@@ -4700,15 +4562,11 @@ See [`backgroundOrigins`](#backgroundOrigins) to set more than one `background-o
 
 -}
 backgroundOrigin :
-    Value
+    Stylist
         { borderBox : Supported
         , paddingBox : Supported
         , contentBox : Supported
-        , initial : Supported
-        , inherit : Supported
-        , unset : Supported
         }
-    -> Style
 backgroundOrigin (Value str) =
     AppendProperty ("background-origin:" ++ str)
 
@@ -4755,15 +4613,11 @@ See also [`backgroundImages`](#backgroundImages) if you need multiple images.
 
 -}
 backgroundImage :
-    Value
+    Stylist
         { url : Supported
         , linearGradient : Supported
         , none : Supported
-        , inherit : Supported
-        , initial : Supported
-        , unset : Supported
         }
-    -> Style
 backgroundImage (Value value) =
     AppendProperty ("background-image:" ++ value)
 
@@ -4823,18 +4677,14 @@ If you need to set the offsets from the right or bottom, use
 
 -}
 backgroundPosition :
-    Value
+    Stylist
         (LengthSupported
             { pct : Supported
             , left_ : Supported
             , right_ : Supported
             , center : Supported
-            , inherit : Supported
-            , unset : Supported
-            , initial : Supported
             }
         )
-    -> Style
 backgroundPosition (Value horiz) =
     AppendProperty ("background-position:" ++ horiz)
 
@@ -4858,7 +4708,7 @@ If you need to set the offsets from the right or bottom, use
 
 -}
 backgroundPosition2 :
-    Value
+    Stylist2
         (LengthSupported
             { pct : Supported
             , left_ : Supported
@@ -4866,16 +4716,13 @@ backgroundPosition2 :
             , center : Supported
             }
         )
-    ->
-        Value
-            (LengthSupported
-                { pct : Supported
-                , top_ : Supported
-                , bottom_ : Supported
-                , center : Supported
-                }
-            )
-    -> Style
+        (LengthSupported
+            { pct : Supported
+            , top_ : Supported
+            , bottom_ : Supported
+            , center : Supported
+            }
+        )
 backgroundPosition2 (Value horiz) (Value vert) =
     AppendProperty ("background-position:" ++ horiz ++ " " ++ vert)
 
@@ -4894,28 +4741,21 @@ vertical (from top) alignment.
 
 -}
 backgroundPosition4 :
-    Value
+    Stylist4
         { left_ : Supported
         , right_ : Supported
         }
-    ->
-        Value
-            (LengthSupported
-                { pct : Supported
-                }
-            )
-    ->
-        Value
-            { top_ : Supported
-            , bottom_ : Supported
+        (LengthSupported
+            { pct : Supported
             }
-    ->
-        Value
-            (LengthSupported
-                { pct : Supported
-                }
-            )
-    -> Style
+        )
+        { top_ : Supported
+        , bottom_ : Supported
+        }
+        (LengthSupported
+            { pct : Supported
+            }
+        )
 backgroundPosition4 (Value horiz) (Value horizAmount) (Value vert) (Value vertAmount) =
     AppendProperty
         ("background-position:"
@@ -4944,18 +4784,14 @@ If you need to set horizontal and vertical direction separately, see
 
 -}
 backgroundRepeat :
-    Value
+    Stylist
         { repeat : Supported
         , repeatX : Supported
         , repeatY : Supported
         , space : Supported
         , round : Supported
         , noRepeat : Supported
-        , initial : Supported
-        , unset : Supported
-        , inherit : Supported
         }
-    -> Style
 backgroundRepeat (Value repeat) =
     AppendProperty ("background-repeat:" ++ repeat)
 
@@ -4971,20 +4807,17 @@ If you only need to set one value for both, see
 
 -}
 backgroundRepeat2 :
-    Value
+    Stylist2
         { repeat : Supported
         , space : Supported
         , round : Supported
         , noRepeat : Supported
         }
-    ->
-        Value
-            { repeat : Supported
-            , space : Supported
-            , round : Supported
-            , noRepeat : Supported
-            }
-    -> Style
+        { repeat : Supported
+        , space : Supported
+        , round : Supported
+        , noRepeat : Supported
+        }
 backgroundRepeat2 (Value horiz) (Value vert) =
     AppendProperty ("background-repeat:" ++ horiz ++ " " ++ vert)
 
@@ -5081,17 +4914,13 @@ need to set both width and height explicitly, use
 
 -}
 backgroundSize :
-    Value
+    Stylist
         (LengthSupported
             { pct : Supported
             , auto : Supported
             , cover : Supported
-            , inherit : Supported
-            , initial : Supported
-            , unset : Supported
             }
         )
-    -> Style
 backgroundSize (Value size) =
     AppendProperty ("background-size:" ++ size)
 
@@ -5106,20 +4935,17 @@ If you only want to set the width, use [`backgroundImage`](#backgroundImage) ins
 
 -}
 backgroundSize2 :
-    Value
+    Stylist2
         (LengthSupported
             { pct : Supported
             , auto : Supported
             }
         )
-    ->
-        Value
-            (LengthSupported
-                { pct : Supported
-                , auto : Supported
-                }
-            )
-    -> Style
+        (LengthSupported
+            { pct : Supported
+            , auto : Supported
+            }
+        )
 backgroundSize2 (Value width) (Value height) =
     AppendProperty ("background-size:" ++ width ++ " " ++ height)
 
@@ -5339,15 +5165,7 @@ toTopRight =
 
 {-| The [`list-style`](https://css-tricks.com/almanac/properties/l/list-style/) shorthand property.
 -}
-listStyle :
-    Value
-        (ListStyleSupported
-            { inherit : Supported
-            , initial : Supported
-            , unset : Supported
-            }
-        )
-    -> Style
+listStyle : Stylist ListStyle
 listStyle (Value val) =
     AppendProperty ("list-style:" ++ val)
 
@@ -5384,21 +5202,14 @@ type alias ListStyle =
 
 {-| The [`list-style`](https://css-tricks.com/almanac/properties/l/list-style/) shorthand property.
 -}
-listStyle2 :
-    Value ListStyle
-    -> Value ListStyle
-    -> Style
+listStyle2 : Stylist2 ListStyle ListStyle
 listStyle2 (Value val1) (Value val2) =
     AppendProperty ("list-style:" ++ val1 ++ " " ++ val2)
 
 
 {-| The [`list-style`](https://css-tricks.com/almanac/properties/l/list-style/) shorthand property.
 -}
-listStyle3 :
-    Value ListStyle
-    -> Value ListStyle
-    -> Value ListStyle
-    -> Style
+listStyle3 : Stylist3 ListStyle ListStyle ListStyle
 listStyle3 (Value val1) (Value val2) (Value val3) =
     AppendProperty ("list-style:" ++ val1 ++ " " ++ val2 ++ " " ++ val3)
 
@@ -5414,15 +5225,7 @@ listStyle3 (Value val1) (Value val2) (Value val3) =
     border3 (px 1) solid (hex "#f00")
 
 -}
-border :
-    Value
-        (BorderWidthSupported
-            { inherit : Supported
-            , initial : Supported
-            , unset : Supported
-            }
-        )
-    -> Style
+border : Stylist BorderWidth
 border (Value width) =
     AppendProperty ("border:" ++ width)
 
@@ -5434,10 +5237,7 @@ border (Value width) =
     border3 (px 1) solid (hex "#f00")
 
 -}
-border2 :
-    Value BorderWidth
-    -> Value BorderStyle
-    -> Style
+border2 : Stylist2 BorderWidth BorderStyle
 border2 (Value width) (Value style) =
     AppendProperty ("border:" ++ width ++ " " ++ style)
 
@@ -5449,11 +5249,7 @@ border2 (Value width) (Value style) =
     border3 (px 1) solid (hex "#f00")
 
 -}
-border3 :
-    Value BorderWidth
-    -> Value BorderStyle
-    -> Value Color
-    -> Style
+border3 : Stylist3 BorderWidth BorderStyle Color
 border3 (Value width) (Value style) (Value color) =
     AppendProperty ("border:" ++ width ++ " " ++ style ++ " " ++ color)
 
@@ -5465,15 +5261,7 @@ border3 (Value width) (Value style) (Value color) =
     borderTop3 (px 1) solid (hex "#f00")
 
 -}
-borderTop :
-    Value
-        (BorderWidthSupported
-            { inherit : Supported
-            , initial : Supported
-            , unset : Supported
-            }
-        )
-    -> Style
+borderTop : Stylist BorderWidth
 borderTop (Value width) =
     AppendProperty ("border-top:" ++ width)
 
@@ -5485,10 +5273,7 @@ borderTop (Value width) =
     borderTop3 (px 1) solid (hex "#f00")
 
 -}
-borderTop2 :
-    Value BorderWidth
-    -> Value BorderStyle
-    -> Style
+borderTop2 : Stylist2 BorderWidth BorderStyle
 borderTop2 (Value width) (Value style) =
     AppendProperty ("border-top:" ++ width ++ " " ++ style)
 
@@ -5500,11 +5285,7 @@ borderTop2 (Value width) (Value style) =
     borderTop3 (px 1) solid (hex "#f00")
 
 -}
-borderTop3 :
-    Value BorderWidth
-    -> Value BorderStyle
-    -> Value Color
-    -> Style
+borderTop3 : Stylist3 BorderWidth BorderStyle Color
 borderTop3 (Value width) (Value style) (Value color) =
     AppendProperty ("border-top:" ++ width ++ " " ++ style ++ " " ++ color)
 
@@ -5516,15 +5297,7 @@ borderTop3 (Value width) (Value style) (Value color) =
     borderRight3 (px 1) solid (hex "#f00")
 
 -}
-borderRight :
-    Value
-        (BorderWidthSupported
-            { inherit : Supported
-            , initial : Supported
-            , unset : Supported
-            }
-        )
-    -> Style
+borderRight : Stylist BorderWidth
 borderRight (Value width) =
     AppendProperty ("border-right:" ++ width)
 
@@ -5536,10 +5309,7 @@ borderRight (Value width) =
     borderRight3 (px 1) solid (hex "#f00")
 
 -}
-borderRight2 :
-    Value BorderWidth
-    -> Value BorderStyle
-    -> Style
+borderRight2 : Stylist2 BorderWidth BorderStyle
 borderRight2 (Value width) (Value style) =
     AppendProperty ("border-right:" ++ width ++ " " ++ style)
 
@@ -5551,11 +5321,7 @@ borderRight2 (Value width) (Value style) =
     borderRight3 (px 1) solid (hex "#f00")
 
 -}
-borderRight3 :
-    Value BorderWidth
-    -> Value BorderStyle
-    -> Value Color
-    -> Style
+borderRight3 : Stylist3 BorderWidth BorderStyle Color
 borderRight3 (Value width) (Value style) (Value color) =
     AppendProperty ("border-right:" ++ width ++ " " ++ style ++ " " ++ color)
 
@@ -5567,15 +5333,7 @@ borderRight3 (Value width) (Value style) (Value color) =
     borderBottom3 (px 1) solid (hex "#f00")
 
 -}
-borderBottom :
-    Value
-        (BorderWidthSupported
-            { inherit : Supported
-            , initial : Supported
-            , unset : Supported
-            }
-        )
-    -> Style
+borderBottom : Stylist BorderWidth
 borderBottom (Value width) =
     AppendProperty ("border-bottom:" ++ width)
 
@@ -5587,10 +5345,7 @@ borderBottom (Value width) =
     borderBottom3 (px 1) solid (hex "#f00")
 
 -}
-borderBottom2 :
-    Value BorderWidth
-    -> Value BorderStyle
-    -> Style
+borderBottom2 : Stylist2 BorderWidth BorderStyle
 borderBottom2 (Value width) (Value style) =
     AppendProperty ("border-bottom:" ++ width ++ " " ++ style)
 
@@ -5602,11 +5357,7 @@ borderBottom2 (Value width) (Value style) =
     borderBottom3 (px 1) solid (hex "#f00")
 
 -}
-borderBottom3 :
-    Value BorderWidth
-    -> Value BorderStyle
-    -> Value Color
-    -> Style
+borderBottom3 : Stylist3 BorderWidth BorderStyle Color
 borderBottom3 (Value width) (Value style) (Value color) =
     AppendProperty ("border-bottom:" ++ width ++ " " ++ style ++ " " ++ color)
 
@@ -5618,15 +5369,7 @@ borderBottom3 (Value width) (Value style) (Value color) =
     borderLeft3 (px 1) solid (hex "#f00")
 
 -}
-borderLeft :
-    Value
-        (BorderWidthSupported
-            { inherit : Supported
-            , initial : Supported
-            , unset : Supported
-            }
-        )
-    -> Style
+borderLeft : Stylist BorderWidth
 borderLeft (Value width) =
     AppendProperty ("border-left:" ++ width)
 
@@ -5638,10 +5381,7 @@ borderLeft (Value width) =
     borderLeft3 (px 1) solid (hex "#f00")
 
 -}
-borderLeft2 :
-    Value BorderWidth
-    -> Value BorderStyle
-    -> Style
+borderLeft2 : Stylist2 BorderWidth BorderStyle
 borderLeft2 (Value width) (Value style) =
     AppendProperty ("border-left:" ++ width ++ " " ++ style)
 
@@ -5653,11 +5393,7 @@ borderLeft2 (Value width) (Value style) =
     borderLeft3 (px 1) solid (hex "#f00")
 
 -}
-borderLeft3 :
-    Value BorderWidth
-    -> Value BorderStyle
-    -> Value Color
-    -> Style
+borderLeft3 : Stylist3 BorderWidth BorderStyle Color
 borderLeft3 (Value width) (Value style) (Value color) =
     AppendProperty ("border-left:" ++ width ++ " " ++ style ++ " " ++ color)
 
@@ -5670,15 +5406,7 @@ borderLeft3 (Value width) (Value style) (Value color) =
     borderWidth4 (px 1) thin zero (em 1)
 
 -}
-borderWidth :
-    Value
-        (BorderWidthSupported
-            { inherit : Supported
-            , initial : Supported
-            , unset : Supported
-            }
-        )
-    -> Style
+borderWidth : Stylist BorderWidth
 borderWidth (Value width) =
     AppendProperty ("border-width:" ++ width)
 
@@ -5691,10 +5419,7 @@ borderWidth (Value width) =
     borderWidth4 (px 1) thin zero (em 1)
 
 -}
-borderWidth2 :
-    Value BorderWidth
-    -> Value BorderWidth
-    -> Style
+borderWidth2 : Stylist2 BorderWidth BorderWidth
 borderWidth2 (Value widthTopBottom) (Value widthRightLeft) =
     AppendProperty ("border-width:" ++ widthTopBottom ++ " " ++ widthRightLeft)
 
@@ -5707,11 +5432,7 @@ borderWidth2 (Value widthTopBottom) (Value widthRightLeft) =
     borderWidth4 (px 1) thin zero (em 1)
 
 -}
-borderWidth3 :
-    Value BorderWidth
-    -> Value BorderWidth
-    -> Value BorderWidth
-    -> Style
+borderWidth3 : Stylist3 BorderWidth BorderWidth BorderWidth
 borderWidth3 (Value widthTop) (Value widthRightLeft) (Value widthBottom) =
     AppendProperty ("border-width:" ++ widthTop ++ " " ++ widthRightLeft ++ " " ++ widthBottom)
 
@@ -5724,12 +5445,7 @@ borderWidth3 (Value widthTop) (Value widthRightLeft) (Value widthBottom) =
     borderWidth4 (px 1) thin zero (em 1)
 
 -}
-borderWidth4 :
-    Value BorderWidth
-    -> Value BorderWidth
-    -> Value BorderWidth
-    -> Value BorderWidth
-    -> Style
+borderWidth4 : Stylist4 BorderWidth BorderWidth BorderWidth BorderWidth
 borderWidth4 (Value widthTop) (Value widthRight) (Value widthBottom) (Value widthLeft) =
     AppendProperty ("border-width:" ++ widthTop ++ " " ++ widthRight ++ " " ++ widthBottom ++ " " ++ widthLeft)
 
@@ -5739,15 +5455,7 @@ borderWidth4 (Value widthTop) (Value widthRight) (Value widthBottom) (Value widt
     borderTopWidth (px 1)
 
 -}
-borderTopWidth :
-    Value
-        (BorderWidthSupported
-            { inherit : Supported
-            , initial : Supported
-            , unset : Supported
-            }
-        )
-    -> Style
+borderTopWidth : Stylist BorderWidth
 borderTopWidth (Value width) =
     AppendProperty ("border-top-width:" ++ width)
 
@@ -5757,15 +5465,7 @@ borderTopWidth (Value width) =
     borderRightWidth (px 1)
 
 -}
-borderRightWidth :
-    Value
-        (BorderWidthSupported
-            { inherit : Supported
-            , initial : Supported
-            , unset : Supported
-            }
-        )
-    -> Style
+borderRightWidth : Stylist BorderWidth
 borderRightWidth (Value width) =
     AppendProperty ("border-right-width:" ++ width)
 
@@ -5775,15 +5475,7 @@ borderRightWidth (Value width) =
     borderBottomWidth (px 1)
 
 -}
-borderBottomWidth :
-    Value
-        (BorderWidthSupported
-            { inherit : Supported
-            , initial : Supported
-            , unset : Supported
-            }
-        )
-    -> Style
+borderBottomWidth : Stylist BorderWidth
 borderBottomWidth (Value width) =
     AppendProperty ("border-bottom-width:" ++ width)
 
@@ -5793,15 +5485,7 @@ borderBottomWidth (Value width) =
     borderLeftWidth (px 1)
 
 -}
-borderLeftWidth :
-    Value
-        (BorderWidthSupported
-            { inherit : Supported
-            , initial : Supported
-            , unset : Supported
-            }
-        )
-    -> Style
+borderLeftWidth : Stylist BorderWidth
 borderLeftWidth (Value width) =
     AppendProperty ("border-left-width:" ++ width)
 
@@ -5814,15 +5498,7 @@ borderLeftWidth (Value width) =
     borderStyle4 solid none dotted inherit
 
 -}
-borderStyle :
-    Value
-        (BorderStyleSupported
-            { inherit : Supported
-            , initial : Supported
-            , unset : Supported
-            }
-        )
-    -> Style
+borderStyle : Stylist BorderStyle
 borderStyle (Value style) =
     AppendProperty ("border-style:" ++ style)
 
@@ -5835,10 +5511,7 @@ borderStyle (Value style) =
     borderStyle4 solid none dotted inherit
 
 -}
-borderStyle2 :
-    Value BorderStyle
-    -> Value BorderStyle
-    -> Style
+borderStyle2 : Stylist2 BorderStyle BorderStyle
 borderStyle2 (Value styleTopBottom) (Value styleRigthLeft) =
     AppendProperty ("border-style:" ++ styleTopBottom ++ " " ++ styleRigthLeft)
 
@@ -5851,11 +5524,7 @@ borderStyle2 (Value styleTopBottom) (Value styleRigthLeft) =
     borderStyle4 solid none dotted inherit
 
 -}
-borderStyle3 :
-    Value BorderStyle
-    -> Value BorderStyle
-    -> Value BorderStyle
-    -> Style
+borderStyle3 : Stylist3 BorderStyle BorderStyle BorderStyle
 borderStyle3 (Value styleTop) (Value styleRigthLeft) (Value styleBottom) =
     AppendProperty ("border-style:" ++ styleTop ++ " " ++ styleRigthLeft ++ " " ++ styleBottom)
 
@@ -5868,12 +5537,7 @@ borderStyle3 (Value styleTop) (Value styleRigthLeft) (Value styleBottom) =
     borderStyle4 solid none dotted inherit
 
 -}
-borderStyle4 :
-    Value BorderStyle
-    -> Value BorderStyle
-    -> Value BorderStyle
-    -> Value BorderStyle
-    -> Style
+borderStyle4 : Stylist4 BorderStyle BorderStyle BorderStyle BorderStyle
 borderStyle4 (Value styleTop) (Value styleRigt) (Value styleBottom) (Value styleLeft) =
     AppendProperty ("border-style:" ++ styleTop ++ " " ++ styleRigt ++ " " ++ styleBottom ++ " " ++ styleLeft)
 
@@ -5883,15 +5547,7 @@ borderStyle4 (Value styleTop) (Value styleRigt) (Value styleBottom) (Value style
     borderTopStyle solid
 
 -}
-borderTopStyle :
-    Value
-        (BorderStyleSupported
-            { inherit : Supported
-            , initial : Supported
-            , unset : Supported
-            }
-        )
-    -> Style
+borderTopStyle : Stylist BorderStyle
 borderTopStyle (Value style) =
     AppendProperty ("border-top-style:" ++ style)
 
@@ -5901,15 +5557,7 @@ borderTopStyle (Value style) =
     borderRightStyle solid
 
 -}
-borderRightStyle :
-    Value
-        (BorderStyleSupported
-            { inherit : Supported
-            , initial : Supported
-            , unset : Supported
-            }
-        )
-    -> Style
+borderRightStyle : Stylist BorderStyle
 borderRightStyle (Value style) =
     AppendProperty ("border-right-style:" ++ style)
 
@@ -5919,15 +5567,7 @@ borderRightStyle (Value style) =
     borderBottomStyle solid
 
 -}
-borderBottomStyle :
-    Value
-        (BorderStyleSupported
-            { inherit : Supported
-            , initial : Supported
-            , unset : Supported
-            }
-        )
-    -> Style
+borderBottomStyle : Stylist BorderStyle
 borderBottomStyle (Value style) =
     AppendProperty ("border-bottom-style:" ++ style)
 
@@ -5937,15 +5577,7 @@ borderBottomStyle (Value style) =
     borderLeftStyle solid
 
 -}
-borderLeftStyle :
-    Value
-        (BorderStyleSupported
-            { inherit : Supported
-            , initial : Supported
-            , unset : Supported
-            }
-        )
-    -> Style
+borderLeftStyle : Stylist BorderStyle
 borderLeftStyle (Value style) =
     AppendProperty ("border-left-style:" ++ style)
 
@@ -5958,15 +5590,7 @@ borderLeftStyle (Value style) =
     borderColor4 (rgb 0 0 0) (hsl 10 10 10) (hex "#fff") transparent
 
 -}
-borderColor :
-    Value
-        (ColorSupported
-            { inherit : Supported
-            , initial : Supported
-            , unset : Supported
-            }
-        )
-    -> Style
+borderColor : Stylist Color
 borderColor (Value color) =
     AppendProperty ("border-color:" ++ color)
 
@@ -5979,10 +5603,7 @@ borderColor (Value color) =
     borderColor4 (rgb 0 0 0) (hsl 10 10 10) (hex "#fff") transparent
 
 -}
-borderColor2 :
-    Value Color
-    -> Value Color
-    -> Style
+borderColor2 : Stylist2 Color Color
 borderColor2 (Value colorTopBottom) (Value colorRightLeft) =
     AppendProperty ("border-color:" ++ colorTopBottom ++ " " ++ colorRightLeft)
 
@@ -5995,11 +5616,7 @@ borderColor2 (Value colorTopBottom) (Value colorRightLeft) =
     borderColor4 (rgb 0 0 0) (hsl 10 10 10) (hex "#fff") transparent
 
 -}
-borderColor3 :
-    Value Color
-    -> Value Color
-    -> Value Color
-    -> Style
+borderColor3 : Stylist3 Color Color Color
 borderColor3 (Value colorTop) (Value colorRightLeft) (Value colorBottom) =
     AppendProperty ("border-color:" ++ colorTop ++ " " ++ colorRightLeft ++ " " ++ colorBottom)
 
@@ -6012,12 +5629,7 @@ borderColor3 (Value colorTop) (Value colorRightLeft) (Value colorBottom) =
     borderColor4 (rgb 0 0 0) (hsl 10 10 10) (hex "#fff") transparent
 
 -}
-borderColor4 :
-    Value Color
-    -> Value Color
-    -> Value Color
-    -> Value Color
-    -> Style
+borderColor4 : Stylist4 Color Color Color Color
 borderColor4 (Value colorTop) (Value colorRight) (Value colorBottom) (Value colorLeft) =
     AppendProperty ("border-color:" ++ colorTop ++ " " ++ colorRight ++ " " ++ colorBottom ++ " " ++ colorLeft)
 
@@ -6027,15 +5639,7 @@ borderColor4 (Value colorTop) (Value colorRight) (Value colorBottom) (Value colo
     borderTopColor (rgb 0 0 0)
 
 -}
-borderTopColor :
-    Value
-        (ColorSupported
-            { inherit : Supported
-            , initial : Supported
-            , unset : Supported
-            }
-        )
-    -> Style
+borderTopColor : Stylist Color
 borderTopColor (Value color) =
     AppendProperty ("border-top-color:" ++ color)
 
@@ -6045,15 +5649,7 @@ borderTopColor (Value color) =
     borderRightColor (rgb 0 0 0)
 
 -}
-borderRightColor :
-    Value
-        (ColorSupported
-            { inherit : Supported
-            , initial : Supported
-            , unset : Supported
-            }
-        )
-    -> Style
+borderRightColor : Stylist Color
 borderRightColor (Value color) =
     AppendProperty ("border-right-color:" ++ color)
 
@@ -6063,15 +5659,7 @@ borderRightColor (Value color) =
     borderBottomColor (rgb 0 0 0)
 
 -}
-borderBottomColor :
-    Value
-        (ColorSupported
-            { inherit : Supported
-            , initial : Supported
-            , unset : Supported
-            }
-        )
-    -> Style
+borderBottomColor : Stylist Color
 borderBottomColor (Value color) =
     AppendProperty ("border-bottom-color:" ++ color)
 
@@ -6081,15 +5669,7 @@ borderBottomColor (Value color) =
     borderLeftColor (rgb 0 0 0)
 
 -}
-borderLeftColor :
-    Value
-        (ColorSupported
-            { inherit : Supported
-            , initial : Supported
-            , unset : Supported
-            }
-        )
-    -> Style
+borderLeftColor : Stylist Color
 borderLeftColor (Value color) =
     AppendProperty ("border-left-color:" ++ color)
 
@@ -6268,15 +5848,11 @@ outset =
 
 -}
 borderRadius :
-    Value
+    Stylist
         (LengthSupported
             { pct : Supported
-            , inherit : Supported
-            , initial : Supported
-            , unset : Supported
             }
         )
-    -> Style
 borderRadius (Value radius) =
     AppendProperty ("border-radius:" ++ radius)
 
@@ -6290,18 +5866,15 @@ borderRadius (Value radius) =
 
 -}
 borderRadius2 :
-    Value
+    Stylist2
         (LengthSupported
             { pct : Supported
             }
         )
-    ->
-        Value
-            (LengthSupported
-                { pct : Supported
-                }
-            )
-    -> Style
+        (LengthSupported
+            { pct : Supported
+            }
+        )
 borderRadius2 (Value radiusTopLeftAndBottomRight) (Value radiusTopRightAndBottomLeft) =
     AppendProperty ("border-radius:" ++ radiusTopLeftAndBottomRight ++ " " ++ radiusTopRightAndBottomLeft)
 
@@ -6315,24 +5888,19 @@ borderRadius2 (Value radiusTopLeftAndBottomRight) (Value radiusTopRightAndBottom
 
 -}
 borderRadius3 :
-    Value
+    Stylist3
         (LengthSupported
             { pct : Supported
             }
         )
-    ->
-        Value
-            (LengthSupported
-                { pct : Supported
-                }
-            )
-    ->
-        Value
-            (LengthSupported
-                { pct : Supported
-                }
-            )
-    -> Style
+        (LengthSupported
+            { pct : Supported
+            }
+        )
+        (LengthSupported
+            { pct : Supported
+            }
+        )
 borderRadius3 (Value radiusTopLeft) (Value radiusTopRightAndBottomLeft) (Value radiusBottomRight) =
     AppendProperty ("border-radius:" ++ radiusTopLeft ++ " " ++ radiusTopRightAndBottomLeft ++ " " ++ radiusBottomRight)
 
@@ -6346,30 +5914,23 @@ borderRadius3 (Value radiusTopLeft) (Value radiusTopRightAndBottomLeft) (Value r
 
 -}
 borderRadius4 :
-    Value
+    Stylist4
         (LengthSupported
             { pct : Supported
             }
         )
-    ->
-        Value
-            (LengthSupported
-                { pct : Supported
-                }
-            )
-    ->
-        Value
-            (LengthSupported
-                { pct : Supported
-                }
-            )
-    ->
-        Value
-            (LengthSupported
-                { pct : Supported
-                }
-            )
-    -> Style
+        (LengthSupported
+            { pct : Supported
+            }
+        )
+        (LengthSupported
+            { pct : Supported
+            }
+        )
+        (LengthSupported
+            { pct : Supported
+            }
+        )
 borderRadius4 (Value radiusTopLeft) (Value radiusTopRight) (Value radiusBottomRight) (Value radiusBottomLeft) =
     AppendProperty ("border-radius:" ++ radiusTopLeft ++ " " ++ radiusTopRight ++ " " ++ radiusBottomRight ++ " " ++ radiusBottomLeft)
 
@@ -6381,15 +5942,11 @@ borderRadius4 (Value radiusTopLeft) (Value radiusTopRight) (Value radiusBottomRi
 
 -}
 borderTopLeftRadius :
-    Value
+    Stylist
         (LengthSupported
             { pct : Supported
-            , inherit : Supported
-            , initial : Supported
-            , unset : Supported
             }
         )
-    -> Style
 borderTopLeftRadius (Value radius) =
     AppendProperty ("border-top-left-radius:" ++ radius)
 
@@ -6401,18 +5958,15 @@ borderTopLeftRadius (Value radius) =
 
 -}
 borderTopLeftRadius2 :
-    Value
+    Stylist2
         (LengthSupported
             { pct : Supported
             }
         )
-    ->
-        Value
-            (LengthSupported
-                { pct : Supported
-                }
-            )
-    -> Style
+        (LengthSupported
+            { pct : Supported
+            }
+        )
 borderTopLeftRadius2 (Value horizontal) (Value vertical) =
     AppendProperty ("border-top-left-radius:" ++ horizontal ++ " " ++ vertical)
 
@@ -6424,15 +5978,11 @@ borderTopLeftRadius2 (Value horizontal) (Value vertical) =
 
 -}
 borderTopRightRadius :
-    Value
+    Stylist
         (LengthSupported
             { pct : Supported
-            , inherit : Supported
-            , initial : Supported
-            , unset : Supported
             }
         )
-    -> Style
 borderTopRightRadius (Value radius) =
     AppendProperty ("border-top-right-radius:" ++ radius)
 
@@ -6444,18 +5994,15 @@ borderTopRightRadius (Value radius) =
 
 -}
 borderTopRightRadius2 :
-    Value
+    Stylist2
         (LengthSupported
             { pct : Supported
             }
         )
-    ->
-        Value
-            (LengthSupported
-                { pct : Supported
-                }
-            )
-    -> Style
+        (LengthSupported
+            { pct : Supported
+            }
+        )
 borderTopRightRadius2 (Value horizontal) (Value vertical) =
     AppendProperty ("border-top-right-radius:" ++ horizontal ++ " " ++ vertical)
 
@@ -6467,15 +6014,11 @@ borderTopRightRadius2 (Value horizontal) (Value vertical) =
 
 -}
 borderBottomRightRadius :
-    Value
+    Stylist
         (LengthSupported
             { pct : Supported
-            , inherit : Supported
-            , initial : Supported
-            , unset : Supported
             }
         )
-    -> Style
 borderBottomRightRadius (Value radius) =
     AppendProperty ("border-bottom-right-radius:" ++ radius)
 
@@ -6487,18 +6030,15 @@ borderBottomRightRadius (Value radius) =
 
 -}
 borderBottomRightRadius2 :
-    Value
+    Stylist2
         (LengthSupported
             { pct : Supported
             }
         )
-    ->
-        Value
-            (LengthSupported
-                { pct : Supported
-                }
-            )
-    -> Style
+        (LengthSupported
+            { pct : Supported
+            }
+        )
 borderBottomRightRadius2 (Value horizontal) (Value vertical) =
     AppendProperty ("border-bottom-right-radius:" ++ horizontal ++ " " ++ vertical)
 
@@ -6510,15 +6050,11 @@ borderBottomRightRadius2 (Value horizontal) (Value vertical) =
 
 -}
 borderBottomLeftRadius :
-    Value
+    Stylist
         (LengthSupported
             { pct : Supported
-            , inherit : Supported
-            , initial : Supported
-            , unset : Supported
             }
         )
-    -> Style
 borderBottomLeftRadius (Value radius) =
     AppendProperty ("border-bottom-left-radius:" ++ radius)
 
@@ -6530,18 +6066,15 @@ borderBottomLeftRadius (Value radius) =
 
 -}
 borderBottomLeftRadius2 :
-    Value
+    Stylist2
         (LengthSupported
             { pct : Supported
             }
         )
-    ->
-        Value
-            (LengthSupported
-                { pct : Supported
-                }
-            )
-    -> Style
+        (LengthSupported
+            { pct : Supported
+            }
+        )
 borderBottomLeftRadius2 (Value horizontal) (Value vertical) =
     AppendProperty ("border-bottom-left-radius:" ++ horizontal ++ " " ++ vertical)
 
@@ -6557,15 +6090,11 @@ Specifies the distance by which an element's border image is set out from its bo
 
 -}
 borderImageOutset :
-    Value
+    Stylist
         (LengthSupported
             { num : Supported
-            , inherit : Supported
-            , initial : Supported
-            , unset : Supported
             }
         )
-    -> Style
 borderImageOutset (Value width) =
     AppendProperty ("border-image-outset:" ++ width)
 
@@ -6581,18 +6110,15 @@ Specifies the distance by which an element's border image is set out from its bo
 
 -}
 borderImageOutset2 :
-    Value
+    Stylist2
         (LengthSupported
             { num : Supported
             }
         )
-    ->
-        Value
-            (LengthSupported
-                { num : Supported
-                }
-            )
-    -> Style
+        (LengthSupported
+            { num : Supported
+            }
+        )
 borderImageOutset2 (Value valueTopBottom) (Value valueRightLeft) =
     AppendProperty ("border-image-outset:" ++ valueTopBottom ++ " " ++ valueRightLeft)
 
@@ -6608,24 +6134,19 @@ Specifies the distance by which an element's border image is set out from its bo
 
 -}
 borderImageOutset3 :
-    Value
+    Stylist3
         (LengthSupported
             { num : Supported
             }
         )
-    ->
-        Value
-            (LengthSupported
-                { num : Supported
-                }
-            )
-    ->
-        Value
-            (LengthSupported
-                { num : Supported
-                }
-            )
-    -> Style
+        (LengthSupported
+            { num : Supported
+            }
+        )
+        (LengthSupported
+            { num : Supported
+            }
+        )
 borderImageOutset3 (Value valueTop) (Value valueRightLeft) (Value valueBottom) =
     AppendProperty ("border-image-outset:" ++ valueTop ++ " " ++ valueRightLeft ++ " " ++ valueBottom)
 
@@ -6641,30 +6162,23 @@ Specifies the distance by which an element's border image is set out from its bo
 
 -}
 borderImageOutset4 :
-    Value
+    Stylist4
         (LengthSupported
             { num : Supported
             }
         )
-    ->
-        Value
-            (LengthSupported
-                { num : Supported
-                }
-            )
-    ->
-        Value
-            (LengthSupported
-                { num : Supported
-                }
-            )
-    ->
-        Value
-            (LengthSupported
-                { num : Supported
-                }
-            )
-    -> Style
+        (LengthSupported
+            { num : Supported
+            }
+        )
+        (LengthSupported
+            { num : Supported
+            }
+        )
+        (LengthSupported
+            { num : Supported
+            }
+        )
 borderImageOutset4 (Value valueTop) (Value valueRight) (Value valueBottom) (Value valueLeft) =
     AppendProperty ("border-image-outset:" ++ valueTop ++ " " ++ valueRight ++ " " ++ valueBottom ++ " " ++ valueLeft)
 
@@ -6680,17 +6194,13 @@ Specifies the width of an element's border image. Supports values specified as l
 
 -}
 borderImageWidth :
-    Value
+    Stylist
         (LengthSupported
             { pct : Supported
             , num : Supported
             , auto : Supported
-            , inherit : Supported
-            , initial : Supported
-            , unset : Supported
             }
         )
-    -> Style
 borderImageWidth (Value width) =
     AppendProperty ("border-image-width:" ++ width)
 
@@ -6706,22 +6216,19 @@ Specifies the width of an element's border image. Supports values specified as l
 
 -}
 borderImageWidth2 :
-    Value
+    Stylist2
         (LengthSupported
             { pct : Supported
             , num : Supported
             , auto : Supported
             }
         )
-    ->
-        Value
-            (LengthSupported
-                { pct : Supported
-                , num : Supported
-                , auto : Supported
-                }
-            )
-    -> Style
+        (LengthSupported
+            { pct : Supported
+            , num : Supported
+            , auto : Supported
+            }
+        )
 borderImageWidth2 (Value valueTopBottom) (Value valueRightLeft) =
     AppendProperty ("border-image-width:" ++ valueTopBottom ++ " " ++ valueRightLeft)
 
@@ -6737,30 +6244,25 @@ Specifies the width of an element's border image. Supports values specified as l
 
 -}
 borderImageWidth3 :
-    Value
+    Stylist3
         (LengthSupported
             { pct : Supported
             , num : Supported
             , auto : Supported
             }
         )
-    ->
-        Value
-            (LengthSupported
-                { pct : Supported
-                , num : Supported
-                , auto : Supported
-                }
-            )
-    ->
-        Value
-            (LengthSupported
-                { pct : Supported
-                , num : Supported
-                , auto : Supported
-                }
-            )
-    -> Style
+        (LengthSupported
+            { pct : Supported
+            , num : Supported
+            , auto : Supported
+            }
+        )
+        (LengthSupported
+            { pct : Supported
+            , num : Supported
+            , auto : Supported
+            }
+        )
 borderImageWidth3 (Value valueTop) (Value valueRightLeft) (Value valueBottom) =
     AppendProperty ("border-image-width:" ++ valueTop ++ " " ++ valueRightLeft ++ " " ++ valueBottom)
 
@@ -6776,38 +6278,31 @@ Specifies the width of an element's border image. Supports values specified as l
 
 -}
 borderImageWidth4 :
-    Value
+    Stylist4
         (LengthSupported
             { pct : Supported
             , num : Supported
             , auto : Supported
             }
         )
-    ->
-        Value
-            (LengthSupported
-                { pct : Supported
-                , num : Supported
-                , auto : Supported
-                }
-            )
-    ->
-        Value
-            (LengthSupported
-                { pct : Supported
-                , num : Supported
-                , auto : Supported
-                }
-            )
-    ->
-        Value
-            (LengthSupported
-                { pct : Supported
-                , num : Supported
-                , auto : Supported
-                }
-            )
-    -> Style
+        (LengthSupported
+            { pct : Supported
+            , num : Supported
+            , auto : Supported
+            }
+        )
+        (LengthSupported
+            { pct : Supported
+            , num : Supported
+            , auto : Supported
+            }
+        )
+        (LengthSupported
+            { pct : Supported
+            , num : Supported
+            , auto : Supported
+            }
+        )
 borderImageWidth4 (Value valueTop) (Value valueRight) (Value valueBottom) (Value valueLeft) =
     AppendProperty ("border-image-width:" ++ valueTop ++ " " ++ valueRight ++ " " ++ valueBottom ++ " " ++ valueLeft)
 
@@ -6823,15 +6318,11 @@ borderImageWidth4 (Value valueTop) (Value valueRight) (Value valueBottom) (Value
 
 -}
 textOrientation :
-    Value
+    Stylist
         { mixed : Supported
         , sideways : Supported
         , upright : Supported
-        , initial : Supported
-        , inherit : Supported
-        , unset : Supported
         }
-    -> Style
 textOrientation (Value str) =
     AppendProperty ("text-orientation:" ++ str)
 
@@ -6877,16 +6368,12 @@ upright =
 
 -}
 textRendering :
-    Value
+    Stylist
         { auto : Supported
         , geometricPrecision : Supported
         , optimizeLegibility : Supported
         , optimizeSpeed : Supported
-        , initial : Supported
-        , inherit : Supported
-        , unset : Supported
         }
-    -> Style
 textRendering (Value str) =
     AppendProperty ("text-rendering:" ++ str)
 
@@ -6932,17 +6419,13 @@ optimizeSpeed =
 
 -}
 textTransform :
-    Value
+    Stylist
         { capitalize : Supported
         , uppercase : Supported
         , lowercase : Supported
         , fullWidth : Supported
         , none : Supported
-        , initial : Supported
-        , inherit : Supported
-        , unset : Supported
         }
-    -> Style
 textTransform (Value str) =
     AppendProperty ("text-transform:" ++ str)
 
@@ -7001,16 +6484,12 @@ fullWidth =
 
 -}
 textDecoration :
-    Value
+    Stylist
         { none : Supported
         , underline : Supported
         , overline : Supported
         , lineThrough : Supported
-        , inherit : Supported
-        , initial : Supported
-        , unset : Supported
         }
-    -> Style
 textDecoration (Value line) =
     AppendProperty ("text-decoration:" ++ line)
 
@@ -7025,21 +6504,18 @@ textDecoration (Value line) =
 
 -}
 textDecoration2 :
-    Value
+    Stylist2
         { none : Supported
         , underline : Supported
         , overline : Supported
         , lineThrough : Supported
         }
-    ->
-        Value
-            { solid : Supported
-            , double : Supported
-            , dotted : Supported
-            , dashed : Supported
-            , wavy : Supported
-            }
-    -> Style
+        { solid : Supported
+        , double : Supported
+        , dotted : Supported
+        , dashed : Supported
+        , wavy : Supported
+        }
 textDecoration2 (Value line) (Value style) =
     AppendProperty ("text-decoration:" ++ line ++ " " ++ style)
 
@@ -7054,22 +6530,19 @@ textDecoration2 (Value line) (Value style) =
 
 -}
 textDecoration3 :
-    Value
+    Stylist3
         { none : Supported
         , underline : Supported
         , overline : Supported
         , lineThrough : Supported
         }
-    ->
-        Value
-            { solid : Supported
-            , double : Supported
-            , dotted : Supported
-            , dashed : Supported
-            , wavy : Supported
-            }
-    -> Value Color
-    -> Style
+        { solid : Supported
+        , double : Supported
+        , dotted : Supported
+        , dashed : Supported
+        , wavy : Supported
+        }
+        Color
 textDecoration3 (Value line) (Value style) (Value color) =
     AppendProperty ("text-decoration:" ++ line ++ " " ++ style ++ " " ++ color)
 
@@ -7084,16 +6557,12 @@ textDecoration3 (Value line) (Value style) (Value color) =
 
 -}
 textDecorationLine :
-    Value
+    Stylist
         { none : Supported
         , underline : Supported
         , overline : Supported
         , lineThrough : Supported
-        , inherit : Supported
-        , initial : Supported
-        , unset : Supported
         }
-    -> Style
 textDecorationLine (Value line) =
     AppendProperty ("text-decoration-line:" ++ line)
 
@@ -7108,18 +6577,15 @@ textDecorationLine (Value line) =
 
 -}
 textDecorationLine2 :
-    Value
+    Stylist2
         { underline : Supported
         , overline : Supported
         , lineThrough : Supported
         }
-    ->
-        Value
-            { underline : Supported
-            , overline : Supported
-            , lineThrough : Supported
-            }
-    -> Style
+        { underline : Supported
+        , overline : Supported
+        , lineThrough : Supported
+        }
 textDecorationLine2 (Value line1) (Value line2) =
     AppendProperty ("text-decoration-line:" ++ line1 ++ " " ++ line2)
 
@@ -7134,24 +6600,19 @@ textDecorationLine2 (Value line1) (Value line2) =
 
 -}
 textDecorationLine3 :
-    Value
+    Stylist3
         { underline : Supported
         , overline : Supported
         , lineThrough : Supported
         }
-    ->
-        Value
-            { underline : Supported
-            , overline : Supported
-            , lineThrough : Supported
-            }
-    ->
-        Value
-            { underline : Supported
-            , overline : Supported
-            , lineThrough : Supported
-            }
-    -> Style
+        { underline : Supported
+        , overline : Supported
+        , lineThrough : Supported
+        }
+        { underline : Supported
+        , overline : Supported
+        , lineThrough : Supported
+        }
 textDecorationLine3 (Value line1) (Value line2) (Value line3) =
     AppendProperty ("text-decoration-line:" ++ line1 ++ " " ++ line2 ++ " " ++ line3)
 
@@ -7164,17 +6625,13 @@ textDecorationLine3 (Value line1) (Value line2) (Value line3) =
 
 -}
 textDecorationStyle :
-    Value
+    Stylist
         { solid : Supported
         , double : Supported
         , dotted : Supported
         , dashed : Supported
         , wavy : Supported
-        , inherit : Supported
-        , initial : Supported
-        , unset : Supported
         }
-    -> Style
 textDecorationStyle (Value style) =
     AppendProperty ("text-decoration-style:" ++ style)
 
@@ -7186,15 +6643,7 @@ textDecorationStyle (Value style) =
 [text-decoration-color]: https://css-tricks.com/almanac/properties/t/text-decoration-color/
 
 -}
-textDecorationColor :
-    Value
-        (ColorSupported
-            { inherit : Supported
-            , initial : Supported
-            , unset : Supported
-            }
-        )
-    -> Style
+textDecorationColor : Stylist Color
 textDecorationColor (Value color) =
     AppendProperty ("text-decoration-color:" ++ color)
 
@@ -7315,14 +6764,10 @@ lineThrough =
 
 -}
 borderCollapse :
-    Value
+    Stylist
         { collapse : Supported
         , separate : Supported
-        , initial : Supported
-        , inherit : Supported
-        , unset : Supported
         }
-    -> Style
 borderCollapse (Value str) =
     AppendProperty ("border-collapse:" ++ str)
 
@@ -7359,15 +6804,7 @@ separate =
     borderSpacing (px 5)
 
 -}
-borderSpacing :
-    Value
-        (LengthSupported
-            { initial : Supported
-            , inherit : Supported
-            , unset : Supported
-            }
-        )
-    -> Style
+borderSpacing : Stylist Length
 borderSpacing (Value str) =
     AppendProperty ("border-spacing:" ++ str)
 
@@ -7377,10 +6814,7 @@ borderSpacing (Value str) =
     borderSpacing2 (cm 1) (em 2)
 
 -}
-borderSpacing2 :
-    Value Length
-    -> Value Length
-    -> Style
+borderSpacing2 : Stylist2 Length Length
 borderSpacing2 (Value horizontal) (Value vertical) =
     AppendProperty ("border-spacing:" ++ horizontal ++ " " ++ vertical)
 
@@ -7396,14 +6830,10 @@ borderSpacing2 (Value horizontal) (Value vertical) =
 
 -}
 captionSide :
-    Value
+    Stylist
         { top_ : Supported
         , bottom_ : Supported
-        , initial : Supported
-        , inherit : Supported
-        , unset : Supported
         }
-    -> Style
 captionSide (Value str) =
     AppendProperty ("caption-side:" ++ str)
 
@@ -7419,14 +6849,10 @@ captionSide (Value str) =
 
 -}
 emptyCells :
-    Value
+    Stylist
         { show : Supported
         , hide : Supported
-        , initial : Supported
-        , inherit : Supported
-        , unset : Supported
         }
-    -> Style
 emptyCells (Value str) =
     AppendProperty ("empty-cells:" ++ str)
 
@@ -7462,14 +6888,10 @@ hide =
 
 -}
 tableLayout :
-    Value
+    Stylist
         { auto : Supported
         , fixed : Supported
-        , initial : Supported
-        , inherit : Supported
-        , unset : Supported
         }
-    -> Style
 tableLayout (Value str) =
     AppendProperty ("table-layout:" ++ str)
 
@@ -7485,7 +6907,7 @@ tableLayout (Value str) =
 
 -}
 verticalAlign :
-    Value
+    Stylist
         (LengthSupported
             { baseline : Supported
             , sub : Supported
@@ -7496,12 +6918,8 @@ verticalAlign :
             , top_ : Supported
             , bottom_ : Supported
             , pct : Supported
-            , initial : Supported
-            , inherit : Supported
-            , unset : Supported
             }
         )
-    -> Style
 verticalAlign (Value str) =
     AppendProperty ("vertical-align:" ++ str)
 
@@ -7563,14 +6981,10 @@ middle =
 
 -}
 direction :
-    Value
+    Stylist
         { rtl : Supported
         , ltr : Supported
-        , inherit : Supported
-        , initial : Supported
-        , unset : Supported
         }
-    -> Style
 direction (Value str) =
     AppendProperty ("direction:" ++ str)
 
@@ -7582,7 +6996,7 @@ direction (Value str) =
 
 -}
 textAlign :
-    Value
+    Stylist
         { left_ : Supported
         , right_ : Supported
         , center : Supported
@@ -7590,11 +7004,7 @@ textAlign :
         , start : Supported
         , end : Supported
         , matchParent : Supported
-        , inherit : Supported
-        , initial : Supported
-        , unset : Supported
         }
-    -> Style
 textAlign (Value str) =
     AppendProperty ("text-align:" ++ str)
 
@@ -7654,17 +7064,13 @@ rtl =
 
 -}
 whiteSpace :
-    Value
+    Stylist
         { normal : Supported
         , nowrap : Supported
         , pre : Supported
         , preWrap : Supported
         , preLine : Supported
-        , inherit : Supported
-        , initial : Supported
-        , unset : Supported
         }
-    -> Style
 whiteSpace (Value str) =
     AppendProperty ("white-space:" ++ str)
 
@@ -7722,16 +7128,12 @@ preLine =
 
 -}
 wordBreak :
-    Value
+    Stylist
         { normal : Supported
         , breakAll : Supported
         , keepAll : Supported
         , breakWord : Supported
-        , inherit : Supported
-        , initial : Supported
-        , unset : Supported
         }
-    -> Style
 wordBreak (Value str) =
     AppendProperty ("word-break:" ++ str)
 
@@ -7768,15 +7170,11 @@ keepAll =
 
 -}
 float :
-    Value
+    Stylist
         { none : Supported
         , left_ : Supported
         , right_ : Supported
-        , inherit : Supported
-        , initial : Supported
-        , unset : Supported
         }
-    -> Style
 float (Value str) =
     AppendProperty ("float:" ++ str)
 
@@ -7793,15 +7191,11 @@ float (Value str) =
 
 -}
 visibility :
-    Value
+    Stylist
         { visible : Supported
         , hidden : Supported
         , collapse : Supported
-        , inherit : Supported
-        , initial : Supported
-        , unset : Supported
         }
-    -> Style
 visibility (Value str) =
     AppendProperty ("visibility:" ++ str)
 
@@ -7817,14 +7211,10 @@ visibility (Value str) =
 
 -}
 order :
-    Value
+    Stylist
         { num : Supported
         , zero : Supported
-        , inherit : Supported
-        , initial : Supported
-        , unset : Supported
         }
-    -> Style
 order (Value val) =
     AppendProperty ("order:" ++ val)
 
@@ -7839,15 +7229,11 @@ order (Value val) =
 
 -}
 fill :
-    Value
+    Stylist
         (ColorSupported
             { url : Supported
-            , inherit : Supported
-            , initial : Supported
-            , unset : Supported
             }
         )
-    -> Style
 fill (Value val) =
     AppendProperty ("fill:" ++ val)
 
@@ -7863,15 +7249,11 @@ fill (Value val) =
 
 -}
 columns :
-    Value
+    Stylist
         (LengthSupported
             { auto : Supported
-            , initial : Supported
-            , inherit : Supported
-            , unset : Supported
             }
         )
-    -> Style
 columns (Value width) =
     AppendProperty ("columns:" ++ width)
 
@@ -7883,17 +7265,14 @@ columns (Value width) =
 
 -}
 columns2 :
-    Value
+    Stylist2
         (LengthSupported
             { auto : Supported
             }
         )
-    ->
-        Value
-            { auto : Supported
-            , num : Supported
-            }
-    -> Style
+        { auto : Supported
+        , num : Supported
+        }
 columns2 (Value width) (Value count) =
     AppendProperty ("columns:" ++ width ++ " " ++ count)
 
@@ -7905,15 +7284,11 @@ columns2 (Value width) (Value count) =
 
 -}
 columnWidth :
-    Value
+    Stylist
         (LengthSupported
             { auto : Supported
-            , initial : Supported
-            , inherit : Supported
-            , unset : Supported
             }
         )
-    -> Style
 columnWidth (Value width) =
     AppendProperty ("column-width:" ++ width)
 
@@ -7925,14 +7300,10 @@ columnWidth (Value width) =
 
 -}
 columnCount :
-    Value
+    Stylist
         { auto : Supported
         , num : Supported
-        , initial : Supported
-        , inherit : Supported
-        , unset : Supported
         }
-    -> Style
 columnCount (Value count) =
     AppendProperty ("column-count:" ++ count)
 
@@ -7945,15 +7316,11 @@ columnCount (Value count) =
 
 -}
 columnFill :
-    Value
+    Stylist
         { auto : Supported
         , balance : Supported
         , balanceAll : Supported
-        , initial : Supported
-        , inherit : Supported
-        , unset : Supported
         }
-    -> Style
 columnFill (Value val) =
     AppendProperty ("column-fill:" ++ val)
 
@@ -7985,14 +7352,10 @@ balanceAll =
 
 -}
 columnSpan :
-    Value
+    Stylist
         { none : Supported
         , all_ : Supported
-        , initial : Supported
-        , inherit : Supported
-        , unset : Supported
         }
-    -> Style
 columnSpan (Value span) =
     AppendProperty ("column-span:" ++ span)
 
@@ -8014,15 +7377,11 @@ all_ =
 
 -}
 columnGap :
-    Value
+    Stylist
         (LengthSupported
             { normal : Supported
-            , initial : Supported
-            , inherit : Supported
-            , unset : Supported
             }
         )
-    -> Style
 columnGap (Value width) =
     AppendProperty ("column-gap:" ++ width)
 
@@ -8033,15 +7392,7 @@ columnGap (Value width) =
     columnRuleWidth (px 2)
 
 -}
-columnRuleWidth :
-    Value
-        (BorderWidthSupported
-            { initial : Supported
-            , inherit : Supported
-            , unset : Supported
-            }
-        )
-    -> Style
+columnRuleWidth : Stylist BorderWidth
 columnRuleWidth (Value width) =
     AppendProperty ("column-rule-width:" ++ width)
 
@@ -8053,15 +7404,7 @@ columnRuleWidth (Value width) =
     columnRuleStyle dashed
 
 -}
-columnRuleStyle :
-    Value
-        (BorderStyleSupported
-            { inherit : Supported
-            , initial : Supported
-            , unset : Supported
-            }
-        )
-    -> Style
+columnRuleStyle : Stylist BorderStyle
 columnRuleStyle (Value style) =
     AppendProperty ("column-rule-style:" ++ style)
 
@@ -8072,15 +7415,7 @@ columnRuleStyle (Value style) =
     columnRuleColor (hex "#fff")
 
 -}
-columnRuleColor :
-    Value
-        (ColorSupported
-            { inherit : Supported
-            , initial : Supported
-            , unset : Supported
-            }
-        )
-    -> Style
+columnRuleColor : Stylist Color
 columnRuleColor (Value color) =
     AppendProperty ("column-rule-color:" ++ color)
 
@@ -8098,16 +7433,12 @@ columnRuleColor (Value color) =
 
 -}
 strokeDasharray :
-    Value
+    Stylist
         (LengthSupported
             { num : Supported
             , pct : Supported
-            , inherit : Supported
-            , initial : Supported
-            , unset : Supported
             }
         )
-    -> Style
 strokeDasharray (Value val) =
     AppendProperty ("stroke-dasharray:" ++ val)
 
@@ -8120,16 +7451,12 @@ strokeDasharray (Value val) =
 
 -}
 strokeDashoffset :
-    Value
+    Stylist
         { zero : Supported
         , calc : Supported
         , num : Supported
         , pct : Supported
-        , inherit : Supported
-        , initial : Supported
-        , unset : Supported
         }
-    -> Style
 strokeDashoffset (Value val) =
     AppendProperty ("stroke-dashoffset:" ++ val)
 
@@ -8142,15 +7469,11 @@ strokeDashoffset (Value val) =
 
 -}
 strokeLinecap :
-    Value
+    Stylist
         { butt : Supported
         , square : Supported
         , round : Supported
-        , inherit : Supported
-        , initial : Supported
-        , unset : Supported
         }
-    -> Style
 strokeLinecap (Value val) =
     AppendProperty ("stroke-linecap:" ++ val)
 
@@ -8186,16 +7509,12 @@ square =
 
 -}
 strokeWidth :
-    Value
+    Stylist
         (LengthSupported
             { num : Supported
             , pct : Supported
-            , inherit : Supported
-            , initial : Supported
-            , unset : Supported
             }
         )
-    -> Style
 strokeWidth (Value val) =
     AppendProperty ("stroke-width:" ++ val)
 
@@ -8208,15 +7527,11 @@ strokeWidth (Value val) =
 
 -}
 strokeAlign :
-    Value
+    Stylist
         { center : Supported
         , inset : Supported
         , outset : Supported
-        , inherit : Supported
-        , initial : Supported
-        , unset : Supported
         }
-    -> Style
 strokeAlign (Value val) =
     AppendProperty ("stroke-align:" ++ val)
 
@@ -8229,15 +7544,11 @@ strokeAlign (Value val) =
 
 -}
 strokeBreak :
-    Value
+    Stylist
         { boundingBox : Supported
         , slice : Supported
         , clone : Supported
-        , inherit : Supported
-        , initial : Supported
-        , unset : Supported
         }
-    -> Style
 strokeBreak (Value val) =
     AppendProperty ("stroke-break:" ++ val)
 
@@ -8278,15 +7589,7 @@ clone =
     strokeColor (hex "#FF9E2C")
 
 -}
-strokeColor :
-    Value
-        (ColorSupported
-            { inherit : Supported
-            , initial : Supported
-            , unset : Supported
-            }
-        )
-    -> Style
+strokeColor : Stylist Color
 strokeColor (Value val) =
     AppendProperty ("stroke-color:" ++ val)
 
@@ -8298,14 +7601,10 @@ strokeColor (Value val) =
 
 -}
 strokeImage :
-    Value
+    Stylist
         { url : Supported
         , none : Supported
-        , inherit : Supported
-        , initial : Supported
-        , unset : Supported
         }
-    -> Style
 strokeImage (Value value) =
     AppendProperty ("stroke-image:" ++ value)
 
@@ -8316,13 +7615,9 @@ strokeImage (Value value) =
 
 -}
 strokeMiterlimit :
-    Value
+    Stylist
         { num : Supported
-        , inherit : Supported
-        , initial : Supported
-        , unset : Supported
         }
-    -> Style
 strokeMiterlimit (Value val) =
     AppendProperty ("stroke-miterlimit:" ++ val)
 
@@ -8333,13 +7628,9 @@ strokeMiterlimit (Value val) =
 
 -}
 strokeOpacity :
-    Value
+    Stylist
         { num : Supported
-        , inherit : Supported
-        , initial : Supported
-        , unset : Supported
         }
-    -> Style
 strokeOpacity (Value val) =
     AppendProperty ("stroke-opacity:" ++ val)
 
@@ -8355,18 +7646,14 @@ strokeOpacity (Value val) =
 
 -}
 strokeOrigin :
-    Value
+    Stylist
         { matchParent : Supported
         , fillBox : Supported
         , strokeBox : Supported
         , contentBox : Supported
         , paddingBox : Supported
         , borderBox : Supported
-        , inherit : Supported
-        , initial : Supported
-        , unset : Supported
         }
-    -> Style
 strokeOrigin (Value val) =
     AppendProperty ("stroke-origin:" ++ val)
 
@@ -8409,18 +7696,14 @@ If you need to set the offsets from the right or bottom, use
 
 -}
 strokePosition :
-    Value
+    Stylist
         (LengthSupported
             { pct : Supported
             , left_ : Supported
             , right_ : Supported
             , center : Supported
-            , inherit : Supported
-            , unset : Supported
-            , initial : Supported
             }
         )
-    -> Style
 strokePosition (Value horiz) =
     AppendProperty ("stroke-position:" ++ horiz)
 
@@ -8444,7 +7727,7 @@ If you need to set the offsets from the right or bottom, use
 
 -}
 strokePosition2 :
-    Value
+    Stylist2
         (LengthSupported
             { pct : Supported
             , left_ : Supported
@@ -8452,16 +7735,13 @@ strokePosition2 :
             , center : Supported
             }
         )
-    ->
-        Value
-            (LengthSupported
-                { pct : Supported
-                , top_ : Supported
-                , bottom_ : Supported
-                , center : Supported
-                }
-            )
-    -> Style
+        (LengthSupported
+            { pct : Supported
+            , top_ : Supported
+            , bottom_ : Supported
+            , center : Supported
+            }
+        )
 strokePosition2 (Value horiz) (Value vert) =
     AppendProperty ("stroke-position:" ++ horiz ++ " " ++ vert)
 
@@ -8480,28 +7760,21 @@ vertical (from top) alignment.
 
 -}
 strokePosition4 :
-    Value
+    Stylist4
         { left_ : Supported
         , right_ : Supported
         }
-    ->
-        Value
-            (LengthSupported
-                { pct : Supported
-                }
-            )
-    ->
-        Value
-            { top_ : Supported
-            , bottom_ : Supported
+        (LengthSupported
+            { pct : Supported
             }
-    ->
-        Value
-            (LengthSupported
-                { pct : Supported
-                }
-            )
-    -> Style
+        )
+        { top_ : Supported
+        , bottom_ : Supported
+        }
+        (LengthSupported
+            { pct : Supported
+            }
+        )
 strokePosition4 (Value horiz) (Value horizAmount) (Value vert) (Value vertAmount) =
     AppendProperty
         ("stroke-position:"
@@ -8526,18 +7799,14 @@ If you need to set horizontal and vertical direction separately, see
 
 -}
 strokeRepeat :
-    Value
+    Stylist
         { repeat : Supported
         , repeatX : Supported
         , repeatY : Supported
         , space : Supported
         , round : Supported
         , noRepeat : Supported
-        , initial : Supported
-        , unset : Supported
-        , inherit : Supported
         }
-    -> Style
 strokeRepeat (Value repeat) =
     AppendProperty ("stroke-repeat:" ++ repeat)
 
@@ -8553,20 +7822,17 @@ If you only need to set one value for both, see
 
 -}
 strokeRepeat2 :
-    Value
+    Stylist2
         { repeat : Supported
         , space : Supported
         , round : Supported
         , noRepeat : Supported
         }
-    ->
-        Value
-            { repeat : Supported
-            , space : Supported
-            , round : Supported
-            , noRepeat : Supported
-            }
-    -> Style
+        { repeat : Supported
+        , space : Supported
+        , round : Supported
+        , noRepeat : Supported
+        }
 strokeRepeat2 (Value horiz) (Value vert) =
     AppendProperty ("stroke-repeat:" ++ horiz ++ " " ++ vert)
 
@@ -8584,17 +7850,13 @@ need to set both width and height explicitly, use
 
 -}
 strokeSize :
-    Value
+    Stylist
         (LengthSupported
             { pct : Supported
             , auto : Supported
             , cover : Supported
-            , inherit : Supported
-            , initial : Supported
-            , unset : Supported
             }
         )
-    -> Style
 strokeSize (Value size) =
     AppendProperty ("stroke-size:" ++ size)
 
@@ -8609,20 +7871,17 @@ If you only want to set the width, use [`strokeImage`](#strokeImage) instead.
 
 -}
 strokeSize2 :
-    Value
+    Stylist2
         (LengthSupported
             { pct : Supported
             , auto : Supported
             }
         )
-    ->
-        Value
-            (LengthSupported
-                { pct : Supported
-                , auto : Supported
-                }
-            )
-    -> Style
+        (LengthSupported
+            { pct : Supported
+            , auto : Supported
+            }
+        )
 strokeSize2 (Value width) (Value height) =
     AppendProperty ("stroke-size:" ++ width ++ " " ++ height)
 
@@ -8635,18 +7894,14 @@ strokeSize2 (Value width) (Value height) =
 
 -}
 strokeDashCorner :
-    Value
+    Stylist
         (LengthSupported
             { none : Supported
             , pct : Supported
             , auto : Supported
             , cover : Supported
-            , inherit : Supported
-            , initial : Supported
-            , unset : Supported
             }
         )
-    -> Style
 strokeDashCorner (Value size) =
     AppendProperty ("stroke-dash-corner:" ++ size)
 
@@ -8662,15 +7917,11 @@ and set it's first value to `miter` like so: `strokeLinejoin2 miter bevel`.
 
 -}
 strokeLinejoin :
-    Value
+    Stylist
         { crop : Supported
         , arcs : Supported
         , miter : Supported
-        , inherit : Supported
-        , initial : Supported
-        , unset : Supported
         }
-    -> Style
 strokeLinejoin (Value val) =
     AppendProperty ("stroke-linejoin:" ++ val)
 
@@ -8683,18 +7934,15 @@ strokeLinejoin (Value val) =
 
 -}
 strokeLinejoin2 :
-    Value
+    Stylist2
         { crop : Supported
         , arcs : Supported
         , miter : Supported
         }
-    ->
-        Value
-            { bevel : Supported
-            , round : Supported
-            , stupid : Supported
-            }
-    -> Style
+        { bevel : Supported
+        , round : Supported
+        , stupid : Supported
+        }
 strokeLinejoin2 (Value extendCorner) (Value capRender) =
     AppendProperty ("stroke-linejoin:" ++ extendCorner ++ " " ++ capRender)
 
@@ -8759,17 +8007,13 @@ stupid =
 
 -}
 strokeDashJustify :
-    Value
+    Stylist
         { none : Supported
         , stretch : Supported
         , compress : Supported
         , dashes : Supported
         , gaps : Supported
-        , inherit : Supported
-        , initial : Supported
-        , unset : Supported
         }
-    -> Style
 strokeDashJustify (Value val) =
     AppendProperty ("stroke-dash-justify:" ++ val)
 
@@ -8814,15 +8058,7 @@ properties.
     columnRule3 thin solid (hex "#000000")
 
 -}
-columnRule :
-    Value
-        (BorderWidthSupported
-            { initial : Supported
-            , inherit : Supported
-            , unset : Supported
-            }
-        )
-    -> Style
+columnRule : Stylist BorderWidth
 columnRule (Value width) =
     AppendProperty ("column-rule:" ++ width)
 
@@ -8837,10 +8073,7 @@ properties.
     columnRule3 thin solid (hex "#000000")
 
 -}
-columnRule2 :
-    Value BorderWidth
-    -> Value BorderStyle
-    -> Style
+columnRule2 : Stylist2 BorderWidth BorderStyle
 columnRule2 (Value width) (Value style) =
     AppendProperty ("column-rule:" ++ width ++ " " ++ style)
 
@@ -8855,11 +8088,7 @@ properties.
     columnRule3 thin solid (hex "#000000")
 
 -}
-columnRule3 :
-    Value BorderWidth
-    -> Value BorderStyle
-    -> Value Color
-    -> Style
+columnRule3 : Stylist3 BorderWidth BorderStyle Color
 columnRule3 (Value width) (Value style) (Value color) =
     AppendProperty ("column-rule:" ++ width ++ " " ++ style ++ " " ++ color)
 
@@ -9370,18 +8599,14 @@ perspective (Value length) =
 
 -}
 clear :
-    Value
+    Stylist
         { none : Supported
         , left_ : Supported
         , right_ : Supported
         , both : Supported
         , inlineStart : Supported
         , inlineEnd : Supported
-        , inherit : Supported
-        , initial : Supported
-        , unset : Supported
         }
-    -> Style
 clear (Value val) =
     AppendProperty ("clear:" ++ val)
 
@@ -9424,15 +8649,11 @@ inlineEnd =
 
 -}
 opacity :
-    Value
+    Stylist
         { num : Supported
         , zero : Supported
         , calc : Supported
-        , inherit : Supported
-        , initial : Supported
-        , unset : Supported
         }
-    -> Style
 opacity (Value val) =
     AppendProperty ("stroke-opacity:" ++ val)
 
@@ -9445,17 +8666,13 @@ opacity (Value val) =
 
 -}
 zoom :
-    Value
+    Stylist
         { pct : Supported
         , zero : Supported
         , num : Supported
         , normal : Supported
         , calc : Supported
         , auto : Supported
-        , inherit : Supported
-        , initial : Supported
-        , unset : Supported
         }
-    -> Style
 zoom (Value val) =
     AppendProperty ("zoom:" ++ val)

--- a/src/Css/Colors.elm
+++ b/src/Css/Colors.elm
@@ -15,123 +15,123 @@ module Css.Colors exposing (aqua, black, blue, fuchsia, gray, green, lime, maroo
 
 -}
 
-import Css exposing (Color, hex)
+import Css exposing (Color, Value, hex)
 
 
 {-| <img src="https://dummyimage.com/1x1/001f3f/001f3f.png" width="504px" height="40px">
 -}
-navy : Color
+navy : Value Color
 navy =
     hex "001F3F"
 
 
 {-| <img src="https://dummyimage.com/1x1/0074d9/0074d9.png" width="504px" height="40px">
 -}
-blue : Color
+blue : Value Color
 blue =
     hex "0074D9"
 
 
 {-| <img src="https://dummyimage.com/1x1/7fdbff/7fdbff.png" width="504px" height="40px">
 -}
-aqua : Color
+aqua : Value Color
 aqua =
     hex "7FDBFF"
 
 
 {-| <img src="https://dummyimage.com/1x1/39cccc/39cccc.png" width="504px" height="40px">
 -}
-teal : Color
+teal : Value Color
 teal =
     hex "39CCCC"
 
 
 {-| <img src="https://dummyimage.com/1x1/3d9970/3d9970.png" width="504px" height="40px">
 -}
-olive : Color
+olive : Value Color
 olive =
     hex "3D9970"
 
 
 {-| <img src="https://dummyimage.com/1x1/2ecc40/2ecc40.png" width="504px" height="40px">
 -}
-green : Color
+green : Value Color
 green =
     hex "2ECC40"
 
 
 {-| <img src="https://dummyimage.com/1x1/01ff70/01ff70.png" width="504px" height="40px">
 -}
-lime : Color
+lime : Value Color
 lime =
     hex "01FF70"
 
 
 {-| <img src="https://dummyimage.com/1x1/ffdc00/ffdc00.png" width="504px" height="40px">
 -}
-yellow : Color
+yellow : Value Color
 yellow =
     hex "FFDC00"
 
 
 {-| <img src="https://dummyimage.com/1x1/ff851b/ff851b.png" width="504px" height="40px">
 -}
-orange : Color
+orange : Value Color
 orange =
     hex "FF851B"
 
 
 {-| <img src="https://dummyimage.com/1x1/ff4136/ff4136.png" width="504px" height="40px">
 -}
-red : Color
+red : Value Color
 red =
     hex "FF4136"
 
 
 {-| <img src="https://dummyimage.com/1x1/85144b/85144b.png" width="504px" height="40px">
 -}
-maroon : Color
+maroon : Value Color
 maroon =
     hex "85144b"
 
 
 {-| <img src="https://dummyimage.com/1x1/f012be/f012be.png" width="504px" height="40px">
 -}
-fuchsia : Color
+fuchsia : Value Color
 fuchsia =
     hex "F012BE"
 
 
 {-| <img src="https://dummyimage.com/1x1/b10dc9/b10dc9.png" width="504px" height="40px">
 -}
-purple : Color
+purple : Value Color
 purple =
     hex "B10DC9"
 
 
 {-| <img src="https://dummyimage.com/1x1/111111/111111.png" width="504px" height="40px">
 -}
-black : Color
+black : Value Color
 black =
     hex "111111"
 
 
 {-| <img src="https://dummyimage.com/1x1/aaaaaa/aaaaaa.png" width="504px" height="40px">
 -}
-gray : Color
+gray : Value Color
 gray =
     hex "AAAAAA"
 
 
 {-| <img src="https://dummyimage.com/1x1/dddddd/dddddd.png" width="504px" height="40px">
 -}
-silver : Color
+silver : Value Color
 silver =
     hex "dddddd"
 
 
 {-| <img src="https://dummyimage.com/1x1/ffffff/ffffff.png" width="504px" height="40px">
 -}
-white : Color
+white : Value Color
 white =
     hex "ffffff"


### PR DESCRIPTION
When writing the [flexbox phantom types](https://github.com/rtfeldman/elm-css/pull/452), I noticed that using a value that can include a [CSS length](https://developer.mozilla.org/en-US/docs/Web/CSS/length) was quite error prone.

 It required a copy/paste from another similar function or from the spec and double checking each supported value in the record, without [forgetting](https://github.com/rtfeldman/elm-css/blob/32f1b4d0ff836652cb7a6d9ccdbfd600dc70270b/src/Css.elm#L11087) to add `zero` and `calc`. Also if a new unit is added one day (as `rem` or others before), it would be quite difficult to be sure to have updated all functions that support a `length` as they are not easily identified (there are also some inconsistencies in the order of the record values for example). 

At last, making single `Value` supporting `inherit`, `initial` and `unset` also required some attention and could be quite easily misdone (for example look at the [spurious `inherit` in the last `Value` of `borderWidth3` current version](https://github.com/rtfeldman/elm-css/blob/32f1b4d0ff836652cb7a6d9ccdbfd600dc70270b/src/Css.elm#L6955)).

This proposal aims at improving this.

I would advise to read first each commit separately to ease the understanding of the quite large modifications.

## [1. Introduce phantom types aliases](https://github.com/rtfeldman/elm-css/pull/453/commits/e7c880c5336a6f08ec288d7e700784bcc9d1bca4)

This commit introduces phantom types aliases to improve the reliability, readability and ease of modification of the library without loosing the type check properties and error messages of the `phantom-type` branch.

Ex:
```elm
{-| A type alias used to accept a length among other values.
-}
type alias LengthSupported v =
    { v  
        | ch : Supported
        , em : Supported
        , ex : Supported
        , rem : Supported
        , vh : Supported
        , vw : Supported
        , vmin : Supported
        , vmax : Supported
        , px : Supported
        , cm : Supported
        , mm : Supported
        , inches : Supported
        , pc : Supported
        , pt : Supported
        , zero : Supported
        , calc : Supported
    }    


{-| A type alias used to accept a length.
-}
type alias Length =
    LengthSupported {}
```

* the type aliases can be combined, even with duplicate fields

Ex:
```elm
type alias BorderWidthSupported v =
    LengthSupported
        { v
            | thin : Supported
            , medium : Supported
            , thick : Supported
        }

borderLeft :
    Value
        (BorderWidthSupported
            { inherit : Supported
            , initial : Supported
            , unset : Supported
            }
        )
    -> Style
```
* errors messages are strictly identical as before (ie: very nice in this branch)

Ex:
```elm
top :
    Value
        (LengthSupported
            { pct : Supported
            , auto : Supported
            , inherit : Supported
            , initial : Supported
            , unset : Supported
            }
        )
    -> Style
[...]


main = 
    toUnstyled <|
        div
            [ css
                [ top (rgb 2 2 2)
                ]
            ]
            []
```
raises the following error:
```elm
-- TYPE MISMATCH ------------------------------------------------------ Main.elm

The argument to function `top` is causing a mismatch.

18|                   top (rgb 2 2 2)
                           ^^^^^^^^^
Function `top` is expecting the argument to be:

    Value
        { auto : ...
        , calc : ...
        , ch : ...
        , cm : ...
        , em : ...
        , ex : ...
        , inches : ...
        , inherit : ...
        , initial : ...
        , mm : ...
        , pc : ...
        , pct : ...
        , pt : ...
        , px : ...
        , rem : ...
        , unset : ...
        , vh : ...
        , vmax : ...
        , vmin : ...
        , vw : ...
        , zero : ...
        }

But it is:

    Value { provides | rgb : ... }

Hint: The record fields do not match up. One has auto, calc, ch, cm, em, ex,
inches, inherit, initial, mm, pc, pct, pt, px, rem, unset, vh, vmax, vmin, vw,
and zero. The other has rgb.
```
* the signatures might be considered less explicit, but I would say that they are closer to MDN documentation and more readable when there are a lot of supported values (like for `length`). Look at the `margin` functions signature for example:

```elm
margin :
    Value
        (LengthSupported
            { pct : Supported
            , auto : Supported
            , inherit : Supported
            , initial : Supported
            , unset : Supported
            }
        )
    -> Style

margin4 :
    Value
        (LengthSupported
            { pct : Supported
            , auto : Supported
            }
        )
    ->
        Value
            (LengthSupported
                { pct : Supported
                , auto : Supported
                }
            )
    ->
        Value
            (LengthSupported
                { pct : Supported
                , auto : Supported
                }
            )
    ->
        Value
            (LengthSupported
                { pct : Supported
                , auto : Supported
                }
            )
    -> Style

```
With `LengthSupported` being a link to its definition.

Compared to the initial version:

```elm
margin :
    Value
        { ch : Supported
        , cm : Supported
        , em : Supported
        , ex : Supported
        , inches : Supported
        , mm : Supported
        , pc : Supported
        , pt : Supported
        , pct : Supported
        , px : Supported
        , rem : Supported
        , vh : Supported
        , vmax : Supported
        , vmin : Supported
        , vw : Supported
        , zero : Supported
        , calc : Supported
        , auto : Supported
        , inherit : Supported
        , initial : Supported
        , unset : Supported
        }
    -> Style 

margin4 :
    Value
        { ch : Supported
        , cm : Supported
        , em : Supported
        , ex : Supported
        , inches : Supported
        , mm : Supported
        , pc : Supported
        , pt : Supported
        , pct : Supported
        , px : Supported
        , rem : Supported
        , vh : Supported
        , vmax : Supported
        , vmin : Supported
        , vw : Supported
        , zero : Supported
        , calc : Supported
        , auto : Supported
        }
    ->
        Value
            { ch : Supported
            , cm : Supported
            , em : Supported
            , ex : Supported
            , inches : Supported
            , mm : Supported
            , pc : Supported
            , pt : Supported
            , pct : Supported
            , px : Supported
            , rem : Supported
            , vh : Supported
            , vmax : Supported
            , vmin : Supported
            , vw : Supported
            , zero : Supported
            , calc : Supported
            , auto : Supported
            }
   ->
        Value
            { ch : Supported
            , cm : Supported
            , em : Supported
            , ex : Supported
            , inches : Supported
            , mm : Supported
            , pc : Supported
            , pt : Supported
            , pct : Supported
            , px : Supported
            , rem : Supported
            , vh : Supported
            , vmax : Supported
            , vmin : Supported
            , vw : Supported
            , zero : Supported
            , calc : Supported
            , auto : Supported
            }
    ->
        Value
            { ch : Supported
            , cm : Supported
            , em : Supported
            , ex : Supported
            , inches : Supported
            , mm : Supported
            , pc : Supported
            , pt : Supported
            , pct : Supported
            , px : Supported
            , rem : Supported
            , vh : Supported
            , vmax : Supported
            , vmin : Supported
            , vw : Supported
            , zero : Supported
            , calc : Supported
            , auto : Supported
            }

```
 

* the type aliases help to automatically support `zero` or `calc` for types that support it (like `LengthSupported` ones). For example, look at the [missing `zero` and `calc` in `strokeSize` function current version](https://github.com/rtfeldman/elm-css/blob/32f1b4d0ff836652cb7a6d9ccdbfd600dc70270b/src/Css.elm#L11087).

## [2. Introduce Stylist* types aliases](https://github.com/rtfeldman/elm-css/pull/453/commits/40181bc35f5f898f136d101bbc431cf25d924326)

For the special case of global values (`inherit`, `initial` and `unset`), we could also use a type alias like in the previous commit. However this proposal goes one step further by introducing aliases that help to guarantee the following [implementation guidelines](https://github.com/rtfeldman/elm-css/wiki/Phantom-Types:-Contributing):
> - if a function returning Style takes a single Value, that Value should always support inherit, initial, and unset 
> - If a function returning Style takes more than one Value, however, then none of its arguments should support inherit, initial, or unset

```elm
{-| A type alias for functions returning a `Style` from one `Value`. This alias
will make the `Value` support the `initial`, `inherit` and `unset` global values.
-}
type alias Stylist v =
    Value
        { v
            | initial : Supported
            , inherit : Supported
            , unset : Supported
        }
    -> Style

{-| A type alias for functions returning a `Style` from two `Value`.
-}
type alias Stylist2 v1 v2 =
    Value v1 -> Value v2 -> Style

-- then Stylist3, Stylist4, ...
```

This commit make the signatures a little less explicit (the returned value), but it is quite helpful and signatures are quickly understandable once almost every function use the Stylist* types, so I'm not sure if it is too much or not.

Ex:
```elm
margin :
    Stylist
        (LengthSupported
            { pct : Supported
            , auto : Supported
            }
        )

margin4 :
    Stylist4
        (LengthSupported
            { pct : Supported
            , auto : Supported
            }
        )
        (LengthSupported
            { pct : Supported
            , auto : Supported
            }
        )
        (LengthSupported
            { pct : Supported
            , auto : Supported
            }
        )
        (LengthSupported
            { pct : Supported
            , auto : Supported
            }
        )

borderColor : Stylist Color

borderColor4 : Stylist4 Color Color Color Color
```

## Conclusion

If you look into details, you will see that these commits already fix some small mistakes and a lot of inconsistencies, so it seems clear to me that they make errors more visible and harder to make. 

But this is only a proposal, open for discussion, that could be added partially, modified, rejected, ...
Tell me what you think.