### PR TITLE
Fix readme for animationName property

### DIFF
--- a/src/Css/Animations.elm
+++ b/src/Css/Animations.elm
@@ -170,7 +170,7 @@ transform values =
 
 {-| Define a custom animatable property.
 
-    css [ animationName (keyframes [ ( 5, property "backdrop-filter" "blur(3px)" ) ]) ]
+    css [ animationName (keyframes [ ( 5, [ property "backdrop-filter" "blur(3px)" ] ) ]) ]
 
 ...outputs
 


### PR DESCRIPTION
The example suggested keyframes wanted `List ( Int, Css.Animations.Property )` but it actually wants `List ( Int, List Css.Animations.Property )`.