### PR TITLE
Add installation instructions to the README for newcomers

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,14 @@ See [the `Css` module documentation](http://package.elm-lang.org/packages/rtfeld
 - [mixins](http://package.elm-lang.org/packages/rtfeldman/elm-css/latest/Css#batch)
 - [nested media queries](https://davidwalsh.name/write-media-queries-sass) (as well as pseudo-classes like `:hover` and pseudo-elements like `::after`)
 
+### Installation
+
+To install with the Elm package manager (i.e. you have a `elm.json` file), use the following command:
+
+```bash
+elm install rtfeldman/elm-css
+```
+
 ### Examples
 
 - A [reusable datepicker](https://github.com/abadi199/datetimepicker) built by Abadi Kurniawan


### PR DESCRIPTION
I'm just starting using Elm, and it wasn't completely straightforward how to install this package from the manager.

These days, many libraries indicate installation instructions in their README (even simple stuff like `yarn add some-react-lib`).
In this PR, I'm proposing to add these instructions to the README to make it even friendlier for newcomers.