### PR TITLE
Fix SvgKeyed

### DIFF
--- a/src/Svg/Styled/Keyed.elm
+++ b/src/Svg/Styled/Keyed.elm
@@ -18,14 +18,8 @@ efficiently.
 
 -}
 
-import Json.Encode as Json
 import Svg.Styled exposing (Attribute, Svg)
 import VirtualDom.Styled
-
-
-svgNamespace : Attribute msg
-svgNamespace =
-    VirtualDom.Styled.property "namespace" (Json.string "http://www.w3.org/2000/svg")
 
 
 {-| Works just like `Svg.node`, but you add a unique identifier to each child
@@ -35,5 +29,4 @@ the DOM modifications more efficient.
 -}
 node : String -> List (Attribute msg) -> List ( String, Svg msg ) -> Svg msg
 node name =
-    \attributes children ->
-        VirtualDom.Styled.keyedNode name (svgNamespace :: attributes) children
+    VirtualDom.Styled.keyedNodeNS "http://www.w3.org/2000/svg" name

--- a/src/VirtualDom/Styled.elm
+++ b/src/VirtualDom/Styled.elm
@@ -6,6 +6,7 @@ module VirtualDom.Styled exposing
     , attributeNS
     , getClassname
     , keyedNode
+    , keyedNodeNS
     , lazy
     , lazy2
     , lazy3


### PR DESCRIPTION
SvgKeyed used keyedNode instead of keyedNodeNS. The virtual DOM
therefore treated the Svg as a generic element.

The fix reflects the fix made by Evan in the elm/svg package.
https://github.com/elm/svg/blob/master/src/Svg/Keyed.elm

Also, this closes issue #504.

The fix originated from a Keyed Svg of mine that contained no width or height. I noticed that the browser treated it as a generic node instead of an Svg. I compared rtfeldman/elm-css to elm/svg and noticed the difference.
