### PR TITLE
Rename `stupid` to `fallback`

### DIFF
--- a/src/Css.elm
+++ b/src/Css.elm
@@ -106,7 +106,7 @@ module Css exposing
     , strokeLinecap, butt, square
     , strokeBreak, boundingBox, slice, clone
     , strokeOrigin, fillBox, strokeBox
-    , strokeLinejoin, strokeLinejoin2, crop, arcs, miter, bevel, stupid
+    , strokeLinejoin, strokeLinejoin2, crop, arcs, miter, bevel, fallback
     , strokeDashJustify, compress, dashes, gaps
     , columns, columns2, columnWidth, columnCount, columnGap, columnRuleWidth, columnRuleStyle, columnRuleColor, columnRule, columnRule2, columnRule3
     , columnFill, balance, balanceAll
@@ -531,7 +531,7 @@ Multiple CSS properties use these values.
 @docs strokeLinecap, butt, square
 @docs strokeBreak, boundingBox, slice, clone
 @docs strokeOrigin, fillBox, strokeBox
-@docs strokeLinejoin, strokeLinejoin2, crop, arcs, miter, bevel, stupid
+@docs strokeLinejoin, strokeLinejoin2, crop, arcs, miter, bevel, fallback
 @docs strokeDashJustify, compress, dashes, gaps
 
 
@@ -11523,7 +11523,7 @@ strokeLinejoin (Value val) =
 
     strokeLinejoin arcs round
 
-    strokeLinejoin miter stupid
+    strokeLinejoin miter fallback
 
 -}
 strokeLinejoin2 :
@@ -11536,7 +11536,7 @@ strokeLinejoin2 :
         Value
             { bevel : Supported
             , round : Supported
-            , stupid : Supported
+            , fallback : Supported
             }
     -> Style
 strokeLinejoin2 (Value extendCorner) (Value capRender) =
@@ -11583,14 +11583,14 @@ bevel =
     Value "bevel"
 
 
-{-| Sets `stupid` value for usage with [`strokeLinejoin`](#strokeLinejoins2).
+{-| Sets `fallback` value for usage with [`strokeLinejoin`](#strokeLinejoins2).
 
-    strokeLinejoin miter stupid
+    strokeLinejoin miter fallback
 
 -}
-stupid : Value { provides | stupid : Supported }
-stupid =
-    Value "stupid"
+fallback : Value { provides | fallback : Supported }
+fallback =
+    Value "fallback"
 
 
 {-| Sets [`stroke-dash-justify`](https://www.w3.org/TR/fill-stroke-3/#propdef-stroke-dash-justify).


### PR DESCRIPTION
This possibly a typo or find-replace error in the W3 documentation.
The values in the specification indicate a `stupid` value. But, the
issue below it describes it as `fallback`.
See: https://www.w3.org/TR/fill-stroke-3/#stroke-linejoin


- [x] Each `Value` is an **open record** with a single field. The field's name is the value's name, and its type is `Supported`. For example `foo : Value { provides | foo : Supported }`
- [x] Each function returning `Style` accepts a **closed record** of `Supported` fields.
- [x] If a function returning `Style` takes a single `Value`, that `Value` should always support `inherit`, `initial`, and `unset` because all CSS properties support those three values! For example, `borderFoo : Value { foo : Supported, bar : Supported, inherit : Supported, initial : Supported, unset : Supported } -> Style`
- [x] If a function returning `Style` takes **more than one** `Value`, however, then **none** of its arguments should support `inherit`, `initial`, or `unset`, because these can never be used in conjunction with other values! For example, `border-radius: 5px 5px;` is valid CSS, `border-radius: inherit;` is valid CSS, but `border-radius: 5px inherit;` is invalid CSS. To reflect this, `borderRadius : Value { ... } -> Style` must have `inherit : Supported` in its record, but `borderRadius2 : Value { ... } -> Value { ... } -> Style` must **not** have `inherit : Supported` in *either* argument's record. If a user wants to get `border-radius: inherit`, they must call `borderRadius`, not `borderRadius2`! 
- [x] When accepting a numeric `Value` (e.g. a length like `px`, an angle like `deg`, or a unitless number like `int` or `num`), *always* include `zero : Supported` as well as `calc : Supported`!
- [x] Every exposed value has documentation which includes at least 1 code sample.
- [x] Documentation links to to a [**CSS Tricks** article](https://css-tricks.com/) if available, and [MDN](https://developer.mozilla.org/en-US/docs/Web/CSS) if not.
- [x] Make a pull request against the `phantom-types` branch, not `master`!