### PR TITLE
Add `list-style-position`

### DIFF
--- a/src/Css.elm
+++ b/src/Css.elm
@@ -52,7 +52,7 @@ module Css exposing
     , notAllowed, allScroll, colResize, rowResize, nResize, eResize, sResize
     , wResize, neResize, nwResize, seResize, swResize, ewResize, nsResize
     , neswResize, nwseResize, zoomIn, zoomOut, grab, grabbing
-    , listStyle, listStyle2, listStyle3
+    , listStyle, listStyle2, listStyle3, listStylePosition
     , arabicIndic, armenian, bengali, cjkEarthlyBranch, cjkHeavenlyStem, devanagari, georgian, gujarati, gurmukhi, kannada, khmer, lao, malayalam, myanmar, oriya, telugu, thai
     , auto, none
     , hidden, visible
@@ -71,7 +71,7 @@ module Css exposing
     , capitalize, uppercase, lowercase, fullWidth
     , textDecoration, textDecoration2, textDecoration3, textDecorationLine, textDecorationLine2, textDecorationLine3, textDecorationStyle, textDecorationColor
     , wavy, underline, overline, lineThrough
-    , borderCollapse
+    , borderCollapse 
     , collapse, separate
     , borderSpacing, borderSpacing2
     , captionSide
@@ -5812,6 +5812,45 @@ listStyle3 :
 listStyle3 (Value val1) (Value val2) (Value val3) =
     AppendProperty ("list-style:" ++ val1 ++ " " ++ val2 ++ " " ++ val3)
 
+
+{-| The [`list-style-position`](https://developer.mozilla.org/en-US/docs/Web/CSS/list-style-position) property
+
+    listStylePosition inside
+    
+    listStylePosition outside
+
+-}
+listStylePosition :
+    Value
+        { inside : Supported
+        , outside : Supported
+        , inherit : Supported
+        , initial : Supported
+        , unset : Supported
+        }
+    -> Style
+listStylePosition (Value pos) =
+    AppendProperty ("list-style-position:" ++ pos)
+
+
+{-| The `inside` value for [`list-style-position`](#listStylePosition)
+
+    listStylePosition inside
+
+-}
+inside : Value { provides | inside : Supported } 
+inside =
+    Value "inside"
+
+
+{-| The `inside` value for [`list-style-position`](#listStylePosition)
+
+    listStylePosition outside
+
+-}
+outside : Value { provides | outside : Supported }
+outside =
+    Value "outside"
 
 
 -- BORDERS --

--- a/src/Css.elm
+++ b/src/Css.elm
@@ -52,7 +52,8 @@ module Css exposing
     , notAllowed, allScroll, colResize, rowResize, nResize, eResize, sResize
     , wResize, neResize, nwResize, seResize, swResize, ewResize, nsResize
     , neswResize, nwseResize, zoomIn, zoomOut, grab, grabbing
-    , listStyle, listStyle2, listStyle3, listStylePosition, inside, outside
+    , listStyle, listStyle2, listStyle3, listStylePosition
+    , inside, outside
     , arabicIndic, armenian, bengali, cjkEarthlyBranch, cjkHeavenlyStem, devanagari, georgian, gujarati, gurmukhi, kannada, khmer, lao, malayalam, myanmar, oriya, telugu, thai
     , auto, none
     , hidden, visible

--- a/src/Css.elm
+++ b/src/Css.elm
@@ -52,7 +52,7 @@ module Css exposing
     , notAllowed, allScroll, colResize, rowResize, nResize, eResize, sResize
     , wResize, neResize, nwResize, seResize, swResize, ewResize, nsResize
     , neswResize, nwseResize, zoomIn, zoomOut, grab, grabbing
-    , listStyle, listStyle2, listStyle3, listStylePosition
+    , listStyle, listStyle2, listStyle3, listStylePosition, inside, outside
     , arabicIndic, armenian, bengali, cjkEarthlyBranch, cjkHeavenlyStem, devanagari, georgian, gujarati, gurmukhi, kannada, khmer, lao, malayalam, myanmar, oriya, telugu, thai
     , auto, none
     , hidden, visible

--- a/src/Css.elm
+++ b/src/Css.elm
@@ -71,7 +71,7 @@ module Css exposing
     , capitalize, uppercase, lowercase, fullWidth
     , textDecoration, textDecoration2, textDecoration3, textDecorationLine, textDecorationLine2, textDecorationLine3, textDecorationStyle, textDecorationColor
     , wavy, underline, overline, lineThrough
-    , borderCollapse 
+    , borderCollapse
     , collapse, separate
     , borderSpacing, borderSpacing2
     , captionSide
@@ -333,7 +333,8 @@ All CSS properties can have the values `unset`, `initial`, and `inherit`.
 
 ## List Style Type
 
-@docs listStyle, listStyle2, listStyle3
+@docs listStyle, listStyle2, listStyle3, listStylePosition
+@docs inside, outside
 @docs arabicIndic, armenian, bengali, cjkEarthlyBranch, cjkHeavenlyStem, devanagari, georgian, gujarati, gurmukhi, kannada, khmer, lao, malayalam, myanmar, oriya, telugu, thai
 
 
@@ -5816,7 +5817,7 @@ listStyle3 (Value val1) (Value val2) (Value val3) =
 {-| The [`list-style-position`](https://developer.mozilla.org/en-US/docs/Web/CSS/list-style-position) property
 
     listStylePosition inside
-    
+
     listStylePosition outside
 
 -}
@@ -5838,7 +5839,7 @@ listStylePosition (Value pos) =
     listStylePosition inside
 
 -}
-inside : Value { provides | inside : Supported } 
+inside : Value { provides | inside : Supported }
 inside =
     Value "inside"
 
@@ -5851,6 +5852,7 @@ inside =
 outside : Value { provides | outside : Supported }
 outside =
     Value "outside"
+
 
 
 -- BORDERS --


### PR DESCRIPTION
- [x]  Each Value is an open record with a single field. The field's name is the value's name, and its type is Supported. For example foo : Value { provides | foo : Supported }
- [x] Each function returning Style accepts a closed record of Supported fields.
- [x] If a function returning Style takes a single Value, that Value should always support inherit, initial, and unset because all CSS properties support those three values! For example, borderFoo : Value { foo : Supported, bar : Supported, inherit : Supported, initial : Supported, unset : Supported } -> Style
- [x] If a function returning Style takes more than one Value, however, then none of its arguments should support inherit, initial, or unset, because these can never be used in conjunction with other values! For example, border-radius: 5px 5px; is valid CSS, border-radius: inherit; is valid CSS, but border-radius: 5px inherit; is invalid CSS. To reflect this, borderRadius : Value { ... } -> Style must have inherit : Supported in its record, but borderRadius2 : Value { ... } -> Value { ... } -> Style must not have inherit : Supported in either argument's record. If a user wants to get border-radius: inherit, they must call borderRadius, not borderRadius2!
- [x] When accepting a numeric Value (e.g. a length like px, an angle like deg, or a unitless number like int or num), always include zero : Supported as well as calc : Supported!
- [x] Every exposed value has documentation which includes at least 1 code sample.
- [x] Documentation links to to a CSS Tricks article if available, and MDN if not.
- [x] Make a pull request against the phantom-types branch, not master!