### PR TITLE
Line height letter spacing

### DIFF
--- a/src/Css.elm
+++ b/src/Css.elm
@@ -38,7 +38,7 @@ module Css exposing
     , margin, margin2, margin3, margin4, marginTop, marginRight, marginBottom, marginLeft
     , boxSizing
     , alignItems, alignSelf
-    , fontSize, xxSmall, xSmall, small, medium, large, xLarge, xxLarge, smaller, larger
+    , fontSize, xxSmall, xSmall, small, medium, large, xLarge, xxLarge, smaller, larger, lineHeight, letterSpacing
     , fontFamily, fontFamilies, serif, sansSerif, monospace, cursive, fantasy, systemUi
     , fontStyle, italic, oblique
     , fontWeight, bold, lighter, bolder
@@ -275,7 +275,7 @@ All CSS properties can have the values `unset`, `initial`, and `inherit`.
 
 ## Font Size
 
-@docs fontSize, xxSmall, xSmall, small, medium, large, xLarge, xxLarge, smaller, larger
+@docs fontSize, xxSmall, xSmall, small, medium, large, xLarge, xxLarge, smaller, larger, lineHeight, letterSpacing
 
 
 ## Font Family
@@ -12264,3 +12264,57 @@ zoom :
     -> Style
 zoom (Value val) =
     AppendProperty ("zoom:" ++ val)
+
+
+{-| Sets [`line-height`](https://css-tricks.com/almanac/properties/l/line-height/)
+
+    lineHeight (pct 150)
+
+    lineHeight (em 2)
+
+    lineHeight (num 1.5)
+
+    lineHeight normal
+
+-}
+lineHeight :  
+    Value
+        { pct : Supported
+        , normal : Supported
+        , num : Supported
+        , inherit : Supported
+        , initial : Supported
+        , unset : Supported
+        , px : Supported
+        , em : Supported
+        , rem : Supported
+        }
+        -> Style
+lineHeight (Value val) =
+    AppendProperty ("line-height:" ++ val)
+
+
+{-| Sets [`letter-spacing`](https://css-tricks.com/almanac/properties/l/letter-spacing/)
+
+    letterSpacing (pct 150)
+
+    letterSpacing (em 2)
+
+    letterSpacing (num 1.5)
+
+    letterSpacing normal
+
+-}
+letterSpacing : 
+    Value
+        { inherit : Supported
+        , normal : Supported
+        , initial : Supported
+        , unset : Supported
+        , rem : Supported
+        , px : Supported
+        , em : Supported
+        }
+        -> Style
+letterSpacing (Value val) =
+    AppendProperty ("letter-spacing:" ++ val)

--- a/src/Css.elm
+++ b/src/Css.elm
@@ -12331,7 +12331,7 @@ zoom (Value val) =
     lineHeight normal
 
 -}
-lineHeight :  
+lineHeight :
     Value
         { pct : Supported
         , normal : Supported
@@ -12345,7 +12345,7 @@ lineHeight :
         , zero : Supported
         , calc : Supported
         }
-        -> Style
+    -> Style
 lineHeight (Value val) =
     AppendProperty ("line-height:" ++ val)
 
@@ -12361,7 +12361,7 @@ lineHeight (Value val) =
     letterSpacing normal
 
 -}
-letterSpacing : 
+letterSpacing :
     Value
         { inherit : Supported
         , normal : Supported
@@ -12373,7 +12373,7 @@ letterSpacing :
         , zero : Supported
         , calc : Supported
         }
-        -> Style
+    -> Style
 letterSpacing (Value val) =
     AppendProperty ("letter-spacing:" ++ val)
 

--- a/src/Css.elm
+++ b/src/Css.elm
@@ -12288,6 +12288,8 @@ lineHeight :
         , px : Supported
         , em : Supported
         , rem : Supported
+        , zero : Supported
+        , calc : Supported
         }
         -> Style
 lineHeight (Value val) =
@@ -12314,6 +12316,8 @@ letterSpacing :
         , rem : Supported
         , px : Supported
         , em : Supported
+        , zero : Supported
+        , calc : Supported
         }
         -> Style
 letterSpacing (Value val) =


### PR DESCRIPTION
- [x]  Each Value is an open record with a single field. The field's name is the value's name, and its type is Supported. For example foo : Value { provides | foo : Supported }
- [x]  Each function returning Style accepts a closed record of Supported fields.
- [x]  If a function returning Style takes a single Value, that Value should always support inherit, initial, and unset because all CSS properties support those three values! For example, borderFoo : Value { foo : Supported, bar : Supported, inherit : Supported, initial : Supported, unset : Supported } -> Style
- [x]  If a function returning Style takes more than one Value, however, then none of its arguments should support inherit, initial, or unset, because these can never be used in conjunction with other values! For example, border-radius: 5px 5px; is valid CSS, border-radius: inherit; is valid CSS, but border-radius: 5px inherit; is invalid CSS. To reflect this, borderRadius : Value { ... } -> Style must have inherit : Supported in its record, but borderRadius2 : Value { ... } -> Value { ... } -> Style must not have inherit : Supported in either argument's record. If a user wants to get border-radius: inherit, they must call borderRadius, not borderRadius2!
- [x]  When accepting a numeric Value (e.g. a length like px, an angle like deg, or a unitless number like int or num), always include zero : Supported as well as calc : Supported!
- [x]  Every exposed value has documentation which includes at least 1 code sample.
- [x]  Documentation links to to a CSS Tricks article if available, and MDN if not.
- [x]  Make a pull request against the phantom-types branch, not master!