### PR TITLE
Reduce hash content

### DIFF
--- a/src/Css/Preprocess/Resolve.elm
+++ b/src/Css/Preprocess/Resolve.elm
@@ -1,4 +1,4 @@
-module Css.Preprocess.Resolve exposing (compile)
+module Css.Preprocess.Resolve exposing (compile, hashSnippetDeclaration)
 
 {-| Functions responsible for resolving Preprocess data structures into
 Structure data structures.
@@ -6,6 +6,7 @@ Structure data structures.
 
 import Css.Preprocess as Preprocess exposing (Snippet(..), SnippetDeclaration, Style(..), unwrapSnippet)
 import Css.Structure as Structure exposing (Property, mapLast, styleBlockToMediaRule)
+import Css.Structure.Hash as HashDec
 import Css.Structure.Output as Output
 import Hash
 import String
@@ -19,6 +20,11 @@ compile styles =
 compileHelp : Preprocess.Stylesheet -> String
 compileHelp sheet =
     Output.prettyPrint (Structure.compactStylesheet (toStructure sheet))
+
+
+hashSnippetDeclaration : Preprocess.SnippetDeclaration -> Int
+hashSnippetDeclaration decl =
+    HashDec.hashDeclarations (Structure.compactDeclarations (toDeclarations decl))
 
 
 resolveMediaRule : List Structure.MediaQuery -> List Preprocess.StyleBlock -> List Structure.Declaration

--- a/src/Css/Structure.elm
+++ b/src/Css/Structure.elm
@@ -1,4 +1,4 @@
-module Css.Structure exposing (Compatible(..), Declaration(..), KeyframeProperty, MediaExpression, MediaQuery(..), MediaType(..), Number, Property, PseudoElement(..), RepeatableSimpleSelector(..), Selector(..), SelectorCombinator(..), SimpleSelectorSequence(..), StyleBlock(..), Stylesheet, TypeSelector(..), appendProperty, appendPseudoElementToLastSelector, appendRepeatable, appendRepeatableSelector, appendRepeatableToLastSelector, appendRepeatableWithCombinator, appendToLastSelector, applyPseudoElement, compactHelp, compactStylesheet, concatMapLast, concatMapLastStyleBlock, extendLastSelector, mapLast, styleBlockToMediaRule, withKeyframeDeclarations, withPropertyAppended)
+module Css.Structure exposing (Compatible(..), Declaration(..), KeyframeProperty, MediaExpression, MediaQuery(..), MediaType(..), Number, Property, PseudoElement(..), RepeatableSimpleSelector(..), Selector(..), SelectorCombinator(..), SimpleSelectorSequence(..), StyleBlock(..), Stylesheet, TypeSelector(..), appendProperty, appendPseudoElementToLastSelector, appendRepeatable, appendRepeatableSelector, appendRepeatableToLastSelector, appendRepeatableWithCombinator, appendToLastSelector, applyPseudoElement, compactDeclarations, compactHelp, compactStylesheet, concatMapLast, concatMapLastStyleBlock, extendLastSelector, mapLast, styleBlockToMediaRule, withKeyframeDeclarations, withPropertyAppended)
 
 {-| A representation of the structure of a stylesheet. This module is concerned
 solely with representing valid stylesheets; it is not concerned with the
@@ -427,18 +427,20 @@ concatMapLast update list =
 
 compactStylesheet : Stylesheet -> Stylesheet
 compactStylesheet { charset, imports, namespaces, declarations } =
-    let
-        ( keyframesByName, compactedDeclarations ) =
-            List.foldr compactHelp ( Dict.empty, [] ) declarations
-
-        finalDeclarations =
-            withKeyframeDeclarations keyframesByName compactedDeclarations
-    in
     { charset = charset
     , imports = imports
     , namespaces = namespaces
-    , declarations = finalDeclarations
+    , declarations = compactDeclarations declarations
     }
+
+
+compactDeclarations : List Declaration -> List Declaration
+compactDeclarations declarations =
+    let
+        ( keyframesByName, compactedDeclarations ) =
+            List.foldr compactHelp ( Dict.empty, [] ) declarations
+    in
+    withKeyframeDeclarations keyframesByName compactedDeclarations
 
 
 withKeyframeDeclarations : Dict String String -> List Declaration -> List Declaration

--- a/src/Css/Structure/Hash.elm
+++ b/src/Css/Structure/Hash.elm
@@ -1,0 +1,64 @@
+module Css.Structure.Hash exposing (hashDeclarations)
+
+import Css.Structure exposing (..)
+import Css.Structure.Output as Output
+import Hash exposing (hash)
+import String
+
+
+hashDeclarations : List Declaration -> Int
+hashDeclarations declarations =
+    List.foldl hashDeclaration Hash.initialSeed declarations
+
+
+hashDeclaration : Declaration -> Int -> Int
+hashDeclaration decl hash =
+    case decl of
+        StyleBlockDeclaration styleBlock ->
+            hashStyleBlock styleBlock hash
+
+        MediaRule mediaQueries styleBlocks ->
+            let
+                queryHash =
+                    List.map Output.mediaQueryToString mediaQueries
+                        |> List.foldl Hash.hash hash
+
+                blockHash =
+                    List.foldl hashStyleBlock queryHash styleBlocks
+            in
+            Hash.hash "@media" blockHash
+
+        SupportsRule _ _ ->
+            hash
+
+        DocumentRule _ _ _ _ _ ->
+            hash
+
+        PageRule _ _ ->
+            hash
+
+        FontFace _ ->
+            hash
+
+        Keyframes { name, declaration } ->
+            List.foldl Hash.hash hash [ "@keyframes", name, declaration ]
+
+        Viewport _ ->
+            hash
+
+        CounterStyle _ ->
+            hash
+
+        FontFeatureValues _ ->
+            hash
+
+
+hashStyleBlock : StyleBlock -> Int -> Int
+hashStyleBlock (StyleBlock firstSelector otherSelectors properties) hash =
+    let
+        selectorStr =
+            (firstSelector :: otherSelectors)
+                |> List.map Output.selectorToString
+                |> String.join ", "
+    in
+    List.foldl Hash.hash hash (selectorStr :: properties)

--- a/src/Css/Structure/Output.elm
+++ b/src/Css/Structure/Output.elm
@@ -1,4 +1,4 @@
-module Css.Structure.Output exposing (prettyPrint)
+module Css.Structure.Output exposing (mediaQueryToString, prettyPrint, selectorToString)
 
 import Css.Structure exposing (..)
 import String

--- a/src/Hash.elm
+++ b/src/Hash.elm
@@ -1,17 +1,22 @@
-module Hash exposing (fromString)
+module Hash exposing (fromString, hash, initialSeed)
 
 import ElmCssVendor.Murmur3 as Murmur3
 import Hex
 
 
+hash : String -> Int -> Int
+hash str seed =
+    Murmur3.hashString seed str
+
+
 fromString : String -> String
 fromString str =
     str
-        |> Murmur3.hashString murmurSeed
+        |> Murmur3.hashString initialSeed
         |> Hex.toString
         |> String.cons '_'
 
 
-murmurSeed : Int
-murmurSeed =
+initialSeed : Int
+initialSeed =
     15739

--- a/src/VirtualDom/Styled.elm
+++ b/src/VirtualDom/Styled.elm
@@ -270,15 +270,14 @@ getClassname styles =
         "unstyled"
 
     else
-        -- TODO Replace this comically inefficient implementation
-        -- with crawling these union types and building up a hash along the way.
-        Structure.UniversalSelectorSequence []
-            |> makeSnippet styles
-            |> List.singleton
-            |> Preprocess.stylesheet
-            |> List.singleton
-            |> Resolve.compile
-            |> Murmur3.hashString murmurSeed
+        let
+            selector =
+                Structure.Selector (Structure.UniversalSelectorSequence []) [] Nothing
+
+            snippetDeclaration =
+                Preprocess.StyleBlockDeclaration (Preprocess.StyleBlock selector [] styles)
+        in
+        Resolve.hashSnippetDeclaration snippetDeclaration
             |> Hex.toString
             |> String.cons '_'
 
@@ -689,8 +688,3 @@ containsKey key pairs =
 
             else
                 containsKey key rest
-
-
-murmurSeed : Int
-murmurSeed =
-    15739

--- a/tests/Styled.elm
+++ b/tests/Styled.elm
@@ -99,28 +99,28 @@ all =
             (\_ ->
                 Query.fromHtml (toUnstyled <| view "BUY TICKETS")
                     |> Query.has
-                        [ Selector.text """._950e85ab {
+                        [ Selector.text """._3de4d102 {
     background-color:#333333;
     padding:20px;
 }"""
-                        , Selector.text """._9052bb8e {
+                        , Selector.text """._e9904f07 {
     margin:12px;
     color:rgb(255, 255, 255);
 }"""
-                        , Selector.text """._7bfd0c7b {
+                        , Selector.text """._3ac819d0 {
     display:inline-block;
     padding-bottom:12px;
 }"""
-                        , Selector.text """._33aa99cc {
+                        , Selector.text """._c9b3bf47 {
     display:inline-block;
     margin-left:150px;
     margin-right:80px;
     vertical-align:middle;
 }"""
-                        , Selector.text """._1b2cec01 {
+                        , Selector.text """._b9f3f75d {
     background-color:#222222;
 }"""
-                        , Selector.text """._4503f439 {
+                        , Selector.text """._33ecd3f8 {
     padding:16px;
     padding-left:24px;
     padding-right:24px;


### PR DESCRIPTION
I recently setup an elm-css benchmark based on code from our production code base, and after profiling said benchmark, I discovered that string concatination and hashing is where elm-css spends most of its time.

This PR improves the performance of elm-css by reducing the amount of text that has to be hashed in order to generate a classname.

From my testing, this improves performance by 10-15% depending on the browser being run.

The benchmark I ran can be found here: https://github.com/robinheghan/elm-css-playground

Check out the `reduce-hash-content` branch to test this particular optimization in isolation.


When combined with the changes in #544 , I see performance improvements in the 30-40% range, depending on the browser being run.