### PR TITLE
Remove elm-css-util dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## Releases
 | Version | Notes |
 | ------- | ----- |
-| [**15.0.0** (unreleased)](https://github.com/rtfeldman/elm-css/tree/15.0.0) | Remove `asPairs`, `Css.Namespace`, and arithmetic operators. Don't report warnings, just emit CSS. Make `Property` opaque and more efficient. Fix `withMedia` nesting bug. (#352) Rename `Css.Foreign` to `Css.Global`. (#360) Remove `Css.Colors`. (#358) Remove experimental border properties. (#438) Remove experimental `dir` pseudo-class. (#442)
+| [**15.0.0** (unreleased)](https://github.com/rtfeldman/elm-css/tree/15.0.0) | Remove `asPairs`, `Css.Namespace`, and arithmetic operators. Don't report warnings, just emit CSS. Make `Property` opaque and more efficient. Fix `withMedia` nesting bug. (#352) Rename `Css.Foreign` to `Css.Global`. (#360) Remove `Css.Colors`. (#358) Remove experimental border properties. (#438) Remove experimental `dir` pseudo-class. (#442) Change `class`, `id`, and `animationName` to accept a `String`.
 | [**14.0.0**](https://github.com/rtfeldman/elm-css/tree/14.0.0) | Remove `Css.asPairsDEPRECATED` in favor of `DEPRECATED.Css.asPairs`. (#352) Fix bug in `borderBottomWidth` functions. (#380) Make `styled` more flexible. (#420) Add `pointerEvents` (#377). Add `Css.Transitions`.
 | [**13.1.1**](https://github.com/rtfeldman/elm-css/tree/13.1.1) | Fix `AngleOrDirection` bug (#356)
 | [**13.1.0**](https://github.com/rtfeldman/elm-css/tree/13.1.0) | Add program, programWithFlags, and beginnerProgram to Html.Styled. (#381) Add `withAttribute`. (#389)

--- a/elm-package.json
+++ b/elm-package.json
@@ -27,7 +27,6 @@
         "Skinney/murmur3": "2.0.4 <= v < 3.0.0",
         "elm-lang/core": "5.0.0 <= v < 6.0.0",
         "elm-lang/virtual-dom": "2.0.0 <= v < 3.0.0",
-        "rtfeldman/elm-css-util": "1.0.2 <= v < 2.0.0",
         "rtfeldman/hex": "1.0.0 <= v < 2.0.0"
     },
     "elm-version": "0.18.0 <= v < 0.19.0"

--- a/src/Css.elm
+++ b/src/Css.elm
@@ -1014,7 +1014,6 @@ deprecated or discouraged.
 -}
 
 import Color
-import Css.Helpers exposing (identifierToString, toCssIdentifier)
 import Css.Preprocess as Preprocess exposing (Style, unwrapSnippet)
 import Css.Structure as Structure exposing (..)
 import Hex
@@ -7443,7 +7442,7 @@ names, or to set `animation-name: none;`
     animationNames [] -- outputs "animation-name: none;"
 
 -}
-animationName : animation -> Style
+animationName : String -> Style
 animationName identifier =
     animationNames [ identifier ]
 
@@ -7457,13 +7456,11 @@ Pass `[]` to set `animation-name: none;`
     animationNames [] -- outputs "animation-name: none;"
 
 -}
-animationNames : List animation -> Style
-animationNames identifiers =
+animationNames : List String -> Style
+animationNames ids =
     let
         value =
-            identifiers
-                |> List.map (identifierToString "")
-                |> String.join ", "
+            String.join ", " ids
     in
     property "animation-name" value
 

--- a/src/Css/Global.elm
+++ b/src/Css/Global.elm
@@ -154,7 +154,6 @@ do to it using `Style` instead!
 
 -}
 
-import Css.Helpers exposing (identifierToString)
 import Css.Media exposing (MediaQuery)
 import Css.Preprocess as Preprocess
     exposing
