### PR TITLE
Phantom Types: add :disabled

### DIFF
--- a/src/Css.elm
+++ b/src/Css.elm
@@ -173,6 +173,7 @@ module Css
         , diagonalFractions
         , difference
         , direction
+        , disabled
         , discretionaryLigatures
         , display
         , displayFlex
@@ -552,7 +553,7 @@ All CSS properties can have the values `unset`, `initial`, and `inherit`.
 
 ## Pseudo-Classes
 
-@docs pseudoClass, active
+@docs pseudoClass, active, disabled
 
 
 ## Pseudo-Elements
@@ -2629,6 +2630,17 @@ pseudoClass pseudoClassName =
 active : List Style -> Style
 active =
     Preprocess.ExtendSelector (Structure.PseudoClassSelector "active")
+
+
+{-| A [`:disabled`](https://developer.mozilla.org/en-US/docs/Web/CSS/:disabled)
+[pseudo-class](https://css-tricks.com/pseudo-class-selectors/).
+
+    button [ disabled [ color (rgb 194 194 194) ] ]
+
+-}
+disabled : List Style -> Style
+disabled =
+    Preprocess.ExtendSelector (Structure.PseudoClassSelector "disabled")
 
 
 


### PR DESCRIPTION
- (n/a) Each Value is an open record with a single field. The field's name is the value's name, and its type is Supported. For example foo : Value { provides | foo : Supported }
 - (n/a) Each function returning Style accepts a closed record of Supported fields.
 - (n/a) If a function returning Style takes a single Value, that Value should always support inherit, initial, and unset because all CSS properties support those three values! For example, borderFoo : Value { foo : Supported, bar : Supported, inherit : Supported, initial : Supported, unset : Supported } -> Style
 - (n/a) If a function returning Style takes more than one Value, however, then none of its arguments should support inherit, initial, or unset, because these can never be used in conjunction with other values! For example, border-radius: 5px 5px; is valid CSS, border-radius: inherit; is valid CSS, but border-radius: 5px inherit; is invalid CSS. To reflect this, borderRadius : Value { ... } -> Style must have inherit : Supported in its record, but borderRadius2 : Value { ... } -> Value { ... } -> Style must not have inherit : Supported in either argument's record. If a user wants to get border-radius: inherit, they must call borderRadius, not borderRadius2!
 - (n/a) When accepting a numeric Value (e.g. a length like px, an angle like deg, or a unitless number like int or num), always include zero : Supported as well as calc : Supported!
 - [x] Every exposed value has documentation which includes at least 1 code sample.
 - [x] Documentation links to to a CSS Tricks article if available, and MDN if not.
 - [x] Make a pull request against the phantom-types branch, not master!