### PR TITLE
Fix "seconds"

### DIFF
--- a/0.18-src/Css.elm
+++ b/0.18-src/Css.elm
@@ -2163,7 +2163,7 @@ type alias Duration compatible =
 -}
 sec : Float -> Duration {}
 sec amount =
-    { value = toString amount ++ "sec"
+    { value = toString amount ++ "s"
     , duration = Compatible
     }
 

--- a/src/Css.elm
+++ b/src/Css.elm
@@ -2163,7 +2163,7 @@ type alias Duration compatible =
 -}
 sec : Float -> Duration {}
 sec amount =
-    { value = String.fromFloat amount ++ "sec"
+    { value = String.fromFloat amount ++ "s"
     , duration = Compatible
     }
 


### PR DESCRIPTION
The output for "seconds" should be `"s"`, not `"sec"`

h/t @lukewestby for reporting this!