### PR TITLE
Wrap style node to deal with DarkReader

### DIFF
--- a/src/Css/Global.elm
+++ b/src/Css/Global.elm
@@ -106,7 +106,7 @@ global snippets =
         |> VirtualDom.node "style" []
         -- wrap the style node in a div to prevent `Dark Reader` from blowin up the dom.
         |> List.singleton
-        |> VirtualDom.node "div" []
+        |> VirtualDom.node "span" []
         |> VirtualDom.Styled.unstyledNode
 
 

--- a/src/VirtualDom/Styled.elm
+++ b/src/VirtualDom/Styled.elm
@@ -438,7 +438,7 @@ toKeyedStyleNode allStyles keyedChildNodes =
 toStyleNode : Dict Classname (List Style) -> VirtualDom.Node msg
 toStyleNode styles =
     -- wrap the style node in a div to prevent `Dark Reader` from blowin up the dom.
-    VirtualDom.node "div"
+    VirtualDom.node "span"
         []
         [ -- this <style> node will be the first child of the requested one
           toDeclaration styles


### PR DESCRIPTION
Apps using elm-css will break in the presence of DarkReader. This is explained at https://github.com/jinjor/elm-break-dom.

In order to avoid braking the virtual dom diff due to the changes introduced by DarkReader the same workaround as in mdgriffith/elm-ui cab be applied. https://github.com/mdgriffith/elm-ui/blob/acae8857a02e600cc4b4737ca2f70607228b4489/src/Internal/Model.elm#L1824-L1827

This might break view test in the app so I am not sure if this is a breaking change or not.