### PR TITLE
Optimize string concatination.

### DIFF
--- a/src/Css.elm
+++ b/src/Css.elm
@@ -482,6 +482,7 @@ deprecated or discouraged.
 import Css.Animations exposing (Keyframes)
 import Css.Internal exposing (getOverloadedProperty, lengthConverter, lengthForOverloadedProperty)
 import Css.Preprocess as Preprocess exposing (Style, unwrapSnippet)
+import Css.String as String
 import Css.Structure as Structure exposing (..)
 import Hex
 import String
@@ -974,8 +975,7 @@ combineLengths operation firstLength secondLength =
             [ String.fromFloat numericValue
             , firstLength.unitLabel
             ]
-                |> List.filter (not << String.isEmpty)
-                |> String.join ""
+                |> String.filterJoin (not << String.isEmpty) ""
     in
     { firstLength | value = value, numericValue = numericValue }
 
@@ -6299,7 +6299,7 @@ borderColor2 : ColorValue compatibleA -> ColorValue compatibleB -> Style
 borderColor2 c1 c2 =
     let
         value =
-            String.join " " [ c1.value, c2.value ]
+            c1.value ++ " " ++ c2.value
     in
     property "border-color" value
 
@@ -6692,8 +6692,7 @@ fontFeatureSettings { value } =
 fontFeatureSettingsList : List (FeatureTagValue a) -> Style
 fontFeatureSettingsList featureTagValues =
     featureTagValues
-        |> List.map .value
-        |> String.join ", "
+        |> String.mapJoin .value ", "
         |> property "font-feature-settings"
 
 
@@ -7671,7 +7670,7 @@ valuesOrNone list =
         { value = "none" }
 
     else
-        { value = String.join " " (List.map .value list) }
+        { value = String.mapJoin .value " " list }
 
 
 stringsToValue : List String -> Value {}
@@ -7680,7 +7679,7 @@ stringsToValue list =
         { value = "none" }
 
     else
