### PR TITLE
Docs fix: class no longer accepts custom types

### DIFF
--- a/0.18-src/Css/Global.elm
+++ b/0.18-src/Css/Global.elm
@@ -166,7 +166,7 @@ selector selectorStr styles =
 
 {-| A [`*` selector](https://developer.mozilla.org/en-US/docs/Web/CSS/Universal_selectors).
 
-    class Foo
+    class "Foo"
         [ children
             [ everything
                 [ color (rgb 14 15 16)

--- a/src/Css/Global.elm
+++ b/src/Css/Global.elm
@@ -166,7 +166,7 @@ selector selectorStr styles =
 
 {-| A [`*` selector](https://developer.mozilla.org/en-US/docs/Web/CSS/Universal_selectors).
 
-    class Foo
+    class "Foo"
         [ children
             [ everything
                 [ color (rgb 14 15 16)


### PR DESCRIPTION
Just a quick documentation fix.

Also, I the old snippet kinda makes me laugh since it looks like we are about to do some good ol' OOP. (`class Foo`)