@@ -193,16 +192,16 @@ type alias Snippet =
 {-| An [id selector](https://developer.mozilla.org/en-US/docs/Web/CSS/ID_selectors).
 
     global
-        [ id NavBar
+        [ id "nav-bar"
             [ width 960 px
             , backgroundColor (rgb 123 42 208)
             ]
         ]
 
 -}
-id : id -> List Style -> Snippet
-id identifier styles =
-    [ Structure.IdSelector (identifierToString "" identifier) ]
+id : String -> List Style -> Snippet
+id str styles =
+    [ Structure.IdSelector str ]
         |> Structure.UniversalSelectorSequence
         |> makeSnippet styles
 
@@ -210,16 +209,16 @@ id identifier styles =
 {-| A [class selector](https://developer.mozilla.org/en-US/docs/Web/CSS/Class_selectors).
 
     global
-        [ class LoginFormButton
+        [ class "login-form-button"
             [ fontWeight normal
             , color (rgb 128 64 32)
             ]
         ]
 
 -}
-class : class -> List Style -> Snippet
-class class styles =
-    [ Structure.ClassSelector (identifierToString "" class) ]
+class : String -> List Style -> Snippet
+class str styles =
+    [ Structure.ClassSelector str ]
         |> Structure.UniversalSelectorSequence
         |> makeSnippet styles
 
@@ -401,9 +400,9 @@ div.is-bold {
 ```
 
 -}
-withClass : class -> List Style -> Style
-withClass class =
-    Preprocess.ExtendSelector (Structure.ClassSelector (identifierToString "" class))
+withClass : String -> List Style -> Style
+withClass str =
+    Preprocess.ExtendSelector (Structure.ClassSelector str)
 
 
 {-| Apply styles to the current selector plus an attribute selector

--- a/tests/CompileFixtures.elm
+++ b/tests/CompileFixtures.elm
@@ -15,16 +15,6 @@ pageDefaultText =
     rgb 40 35 76
 
 
-type CssClasses
-    = Hidden
-    | BasicStyle1
-    | BasicStyle2
-
-
-type CssIds
-    = Page
-
-
 unstyledDiv : Stylesheet
 unstyledDiv =
     stylesheet [ div [] ]
@@ -50,8 +40,8 @@ dreamwriter =
                     ]
                 ]
             ]
-        , class Hidden [ display none |> important ]
-        , id Page
+        , class "Hidden" [ display none |> important ]
+        , id "Page"
             [ width (pct 100)
             , height (pct 100)
             , boxSizing borderBox
@@ -66,7 +56,7 @@ dreamwriter =
 basicStyle1 : Stylesheet
 basicStyle1 =
     stylesheet
-        [ class BasicStyle1
+        [ class "BasicStyle1"
             [ display none ]
         ]
 
@@ -74,6 +64,6 @@ basicStyle1 =
 basicStyle2 : Stylesheet
 basicStyle2 =
     stylesheet
-        [ class BasicStyle2
+        [ class "BasicStyle2"
             [ display none ]
         ]

--- a/tests/Fixtures.elm
+++ b/tests/Fixtures.elm
@@ -6,14 +6,6 @@ import Css.Media exposing (only, print, withMedia)
 import Css.Preprocess exposing (Stylesheet, stylesheet)
 
 
-type CssClasses
-    = Hidden
-
-
-type CssIds
-    = Page
-
-
 type CssAnimations
     = Wobble
 
@@ -166,8 +158,8 @@ multiSelector : Stylesheet
 multiSelector =
     stylesheet
         [ div
-            [ withClass Page
-                [ withClass Hidden
+            [ withClass "Page"
+                [ withClass "Hidden"
                     [ display none
                     , width (pct 100)
                     , height (pct 100)
@@ -374,7 +366,7 @@ colorHexAbbrWarning =
 pseudoElementStylesheet : Stylesheet
 pseudoElementStylesheet =
     stylesheet
-        [ id Page
+        [ id "Page"
             [ margin (px 10)
             , before
                 [ color (hex "#fff") ]
@@ -390,7 +382,7 @@ pseudoElementStylesheet =
 pseudoClassStylesheet : Stylesheet
 pseudoClassStylesheet =
     stylesheet
-        [ id Page
+        [ id "Page"
             [ color (hex "#fff")
             , hover
                 [ marginTop (px 10)

--- a/tests/Media.elm
+++ b/tests/Media.elm
@@ -245,10 +245,6 @@ testMedia =
         ]
 
 
-type CssClasses
-    = Container
-
-
 testWithMedia : Test
 testWithMedia =
     let
@@ -279,7 +275,7 @@ testWithMedia =
                     , withMedia [ only screen [] ] [ textDecoration underline ]
                     , Css.backgroundColor (hex "EE0000")
                     ]
-                , class Container
+                , class "Container"
                     [ Css.maxWidth (px 800)
                     , withMedia [ only screen [ Media.maxWidth (px 375) ], only screen [ Media.maxHeight (px 667) ] ]
                         [ Css.maxWidth (px 300) ]
@@ -542,7 +538,7 @@ bug352 =
                             [ marginRight (px 16) ]
                         ]
                     ]
-                , class Container
+                , class "Container"
                     [ Css.maxWidth (px 800)
                     , withMedia [ only screen [ Media.maxWidth (px 375) ], only screen [ Media.maxHeight (px 667) ] ]
                         [ Css.maxWidth (px 300) ]


### PR DESCRIPTION
For 0.19 the type of `class`, `id`, `animationName`, and `animationNames` will need to change - they will have to accept a `String` instead of any type since `toString` will no longer accept any type.

This changes that, and removes the dependency on `elm-css-util`, since helping with this scenario is the only reason that package existed.