### PR TITLE
Placeholder pseudo-element

### DIFF
--- a/src/Css.elm
+++ b/src/Css.elm
@@ -7593,6 +7593,13 @@ firstLine : List Style -> Style
 firstLine =
     pseudoElement "first-line"
 
+{-| A [`::placeholder`](https://developer.mozilla.org/en-US/docs/Web/CSS/::placeholder)
+[pseudo-element](https://developer.mozilla.org/en-US/docs/Web/CSS/Pseudo-elements).
+-}
+placeholder : List Style -> Style
+placeholder =
+    pseudoElement "placeholder"
+
 
 {-| A [`::selection`](https://developer.mozilla.org/en-US/docs/Web/CSS/%3A%3Aselection)
 [pseudo-element](https://developer.mozilla.org/en-US/docs/Web/CSS/Pseudo-elements).

--- a/src/Css.elm
+++ b/src/Css.elm
@@ -9,7 +9,7 @@ module Css exposing
     , deg, rad, grad, turn
     , Duration, sec, ms
     , pseudoClass, active, any, checked, disabled, empty, enabled, first, firstChild, firstOfType, fullscreen, focus, hover, visited, indeterminate, invalid, lang, lastChild, lastOfType, link, nthChild, nthLastChild, nthLastOfType, nthOfType, onlyChild, onlyOfType, optional, outOfRange, readWrite, required, root, scope, target, valid
-    , pseudoElement, after, before, firstLetter, firstLine, selection
+    , pseudoElement, after, before, firstLetter, firstLine, placeholder, selection
     , src_
     , qt
     , listStyleType, disc, circle, square, decimal, decimalLeadingZero, lowerRoman, upperRoman, lowerGreek, lowerAlpha, lowerLatin, upperAlpha, upperLatin, arabicIndic, armenian, bengali, cjkEarthlyBranch, cjkHeavenlyStem, devanagari, georgian, gujarati, gurmukhi, kannada, khmer, lao, malayalam, myanmar, oriya, telugu, thai


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/CSS/::placeholder

While the MDN article mentions there are accessibility concerns in using this, as long as you understand the constraints and work with/counteract default browser styling it can be a useful part of designing inputs IMO.

If this would be an obstacle to including it in elm-css, perhaps the docs can mention that it's something that designers need to be aware of these sorts of issues if they want to use it.