### PR TITLE
Added justifyContent

### DIFF
--- a/src/Css.elm
+++ b/src/Css.elm
@@ -37,7 +37,7 @@ module Css exposing
     , padding, padding2, padding3, padding4, paddingTop, paddingRight, paddingBottom, paddingLeft
     , margin, margin2, margin3, margin4, marginTop, marginRight, marginBottom, marginLeft
     , boxSizing
-    , alignItems, alignSelf
+    , alignItems, alignSelf, justifyContent
     , fontSize, xxSmall, xSmall, small, medium, large, xLarge, xxLarge, smaller, larger
     , fontFamily, fontFamilies, serif, sansSerif, monospace, cursive, fantasy, systemUi
     , fontStyle, italic, oblique
@@ -270,7 +270,7 @@ All CSS properties can have the values `unset`, `initial`, and `inherit`.
 
 ## Flexbox
 
-@docs alignItems, alignSelf
+@docs alignItems, alignSelf, justifyContent
 
 
 ## Font Size
@@ -3287,6 +3287,28 @@ alignSelf :
     -> Style
 alignSelf (Value val) =
     AppendProperty ("align-self:" ++ val)
+
+
+{-| Sets [`justify-content`](https://css-tricks.com/almanac/properties/j/justify-content/).
+
+    justifyContent center
+
+-}
+justifyContent :
+    Value
+        { flexStart : Supported
+        , flexEnd : Supported
+        , center : Supported
+        , spaceBetween : Supported
+        , spaceAround : Supported
+        , spaceEvenly : Supported
+        , inherit : Supported
+        , initial : Supported
+        , unset : Supported
+        }
+    -> Style
+justifyContent (Value val) =
+    AppendProperty ("justify-content:" ++ val)
 
 
 

--- a/src/Css.elm
+++ b/src/Css.elm
@@ -37,7 +37,7 @@ module Css exposing
     , padding, padding2, padding3, padding4, paddingTop, paddingRight, paddingBottom, paddingLeft
     , margin, margin2, margin3, margin4, marginTop, marginRight, marginBottom, marginLeft
     , boxSizing
-    , alignItems, alignSelf, justifyContent
+    , alignItems, alignSelf, justifyContent, spaceBetween, spaceAround, spaceEvenly
     , fontSize, xxSmall, xSmall, small, medium, large, xLarge, xxLarge, smaller, larger
     , fontFamily, fontFamilies, serif, sansSerif, monospace, cursive, fantasy, systemUi
     , fontStyle, italic, oblique
@@ -270,7 +270,7 @@ All CSS properties can have the values `unset`, `initial`, and `inherit`.
 
 ## Flexbox
 
-@docs alignItems, alignSelf, justifyContent
+@docs alignItems, alignSelf, justifyContent, spaceBetween, spaceAround, spaceEvenly
 
 
 ## Font Size
@@ -3309,6 +3309,38 @@ justifyContent :
     -> Style
 justifyContent (Value val) =
     AppendProperty ("justify-content:" ++ val)
+
+
+{-| Distribute items evenly, with the first and last items aligned to the start
+and end.
+
+    justifyContent spaceBetween
+
+-}
+spaceBetween : Value { provides | spaceBetween : Supported }
+spaceBetween =
+    Value "space-between"
+
+
+{-| Distribute items evenly, with a half-size space on either end.
+
+    justifyContent spaceAround
+
+-}
+spaceAround : Value { provides | spaceAround : Supported }
+spaceAround =
+    Value "space-around"
+
+
+{-| Distribute items evenly, with an equal size space between each element and
+the start and end.
+
+    justifyContent spaceEvenly
+
+-}
+spaceEvenly : Value { provides | spaceEvenly : Supported }
+spaceEvenly =
+    Value "space-evenly"
 
 
 


### PR DESCRIPTION
- [x] Each Value is an open record with a single field. The field's name is the value's name, and its type is Supported. For example foo : Value { provides | foo : Supported }
- [x]  Each function returning Style accepts a closed record of Supported fields.
- [x]  If a function returning Style takes a single Value, that Value should always support inherit, initial, and unset because all CSS properties support those three values! For example, borderFoo : Value { foo : Supported, bar : Supported, inherit : Supported, initial : Supported, unset : Supported } -> Style
- [x]  If a function returning Style takes more than one Value, however, then none of its arguments should support inherit, initial, or unset, because these can never be used in conjunction with other values! For example, border-radius: 5px 5px; is valid CSS, border-radius: inherit; is valid CSS, but border-radius: 5px inherit; is invalid CSS. To reflect this, borderRadius : Value { ... } -> Style must have inherit : Supported in its record, but borderRadius2 : Value { ... } -> Value { ... } -> Style must not have inherit : Supported in either argument's record. If a user wants to get border-radius: inherit, they must call borderRadius, not borderRadius2!
- [x]  When accepting a numeric Value (e.g. a length like px, an angle like deg, or a unitless number like int or num), always include zero : Supported as well as calc : Supported!
- [x]  Every exposed value has documentation which includes at least 1 code sample.
- [x]  Documentation links to to a CSS Tricks article if available, and MDN if not.
- [x]  Make a pull request against the phantom-types branch, not master!