-        { value = String.join ", " (List.map (\s -> s) list) }
+        { value = String.join ", " list }
 
 
 {-| Sets [`z-index`](https://developer.mozilla.org/en-US/docs/Web/CSS/z-index)

--- a/src/Css.elm
+++ b/src/Css.elm
@@ -482,7 +482,7 @@ deprecated or discouraged.
 import Css.Animations exposing (Keyframes)
 import Css.Internal exposing (getOverloadedProperty, lengthConverter, lengthForOverloadedProperty)
 import Css.Preprocess as Preprocess exposing (Style, unwrapSnippet)
-import Css.String as String
+import Css.String
 import Css.Structure as Structure exposing (..)
 import Hex
 import String
@@ -972,10 +972,7 @@ combineLengths operation firstLength secondLength =
             operation firstLength.numericValue secondLength.numericValue
 
         value =
-            [ String.fromFloat numericValue
-            , firstLength.unitLabel
-            ]
-                |> String.filterJoin (not << String.isEmpty) ""
+            String.fromFloat numericValue ++ firstLength.unitLabel
     in
     { firstLength | value = value, numericValue = numericValue }
 
@@ -6692,7 +6689,7 @@ fontFeatureSettings { value } =
 fontFeatureSettingsList : List (FeatureTagValue a) -> Style
 fontFeatureSettingsList featureTagValues =
     featureTagValues
-        |> String.mapJoin .value ", "
+        |> Css.String.mapJoin .value ", "
         |> property "font-feature-settings"
 
 
@@ -7670,7 +7667,7 @@ valuesOrNone list =
         { value = "none" }
 
     else
-        { value = String.mapJoin .value " " list }
+        { value = Css.String.mapJoin .value " " list }
 
 
 stringsToValue : List String -> Value {}

--- a/src/Css/Animations.elm
+++ b/src/Css/Animations.elm
@@ -25,6 +25,7 @@ Some of the animatable properties (except for experimental properties, or proper
 
 import Css.Internal exposing (AnimationProperty(..), ColorValue, ExplicitLength, Length, LengthOrAutoOrCoverOrContain, lengthConverter, lengthForOverloadedProperty)
 import Css.Preprocess as Preprocess
+import Css.String as String
 import Css.Structure exposing (Compatible(..))
 
 
@@ -165,7 +166,7 @@ transform values =
             "transform:none"
 
         else
-            "transform:" ++ String.join " " (List.map .value values)
+            "transform:" ++ String.mapJoin .value " " values
 
 
 {-| Define a custom animatable property.

--- a/src/Css/Animations.elm
+++ b/src/Css/Animations.elm
@@ -25,7 +25,7 @@ Some of the animatable properties (except for experimental properties, or proper
 
 import Css.Internal exposing (AnimationProperty(..), ColorValue, ExplicitLength, Length, LengthOrAutoOrCoverOrContain, lengthConverter, lengthForOverloadedProperty)
 import Css.Preprocess as Preprocess
-import Css.String as String
+import Css.String
 import Css.Structure exposing (Compatible(..))
 
 
@@ -166,7 +166,7 @@ transform values =
             "transform:none"
 
         else
-            "transform:" ++ String.mapJoin .value " " values
+            "transform:" ++ Css.String.mapJoin .value " " values
 
 
 {-| Define a custom animatable property.

--- a/src/Css/Internal.elm
+++ b/src/Css/Internal.elm
@@ -1,6 +1,7 @@
 module Css.Internal exposing (AnimationProperty(..), ColorValue, ExplicitLength, IncompatibleUnits(..), Length, LengthOrAutoOrCoverOrContain, compileKeyframes, getOverloadedProperty, lengthConverter, lengthForOverloadedProperty)
 
 import Css.Preprocess as Preprocess exposing (Style)
+import Css.String as String
 import Css.Structure exposing (Compatible(..))
 
 
@@ -66,8 +67,7 @@ in keyframe declarations.
 compileKeyframes : List ( Int, List AnimationProperty ) -> String
 compileKeyframes tuples =
     tuples
-        |> List.map printKeyframeSelector
-        |> String.join "\n\n"
+        |> String.mapJoin printKeyframeSelector "\n\n"
 
 
 printKeyframeSelector : ( Int, List AnimationProperty ) -> String
@@ -77,9 +77,7 @@ printKeyframeSelector ( percentage, properties ) =
             String.fromInt percentage ++ "%"
 
         propertiesStr =
-            properties
-                |> List.map (\(Property prop) -> prop ++ ";")
-                |> String.join ""
+            String.mapJoin (\(Property prop) -> prop ++ ";") "" properties
     in
     percentageStr ++ " {" ++ propertiesStr ++ "}"
 

--- a/src/Css/Internal.elm
+++ b/src/Css/Internal.elm
@@ -1,7 +1,7 @@
 module Css.Internal exposing (AnimationProperty(..), ColorValue, ExplicitLength, IncompatibleUnits(..), Length, LengthOrAutoOrCoverOrContain, compileKeyframes, getOverloadedProperty, lengthConverter, lengthForOverloadedProperty)
 
 import Css.Preprocess as Preprocess exposing (Style)
-import Css.String as String
+import Css.String
 import Css.Structure exposing (Compatible(..))
 
 
@@ -66,8 +66,7 @@ in keyframe declarations.
 -}
 compileKeyframes : List ( Int, List AnimationProperty ) -> String
 compileKeyframes tuples =
-    tuples
-        |> String.mapJoin printKeyframeSelector "\n\n"
+    Css.String.mapJoin printKeyframeSelector "\n\n" tuples
 
 
 printKeyframeSelector : ( Int, List AnimationProperty ) -> String
@@ -77,7 +76,7 @@ printKeyframeSelector ( percentage, properties ) =
             String.fromInt percentage ++ "%"
 
         propertiesStr =
-            String.mapJoin (\(Property prop) -> prop ++ ";") "" properties
+            Css.String.mapJoin (\(Property prop) -> prop ++ ";") "" properties
     in
     percentageStr ++ " {" ++ propertiesStr ++ "}"
 

--- a/src/Css/Preprocess/Resolve.elm
+++ b/src/Css/Preprocess/Resolve.elm
@@ -5,6 +5,7 @@ Structure data structures.
 -}
 
 import Css.Preprocess as Preprocess exposing (Snippet(..), SnippetDeclaration, Style(..), unwrapSnippet)
+import Css.String as String
 import Css.Structure as Structure exposing (Property, mapLast, styleBlockToMediaRule)
 import Css.Structure.Hash as HashDec
 import Css.Structure.Output as Output
@@ -14,7 +15,7 @@ import String
 
 compile : List Preprocess.Stylesheet -> String
 compile styles =
-    String.join "\n\n" (List.map compileHelp styles)
+    String.mapJoin compileHelp "\n\n" styles
 
 
 compileHelp : Preprocess.Stylesheet -> String

--- a/src/Css/Preprocess/Resolve.elm
+++ b/src/Css/Preprocess/Resolve.elm
@@ -5,17 +5,16 @@ Structure data structures.
 -}
 
 import Css.Preprocess as Preprocess exposing (Snippet(..), SnippetDeclaration, Style(..), unwrapSnippet)
-import Css.String as String
+import Css.String
 import Css.Structure as Structure exposing (Property, mapLast, styleBlockToMediaRule)
 import Css.Structure.Hash as HashDec
 import Css.Structure.Output as Output
 import Hash
-import String
 
 
 compile : List Preprocess.Stylesheet -> String
 compile styles =
-    String.mapJoin compileHelp "\n\n" styles
+    Css.String.mapJoin compileHelp "\n\n" styles
 
 
 compileHelp : Preprocess.Stylesheet -> String

--- a/src/Css/String.elm
+++ b/src/Css/String.elm
@@ -1,34 +1,4 @@
-module Css.String exposing
-    ( filterJoin
-    , mapJoin
-    )
-
-
-filterJoin : (String -> Bool) -> String -> List String -> String
-filterJoin pred sep strs =
-    filterJoinHelp pred sep strs ""
-
-
-filterJoinHelp : (String -> Bool) -> String -> List String -> String -> String
-filterJoinHelp pred sep strs result =
-    case strs of
-        [] ->
-            result
-
-        first :: [] ->
-            if pred first then
-                -- The final empty string append makes the Elm compiler generate more specialized code
-                result ++ first ++ ""
-
-            else
-                result
-
-        first :: rest ->
-            if pred first then
-                filterJoinHelp pred sep rest (result ++ first ++ sep ++ "")
-
-            else
-                filterJoinHelp pred sep rest result
+module Css.String exposing (mapJoin)
 
 
 mapJoin : (a -> String) -> String -> List a -> String

--- a/src/Css/String.elm
+++ b/src/Css/String.elm
@@ -1,0 +1,49 @@
+module Css.String exposing
+    ( filterJoin
+    , mapJoin
+    )
+
+
+filterJoin : (String -> Bool) -> String -> List String -> String
+filterJoin pred sep strs =
+    filterJoinHelp pred sep strs ""
+
+
+filterJoinHelp : (String -> Bool) -> String -> List String -> String -> String
+filterJoinHelp pred sep strs result =
+    case strs of
+        [] ->
+            result
+
+        first :: [] ->
+            if pred first then
+                -- The final empty string append makes the Elm compiler generate more specialized code
+                result ++ first ++ ""
+
+            else
+                result
+
+        first :: rest ->
+            if pred first then
+                filterJoinHelp pred sep rest (result ++ first ++ sep ++ "")
+
+            else
+                filterJoinHelp pred sep rest result
+
+
+mapJoin : (a -> String) -> String -> List a -> String
+mapJoin map sep strs =
+    mapJoinHelp map sep strs ""
+
+
+mapJoinHelp : (a -> String) -> String -> List a -> String -> String
+mapJoinHelp map sep strs result =
+    case strs of
+        [] ->
+            result
+
+        first :: [] ->
+            result ++ map first ++ ""
+
+        first :: rest ->
+            mapJoinHelp map sep rest (result ++ map first ++ sep ++ "")

--- a/src/Css/Structure/Hash.elm
+++ b/src/Css/Structure/Hash.elm
@@ -1,5 +1,6 @@
 module Css.Structure.Hash exposing (hashDeclarations)
 
+import Css.String
 import Css.Structure exposing (..)
 import Css.Structure.Output as Output
 import Hash exposing (hash)
@@ -58,7 +59,6 @@ hashStyleBlock (StyleBlock firstSelector otherSelectors properties) hash =
     let
         selectorStr =
             (firstSelector :: otherSelectors)
-                |> List.map Output.selectorToString
-                |> String.join ", "
+                |> Css.String.mapJoin Output.selectorToString ", "
     in
     List.foldl Hash.hash hash (selectorStr :: properties)

--- a/src/Html/Styled/Attributes.elm
+++ b/src/Html/Styled/Attributes.elm
@@ -125,7 +125,7 @@ Attributes that can be attached to any HTML tag but are less commonly used.
 -}
 
 import Css exposing (Style)
-import Css.String as String
+import Css.String
 import Html.Styled exposing (Attribute)
 import Html.Styled.Internal as Internal
 import Json.Encode as Json
@@ -211,7 +211,7 @@ you will get both classes!
 classList : List ( String, Bool ) -> Attribute msg
 classList classes =
     class <|
-        String.mapJoin Tuple.first " " <|
+        Css.String.mapJoin Tuple.first " " <|
             List.filter Tuple.second classes
 
 

--- a/src/Html/Styled/Attributes.elm
+++ b/src/Html/Styled/Attributes.elm
@@ -125,6 +125,7 @@ Attributes that can be attached to any HTML tag but are less commonly used.
 -}
 
 import Css exposing (Style)
+import Css.String as String
 import Html.Styled exposing (Attribute)
 import Html.Styled.Internal as Internal
 import Json.Encode as Json
@@ -210,9 +211,8 @@ you will get both classes!
 classList : List ( String, Bool ) -> Attribute msg
 classList classes =
     class <|
-        String.join " " <|
-            List.map Tuple.first <|
-                List.filter Tuple.second classes
+        String.mapJoin Tuple.first " " <|
+            List.filter Tuple.second classes
 
 
 


### PR DESCRIPTION
I recently setup an elm-css benchmark based on code from our production code base, and after profiling said benchmark, I discovered that string concatination and hashing is where elm-css spends most of its time.

This PR improves the performance of elm-css by combining several map+join and filter+join operations into a single operation. It also replaces certain `String.join ""` calls with normal string concatination using the ++ operator.

From my testing, this improves performance by 15-20% depending on the browser being run.

The benchmark I ran can be found here: https://github.com/robinheghan/elm-css-playground

Check out the `reduce-string-joins` branch to test this particular optimization in isolation.
