### PR TITLE
Fix #461: degree/radian mismatch for `hsla` hue

### DIFF
--- a/src/Css.elm
+++ b/src/Css.elm
@@ -2318,7 +2318,7 @@ hslaToRgba : String -> Float -> Float -> Float -> Float -> Color
 hslaToRgba value hue saturation lightness hslAlpha =
     let
         { red, green, blue, alpha } =
-            Color.hsla hue saturation lightness hslAlpha
+            Color.hsla (degreesToRadians hue) saturation lightness hslAlpha
                 |> Color.toRgb
     in
     { value = value
@@ -2328,6 +2328,11 @@ hslaToRgba value hue saturation lightness hslAlpha =
     , blue = blue
     , alpha = alpha
     }
+
+
+degreesToRadians : Float -> Float
+degreesToRadians deg =
+    deg * 180 / pi
 
 
 


### PR DESCRIPTION
I didn't see an easy way to write test for this into the existing test strategy, but I'm happy to take another look with some pointers!

I hit this bug when creating "theme" colors for my site, then trying to lighten/darken them by adjusting the `hsla` lightness. `elm-css` only preserves the rgb values, which takes a bit of conversion to round trip through `hsla`, resulting in this bug.

Thanks!
Augustus