### PR TITLE
Phantom types: Logical paddings and margins

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,16 @@
 # elm-css
 
+## Quick note
+
+This is a fork of rtfeldman's elm-css module. The differences between this one and the original is:
+
+- This uses the `phantom-types` branch. In short, it means you get much better compiler errors.
+- This has been updated with much newer properties. *However, no experimental properties and values have been included.*
+
+
+---
+
+
 `elm-css` lets you define CSS in Elm. (For an Elm styling system that is a
 complete departure from CSS, check out [style-elements](http://package.elm-lang.org/packages/mdgriffith/style-elements/latest).)
 

--- a/src/Css.elm
+++ b/src/Css.elm
@@ -1249,7 +1249,6 @@ Other values you can use for flex item alignment:
 @docs CursorKeyword
 @docs cursor, cursor2, cursor4
 
-
 ## Cursor values
 
 [`text`](#text) is also a supported value for `cursor`.
@@ -1260,14 +1259,12 @@ Other values you can use for flex item alignment:
 @docs wResize, neResize, nwResize, seResize, swResize, ewResize, nsResize
 @docs neswResize, nwseResize, zoomIn, zoomOut, grab, grabbing
 
+## Caret color
 
----------
-
-
-
+@docs caretColor
 
 
-
+------------------------------------------------------
 
 
 
@@ -1282,27 +1279,9 @@ Other values you can use for flex item alignment:
 
 
 
-# SVG
 
 
-## Fill
 
-@docs fill
-
-
-## Stroke
-
-@docs strokeDasharray, strokeDashoffset, strokeWidth, strokeAlign, strokeColor, strokeImage, strokeMiterlimit, strokeOpacity, strokePosition, strokePosition2, strokePosition4, strokeRepeat, strokeRepeat2, strokeSize, strokeSize2, strokeDashCorner
-@docs strokeLinecap, butt, square
-@docs strokeBreak, boundingBox, slice, clone
-@docs strokeOrigin
-@docs strokeLinejoin, strokeLinejoin2, crop, arcs, miter, bevel
-@docs strokeDashJustify, compress, dashes, gaps
-
-
-## Other
-
-@docs paintOrder, paintOrder2, paintOrder3, markers
 
 
 # Transformation
@@ -1352,10 +1331,6 @@ Other values you can use for flex item alignment:
 
 @docs opacity
 
-# Printing
-
-@docs bleed
-
 # Rendering
 
 @docs mixBlendMode
@@ -1363,21 +1338,103 @@ Other values you can use for flex item alignment:
 @docs backfaceVisibility
 @docs clipPath, clipPath2
 
-# Masks
-
-@docs maskBorderMode, maskBorderRepeat, maskBorderRepeat2, maskBorderOutset, maskBorderOutset2, maskBorderOutset3, maskBorderOutset4, maskBorderSlice, maskBorderSlice2, maskBorderSlice3, maskBorderSlice4, maskBorderWidth, maskBorderWidth2, maskBorderWidth3, maskBorderWidth4
-@docs maskClip, maskClipList, maskComposite, maskMode, maskModeList, maskOrigin, maskOriginList, maskPosition, maskRepeat, maskRepeat2, maskSize, maskSize2, maskType
-@docs noClip, add, subtract, intersect, exclude, alpha, luminance, matchSource
 
 # Other / stuff I'm adding to make the compiled result valid while I work on this rewrite
 
-@docs caretColor
+
 @docs BoxShadowConfig, boxShadow, boxShadows, defaultBoxShadow, Image, ImageSupported, LineStyle, LineStyleSupported
 @docs LineWidth, LineWidthSupported
 @docs TextShadowConfig, color, defaultTextShadow
 @docs linearGradient, linearGradient2, stop, stop2, stop3, textShadow
 @docs toBottom, toBottomLeft, toBottomRight, toLeft, toRight, toTop, toTopLeft, toTopRight
-@docs lineClamp, visibility
+@docs visibility
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+------------------------------------------------------
+
+
+## Masks
+
+@docs maskBorderMode
+@docs maskBorderRepeat, maskBorderRepeat2
+@docs maskBorderOutset, maskBorderOutset2, maskBorderOutset3, maskBorderOutset4
+@docs maskBorderSlice, maskBorderSlice2, maskBorderSlice3, maskBorderSlice4
+@docs maskBorderWidth, maskBorderWidth2, maskBorderWidth3, maskBorderWidth4
+@docs maskClip, maskClipList
+@docs maskComposite
+@docs maskMode, maskModeList
+@docs maskOrigin, maskOriginList
+@docs maskPosition
+@docs maskRepeat, maskRepeat2
+@docs maskSize, maskSize2
+@docs maskType
+@docs noClip, add, subtract, intersect, exclude, alpha, luminance, matchSource
+
+
+------------------------------------------------------
+
+
+## Rendering
+
+@docs paintOrder, paintOrder2, paintOrder3, markers
+
+
+------------------------------------------------------
+
+
+# Using a printer
+
+@docs bleed
+
+
+------------------------------------------------------
+
+
+# SVG attributes that can be used as CSS presentation properties.
+
+@docs fill
+@docs strokeDasharray
+@docs strokeDashoffset
+@docs strokeWidth
+@docs strokeAlign
+@docs strokeColor
+@docs strokeImage
+@docs strokeMiterlimit
+@docs strokeOpacity
+@docs strokePosition, strokePosition2, strokePosition4
+@docs strokeRepeat, strokeRepeat2
+@docs strokeSize, strokeSize2
+@docs strokeDashCorner
+@docs strokeLinecap, butt, square
+@docs strokeBreak, boundingBox, slice, clone
+@docs strokeOrigin
+@docs strokeLinejoin, strokeLinejoin2, crop, arcs, miter, bevel
+@docs strokeDashJustify, compress, dashes, gaps
+
+
+------------------------------------------------------
+
+
+# WebKit stuff that's standardised for legacy support
+
+@docs lineClamp
+
+
 
 -}
 

--- a/src/Css.elm
+++ b/src/Css.elm
@@ -145,6 +145,7 @@ module Css exposing
     , scrollMarginBlock, scrollMarginBlock2, scrollMarginInline, scrollMarginInline2
     , scrollMarginBlockStart, scrollMarginBlockEnd, scrollMarginInlineStart, scrollMarginInlineEnd
     , scrollPadding, scrollPadding2, scrollPadding3, scrollPadding4, scrollPaddingTop, scrollPaddingLeft, scrollPaddingRight, scrollPaddingBottom
+    , scrollPaddingBlock, scrollPaddingBlock2, scrollPaddingInline, scrollPaddingInline2
     , speak, spellOut
     , userSelect
     , unicodeBidi, embed, bidiOverride, isolateOverride, plaintext
@@ -693,6 +694,7 @@ Multiple CSS properties use these values.
 @docs scrollMarginBlock, scrollMarginBlock2, scrollMarginInline, scrollMarginInline2
 @docs scrollMarginBlockStart, scrollMarginBlockEnd, scrollMarginInlineStart, scrollMarginInlineEnd
 @docs scrollPadding, scrollPadding2, scrollPadding3, scrollPadding4, scrollPaddingTop, scrollPaddingLeft, scrollPaddingRight, scrollPaddingBottom
+@docs scrollPaddingBlock, scrollPaddingBlock2, scrollPaddingInline, scrollPaddingInline2
 
 
 # Accessibility
@@ -13167,8 +13169,8 @@ scrollMarginBlock2 :
         Value
             Length
     -> Style
-scrollMarginBlock2 (Value valueTopBottom) (Value valueRightLeft) =
-    AppendProperty ("scroll-margin-block:" ++ valueTopBottom ++ " " ++ valueRightLeft)
+scrollMarginBlock2 (Value valueStart) (Value valueEnd) =
+    AppendProperty ("scroll-margin-block:" ++ valueStart ++ " " ++ valueEnd)
 
 
 {-| Sets [`scroll-margin-inline`](https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-margin-inline) property.
@@ -13209,8 +13211,8 @@ scrollMarginInline2 :
         Value
             Length
     -> Style
-scrollMarginInline2 (Value valueTopBottom) (Value valueRightLeft) =
-    AppendProperty ("scroll-margin-inline:" ++ valueTopBottom ++ " " ++ valueRightLeft)
+scrollMarginInline2 (Value valueStart) (Value valueEnd) =
+    AppendProperty ("scroll-margin-inline:" ++ valueStart ++ " " ++ valueEnd)
 
 
 {-| Sets [`scroll-margin-block-start`](https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-margin-block-start) property.
@@ -13277,7 +13279,7 @@ to the first value, the left and right are set to the second, and the bottom is
 set to the third. If there are four values they apply to the top, right,
 bottom, and left, respectively.
 
-    scrollPadding (em 4) -- set all margins to 4em
+    scrollPadding (em 4) -- set all paddings to 4em
 
     scrollPadding2 (em 4) (px 2) -- top & bottom = 4em, right & left = 2px
 
@@ -13474,6 +13476,114 @@ scrollPaddingLeft :
     -> Style
 scrollPaddingLeft (Value value) =
     AppendProperty ("scroll-padding-left:" ++ value)
+
+
+{-| Sets [`scroll-padding-block`](https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-padding-block) property.
+The `scroll-padding-block` property is a shorthand property for setting
+`scroll-padding-block-start` and `scroll-padding-block-end` in a single declaration.
+
+If there is only one argument value, it applies to both sides. If there are two
+values, the block start padding is set to the first value and the block end padding
+is set to the second.
+
+    scrollPaddingBlock (em 4) -- set both block paddings to 4em
+
+    scrollPaddingBlock2 (em 4) (px 2) -- block start = 4em, block end = 2px
+
+-}
+scrollPaddingBlock :
+    BaseValue
+        (LengthSupported
+            { auto : Supported
+            , pct : Supported
+            }
+        )
+    -> Style
+scrollPaddingBlock (Value value) =
+    AppendProperty ("scroll-padding-block:" ++ value)
+
+
+{-| Sets [`scroll-padding-block`](https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-padding-block) property.
+The `scroll-padding-block` property is a shorthand property for setting
+`scroll-padding-block-start` and `scroll-padding-block-end` in a single declaration.
+
+The block start padding is set to the first value and the block end padding
+is set to the second.
+
+    scrollPaddingBlock2 (em 4) (px 2) -- block start = 4em, block end = 2px
+
+-}
+scrollPaddingBlock2 :
+    Value
+        (LengthSupported
+            { auto : Supported
+            , pct : Supported
+            }
+        )
+    ->
+        Value
+            (LengthSupported
+                { auto : Supported
+                , pct : Supported
+                }
+            )
+    -> Style
+scrollPaddingBlock2 (Value valueStart) (Value valueEnd) =
+    AppendProperty ("scroll-padding-block:" ++ valueStart ++ " " ++ valueEnd)
+
+
+{-| Sets [`scroll-padding-inline`](https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-padding-inline) property.
+The `scroll-padding-inline` property is a shorthand property for setting
+`scroll-padding-inline-start` and `scroll-padding-inline-end` in a single declaration.
+
+If there is only one argument value, it applies to both sides. If there are two
+values, the inline start padding is set to the first value and the inline end padding
+is set to the second.
+
+    scrollPaddingInline (em 4) -- set both inline paddings to 4em
+
+    scrollPaddingInline2 (em 4) (px 2) -- inline start = 4em, inline end = 2px
+
+-}
+scrollPaddingInline :
+    BaseValue
+        (LengthSupported
+            { auto : Supported
+            , pct : Supported
+            }
+        )
+    -> Style
+scrollPaddingInline (Value value) =
+    AppendProperty ("scroll-padding-inline:" ++ value)
+
+
+{-| Sets [`scroll-padding-inline`](https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-padding-inline) property.
+The `scroll-padding-inline` property is a shorthand property for setting
+`scroll-padding-inline-start` and `scroll-padding-inline-end` in a single declaration.
+
+The inline start padding is set to the first value and the inline end padding
+is set to the second.
+
+    scrollPaddingInline2 (em 4) (px 2) -- inline start = 4em, inline end = 2px
+
+-}
+scrollPaddingInline2 :
+    Value
+        (LengthSupported
+            { auto : Supported
+            , pct : Supported
+            }
+        )
+    ->
+        Value
+            (LengthSupported
+                { auto : Supported
+                , pct : Supported
+                }
+            )
+    -> Style
+scrollPaddingInline2 (Value valueStart) (Value valueEnd) =
+    AppendProperty ("scroll-padding-inline:" ++ valueStart ++ " " ++ valueEnd)
 
 
 {-| Sets [`scroll-snap-align`](https://css-tricks.com/almanac/properties/s/scroll-snap-align/)

--- a/src/Css.elm
+++ b/src/Css.elm
@@ -15,7 +15,7 @@ module Css exposing
     , auto, none, normal, strict, all_, both, always
     , hidden, visible
     , contentBox, borderBox, paddingBox
-    , left_, right_, top_, bottom_, block, inline, start, end
+    , left_, right_, top_, bottom_, block, inline, start, end, column
     , x, y
     , stretch, center, content, fill_, stroke, text, style
     , clip, cover, contain_
@@ -81,7 +81,7 @@ module Css exposing
     , placeContent, placeContent2, placeItems, placeItems2, placeSelf, placeSelf2
     , flexStart, flexEnd, selfStart, selfEnd, spaceBetween, spaceAround, spaceEvenly
     , firstBaseline, lastBaseline, safe, unsafe, legacy, legacyLeft, legacyRight, legacyCenter
-    , flexDirection, row, rowReverse, column, columnReverse
+    , flexDirection, row, rowReverse, columnReverse
     , order
     , flexGrow, flexShrink, flexBasis
     , flexWrap, nowrap, wrap, wrapReverse
@@ -188,8 +188,8 @@ module Css exposing
     , unicodeBidi, embed, bidiOverride, isolateOverride, plaintext
     , bleed
     , orphans, widows
-    , breakInside, avoid, avoidPage, avoidColumn, avoidRegion
-    , pageBreakBefore, pageBreakInside, pageBreakAfter
+    , breakBefore, breakAfter, breakInside, avoid, avoidPage, avoidColumn, page
+    , pageBreakBefore, pageBreakAfter, pageBreakInside
     , mixBlendMode
     , imageRendering, crispEdges, pixelated
     , backfaceVisibility
@@ -278,7 +278,7 @@ Many different kinds of CSS properties use these keyword values.
 @docs auto, none, normal, strict, all_, both, always
 @docs hidden, visible
 @docs contentBox, borderBox, paddingBox
-@docs left_, right_, top_, bottom_, block, inline, start, end
+@docs left_, right_, top_, bottom_, block, inline, start, end, column
 @docs x, y
 @docs stretch, center, content, fill_, stroke, text, style
 @docs clip, cover, contain_
@@ -511,7 +511,7 @@ Other values you can use for flex item alignment:
 
 ### Flexbox Direction
 
-@docs flexDirection, row, rowReverse, column, columnReverse
+@docs flexDirection, row, rowReverse, columnReverse
 
 
 ### Flexbox Order
@@ -858,8 +858,8 @@ Other values you can use for flex item alignment:
 
 @docs bleed
 @docs orphans, widows
-@docs breakInside, avoid, avoidPage, avoidColumn, avoidRegion
-@docs pageBreakBefore, pageBreakInside, pageBreakAfter
+@docs breakBefore, breakAfter, breakInside, avoid, avoidPage, avoidColumn, page
+@docs pageBreakBefore, pageBreakAfter, pageBreakInside
 
 
 # Rendering
@@ -1733,6 +1733,21 @@ steps2 3 end
 end : Value { provides | end : Supported }
 end =
     Value "end"
+
+
+{-| The `column` value, used in [`flex-direction`](#flexDirection),
+[`break-before`](#breakBefore) and [`break-after`](#breakAfter) properties.
+
+    flexDirection column
+
+    breakBefore column
+
+    breakAfter column
+
+-}
+column : Value { provides | column : Supported }
+column =
+    Value "column"
 
 
 {-| Sets `x` value for usage with [`scrollSnapType2`](#scrollSnapType2)
@@ -6029,16 +6044,6 @@ row =
 rowReverse : Value { provides | rowReverse : Supported }
 rowReverse =
     Value "row-reverse"
-
-
-{-| The `column` [`flex-direction` value](https://developer.mozilla.org/en-US/docs/Web/CSS/flex-direction#Values).
-
-    flexDirection column
-
--}
-column : Value { provides | column : Supported }
-column =
-    Value "column"
 
 
 {-| The `column-reverse` [`flex-direction` value](https://developer.mozilla.org/en-US/docs/Web/CSS/flex-direction#Values).
@@ -15532,70 +15537,6 @@ caretColor (Value val) =
     AppendProperty ("caret-color:" ++ val)
 
 
-{-| Sets `avoid` value for usage with [`breakInside`](#breakInside).
-
-      breakInside avoid
-
--}
-avoid : Value { provides | avoid : Supported }
-avoid =
-    Value "avoid"
-
-
-{-| Sets `avoid-page` value for usage with [`breakInside`](#breakInside).
-
-      breakInside avoidPage
-
--}
-avoidPage : Value { provides | avoidPage : Supported }
-avoidPage =
-    Value "avoid-page"
-
-
-{-| Sets `avoid-column` value for usage with [`breakInside`](#breakInside).
-
-      breakInside avoidColumn
-
--}
-avoidColumn : Value { provides | avoidColumn : Supported }
-avoidColumn =
-    Value "avoid-column"
-
-
-{-| Sets `avoid-region` value for usage with [`breakInside`](#breakInside).
-
-      breakInside avoidRegion
-
--}
-avoidRegion : Value { provides | avoidRegion : Supported }
-avoidRegion =
-    Value "avoid-region"
-
-
-{-| Sets [`break-inside`](https://css-tricks.com/almanac/properties/b/break-inside/)
-
-    breakInside auto
-
-    breakInside avoid
-
-    breakInside avoidPage
-
-    breakInside avoidColumn
-
-    breakInside avoidRegion
-
--}
-breakInside :
-    BaseValue
-        { auto : Supported
-        , avoid : Supported
-        , avoidPage : Supported
-        , avoidColumn : Supported
-        , avoidRegion : Supported
-        }
-    -> Style
-breakInside (Value val) =
-    AppendProperty ("break-inside:" ++ val)
 
 
 {-| Sets [`box-decoration-break`](https://css-tricks.com/almanac/properties/b/box-decoration-break/)
@@ -16456,7 +16397,137 @@ overflowAnchor (Value val) =
 -- Page break
 
 
+{-| Sets [`break-before`](https://css-tricks.com/almanac/properties/b/break-before/).
+
+    breakBefore auto
+-}
+breakBefore :
+    BaseValue
+        { auto : Supported
+        , always : Supported
+        , avoid : Supported
+        , all : Supported
+        , avoidPage : Supported
+        , page : Supported
+        , left_ : Supported
+        , right_ : Supported
+        , avoidColumn : Supported
+        , column : Supported
+        }
+    -> Style
+breakBefore (Value val) =
+    AppendProperty ("break-before:" ++ val)
+
+
+{-| Sets [`break-after`](https://css-tricks.com/almanac/properties/b/break-after/).
+
+    breakAfter auto
+-}
+breakAfter :
+    BaseValue
+        { auto : Supported
+        , always : Supported
+        , avoid : Supported
+        , all : Supported
+        , avoidPage : Supported
+        , page : Supported
+        , left_ : Supported
+        , right_ : Supported
+        , avoidColumn : Supported
+        , column : Supported
+        }
+    -> Style
+breakAfter (Value val) =
+    AppendProperty ("break-after:" ++ val)
+
+
+{-| Sets [`break-inside`](https://css-tricks.com/almanac/properties/b/break-inside/)
+
+    breakInside auto
+
+    breakInside avoid
+
+    breakInside avoidPage
+
+    breakInside avoidColumn
+
+-}
+breakInside :
+    BaseValue
+        { auto : Supported
+        , avoid : Supported
+        , avoidPage : Supported
+        , avoidColumn : Supported
+        }
+    -> Style
+breakInside (Value val) =
+    AppendProperty ("break-inside:" ++ val)
+
+
+
+{-| Sets `avoid` value for usage with [`breakAfter`](#breakAfter),
+[`breakBefore`](#breakBefore) and [`breakInside`](#breakInside).
+
+    breakBefore avoid
+
+    breakAfter avoid
+
+    breakInside avoid
+
+-}
+avoid : Value { provides | avoid : Supported }
+avoid =
+    Value "avoid"
+
+
+{-| Sets `avoid-page` value for usage with [`breakAfter`](#breakAfter),
+[`breakBefore`](#breakBefore) and [`breakInside`](#breakInside).
+
+    breakBefore avoidPage
+
+    breakAfter avoidPage
+
+    breakInside avoidPage
+
+-}
+avoidPage : Value { provides | avoidPage : Supported }
+avoidPage =
+    Value "avoid-page"
+
+
+{-| Sets `avoid-column` value for usage with [`breakAfter`](#breakAfter),
+[`breakBefore`](#breakBefore) and [`breakInside`](#breakInside).
+
+    breakBefore avoidColumn
+
+    breakAfter avoidColumn
+
+    breakInside avoidColumn
+
+-}
+avoidColumn : Value { provides | avoidColumn : Supported }
+avoidColumn =
+    Value "avoid-column"
+
+
+
+{-| Sets `page` value for usage with [`breakAfter`](#breakAfter) and
+[`breakBefore`](#breakBefore).
+
+    breakBefore page
+
+    breakAfter page
+
+-}
+page : Value { provides | page : Supported }
+page =
+    Value "page"
+
 {-| Sets [`page-break-before`](https://css-tricks.com/almanac/properties/p/page-break/)
+
+**This property has been depreciated and replaced with
+[`breakBefore`](#breakBefore), but is still included for backwards
+compatibility.**
 
     pageBreakBefore auto
 
@@ -16482,24 +16553,11 @@ pageBreakBefore (Value val) =
     AppendProperty ("page-break-before:" ++ val)
 
 
-{-| Sets [`page-break-inside`](https://css-tricks.com/almanac/properties/p/page-break/)
-
-    pageBreakInside auto
-
-    pageBreakInside avoid
-
--}
-pageBreakInside :
-    BaseValue
-        { auto : Supported
-        , avoid : Supported
-        }
-    -> Style
-pageBreakInside (Value val) =
-    AppendProperty ("page-break-inside:" ++ val)
-
-
 {-| Sets [`page-break-after`](https://css-tricks.com/almanac/properties/p/page-break/)
+
+**This property has been depreciated and replaced with
+[`breakAfter`](#breakAfter), but is still included for backwards
+compatibility.**
 
     pageBreakAfter auto
 
@@ -16523,6 +16581,25 @@ pageBreakAfter :
     -> Style
 pageBreakAfter (Value val) =
     AppendProperty ("page-break-after:" ++ val)
+
+
+{-| Sets [`page-break-inside`](https://css-tricks.com/almanac/properties/p/page-break/)
+
+    pageBreakInside auto
+
+    pageBreakInside avoid
+
+-}
+pageBreakInside :
+    BaseValue
+        { auto : Supported
+        , avoid : Supported
+        }
+    -> Style
+pageBreakInside (Value val) =
+    AppendProperty ("page-break-inside:" ++ val)
+
+
 
 
 {-| Sets [`pointer-events`](https://css-tricks.com/almanac/properties/b/pointer-events/)

--- a/src/Css.elm
+++ b/src/Css.elm
@@ -47,6 +47,7 @@ module Css exposing
     , margin, margin2, margin3, margin4, marginTop, marginRight, marginBottom, marginLeft
     , boxSizing
     , alignContent, alignContent2, alignItems, alignItems2, alignSelf, alignSelf2, justifyContent, justifyContent2, justifyItems, justifyItems2, justifySelf, justifySelf2
+    , placeContent, placeContent2, placeItems, placeItems2, placeSelf, placeSelf2
     , flexDirection, row, rowReverse, column, columnReverse
     , order
     , flexGrow, flexShrink, flexBasis, content
@@ -361,6 +362,8 @@ See this [complete guide](https://css-tricks.com/snippets/css/a-guide-to-flexbox
 ### Flexbox Alignment
 
 @docs alignContent, alignContent2, alignItems, alignItems2, alignSelf, alignSelf2, justifyContent, justifyContent2, justifyItems, justifyItems2, justifySelf, justifySelf2
+
+@docs placeContent, placeContent2, placeItems, placeItems2, placeSelf, placeSelf2
 
 
 ### Flexbox Direction
@@ -3837,6 +3840,215 @@ justifySelf2 :
     -> Style
 justifySelf2 (Value overflowPosition) (Value contentPosition) =
     AppendProperty ("justify-self:" ++ overflowPosition ++ " " ++ contentPosition)
+
+
+{-| The [`place-content`](https://css-tricks.com/almanac/properties/p/place-content) property.
+
+`placeContent` is a shorthand for the [`alignContent`](#alignContent) and
+[`justifyContent`](#justifyContent) properties in a single declaration.
+
+This one-argument version only accepts global values.
+
+    placeContent inherit
+
+    placeContent2 flexStart flexEnd
+
+-}
+placeContent :
+    BaseValue {}
+    -> Style
+placeContent (Value value) =
+    AppendProperty ("place-content:" ++ value)
+
+
+{-| The [`place-content`](https://css-tricks.com/almanac/properties/p/place-content) property.
+
+`placeContent` is a shorthand for the [`alignContent`](#alignContent) and
+[`justifyContent`](#justifyContent) properties in a single declaration.
+
+This two-argumant version accepts `alignContent` and `justifyContent` values.
+
+    placeContent inherit
+
+    placeContent2 flexStart flexEnd
+
+-}
+placeContent2 :
+    Value
+        { normal : Supported
+        , baseline : Supported
+        , firstBaseline : Supported
+        , lastBaseline : Supported
+        , spaceBetween : Supported
+        , spaceAround : Supported
+        , spaceEvenly : Supported
+        , stretch : Supported
+        , center : Supported
+        , start : Supported
+        , end : Supported
+        , flexStart : Supported
+        , flexEnd : Supported
+        }
+    ->
+        Value
+            { normal : Supported
+            , spaceBetween : Supported
+            , spaceAround : Supported
+            , spaceEvenly : Supported
+            , stretch : Supported
+            , center : Supported
+            , start : Supported
+            , end : Supported
+            , flexStart : Supported
+            , flexEnd : Supported
+            , left_ : Supported
+            , right_ : Supported
+            }
+    -> Style
+placeContent2 (Value alignContentValue) (Value justifyContentValue) =
+    AppendProperty ("place-content:" ++ alignContentValue ++ " " ++ justifyContentValue)
+
+
+{-| The [`place-items`](https://css-tricks.com/almanac/properties/p/place-items) property.
+
+`placeItems` is a shorthand for the [`alignItems`](#alignItems) and
+[`justifyItems`](#justifyItems) properties in a single declaration.
+
+This one-argument version only accepts global values.
+
+    placeItems inherit
+
+    placeItems2 center selfEnd
+
+-}
+placeItems :
+    BaseValue {}
+    -> Style
+placeItems (Value value) =
+    AppendProperty ("place-items:" ++ value)
+
+
+{-| The [`place-items`](https://css-tricks.com/almanac/properties/p/place-items) property.
+
+`placeItems` is a shorthand for the [`alignItems`](#alignItems) and
+[`justifyItems`](#justifyItems) properties in a single declaration.
+
+This one-argument version only accepts global values.
+
+    placeItems inherit
+
+    placeItems2 center selfEnd
+
+-}
+placeItems2 :
+    Value
+        { normal : Supported
+        , stretch : Supported
+        , center : Supported
+        , start : Supported
+        , end : Supported
+        , flexStart : Supported
+        , flexEnd : Supported
+        , selfStart : Supported
+        , selfEnd : Supported
+        , baseline : Supported
+        , firstBaseline : Supported
+        , lastBaseline : Supported
+        }
+    ->
+        Value
+            { normal : Supported
+            , stretch : Supported
+            , baseline : Supported
+            , firstBaseline : Supported
+            , lastBaseline : Supported
+            , center : Supported
+            , start : Supported
+            , end : Supported
+            , flexStart : Supported
+            , flexEnd : Supported
+            , selfStart : Supported
+            , selfEnd : Supported
+            , left_ : Supported
+            , right_ : Supported
+            , legacy : Supported
+            , legacyLeft : Supported
+            , legacyRight : Supported
+            , legacyCenter : Supported
+            }
+    -> Style
+placeItems2 (Value alignItemsValue) (Value justifyItemsValue) =
+    AppendProperty ("place-items:" ++ alignItemsValue ++ " " ++ justifyItemsValue)
+
+
+{-| The [`place-self`](https://css-tricks.com/almanac/properties/p/place-self) property.
+
+`placeSelf` is a shorthand for the [`alignSelf`](#alignSelf) and
+[`justifySelf`](#justifySelf) properties in a single declaration.
+
+This one-argument version only accepts global values.
+
+    placeSelf inherit
+
+    placeSelf2 flexStart flexEnd
+
+-}
+placeSelf :
+    BaseValue {}
+    -> Style
+placeSelf (Value value) =
+    AppendProperty ("place-self:" ++ value)
+
+
+{-| The [`place-self`](https://css-tricks.com/almanac/properties/p/place-self) property.
+
+`placeSelf` is a shorthand for the [`alignSelf`](#alignSelf) and
+[`justifySelf`](#justifySelf) properties in a single declaration.
+
+This one-argument version only accepts global values.
+
+    placeSelf inherit
+
+    placeSelf2 flexStart flexEnd
+
+-}
+placeSelf2 :
+    Value
+        { auto : Supported
+        , normal : Supported
+        , stretch : Supported
+        , baseline : Supported
+        , firstBaseline : Supported
+        , lastBaseline : Supported
+        , center : Supported
+        , start : Supported
+        , end : Supported
+        , flexStart : Supported
+        , flexEnd : Supported
+        , selfStart : Supported
+        , selfEnd : Supported
+        }
+    ->
+        Value
+            { auto : Supported
+            , normal : Supported
+            , stretch : Supported
+            , baseline : Supported
+            , firstBaseline : Supported
+            , lastBaseline : Supported
+            , center : Supported
+            , start : Supported
+            , end : Supported
+            , flexStart : Supported
+            , flexEnd : Supported
+            , selfStart : Supported
+            , selfEnd : Supported
+            , left_ : Supported
+            , right_ : Supported
+            }
+    -> Style
+placeSelf2 (Value alignSelfValue) (Value justifySelfValue) =
+    AppendProperty ("place-self:" ++ alignSelfValue ++ " " ++ justifySelfValue)
 
 
 {-| Sets [`flex-basis`](https://css-tricks.com/almanac/properties/f/flex-basis/).

--- a/src/Css.elm
+++ b/src/Css.elm
@@ -18,7 +18,8 @@ module Css exposing
     , left_, right_, top_, bottom_, block, inline, start, end
     , baseline, clip, ruby
     , stretch, center, content, text
-    , cover, contain_
+    , cover, contain_, fullWidth
+    , sub, super
     , pseudoClass, active, checked, disabled, empty, enabled
     , firstChild, firstOfType, focus, fullscreen, hover, inRange
     , indeterminate, invalid, lastChild, lastOfType, link, onlyChild
@@ -111,7 +112,7 @@ module Css exposing
     , textRendering
     , geometricPrecision, optimizeLegibility, optimizeSpeed
     , textTransform
-    , capitalize, uppercase, lowercase, fullWidth, fullSizeKana
+    , capitalize, uppercase, lowercase, fullSizeKana
     , textDecoration, textDecoration2, textDecoration3, textDecorationLine, textDecorationLine2, textDecorationLine3, textDecorationStyle, textDecorationColor
     , textDecorationSkip, objects, spaces, ink, edges, boxDecoration
     , wavy, underline, overline, lineThrough
@@ -125,7 +126,7 @@ module Css exposing
     , show, hide
     , tableLayout
     , verticalAlign
-    , sub, super, textTop, textBottom, middle
+    , textTop, textBottom, middle
     , whiteSpace
     , pre, preWrap, preLine
     , wordBreak
@@ -264,8 +265,8 @@ Many different kinds of CSS properties use these values.
 @docs left_, right_, top_, bottom_, block, inline, start, end
 @docs baseline, clip, ruby
 @docs stretch, center, content, text
-@docs cover, contain_
-
+@docs cover, contain_, fullWidth
+@docs sub, super
 
 # Pseudo-Classes
 
@@ -621,7 +622,7 @@ Other values you can use for flex item alignment:
 # Text Transform
 
 @docs textTransform
-@docs capitalize, uppercase, lowercase, fullWidth, fullSizeKana
+@docs capitalize, uppercase, lowercase, fullSizeKana
 
 
 # Text Decoration
@@ -669,7 +670,7 @@ Other values you can use for flex item alignment:
 ## Vertical Align
 
 @docs verticalAlign
-@docs sub, super, textTop, textBottom, middle
+@docs textTop, textBottom, middle
 
 
 ## White space
@@ -1791,6 +1792,59 @@ cover : Value { provides | cover : Supported }
 cover =
     Value "cover"
 
+
+{-| A `full-width` value for:
+
+
+### [`textTransform`](#textTransform)
+
+Forces the writing of characters in a square so they can be aligned in East Asian scripts.
+
+
+### [`fontVariantEastAsian`](#fontVariantEastAsian)
+
+Activates the East Asian characters that are roughly be the same width.
+
+    textTransform fullWidth
+
+    fontVariantEastAsian fullWidth
+
+-}
+fullWidth : Value { provides | fullWidth : Supported }
+fullWidth =
+    Value "full-width"
+
+
+{-| A `sub` value for the following properties:
+
+    - [`fontVariantPosition](#fontVariantPosition)
+    - [`verticalAlign`](#verticalAlign)
+
+
+    fontVariantPosition sub
+
+    verticalAlign sub
+
+-}
+sub : Value { provides | sub : Supported }
+sub =
+    Value "sub"
+
+
+{-| A `super` value for the following properties:
+
+    - [`fontVariantPosition](#fontVariantPosition)
+    - [`verticalAlign`](#verticalAlign)
+
+
+    fontVariantPosition super
+
+    verticalAlign super
+
+-}
+super : Value { provides | super : Supported }
+super =
+    Value "super"
 
 
 -- OVERFLOW --
@@ -10361,28 +10415,6 @@ lowercase =
     Value "lowercase"
 
 
-{-| A `full-width` value for:
-
-
-### [`textTransform`](#textTransform)
-
-Forces the writing of characters in a square so they can be aligned in East Asian scripts.
-
-
-### [`fontVariantEastAsian`](#fontVariantEastAsian)
-
-Activates the East Asian characters that are roughly be the same width.
-
-    textTransform fullWidth
-
-    fontVariantEastAsian fullWidth
-
--}
-fullWidth : Value { provides | fullWidth : Supported }
-fullWidth =
-    Value "full-width"
-
-
 {-| The `full-size-kana` value used by [`textTransform`](#textTransform)
 
 textTransform fullSizeKana
@@ -10938,38 +10970,6 @@ verticalAlign (Value str) =
     AppendProperty ("vertical-align:" ++ str)
 
 
-{-| A `sub` value for the following properties:
-
-    - [`fontVariantPosition](#fontVariantPosition)
-    - [`verticalAlign`](#verticalAlign)
-
-
-    fontVariantPosition sub
-
-    verticalAlign sub
-
--}
-sub : Value { provides | sub : Supported }
-sub =
-    Value "sub"
-
-
-{-| A `super` value for the following properties:
-
-    - [`fontVariantPosition](#fontVariantPosition)
-    - [`verticalAlign`](#verticalAlign)
-
-
-    fontVariantPosition super
-
-    verticalAlign super
-
--}
-super : Value { provides | super : Supported }
-super =
-    Value "super"
-
-
 {-| A `textTop` value for the [`vertical-align`](https://css-tricks.com/almanac/properties/v/vertical-align/) property.
 
     verticalAlign textTop
@@ -11015,6 +11015,26 @@ direction :
     -> Style
 direction (Value str) =
     AppendProperty ("direction:" ++ str)
+
+
+{-| A `ltr` value for the [`direction`](https://css-tricks.com/almanac/properties/d/direction/) property.
+
+    direction ltr
+
+-}
+ltr : Value { provides | ltr : Supported }
+ltr =
+    Value "ltr"
+
+
+{-| A `rtl` value for the [`direction`](https://css-tricks.com/almanac/properties/d/direction/) property.
+
+    direction rtl
+
+-}
+rtl : Value { provides | rtl : Supported }
+rtl =
+    Value "rtl"
 
 
 {-| Sets [`text-align`](https://css-tricks.com/almanac/properties/t/text-align/)
@@ -11155,27 +11175,6 @@ textUnderlinePosition2 (Value underVal) (Value val) =
 under : Value { provides | under : Supported }
 under =
     Value "under"
-
-
-{-| A `ltr` value for the [`direction`](https://css-tricks.com/almanac/properties/d/direction/) property.
-
-    direction ltr
-
--}
-ltr : Value { provides | ltr : Supported }
-ltr =
-    Value "ltr"
-
-
-{-| A `rtl` value for the [`direction`](https://css-tricks.com/almanac/properties/d/direction/) property.
-
-    direction rtl
-
--}
-rtl : Value { provides | rtl : Supported }
-rtl =
-    Value "rtl"
-
 
 
 -- WHITE-SPACE --

--- a/src/Css.elm
+++ b/src/Css.elm
@@ -46,7 +46,7 @@ module Css exposing
     , borderImageWidth, borderImageWidth2, borderImageWidth3, borderImageWidth4
     , outline, outline3, outlineWidth, outlineColor, invert, outlineStyle, outlineOffset
     , display, display2, displayListItem2, displayListItem3
-    , block, flex_, flow, flowRoot, grid, contents, listItem, inline, inlineBlock, inlineFlex, inlineTable, inlineGrid, ruby, rubyBase, rubyBaseContainer, rubyText, rubyTextContainer, runIn, table, tableCaption, tableCell, tableColumn, tableColumnGroup, tableFooterGroup, tableHeaderGroup, tableRow, tableRowGroup
+    , flex_, flow, flowRoot, grid, contents, listItem, inlineBlock, inlineFlex, inlineTable, inlineGrid, rubyBase, rubyBaseContainer, rubyText, rubyTextContainer, runIn, table, tableCaption, tableCell, tableColumn, tableColumnGroup, tableFooterGroup, tableHeaderGroup, tableRow, tableRowGroup
     , position, zIndex
     , absolute, fixed, relative, static, sticky
     , inset, inset2, inset3, inset4, top, right, bottom, left
@@ -80,7 +80,7 @@ module Css exposing
     , fontVariantLigatures, commonLigatures, noCommonLigatures, discretionaryLigatures, noDiscretionaryLigatures, historicalLigatures, noHistoricalLigatures, contextual, noContextual
     , fontVariantNumeric, fontVariantNumeric4, ordinal, slashedZero, liningNums, oldstyleNums, proportionalNums, tabularNums, diagonalFractions, stackedFractions
     , fontKerning, fontLanguageOverride, fontSynthesis, fontSynthesis2, fontSynthesis3, fontOpticalSizing, fontVariantPosition
-    , stretch, center, start, end, flexStart, flexEnd, selfStart, selfEnd, spaceBetween, spaceAround, spaceEvenly, left_, right_, top_, bottom_, baseline, firstBaseline, lastBaseline, safe, unsafe, legacy, legacyLeft, legacyRight, legacyCenter
+    , stretch, center, flexStart, flexEnd, selfStart, selfEnd, spaceBetween, spaceAround, spaceEvenly, firstBaseline, lastBaseline, safe, unsafe, legacy, legacyLeft, legacyRight, legacyCenter
     , url
     , CursorKeyword
     , cursor, cursor2, cursor4, pointer, default, contextMenu, help, progress, wait, cell
@@ -94,7 +94,9 @@ module Css exposing
     , auto, none
     , hidden, visible
     , contentBox, borderBox
-    , overflow, overflowX, overflowY, overflowBlock, overflowInline, clip
+    , left_, right_, top_, bottom_, block, inline, start, end
+    , baseline, clip, ruby
+    , overflow, overflowX, overflowY, overflowBlock, overflowInline
     , overflowAnchor
     , overflowWrap
     , breakWord, anywhere
@@ -354,7 +356,7 @@ All CSS properties can have the values `unset`, `initial`, and `inherit`
 
 @docs display, display2, displayListItem2, displayListItem3
 
-@docs block, flex_, flow, flowRoot, grid, contents, listItem, inline, inlineBlock, inlineFlex, inlineTable, inlineGrid, ruby, rubyBase, rubyBaseContainer, rubyText, rubyTextContainer, runIn, table, tableCaption, tableCell, tableColumn, tableColumnGroup, tableFooterGroup, tableHeaderGroup, tableRow, tableRowGroup
+@docs flex_, flow, flowRoot, grid, contents, listItem, inlineBlock, inlineFlex, inlineTable, inlineGrid, rubyBase, rubyBaseContainer, rubyText, rubyTextContainer, runIn, table, tableCaption, tableCell, tableColumn, tableColumnGroup, tableFooterGroup, tableHeaderGroup, tableRow, tableRowGroup
 
 
 ## Positions
@@ -506,7 +508,7 @@ See this [complete guide](https://css-tricks.com/snippets/css/a-guide-to-flexbox
 
 # Align Items
 
-@docs stretch, center, start, end, flexStart, flexEnd, selfStart, selfEnd, spaceBetween, spaceAround, spaceEvenly, left_, right_, top_, bottom_, baseline, firstBaseline, lastBaseline, safe, unsafe, legacy, legacyLeft, legacyRight, legacyCenter
+@docs stretch, center, flexStart, flexEnd, selfStart, selfEnd, spaceBetween, spaceAround, spaceEvenly, firstBaseline, lastBaseline, safe, unsafe, legacy, legacyLeft, legacyRight, legacyCenter
 
 
 # Url
@@ -540,11 +542,13 @@ Multiple CSS properties use these values.
 @docs auto, none
 @docs hidden, visible
 @docs contentBox, borderBox
+@docs left_, right_, top_, bottom_, block, inline, start, end
+@docs baseline, clip, ruby
 
 
 ## Overflow
 
-@docs overflow, overflowX, overflowY, overflowBlock, overflowInline, clip
+@docs overflow, overflowX, overflowY, overflowBlock, overflowInline
 @docs overflowAnchor
 
 @docs overflowWrap
@@ -1200,7 +1204,7 @@ url str =
     Value ("url(" ++ str ++ ")")
 
 
-{-| The `auto` value used for properties such as [`width`](#width),
+{-| The `auto` value used in many properties such as [`width`](#width),
 [`zoom`](#zoom),
 [`outlineStyle`](#outlineStyle),
 and [`flexBasis`](#flexBasis).
@@ -1217,7 +1221,7 @@ auto =
     Value "auto"
 
 
-{-| The `none` value used for properties such as [`display`](#display),
+{-| The `none` value used in many properties such as [`display`](#display),
 [`borderStyle`](#borderStyle),
 [`maxWidth`](#maxWidth),
 [`clear`](#clear),
@@ -1278,9 +1282,13 @@ scroll =
     Value "scroll"
 
 
-{-| The `content-box` value, used with [`boxSizing`](#boxSizing),
-[`backgroundClip`](#backgroundClip), [`backgroundOrigin`](#backgroundOrigin),
-and [`strokeOrigin`](#strokeOrigin).
+{-| The `content-box` value, used in the following properties: 
+
+- [`boxSizing`](#boxSizing)
+- [`backgroundClip`](#backgroundClip)
+- [`backgroundOrigin`](#backgroundOrigin)
+- [`strokeOrigin`](#strokeOrigin)
+
 
     boxSizing contentBox
 
@@ -1296,9 +1304,13 @@ contentBox =
     Value "content-box"
 
 
-{-| The `border-box` value, used with [`boxSizing`](#boxSizing),
-[`backgroundClip`](#backgroundClip), [`backgroundOrigin`](backgroundOrigin),
-and [`strokeOrigin`](#strokeOrigin).
+{-| The `border-box` value, used in the following properties:
+
+- [`boxSizing`](#boxSizing)
+- [`backgroundClip`](#backgroundClip)
+- [`backgroundOrigin`](backgroundOrigin)
+- [`strokeOrigin`](#strokeOrigin)
+
 
     boxSizing borderBox
 
@@ -1313,6 +1325,256 @@ borderBox : Value { provides | borderBox : Supported }
 borderBox =
     Value "border-box"
 
+
+{-| The `left` value, used in many properties such as:
+
+- [`backgroundPosition`](#backgroundPosition)
+- [`clear`](#clear)
+- [`float`](#float)
+- [`justifyContent`](#justifyContent)
+- [`justifyItems`](#justifyItems)
+- [`justifySelf`](#justifySelf)
+- [`pageBreakAfter`](#pageBreakAfter)
+- [`textAlign`](#textAlign)
+
+
+    backgroundPosition left_
+    
+    clear left_
+
+    float left_
+
+    justifyContent left_
+
+    justifyItems left_
+
+    justifySelf left_
+
+    pageBreakAfter left_
+
+    textAlign left_
+
+
+
+The value is called `left_` instead of `left` because [`left` is already a function](#left).
+
+-}
+left_ : Value { provides | left_ : Supported }
+left_ =
+    Value "left"
+
+
+{-| The `right` value, used in many properties such as:
+
+- [`backgroundPosition`](#backgroundPosition)
+- [`clear`](#clear)
+- [`float`](#float)
+- [`justifyContent`](#justifyContent)
+- [`justifyItems`](#justifyItems)
+- [`justifySelf`](#justifySelf)
+- [`pageBreakAfter`](#pageBreakAfter)
+- [`textAlign`](#textAlign)
+
+
+    backgroundPosition right_
+    
+    clear right_
+
+    float right_
+
+    justifyContent right_
+
+    justifyItems right_
+
+    justifySelf right_
+
+    pageBreakAfter right_
+
+    textAlign right_
+
+
+
+The value is called `right_` instead of `right` because [`right` is already a function](#right).
+
+-}
+right_ : Value { provides | right_ : Supported }
+right_ =
+    Value "right"
+
+
+{-| The `top` value, used in the following properties:
+
+- [`backgroundPosition`](#backgroundPosition)
+- [`captionSide`](#captionSide)
+- [`objectPosition2`](#objectPosition2)
+- [`perspectiveOrigin2`](#perspectiveOrigin2)
+- [`strokePosition2`](#strokePosition2)
+- [`transformOrigin`](#transformOrigin)
+- [`verticalAlign`](#verticalAlign)
+
+
+    backgroundPosition top_
+
+    captionSide top_
+
+    objectPosition2 right_ top_
+
+    perspectiveOrigin2 left_ top_
+
+    transformOrigin top_
+
+    verticalAlign top_
+
+The value is called `top_` instead of `top` because [`top` is already a function](#top).
+
+-}
+top_ : Value { provides | top_ : Supported }
+top_ =
+    Value "top"
+
+
+{-| The `bottom` value, used in the following properties:
+
+- [`backgroundPosition`](#backgroundPosition)
+- [`captionSide`](#captionSide)
+- [`objectPosition2`](#objectPosition2)
+- [`perspectiveOrigin2`](#perspectiveOrigin2)
+- [`strokePosition2`](#strokePosition2)
+- [`transformOrigin`](#transformOrigin)
+- [`verticalAlign`](#verticalAlign)
+
+
+    backgroundPosition bottom_
+
+    captionSide bottom_
+
+    objectPosition2 right_ bottom_
+
+    perspectiveOrigin2 left_ bottom_
+
+    transformOrigin bottom_
+
+    verticalAlign bottom_
+
+The value is called `bottom_` instead of `bottom` because [`bottom` is already a function](#bottom).
+
+-}
+bottom_ : Value { provides | bottom_ : Supported }
+bottom_ =
+    Value "bottom"
+
+
+{-| The `block` value used by [`display`](#display) and [`resize`](#resize).
+
+    display block
+
+    resize block
+
+-}
+block : Value { provides | block : Supported }
+block =
+    Value "block"
+
+
+{-| The `inline` value used by [`display`](#display) and [`resize`](#resize).
+
+    display inline
+
+    resize inline
+
+-}
+inline : Value { provides | inline : Supported }
+inline =
+    Value "inline"
+
+
+{-| The `start` value, used in the following properties:
+
+- [`alignItems`](#alignItems)
+- [`alignContent`](#alignContent)
+- [`alignSelf`](#alignSelf)
+- [`justifyContent`](#justifyContent)
+- [`justifyItems`](#justifyItems)
+- [`justifySelf`](#justifySelf)
+- [`steps2`](#steps2)
+
+
+    alignContent start
+
+    steps2 3 start
+
+-}
+start : Value { provides | start : Supported }
+start =
+    Value "start"
+
+
+{-| The `end` value, used in the following properties:
+
+- [`alignItems`](#alignItems)
+- [`alignContent`](#alignContent)
+- [`alignSelf`](#alignSelf)
+- [`justifyContent`](#justifyContent)
+- [`justifyItems`](#justifyItems)
+- [`justifySelf`](#justifySelf)
+- [`steps2`](#steps2)
+
+
+    alignContent end
+
+    steps2 3 end
+
+-}
+end : Value { provides | end : Supported }
+end =
+    Value "end"
+{-| The `baseline` value, used in the following properties:
+
+- [`alignContent`](#alignContent)
+- [`alignItems`](#alignItems)
+- [`alignSelf`](#alignSelf)
+- [`verticalAlign`](#verticalAlign)
+
+
+    alignItems baseline
+
+    verticalAlign baseline
+
+-}
+
+
+baseline : Value { provides | baseline : Supported }
+baseline =
+    Value "baseline"
+
+
+{-| The `clip` value used by [`overflow`](#overflow) and [`textOverflow`](#textOverflow).
+
+    overflow clip
+
+    overflowX clip
+
+    overflowY clip
+
+    textOverflow clip
+
+-}
+clip : Value { provides | clip : Supported }
+clip =
+    Value "clip"
+
+
+
+{-| The `ruby` value used by [`display`](#display) and [`fontVariantEastAsian`](#fontVariantEastAsian).
+
+    display ruby
+
+    fontVariantEastAsian2 ruby jis83 
+
+-}
+ruby : Value { provides | ruby : Supported }
+ruby =
+    Value "ruby"
 
 
 -- OVERFLOW --
@@ -1389,19 +1651,6 @@ overflowY :
 overflowY (Value val) =
     AppendProperty ("overflow-y:" ++ val)
 
-
-{-| The `clip` value used by [`overflow`](#overflow).
-
-    overflow clip
-
-    overflowX clip
-
-    overflowY clip
-
--}
-clip : Value { provides | clip : Supported }
-clip =
-    Value "clip"
 
 
 {-| Sets [`overflow-block`](https://developer.mozilla.org/en-US/docs/Web/CSS/overflow-block).
@@ -3850,19 +4099,7 @@ displayListItem3 (Value displayOutside) (Value displayFlow) =
     AppendProperty ("display:list-item " ++ displayOutside ++ " " ++ displayFlow)
 
 
-{-| The `block` value used by [`display`](#display) and [`resize`].
-
-    display block
-
-    resize block
-
--}
-block : Value { provides | block : Supported }
-block =
-    Value "block"
-
-
-{-| `flex` value use by [`display`](#display)
+{-| The `flex` value used by [`display`](#display).
 
     display flex_
 
@@ -3874,7 +4111,7 @@ flex_ =
     Value "flex"
 
 
-{-| The `flow` value used by [`display`](#display)
+{-| The `flow` value used by [`display`](#display).
 
     display flow
 
@@ -3884,7 +4121,7 @@ flow =
     Value "flow"
 
 
-{-| The `flow-root` value used by [`display`](#display)
+{-| The `flow-root` value used by [`display`](#display).
 
     display flowRoot
 
@@ -3894,7 +4131,7 @@ flowRoot =
     Value "flow-root"
 
 
-{-| The `grid` value used by [`display`](#display)
+{-| The `grid` value used by [`display`](#display).
 
     display grid
 
@@ -3904,7 +4141,7 @@ grid =
     Value "grid"
 
 
-{-| The `contents` value used by [`display`](#display)
+{-| The `contents` value used by [`display`](#display).
 
     display contents
 
@@ -3914,19 +4151,7 @@ contents =
     Value "contents"
 
 
-{-| The `inline` value used by [`display`](#display) and [`resize`].
-
-    display inline
-
-    resize inline
-
--}
-inline : Value { provides | inline : Supported }
-inline =
-    Value "inline"
-
-
-{-| The `inline-block` value used by [`display`](#display)
+{-| The `inline-block` value used by [`display`](#display).
 
     display inlineBlock
 
@@ -3936,7 +4161,7 @@ inlineBlock =
     Value "inline-block"
 
 
-{-| The `inline-flex` value used by [`display`](#display)
+{-| The `inline-flex` value used by [`display`](#display).
 
     display inlineFlex
 
@@ -3946,7 +4171,7 @@ inlineFlex =
     Value "inline-flex"
 
 
-{-| The `list-item` value used by [`display`](#display)
+{-| The `list-item` value used by [`display`](#display).
 
     display listItem
 
@@ -3956,7 +4181,7 @@ listItem =
     Value "list-item"
 
 
-{-| The `inline-table` value used by [`display`](#display)
+{-| The `inline-table` value used by [`display`](#display).
 
     display inlineTable
 
@@ -3966,7 +4191,7 @@ inlineTable =
     Value "inline-table"
 
 
-{-| The `inline-grid` value used by [`display`](#display)
+{-| The `inline-grid` value used by [`display`](#display).
 
     display inlineGrid
 
@@ -3976,17 +4201,7 @@ inlineGrid =
     Value "inline-grid"
 
 
-{-| The `ruby` value used by [`display`](#display)
-
-    display ruby
-
--}
-ruby : Value { provides | ruby : Supported }
-ruby =
-    Value "ruby"
-
-
-{-| The `ruby-base` value used by [`display`](#display)
+{-| The `ruby-base` value used by [`display`](#display).
 
     display rubyBase
 
@@ -3996,7 +4211,7 @@ rubyBase =
     Value "ruby-base"
 
 
-{-| The `ruby-base-container` value used by [`display`](#display)
+{-| The `ruby-base-container` value used by [`display`](#display).
 
     display rubyBaseContainer
 
@@ -4006,7 +4221,7 @@ rubyBaseContainer =
     Value "ruby-base-container"
 
 
-{-| The `ruby-text` value used by [`display`](#display)
+{-| The `ruby-text` value used by [`display`](#display).
 
     display rubyText
 
@@ -4016,7 +4231,7 @@ rubyText =
     Value "ruby-text"
 
 
-{-| The `ruby-text-container` value used by [`display`](#display)
+{-| The `ruby-text-container` value used by [`display`](#display).
 
     display rubyTextContainer
 
@@ -4026,7 +4241,7 @@ rubyTextContainer =
     Value "ruby-text-container"
 
 
-{-| The `run-in` value used by [`display`](#display)
+{-| The `run-in` value used by [`display`](#display).
 
     display runIn
 
@@ -4036,7 +4251,7 @@ runIn =
     Value "run-in"
 
 
-{-| The `table` value used by [`display`](#display)
+{-| The `table` value used by [`display`](#display).
 
     display table
 
@@ -4046,7 +4261,7 @@ table =
     Value "table"
 
 
-{-| The `table-caption` value used by [`display`](#display)
+{-| The `table-caption` value used by [`display`](#display).
 
     display tableCaption
 
@@ -4056,7 +4271,7 @@ tableCaption =
     Value "table-caption"
 
 
-{-| The `table-cell` value used by [`display`](#display)
+{-| The `table-cell` value used by [`display`](#display).
 
     display tableCell
 
@@ -4066,7 +4281,7 @@ tableCell =
     Value "table-cell"
 
 
-{-| The `table-column` value used by [`display`](#display)
+{-| The `table-column` value used by [`display`](#display).
 
     display tableColumn
 
@@ -4076,7 +4291,7 @@ tableColumn =
     Value "table-column"
 
 
-{-| The `table-column-group` value used by [`display`](#display)
+{-| The `table-column-group` value used by [`display`](#display).
 
     display tableColumnGroup
 
@@ -4086,7 +4301,7 @@ tableColumnGroup =
     Value "table-column-group"
 
 
-{-| The `table-footer-group` value used by [`display`](#display)
+{-| The `table-footer-group` value used by [`display`](#display).
 
     display tableFooterGroup
 
@@ -4096,7 +4311,7 @@ tableFooterGroup =
     Value "table-footer-group"
 
 
-{-| The `table-header-group` value used by [`display`](#display)
+{-| The `table-header-group` value used by [`display`](#display).
 
     display tableHeaderGroup
 
@@ -4106,7 +4321,7 @@ tableHeaderGroup =
     Value "table-header-group"
 
 
-{-| The `table-row` value used by [`display`](#display)
+{-| The `table-row` value used by [`display`](#display).
 
     display tableRow
 
@@ -4116,7 +4331,7 @@ tableRow =
     Value "table-row"
 
 
-{-| The `table-row-group` value used by [`display`](#display)
+{-| The `table-row-group` value used by [`display`](#display).
 
     display tableRowGroup
 
@@ -4141,41 +4356,6 @@ center : Value { provides | center : Supported }
 center =
     Value "center"
 
-
-{-| The `start` value used for properties such as [`alignItems`](#alignItems),
-[`alignContent`](#alignContent),
-[`alignSelf`](#alignSelf),
-[`justifyContent`](#justifyContent),
-[`justifyItems`](#justifyItems),
-[`justifySelf`](#justifySelf),
-and [`steps2`](#steps2).
-
-    alignContent start
-
-    steps2 3 start
-
--}
-start : Value { provides | start : Supported }
-start =
-    Value "start"
-
-
-{-| The `end` value used for properties such as [`alignItems`](#alignItems),
-[`alignContent`](#alignContent),
-[`alignSelf`](#alignSelf),
-[`justifyContent`](#justifyContent),
-[`justifyItems`](#justifyItems),
-[`justifySelf`](#justifySelf),
-and [`steps2`](#steps2).
-
-    alignContent end
-
-    steps2 3 end
-
--}
-end : Value { provides | end : Supported }
-end =
-    Value "end"
 
 
 {-| The `flex-start` value used by [`alignItems`](#alignItems),
@@ -4257,67 +4437,6 @@ the start and end.
 spaceEvenly : Value { provides | spaceEvenly : Supported }
 spaceEvenly =
     Value "space-evenly"
-
-
-{-| The `left` value used for alignment.
-
-    float left_
-
-The value is called `left_` instead of `left` because [`left` is already a function](#left).
-
--}
-left_ : Value { provides | left_ : Supported }
-left_ =
-    Value "left"
-
-
-{-| The `right` value used for alignment.
-
-    float right_
-
-The value is called `right_` instead of `right` because [`right` is already a function](#right).
-
--}
-right_ : Value { provides | right_ : Supported }
-right_ =
-    Value "right"
-
-
-{-| The `top` value used by [`verticalAlign`](#verticalAlign).
-
-    verticalAlign top_
-
-The value is called `top_` instead of `top` because [`top` is already a function](#top).
-
--}
-top_ : Value { provides | top_ : Supported }
-top_ =
-    Value "top"
-
-
-{-| The `bottom` value used by [`verticalAlign`](#verticalAlign).
-
-    verticalAlign bottom_
-
-The value is called `bottom_` instead of `bottom` because [`bottom` is already a function](#bottom).
-
--}
-bottom_ : Value { provides | bottom_ : Supported }
-bottom_ =
-    Value "bottom"
-
-
-{-| The `baseline` value used for properties such as [`alignContent`](#alignContent),
-[`alignItems`](#alignItems),
-[`alignSelf`](#alignSelf),
-and [`verticalAlign`](#verticalAlign).
-
-    alignItems baseline
-
--}
-baseline : Value { provides | baseline : Supported }
-baseline =
-    Value "baseline"
 
 
 {-| The `first baseline` value used for properties such as [`alignContent`](#alignContent),

--- a/src/Css.elm
+++ b/src/Css.elm
@@ -11,7 +11,7 @@ module Css exposing
     , Color, ColorSupported, color, backgroundColor, hex, rgb, rgba, hsl, hsla, currentcolor
     , Time, TimeSupported, s, ms
     , pseudoClass, active, disabled
-    , pseudoElement, before, after
+    , pseudoElement, before, after, backdrop, cue, marker, placeholder, selection
     , width, minWidth, maxWidth, height, minHeight, maxHeight
     , minContent, maxContent, fitContent
     , backgroundAttachment, backgroundAttachments, scroll, local
@@ -230,7 +230,7 @@ All CSS properties can have the values `unset`, `initial`, and `inherit`
 
 ## Pseudo-Elements
 
-@docs pseudoElement, before, after
+@docs pseudoElement, before, after, backdrop, cue, marker, placeholder, selection
 
 
 ## Sizing
@@ -2249,7 +2249,7 @@ pseudoElement element =
 
     div [ after [ content "hi!" ] ]
 
---TODO : Introduce aw way to do [`content`](https://developer.mozilla.org/en-US/docs/Web/CSS/content) - lots of options there, not just text. Also it's overloaded with `flexBasis content`.
+--TODO : Introduce a way to do [`content`](https://developer.mozilla.org/en-US/docs/Web/CSS/content) - lots of options there, not just text. Also it's overloaded with `flexBasis content`.
 
 -}
 after : List Style -> Style
@@ -2262,12 +2262,80 @@ after =
 
     div [ before [ content "hi!" ] ]
 
---TODO : Introduce aw way to do [`content`](https://developer.mozilla.org/en-US/docs/Web/CSS/content) - lots of options there, not just text. Also it's overloaded with `flexBasis content`.
+--TODO : Introduce a way to do [`content`](https://developer.mozilla.org/en-US/docs/Web/CSS/content) - lots of options there, not just text. Also it's overloaded with `flexBasis content`.
 
 -}
 before : List Style -> Style
 before =
     pseudoElement "before"
+
+
+{-| A [`::backdrop`](https://developer.mozilla.org/en-US/docs/Web/CSS/::backdrop)
+[pseudo-element](https://developer.mozilla.org/en-US/docs/Web/CSS/Pseudo-elements).
+
+    backdrop
+        [ background (rgba 255 0 0 0.25)
+        ]
+-}
+backdrop : List Style -> Style
+backdrop =
+    pseudoElement "backdrop"
+
+
+{-| A [`::cue`](https://developer.mozilla.org/en-US/docs/Web/CSS/::cue)
+[pseudo-element](https://developer.mozilla.org/en-US/docs/Web/CSS/Pseudo-elements).
+
+    cue
+        [ color (rgba 255 255 0 1)
+        , fontWeight (int 600)
+        ]
+-}
+cue : List Style -> Style
+cue =
+    pseudoElement "cue"
+
+{-| A [`::marker`](https://developer.mozilla.org/en-US/docs/Web/CSS/::marker)
+[pseudo-element](https://developer.mozilla.org/en-US/docs/Web/CSS/Pseudo-elements).
+
+    marker
+        [ color (rgba 255 255 0 1)
+        , fontWeight (int 600)
+        ]
+-}
+marker : List Style -> Style
+marker =
+    pseudoElement "marker"
+
+
+{-| A [`::placeholder`](https://developer.mozilla.org/en-US/docs/Web/CSS/::placeholder)
+[pseudo-element](https://developer.mozilla.org/en-US/docs/Web/CSS/Pseudo-elements).
+
+Be careful when using placeholders as they can compromise accessibility.
+
+    placeholder
+        [ opacity (num 1) <| important
+        , color (rgb 90 90 90)
+        , fontWeight (int 300)
+        ]
+]
+-}
+placeholder : List Style -> Style
+placeholder =
+    pseudoElement "placeholder"
+
+
+{-| A [`::selection`](https://developer.mozilla.org/en-US/docs/Web/CSS/::selection)
+[pseudo-element](https://developer.mozilla.org/en-US/docs/Web/CSS/Pseudo-elements).
+
+    selection
+        [ backgroundColor (rgb 200 140 15)
+        ]
+    
+
+-}
+selection : List Style -> Style
+selection =
+    pseudoElement "selection"
 
 
 

--- a/src/Css.elm
+++ b/src/Css.elm
@@ -202,7 +202,7 @@ module Css exposing
     , backgroundRepeat, backgroundRepeat2
     , backgroundSize, backgroundSize2
 
-    -- font size
+    -- Font size
     , fontSize
     , xxSmall, xSmall, small, medium, large, xLarge, xxLarge, smaller, larger
     , fontSizeAdjust
@@ -210,17 +210,23 @@ module Css exposing
     -- @font-face
     , fontDisplay, fallback, swap, optional
 
-    -- font family
-    , fontFamily, fontFamilies, serif, sansSerif, monospace, cursive, fantasy, systemUi
+    -- Font family
+    , fontFamily, fontFamilies
+    , serif, sansSerif, monospace, cursive, fantasy, systemUi
 
-    -- font style, weight + stretch
+    -- Font style, weight + stretch
     , fontStyle, italic, oblique
     , fontWeight, bold, lighter, bolder
     , fontStretch, ultraCondensed, extraCondensed, condensed, semiCondensed, semiExpanded, expanded, extraExpanded, ultraExpanded
-    
-    -- font features and variants
-    , fontFeatureSettings, fontFeatureSettingsList, featureTag, featureTag2
-    , fontVariantCaps, smallCaps, allSmallCaps, petiteCaps, allPetiteCaps, unicase, titlingCaps
+    , fontSynthesis, fontSynthesis2, fontSynthesis3
+    , weight
+    , fontVariationSettings, fontVariationSettingsList
+
+    -- Typographic features
+    , fontFeatureSettings, fontFeatureSettingsList
+    , featureTag, featureTag2
+    , fontVariantCaps
+    , smallCaps, allSmallCaps, petiteCaps, allPetiteCaps, unicase, titlingCaps
     , fontVariantEastAsian, fontVariantEastAsian2, fontVariantEastAsian3
     , jis78, jis83, jis90, jis04, simplified, traditional, proportionalWidth
     , fontVariantLigatures
@@ -229,71 +235,55 @@ module Css exposing
     , ordinal, slashedZero, liningNums, oldstyleNums, proportionalNums, tabularNums, diagonalFractions, stackedFractions
     , fontKerning
     , fontLanguageOverride
-    , fontSynthesis, fontSynthesis2, fontSynthesis3
     , fontOpticalSizing
     , fontVariantPosition
-    , weight
-
-    -- variable fonts (not to be confused with variants)
-    , fontVariationSettings, fontVariationSettingsList
     
-    -- list styles
-    , ListStyleType, ListStyleTypeSupported
-    , listStyle, listStyle2, listStyle3, listStylePosition, inside, outside
-    , listStyleType
-    , listStyleImage
-    , arabicIndic, armenian, bengali, cambodian, cjkDecimal, cjkEarthlyBranch, cjkHeavenlyStem, cjkIdeographic, decimal, decimalLeadingZero, devanagari, disclosureClosed, disclosureOpen, disc, ethiopicNumeric, georgian, gujarati, gurmukhi, hebrew, hiragana, hiraganaIroha, japaneseFormal, japaneseInformal, kannada, katakana, katakanaIroha, khmer, koreanHangulFormal, koreanHanjaFormal, koreanHanjaInformal, lao, lowerAlpha, lowerArmenian, lowerGreek, lowerLatin, lowerRoman, malayalam, monogolian, myanmar, oriya, persian, simpChineseFormal, simpChineseInformal, tamil, telugu, thai, tibetan, tradChineseFormal, tradChineseInformal, upperAlpha, upperArmenian, upperLatin, upperRoman
+    -- Typographic metrics
+    , lineHeight
+    , letterSpacing
+    , textIndent, textIndent2, textIndent3
+    , hanging, eachLine
+    , wordSpacing
+    , tabSize
 
-    -- text transform + decoration
-    , textTransform
-    , capitalize, uppercase, lowercase, fullSizeKana
+    -- Text wrapping, overflow and newlines
+    , wordBreak, breakAll, keepAll
+    , lineBreak, loose
+    , whiteSpace, pre, preWrap, preLine
+    , textOverflow, textOverflow2, ellipsis
+    , hyphens, manual
+    , hangingPunctuation, hangingPunctuation2, hangingPunctuation3
+    , first, last, forceEnd, allowEnd
+
+    -- Text decoration + transform
     , textDecoration, textDecoration2, textDecoration3
     , textDecorationLine, textDecorationLine2, textDecorationLine3
     , textDecorationStyle
-    , textDecorationColor
-    , textDecorationThickness
-    , fromFont
-    , textDecorationSkip
-    , textDecorationSkipInk
-    , objects, spaces, ink, edges, boxDecoration
     , wavy, underline, overline, lineThrough
-
-    -- text decoration (other)
-    , lineHeight
-    , letterSpacing
-    , textIndent, textIndent2, textIndent3, hanging, eachLine
+    , textDecorationColor
+    , textDecorationThickness, fromFont
+    , textDecorationSkipInk
+    , textUnderlinePosition, textUnderlinePosition2
     , textUnderlineOffset
     , textEmphasis, textEmphasis2
     , textEmphasisStyle, textEmphasisStyle2
-    , textEmphasisColor, textEmphasisPosition, textEmphasisPosition2
+    , textEmphasisColor
+    , textEmphasisPosition, textEmphasisPosition2
     , filled, open, dot, doubleCircle, triangle, sesame, over
+    , textTransform
+    , capitalize, uppercase, lowercase, fullSizeKana
 
-    -- more text stuff to rearrange
+    -- text alignment and justification
     , textAlign, justify 
     , textJustify, interWord, interCharacter
-    , textUnderlinePosition, textUnderlinePosition2
-    , textOrientation
-    , mixed, sideways, sidewaysRight, upright, useGlyphOrientation
-    , wordBreak
-    , breakAll, keepAll
-    , wordSpacing
-    , tabSize
-    , hyphens
-    , manual
-    , quotes, quotes2, quotes4
-    , textOverflow, textOverflow2
-    , ellipsis
-    , lineBreak
-    , loose
-    , hangingPunctuation, hangingPunctuation2, hangingPunctuation3
-    , first, last, forceEnd, allowEnd
-    , whiteSpace
-    , pre, preWrap, preLine
-
+    
     -- script handling
     , direction, ltr, rtl
     , writingMode, verticalLr, verticalRl, horizontalTb
     , unicodeBidi, embed, plaintext, bidiOverride, isolateOverride
+    , textOrientation
+    , mixed, sideways, sidewaysRight, upright, useGlyphOrientation
+    , quotes, quotes2, quotes4
 
     -- text rendering
     , textRendering
@@ -304,6 +294,13 @@ module Css exposing
 
     -- accessibility
     , speak, spellOut
+    
+    -- list styles
+    , ListStyleType, ListStyleTypeSupported
+    , listStyle, listStyle2, listStyle3, listStylePosition, inside, outside
+    , listStyleType
+    , listStyleImage
+    , arabicIndic, armenian, bengali, cambodian, cjkDecimal, cjkEarthlyBranch, cjkHeavenlyStem, cjkIdeographic, decimal, decimalLeadingZero, devanagari, disclosureClosed, disclosureOpen, disc, ethiopicNumeric, georgian, gujarati, gurmukhi, hebrew, hiragana, hiraganaIroha, japaneseFormal, japaneseInformal, kannada, katakana, katakanaIroha, khmer, koreanHangulFormal, koreanHanjaFormal, koreanHanjaInformal, lao, lowerAlpha, lowerArmenian, lowerGreek, lowerLatin, lowerRoman, malayalam, monogolian, myanmar, oriya, persian, simpChineseFormal, simpChineseInformal, tamil, telugu, thai, tibetan, tradChineseFormal, tradChineseInformal, upperAlpha, upperArmenian, upperLatin, upperRoman
 
     -- columns
     , columns, columns2
@@ -327,13 +324,9 @@ module Css exposing
     , tableLayout
 
     -- content fragmentation
-    , breakBefore
-    , breakAfter
-    , breakInside
+    , breakBefore, breakAfter, breakInside
     , avoid, avoidPage, avoidColumn, page
-    , pageBreakBefore
-    , pageBreakAfter
-    , pageBreakInside
+    , pageBreakBefore, pageBreakAfter, pageBreakInside
     , orphans, widows
     , boxDecorationBreak
 
@@ -522,37 +515,42 @@ functions let you define custom properties and selectors, respectively.
 ## Numerical units
 
 ### Lengths
+
 @docs Length, LengthSupported
 @docs zero, px, em, ex, ch, rem, vh, vw, vmin, vmax, mm, cm, q, inch, pt, pc, pct, num, int
 
-
 ### Angles
+
 @docs Angle, AngleSupported, Width, WidthSupported
 @docs deg, grad, rad, turn
 
 ### Time
+
 @docs Time, TimeSupported, s, ms
 
 ### Flex
+
 @docs fr, minmax, fitContentTo
 
+## Names & URLs
+
+@docs customIdent, string, url
+
 ## Color
+
 @docs Color, ColorSupported, hex, rgb, rgba, hsl, hsla, currentcolor
 
 ## Shapes
+
 @docs BasicShape, BasicShapeSupported
 @docs circle, circleAt, circleAt2, ellipse, ellipseAt, ellipseAt2, closestSide, farthestSide, polygon, path
 
 ## Resolution
+
 @docs Resolution, ResolutionSupported, dpi, dpcm, dppx
 
-## Ident
-@docs customIdent
-
-## URLs
-@docs url
-
 ## Calc
+
 @docs calc, CalcOperation, minus, plus, times, dividedBy
 
 
@@ -919,7 +917,8 @@ Other values you can use for flex item alignment:
 # Background
 
 @docs backgroundColor
-@docs backgroundAttachment, backgroundAttachments, local
+@docs backgroundAttachment, backgroundAttachments
+@docs local
 @docs backgroundBlendMode, backgroundBlendModes
 @docs multiply, screen, overlay, darken, lighten, colorDodge, colorBurn, hardLight, softLight, difference, exclusion, hue, saturation, color_, luminosity
 @docs backgroundClip, backgroundClips, backgroundOrigin, backgroundOrigins
@@ -927,6 +926,198 @@ Other values you can use for flex item alignment:
 @docs backgroundPosition, backgroundPosition2, backgroundPosition3, backgroundPosition4
 @docs backgroundRepeat, backgroundRepeat2
 @docs backgroundSize, backgroundSize2
+
+
+------------------------------------------------------
+
+
+# Basic typographic options
+
+## Sizing
+
+@docs fontSize
+@docs xxSmall, xSmall, small, medium, large, xLarge, xxLarge, smaller, larger
+@docs fontSizeAdjust
+
+## @font-face
+
+@docs fontDisplay, fallback, swap, optional
+
+## Font family
+
+@docs fontFamily, fontFamilies
+@docs serif, sansSerif, monospace, cursive, fantasy, systemUi
+
+## Font style, weight & stretch
+
+@docs fontStyle, italic, oblique
+@docs fontWeight, bold, lighter, bolder
+@docs fontStretch, ultraCondensed, extraCondensed, condensed, semiCondensed, semiExpanded, expanded, extraExpanded, ultraExpanded
+    
+## Missing typeface synthesis
+
+@docs fontSynthesis, fontSynthesis2, fontSynthesis3
+@docs weight
+
+## Variable fonts (not to be confused with font variants)
+
+@docs fontVariationSettings, fontVariationSettingsList
+
+
+------------------------------------------------------
+
+
+# Typographic features
+
+## OpenType typographic features
+
+@docs fontFeatureSettings, fontFeatureSettingsList
+@docs featureTag, featureTag2
+
+## Alternative capitals
+
+@docs fontVariantCaps
+@docs smallCaps, allSmallCaps, petiteCaps, allPetiteCaps, unicase, titlingCaps
+
+## East Asian glyph variants
+
+@docs fontVariantEastAsian, fontVariantEastAsian2, fontVariantEastAsian3
+@docs jis78, jis83, jis90, jis04, simplified, traditional, proportionalWidth
+
+## Ligatures & contextual forms
+
+@docs fontVariantLigatures
+@docs commonLigatures, noCommonLigatures, discretionaryLigatures, noDiscretionaryLigatures, historicalLigatures, noHistoricalLigatures, contextual, noContextual
+    
+## Numerical variants
+
+@docs fontVariantNumeric, fontVariantNumeric4
+@docs ordinal, slashedZero, liningNums, oldstyleNums, proportionalNums, tabularNums, diagonalFractions, stackedFractions
+    
+## Kerning
+
+@docs fontKerning
+
+## Language override
+
+@docs fontLanguageOverride
+
+## Optical sizing
+
+@docs fontOpticalSizing
+
+## Superscript & subscript
+
+@docs fontVariantPosition
+
+
+------------------------------------------------------
+
+
+# Typographic metrics
+
+@docs lineHeight
+@docs letterSpacing
+@docs textIndent, textIndent2, textIndent3
+@docs hanging, eachLine
+@docs wordSpacing
+@docs tabSize
+
+
+------------------------------------------------------
+
+
+# Text wrapping, overflow and newlines
+
+@docs wordBreak, breakAll, keepAll
+@docs lineBreak, loose
+@docs whiteSpace, pre, preWrap, preLine
+@docs textOverflow, textOverflow2, ellipsis
+@docs hyphens, manual
+@docs hangingPunctuation, hangingPunctuation2, hangingPunctuation3
+@docs first, last, forceEnd, allowEnd
+
+
+------------------------------------------------------
+
+
+# Text decoration and transform
+
+@docs textDecoration, textDecoration2, textDecoration3
+@docs textDecorationLine, textDecorationLine2, textDecorationLine3
+@docs textDecorationStyle
+@docs wavy, underline, overline, lineThrough
+@docs textDecorationColor
+@docs textDecorationThickness, fromFont
+@docs textDecorationSkipInk
+@docs textUnderlinePosition, textUnderlinePosition2
+@docs textUnderlineOffset
+@docs textEmphasis, textEmphasis2
+@docs textEmphasisStyle, textEmphasisStyle2
+@docs textEmphasisColor
+@docs textEmphasisPosition, textEmphasisPosition2
+@docs filled, open, dot, doubleCircle, triangle, sesame, over
+@docs textTransform
+@docs capitalize, uppercase, lowercase, fullSizeKana
+
+
+------------------------------------------------------
+
+
+# Text alignment and justification
+
+@docs textAlign, justify
+@docs textJustify, interWord, interCharacter
+
+
+------------------------------------------------------
+
+
+# Script handling
+
+@docs direction, ltr, rtl
+@docs writingMode, verticalLr, verticalRl, horizontalTb
+@docs unicodeBidi, embed, plaintext, bidiOverride, isolateOverride
+@docs textOrientation
+@docs mixed, sideways, sidewaysRight, upright, useGlyphOrientation
+@docs quotes, quotes2, quotes4
+
+
+------------------------------------------------------
+
+
+# Text rendering
+
+@docs textRendering
+@docs geometricPrecision, optimizeLegibility, optimizeSpeed
+
+
+------------------------------------------------------
+
+
+# Text selection
+
+@docs userSelect
+
+
+------------------------------------------------------
+
+
+# Accessibility
+
+@docs speak, spellOut
+
+
+------------------------------------------------------
+
+
+# List styles
+
+@docs ListStyleType, ListStyleTypeSupported
+@docs listStyle, listStyle2, listStyle3, listStylePosition, inside, outside
+@docs listStyleType
+@docs listStyleImage
+@docs arabicIndic, armenian, bengali, cambodian, cjkDecimal, cjkEarthlyBranch, cjkHeavenlyStem, cjkIdeographic, decimal, decimalLeadingZero, devanagari, disclosureClosed, disclosureOpen, disc, ethiopicNumeric, georgian, gujarati, gurmukhi, hebrew, hiragana, hiraganaIroha, japaneseFormal, japaneseInformal, kannada, katakana, katakanaIroha, khmer, koreanHangulFormal, koreanHanjaFormal, koreanHanjaInformal, lao, lowerAlpha, lowerArmenian, lowerGreek, lowerLatin, lowerRoman, malayalam, monogolian, myanmar, oriya, persian, simpChineseFormal, simpChineseInformal, tamil, telugu, thai, tibetan, tradChineseFormal, tradChineseInformal, upperAlpha, upperArmenian, upperLatin, upperRoman
 
 
 ------------------------------------------------------
@@ -943,85 +1134,16 @@ Other values you can use for flex item alignment:
 
 
 
-# Typography
 
 
-## Spacing
-
-@docs wordSpacing
-@docs tabSize
 
 
-## Display
-
-@docs fontDisplay, fallback, swap, optional
-@docs writingMode, verticalLr, verticalRl, horizontalTb
-@docs hyphens, quotes, quotes2, quotes4, textOverflow, textOverflow2, lineBreak, manual, ellipsis, loose
-@docs hangingPunctuation, hangingPunctuation2, hangingPunctuation3, first, last, forceEnd, allowEnd
-@docs lineClamp
 
 
-## Font Size
-
-@docs fontSize, xxSmall, xSmall, small, medium, large, xLarge, xxLarge, smaller, larger, lineHeight, letterSpacing
-@docs fontSizeAdjust
 
 
-## Font Family
-
-@docs fontFamily, fontFamilies, serif, sansSerif, monospace, cursive, fantasy, systemUi
 
 
-## Font Styles
-
-@docs fontStyle, italic, oblique
-
-[`normal`](#normal) is also a supported font style.
-
-
-## Font Weights
-
-@docs fontWeight, bold, lighter, bolder
-
-[`normal`](#normal) is also a supported font weight.
-
-@docs fontStretch, ultraCondensed, extraCondensed, condensed, semiCondensed, semiExpanded, expanded, extraExpanded, ultraExpanded
-
-
-## Font Feature Settings
-
-@docs fontFeatureSettings, fontFeatureSettingsList, featureTag, featureTag2
-
-[`normal`](#normal) is also a supported font feature settings.
-
-
-## Font Variation Settings
-
-@docs fontVariationSettings, fontVariationSettingsList
-
-## Font Variant Caps
-
-@docs fontVariantCaps, smallCaps, allSmallCaps, petiteCaps, allPetiteCaps, unicase, titlingCaps
-
-
-## Font Variant East Asian
-
-@docs fontVariantEastAsian, fontVariantEastAsian2, fontVariantEastAsian3, jis78, jis83, jis90, jis04, simplified, traditional, proportionalWidth
-
-
-## Font Variant Ligatures
-
-@docs fontVariantLigatures, commonLigatures, noCommonLigatures, discretionaryLigatures, noDiscretionaryLigatures, historicalLigatures, noHistoricalLigatures, contextual, noContextual
-
-
-## Font Variant Numeric
-
-@docs fontVariantNumeric, fontVariantNumeric4, ordinal, slashedZero, liningNums, oldstyleNums, proportionalNums, tabularNums, diagonalFractions, stackedFractions
-
-
-## Font Optical Sizing
-
-@docs fontKerning, fontLanguageOverride, fontSynthesis, fontSynthesis2, fontSynthesis3, fontOpticalSizing, fontVariantPosition, weight
 
 
 # Cursors
@@ -1040,56 +1162,6 @@ Other values you can use for flex item alignment:
 @docs wResize, neResize, nwResize, seResize, swResize, ewResize, nsResize
 @docs neswResize, nwseResize, zoomIn, zoomOut, grab, grabbing
 
-
-# List Style
-
-@docs ListStyleType, ListStyleTypeSupported
-@docs listStyle, listStyle2, listStyle3, listStylePosition, inside, outside, listStyleType, string, listStyleImage
-@docs arabicIndic, armenian, bengali, cambodian, cjkDecimal, cjkEarthlyBranch, cjkHeavenlyStem, cjkIdeographic, decimal, decimalLeadingZero, devanagari, disclosureClosed, disclosureOpen, disc, ethiopicNumeric, georgian, gujarati, gurmukhi, hebrew, hiragana, hiraganaIroha, japaneseFormal, japaneseInformal, kannada, katakana, katakanaIroha, khmer, koreanHangulFormal, koreanHanjaFormal, koreanHanjaInformal, lao, lowerAlpha, lowerArmenian, lowerGreek, lowerLatin, lowerRoman, malayalam, monogolian, myanmar, oriya, persian, simpChineseFormal, simpChineseInformal, tamil, telugu, thai, tibetan, tradChineseFormal, tradChineseInformal, upperAlpha, upperArmenian, upperLatin, upperRoman
-
-[`square`](#square) is also a supported value for [`listStyle`](#listStyle) and [`listStyleType`](#listStyleType).
-
-
-# Direction
-
-@docs direction, ltr, rtl
-
-
-# Text Align
-
-@docs justify, textAlign, textJustify, interWord, interCharacter, textUnderlinePosition, textUnderlinePosition2
-
-
-# Text Orientation
-
-@docs textOrientation
-@docs mixed, sideways, sidewaysRight, upright, useGlyphOrientation
-
-
-# Text Rendering
-
-@docs textRendering
-@docs geometricPrecision, optimizeLegibility, optimizeSpeed
-
-
-# Text Transform
-
-@docs textTransform
-@docs capitalize, uppercase, lowercase, fullSizeKana
-
-
-# Text Decoration
-
-@docs textDecoration, textDecoration2, textDecoration3, textDecorationLine, textDecorationLine2, textDecorationLine3, textDecorationStyle, textDecorationColor, textDecorationThickness, fromFont
-@docs textDecorationSkip, textDecorationSkipInk, objects, spaces, ink, edges, boxDecoration
-
-@docs wavy, underline, overline, lineThrough
-
-@docs textIndent, textIndent2, textIndent3, hanging, eachLine
-
-@docs textUnderlineOffset
-
-@docs textEmphasis, textEmphasis2, textEmphasisStyle, textEmphasisStyle2, textEmphasisColor, textEmphasisPosition, textEmphasisPosition2, filled, open, dot, doubleCircle, triangle, sesame, over
 
 
 # Tables
@@ -1120,24 +1192,6 @@ Other values you can use for flex item alignment:
 ## Table Layout
 
 @docs tableLayout
-
-
-## Vertical Align
-
-@docs verticalAlign
-@docs textTop, textBottom, middle
-
-
-## White space
-
-@docs whiteSpace
-@docs pre, preWrap, preLine
-
-
-## Word break
-
-@docs wordBreak
-@docs breakAll, keepAll
 
 
 ## Float
@@ -1243,13 +1297,6 @@ Other values you can use for flex item alignment:
 @docs overscrollBehavior, overscrollBehavior2, overscrollBehaviorX, overscrollBehaviorY, overscrollBehaviorBlock, overscrollBehaviorInline
 
 
-# Accessibility
-
-@docs speak, spellOut
-@docs userSelect
-@docs unicodeBidi, embed, bidiOverride, isolateOverride, plaintext
-
-
 # Printing
 
 @docs bleed
@@ -1284,13 +1331,12 @@ Other values you can use for flex item alignment:
 @docs TextShadowConfig, color, defaultTextShadow
 @docs linearGradient, linearGradient2, stop, stop2, stop3, textShadow
 @docs toBottom, toBottomLeft, toBottomRight, toLeft, toRight, toTop, toTopLeft, toTopRight
-
+@docs lineClamp, middle, textTop, textBottom, verticalAlign
 
 -}
 
 import Css.Preprocess as Preprocess exposing (Style(..))
 import Css.Structure as Structure
-
 
 
 ------------------------------------------------------------------------
@@ -11985,6 +12031,141 @@ semiExpanded =
     Value "semi-expanded"
 
 
+{-| The [`font-synthesis`](https://developer.mozilla.org/en-US/docs/Web/CSS/font-synthesis) property.
+
+    fontSynthesis none
+
+    fontSynthesis smallCaps
+
+    fontSynthesis2 smallCaps weight
+
+    fontSynthesis3 weight style smallCaps
+
+-}
+fontSynthesis :
+    BaseValue
+        { none : Supported
+        , weight : Supported
+        , style : Supported
+        , smallCaps : Supported
+        }
+    -> Style
+fontSynthesis (Value val) =
+    AppendProperty ("font-synthesis:" ++ val)
+
+
+{-| The [`font-synthesis`](https://developer.mozilla.org/en-US/docs/Web/CSS/font-synthesis) property.
+
+This is the two-argument variant, in which you can indicate
+two different font properties to be synthesised by the browser.
+
+    fontSynthesis2 smallCaps weight
+
+-}
+fontSynthesis2 :
+    Value
+        { weight : Supported
+        , style : Supported
+        , smallCaps : Supported
+        }
+    ->
+        Value
+            { weight : Supported
+            , style : Supported
+            , smallCaps : Supported
+            }
+    -> Style
+fontSynthesis2 (Value val1) (Value val2) =
+    AppendProperty ("font-synthesis:" ++ val1 ++ " " ++ val2)
+
+
+{-| The [`font-synthesis`](https://developer.mozilla.org/en-US/docs/Web/CSS/font-synthesis) property.
+
+This is the three-argument variant, in which you can indicate
+all three different font properties to be synthesised by the browser.
+
+    fontSynthesis3 weight style smallCaps
+
+-}
+fontSynthesis3 :
+    Value
+        { weight : Supported
+        , style : Supported
+        , smallCaps : Supported
+        }
+    ->
+        Value
+            { weight : Supported
+            , style : Supported
+            , smallCaps : Supported
+            }
+    ->
+        Value
+            { weight : Supported
+            , style : Supported
+            , smallCaps : Supported
+            }
+    -> Style
+fontSynthesis3 (Value val1) (Value val2) (Value val3) =
+    AppendProperty ("font-synthesis:" ++ val1 ++ " " ++ val2 ++ " " ++ val3)
+
+
+{-| The `weight` value for the [`fontSynthesis`](#fontSynthesis) property.
+
+    fontSynthesis weight
+
+-}
+weight : Value { provides | weight : Supported }
+weight =
+    Value "weight"
+
+
+{-| The 1-argument variant of the [`font-variation-settings`](https://developer.mozilla.org/en-US/docs/Web/CSS/font-variation-settings)
+property.
+
+For controlling aspects of variable fonts.
+Use [`fontVariationSettingsList`](#fontVariationSettingsList) to work with variable font tags.
+
+    fontVariationSettings normal
+
+    fontVariationSettings inherit
+
+    fontVariationSettingsList [ ("XHGT", 0.7) ]
+-}
+fontVariationSettings :
+    BaseValue
+        { normal : Supported
+        }
+    -> Style
+fontVariationSettings (Value val) =
+    AppendProperty ("font-variation-settings:" ++ val)
+
+
+{-| The multi-argument variant of the [`font-variation-settings`](https://developer.mozilla.org/en-US/docs/Web/CSS/font-variation-settings)
+property.
+
+For using single keywords with this property, use [`fontVariationSettings`](#fontVariationSettings).
+
+    fontVariationSettingsList [ ("XHGT", 0.7) ]
+-}
+fontVariationSettingsList :
+    List
+        ( String
+        , Float
+        )
+    -> Style
+fontVariationSettingsList list =
+    AppendProperty <|
+        "font-variation-settings:"
+        ++
+        ( list
+        |> List.map
+            (\(tagVal, numberVal) -> (enquoteString tagVal) ++ " " ++ (String.fromFloat numberVal)
+            )
+        |> String.join ", "
+        )
+
+
 ------------------------------------------------------------------------
 ------------------------------------------------------------------------
 ------------------------------------------------------------------------
@@ -12659,85 +12840,6 @@ fontLanguageOverride (Value val) =
     AppendProperty ("font-language-override:" ++ val)
 
 
-{-| The [`font-synthesis`](https://developer.mozilla.org/en-US/docs/Web/CSS/font-synthesis) property.
-
-    fontSynthesis none
-
-    fontSynthesis smallCaps
-
-    fontSynthesis2 smallCaps weight
-
-    fontSynthesis3 weight style smallCaps
-
--}
-fontSynthesis :
-    BaseValue
-        { none : Supported
-        , weight : Supported
-        , style : Supported
-        , smallCaps : Supported
-        }
-    -> Style
-fontSynthesis (Value val) =
-    AppendProperty ("font-synthesis:" ++ val)
-
-
-{-| The [`font-synthesis`](https://developer.mozilla.org/en-US/docs/Web/CSS/font-synthesis) property.
-
-This is the two-argument variant, in which you can indicate
-two different font properties to be synthesised by the browser.
-
-    fontSynthesis2 smallCaps weight
-
--}
-fontSynthesis2 :
-    Value
-        { weight : Supported
-        , style : Supported
-        , smallCaps : Supported
-        }
-    ->
-        Value
-            { weight : Supported
-            , style : Supported
-            , smallCaps : Supported
-            }
-    -> Style
-fontSynthesis2 (Value val1) (Value val2) =
-    AppendProperty ("font-synthesis:" ++ val1 ++ " " ++ val2)
-
-
-{-| The [`font-synthesis`](https://developer.mozilla.org/en-US/docs/Web/CSS/font-synthesis) property.
-
-This is the three-argument variant, in which you can indicate
-all three different font properties to be synthesised by the browser.
-
-    fontSynthesis3 weight style smallCaps
-
--}
-fontSynthesis3 :
-    Value
-        { weight : Supported
-        , style : Supported
-        , smallCaps : Supported
-        }
-    ->
-        Value
-            { weight : Supported
-            , style : Supported
-            , smallCaps : Supported
-            }
-    ->
-        Value
-            { weight : Supported
-            , style : Supported
-            , smallCaps : Supported
-            }
-    -> Style
-fontSynthesis3 (Value val1) (Value val2) (Value val3) =
-    AppendProperty ("font-synthesis:" ++ val1 ++ " " ++ val2 ++ " " ++ val3)
-
-
 {-| The [`font-optical-sizing`](https://developer.mozilla.org/en-US/docs/Web/CSS/font-optical-sizing) property.
 
     fontOpticalSizing none
@@ -12771,75 +12873,1769 @@ fontVariantPosition (Value val) =
     AppendProperty ("font-variant-position:" ++ val)
 
 
-{-| The `weight` value for the [`fontSynthesis`](#fontSynthesis) property.
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+----------------------- TYPOGRAPHIC METRICS ----------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
 
-    fontSynthesis weight
+
+{-| Sets [`line-height`](https://css-tricks.com/almanac/properties/l/line-height/)
+
+    lineHeight (pct 150)
+
+    lineHeight (em 2)
+
+    lineHeight (num 1.5)
+
+    lineHeight normal
 
 -}
-weight : Value { provides | weight : Supported }
-weight =
-    Value "weight"
+lineHeight :
+    BaseValue
+        (LengthSupported
+            { pct : Supported
+            , normal : Supported
+            , num : Supported
+            }
+        )
+    -> Style
+lineHeight (Value val) =
+    AppendProperty ("line-height:" ++ val)
 
 
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
------------------------------ VARIABLE FONTS ---------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
+{-| Sets [`letter-spacing`](https://css-tricks.com/almanac/properties/l/letter-spacing/)
 
+    letterSpacing (pct 150)
 
-{-| The 1-argument variant of the [`font-variation-settings`](https://developer.mozilla.org/en-US/docs/Web/CSS/font-variation-settings)
-property.
+    letterSpacing (em 2)
 
-For controlling aspects of variable fonts.
-Use [`fontVariationSettingsList`](#fontVariationSettingsList) to work with variable font tags.
+    letterSpacing (num 1.5)
 
-    fontVariationSettings normal
+    letterSpacing normal
 
-    fontVariationSettings inherit
-
-    fontVariationSettingsList [ ("XHGT", 0.7) ]
 -}
-fontVariationSettings :
+letterSpacing :
+    BaseValue
+        (LengthSupported
+            { normal : Supported
+            }
+        )
+    -> Style
+letterSpacing (Value val) =
+    AppendProperty ("letter-spacing:" ++ val)
+
+
+{-| The [`text-indent`](https://css-tricks.com/almanac/properties/t/text-indent/) property.
+
+    textIndent (em 1.5)
+
+-}
+textIndent : BaseValue (LengthSupported { pct : Supported }) -> Style
+textIndent (Value val) =
+    AppendProperty ("text-indent:" ++ val)
+
+
+{-| The [`text-indent`](https://css-tricks.com/almanac/properties/t/text-indent/) property.
+
+    textIndent2 (em 1.5) hanging
+
+-}
+textIndent2 :
+    Value (LengthSupported { pct : Supported })
+    ->
+        Value
+            { hanging : Supported
+            , eachLine : Supported
+            }
+    -> Style
+textIndent2 (Value lengthVal) (Value optionVal) =
+    AppendProperty ("text-indent:" ++ lengthVal ++ " " ++ optionVal)
+
+
+{-| The [`text-indent`](https://css-tricks.com/almanac/properties/t/text-indent/) property.
+
+    textIndent3 (em 1.5) hanging eachLine
+
+-}
+textIndent3 :
+    Value (LengthSupported { pct : Supported })
+    -> Value { hanging : Supported }
+    -> Value { eachLine : Supported }
+    -> Style
+textIndent3 (Value lengthVal) (Value hangingVal) (Value eachLineVal) =
+    AppendProperty
+        ("text-indent:"
+            ++ lengthVal
+            ++ " "
+            ++ hangingVal
+            ++ " "
+            ++ eachLineVal
+        )
+
+
+{-| The `hanging` value used for properties such as [`textIdent2`](#textIdent2).
+
+    textIdent2 (px 20) hanging
+
+-}
+hanging : Value { provides | hanging : Supported }
+hanging =
+    Value "hanging"
+
+
+{-| The `each-line` value used for properties such as [`textIdent2`](#textIdent2).
+
+    textIdent2 (px 20) eachLine
+
+-}
+eachLine : Value { provides | eachLine : Supported }
+eachLine =
+    Value "each-line"
+
+
+{-| Sets [`word-spacing`](https://css-tricks.com/almanac/properties/w/word-spacing/).
+
+    wordSpacing normal
+
+    wordSpacing zero
+
+    wordSpacing (px 5)
+
+-}
+wordSpacing :
+    BaseValue
+        (LengthSupported
+            { normal : Supported
+            , pct : Supported
+            }
+        )
+    -> Style
+wordSpacing (Value str) =
+    AppendProperty ("word-spacing:" ++ str)
+
+
+{-| Sets [`tab-size`](https://css-tricks.com/almanac/properties/t/tab-size/)
+**Note:** only positive integer values are allowed.
+
+    tabSize (int 4)
+
+-}
+tabSize :
+    BaseValue
+        (LengthSupported
+            { auto : Supported
+            , int : Supported
+            }
+        )
+    -> Style
+tabSize (Value val) =
+    AppendProperty ("tab-size:" ++ val)
+
+
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+---------------- TEXT WRAPPING, OVERFLOW AND NEWLINES ------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+
+
+
+{-| Sets [`word-break`](https://css-tricks.com/almanac/properties/w/word-break/)
+
+      wordBreak normal
+      wordBreak breakAll
+      wordBreak keepAll
+      wordBreak breakWord
+
+-}
+wordBreak :
     BaseValue
         { normal : Supported
+        , breakAll : Supported
+        , keepAll : Supported
+        , breakWord : Supported
         }
     -> Style
-fontVariationSettings (Value val) =
-    AppendProperty ("font-variation-settings:" ++ val)
+wordBreak (Value str) =
+    AppendProperty ("word-break:" ++ str)
 
 
-{-| The multi-argument variant of the [`font-variation-settings`](https://developer.mozilla.org/en-US/docs/Web/CSS/font-variation-settings)
-property.
+{-| A `breakAll` value for the [`word-break`](https://css-tricks.com/almanac/properties/w/word-break/) property.
 
-For using single keywords with this property, use [`fontVariationSettings`](#fontVariationSettings).
+      wordBreak breakAll
 
-    fontVariationSettingsList [ ("XHGT", 0.7) ]
 -}
-fontVariationSettingsList :
-    List
-        ( String
-        , Float
+breakAll : Value { provides | breakAll : Supported }
+breakAll =
+    Value "break-all"
+
+
+{-| A `keepAll` value for the [`word-break`](https://css-tricks.com/almanac/properties/w/word-break/) property.
+
+      wordBreak keepAll
+
+-}
+keepAll : Value { provides | keepAll : Supported }
+keepAll =
+    Value "keep-all"
+
+
+{-| Sets the [`lineBreak`](https://css-tricks.com/almanac/properties/l/line-break/) property.
+
+    lineBreak auto
+
+    lineBreak strict
+
+-}
+lineBreak :
+    BaseValue
+        { auto : Supported
+        , loose : Supported
+        , normal : Supported
+        , strict : Supported
+        , anywhere : Supported
+        }
+    -> Style
+lineBreak (Value value) =
+    AppendProperty ("line-break:" ++ value)
+
+
+{-| Sets `loose` value for usage with [`lineBreak`](#lineBreak).
+
+    lineBreak loose
+
+-}
+loose : Value { provides | loose : Supported }
+loose =
+    Value "loose"
+
+
+{-| Sets [`white-space`](https://css-tricks.com/almanac/properties/w/whitespace/)
+
+    whiteSpace pre
+
+    whiteSpace nowrap
+
+    whiteSpace preWrap
+
+    whiteSpace preLine
+
+-}
+whiteSpace :
+    BaseValue
+        { normal : Supported
+        , nowrap : Supported
+        , pre : Supported
+        , preWrap : Supported
+        , preLine : Supported
+        }
+    -> Style
+whiteSpace (Value str) =
+    AppendProperty ("white-space:" ++ str)
+
+
+{-| A `nowrap` value for the [`white-space`](https://css-tricks.com/almanac/properties/w/whitespace/)
+and [`flex-wrap`](https://css-tricks.com/almanac/properties/f/flex-wrap/) properties.
+
+    whiteSpace nowrap
+
+    flexWrap nowrap
+
+-}
+nowrap : Value { provides | nowrap : Supported }
+nowrap =
+    Value "nowrap"
+
+
+{-| A `pre` value for the [`white-space`](https://css-tricks.com/almanac/properties/w/whitespace/) property.
+
+    whiteSpace pre
+
+-}
+pre : Value { provides | pre : Supported }
+pre =
+    Value "pre"
+
+
+{-| A `pre-wrap` value for the [`white-space`](https://css-tricks.com/almanac/properties/w/whitespace/) property.
+
+    whiteSpace preWrap
+
+-}
+preWrap : Value { provides | preWrap : Supported }
+preWrap =
+    Value "pre-wrap"
+
+
+{-| A `pre-line` value for the [`white-space`](https://css-tricks.com/almanac/properties/w/whitespace/) property.
+
+    whiteSpace preLine
+
+-}
+preLine : Value { provides | preLine : Supported }
+preLine =
+    Value "pre-line"
+
+
+{-| Sets the [`text-overflow`](https://css-tricks.com/almanac/properties/t/text-overflow/) property.
+
+`text-overflow` describes how text that gets cut off is signalled to users.
+
+When the one-argument version is used, it sets the end of text (right end for LTR users) that is cut off.
+
+    textOverflow ellipsis
+
+When the two-argument version is used, it specifies how the
+text cut-off is displayed at the start (left in LTR) and
+the end (right in LTR) of the text.
+
+    textOverflow2 ellipsis ellipsis
+
+-}
+textOverflow :
+    BaseValue
+        { clip : Supported
+        , ellipsis : Supported
+        }
+    -> Style
+textOverflow (Value value) =
+    AppendProperty ("text-overflow:" ++ value)
+
+
+{-| Sets the [`text-overflow`](https://css-tricks.com/almanac/properties/t/text-overflow/) property.
+
+`text-overflow` describes how text that gets cut off is signalled to users.
+
+This version specifies how the text cut-off is displayed at the start
+(left in LTR) and at the end (right in LTR) of the text.
+
+    textOverflow2 ellipsis ellipsis
+
+-}
+textOverflow2 :
+    Value
+        { clip : Supported
+        , ellipsis : Supported
+        }
+    ->
+        Value
+            { clip : Supported
+            , ellipsis : Supported
+            }
+    -> Style
+textOverflow2 (Value startValue) (Value endValue) =
+    AppendProperty ("text-overflow:" ++ startValue ++ " " ++ endValue)
+
+
+{-| Sets `ellipsis` value for usage with [`textOverflow`](#textOverflow).
+
+    textOverflow ellipsis
+
+-}
+ellipsis : Value { provides | ellipsis : Supported }
+ellipsis =
+    Value "ellipsis"
+
+
+{-| Sets [`hyphens`](https://css-tricks.com/almanac/properties/h/hyphens/)
+
+    hyphens none
+
+    hyphens manual
+
+    hyphens auto
+
+-}
+hyphens :
+    BaseValue
+        { none : Supported
+        , manual : Supported
+        , auto : Supported
+        }
+    -> Style
+hyphens (Value val) =
+    AppendProperty ("hyphens:" ++ val)
+
+
+{-| Sets `manual` value for usage with [`hyphens`](#hyphens).
+
+    hyphens manual
+
+-}
+manual : Value { provides | manual : Supported }
+manual =
+    Value "manual"
+
+
+{-| Sets [`hanging-punctuation`](https://css-tricks.com/almanac/properties/h/hanging-punctuation/)
+
+    hangingPunctuation none
+
+    hangingPunctuation first
+
+    hangingPunctuation2 first forceEnd
+
+    hangingPunctuation3 first allowEnd last
+
+-}
+hangingPunctuation :
+    BaseValue
+        { none : Supported
+        , first : Supported
+        , forceEnd : Supported
+        , allowEnd : Supported
+        , last : Supported
+        }
+    -> Style
+hangingPunctuation (Value val) =
+    AppendProperty ("hanging-punctuation:" ++ val)
+
+
+{-| Sets [`hanging-punctuation`](https://css-tricks.com/almanac/properties/h/hanging-punctuation/)
+
+    hangingPunctuation2 first forceEnd
+
+-}
+hangingPunctuation2 :
+    Value
+        { first : Supported
+        , last : Supported
+        }
+    ->
+        Value
+            { first : Supported
+            , forceEnd : Supported
+            , allowEnd : Supported
+            , last : Supported
+            }
+    -> Style
+hangingPunctuation2 (Value val1) (Value val2) =
+    AppendProperty ("hanging-punctuation:" ++ val1 ++ " " ++ val2)
+
+
+{-| Sets [`hanging-punctuation`](https://css-tricks.com/almanac/properties/h/hanging-punctuation/)
+
+    hangingPunctuation3 first allowEnd last
+
+-}
+hangingPunctuation3 :
+    Value
+        { first : Supported
+        , last : Supported
+        }
+    ->
+        Value
+            { forceEnd : Supported
+            , allowEnd : Supported
+            }
+    ->
+        Value
+            { first : Supported
+            , last : Supported
+            }
+    -> Style
+hangingPunctuation3 (Value val1) (Value val2) (Value val3) =
+    AppendProperty ("hanging-punctuation:" ++ val1 ++ " " ++ val2 ++ " " ++ val3)
+
+
+{-| Sets `first` value for usage with [`hangingPunctuation`](#hangingPunctuation).
+
+      hangingPunctuation first
+
+-}
+first : Value { provides | first : Supported }
+first =
+    Value "first"
+
+
+{-| Sets `last` value for usage with [`hangingPunctuation`](#hangingPunctuation).
+
+      hangingPunctuation last
+
+-}
+last : Value { provides | last : Supported }
+last =
+    Value "last"
+
+
+{-| Sets `force-end` value for usage with [`hangingPunctuation`](#hangingPunctuation).
+
+      hangingPunctuation forceEnd
+
+-}
+forceEnd : Value { provides | forceEnd : Supported }
+forceEnd =
+    Value "force-end"
+
+
+{-| Sets `allow-end` value for usage with [`hangingPunctuation`](#hangingPunctuation).
+
+      hangingPunctuation allowEnd
+
+-}
+allowEnd : Value { provides | allowEnd : Supported }
+allowEnd =
+    Value "allow-end"
+
+
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+--------------------- TEXT TRANSFORM + DECORATION ----------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+
+
+{-| Sets [`text-decoration`][text-decoration] shorthand property.
+
+    textDecoration underline
+
+[text-decoration]: https://css-tricks.com/almanac/properties/t/text-decoration/
+
+-}
+textDecoration :
+    BaseValue
+        (ColorSupported
+            { none : Supported
+            , underline : Supported
+            , overline : Supported
+            , lineThrough : Supported
+            , solid : Supported
+            , double : Supported
+            , dotted : Supported
+            , dashed : Supported
+            , wavy : Supported
+            }
         )
     -> Style
-fontVariationSettingsList list =
-    AppendProperty <|
-        "font-variation-settings:"
-        ++
-        ( list
-        |> List.map
-            (\(tagVal, numberVal) -> (enquoteString tagVal) ++ " " ++ (String.fromFloat numberVal)
-            )
-        |> String.join ", "
+textDecoration (Value line) =
+    AppendProperty ("text-decoration:" ++ line)
+
+
+{-| Sets [`text-decoration`][text-decoration] property.
+
+    textDecoration2 underline dotted
+
+[text-decoration]: https://css-tricks.com/almanac/properties/t/text-decoration/
+
+-}
+textDecoration2 :
+    Value
+        { none : Supported
+        , underline : Supported
+        , overline : Supported
+        , lineThrough : Supported
+        }
+    ->
+        Value
+            { solid : Supported
+            , double : Supported
+            , dotted : Supported
+            , dashed : Supported
+            , wavy : Supported
+            }
+    -> Style
+textDecoration2 (Value line) (Value styleVal) =
+    AppendProperty ("text-decoration:" ++ line ++ " " ++ styleVal)
+
+
+{-| Sets [`text-decoration`][text-decoration] property.
+
+    textDecoration3 underline dotted (hex "#cf0")
+
+[text-decoration]: https://css-tricks.com/almanac/properties/t/text-decoration/
+
+-}
+textDecoration3 :
+    Value
+        { none : Supported
+        , underline : Supported
+        , overline : Supported
+        , lineThrough : Supported
+        }
+    ->
+        Value
+            { solid : Supported
+            , double : Supported
+            , dotted : Supported
+            , dashed : Supported
+            , wavy : Supported
+            }
+    -> Value Color
+    -> Style
+textDecoration3 (Value line) (Value styleVal) (Value colorVal) =
+    AppendProperty ("text-decoration:" ++ line ++ " " ++ styleVal ++ " " ++ colorVal)
+
+
+{-| Sets [`text-decoration-line`][text-decoration-line] property.
+
+    textDecorationLine underline
+
+[text-decoration-line]: https://css-tricks.com/almanac/properties/t/text-decoration-line/
+
+-}
+textDecorationLine :
+    BaseValue
+        { none : Supported
+        , underline : Supported
+        , overline : Supported
+        , lineThrough : Supported
+        }
+    -> Style
+textDecorationLine (Value line) =
+    AppendProperty ("text-decoration-line:" ++ line)
+
+
+{-| Sets [`text-decoration-line`][text-decoration-line] property.
+
+    textDecorationLine2 underline overline
+
+**Note:** The first and second argument **MUST NOT** be the same.
+
+[text-decoration-line]: https://css-tricks.com/almanac/properties/t/text-decoration-line/
+
+-}
+textDecorationLine2 :
+    Value
+        { underline : Supported
+        , overline : Supported
+        , lineThrough : Supported
+        }
+    ->
+        Value
+            { underline : Supported
+            , overline : Supported
+            , lineThrough : Supported
+            }
+    -> Style
+textDecorationLine2 (Value line1) (Value line2) =
+    AppendProperty ("text-decoration-line:" ++ line1 ++ " " ++ line2)
+
+
+{-| Sets [`text-decoration-line`][text-decoration-line] property.
+
+    textDecorationLine3 underline overline lineThrough
+
+[text-decoration-line]: https://css-tricks.com/almanac/properties/t/text-decoration-line/
+
+-}
+textDecorationLine3 :
+    Value { underline : Supported }
+    -> Value { overline : Supported }
+    -> Value { lineThrough : Supported }
+    -> Style
+textDecorationLine3 (Value line1) (Value line2) (Value line3) =
+    AppendProperty ("text-decoration-line:" ++ line1 ++ " " ++ line2 ++ " " ++ line3)
+
+
+{-| Sets [`text-decoration-style`][text-decoration-style] property.
+
+    textDecorationStyle wavy
+
+[text-decoration-style]: https://css-tricks.com/almanac/properties/t/text-decoration-style/
+
+-}
+textDecorationStyle :
+    BaseValue
+        { solid : Supported
+        , double : Supported
+        , dotted : Supported
+        , dashed : Supported
+        , wavy : Supported
+        }
+    -> Style
+textDecorationStyle (Value styleVal) =
+    AppendProperty ("text-decoration-style:" ++ styleVal)
+
+
+{-| The `wavy` [`text-decoration-style`][text-decoration-style] value.
+
+    textDecorationStyle wavy
+
+[text-decoration-style]: https://css-tricks.com/almanac/properties/t/text-decoration-style/#article-header-id-0
+
+-}
+wavy : Value { provides | wavy : Supported }
+wavy =
+    Value "wavy"
+
+
+{-| The `underline` [`text-decoration-line`][text-decoration-line] value.
+
+    textDecorationLine underline
+
+[text-decoration-line]: https://css-tricks.com/almanac/properties/t/text-decoration-line/#article-header-id-0
+
+-}
+underline : Value { provides | underline : Supported }
+underline =
+    Value "underline"
+
+
+{-| The `overline` [`text-decoration-line`][text-decoration-line] value.
+
+    textDecorationLine overline
+
+[text-decoration-line]: https://css-tricks.com/almanac/properties/t/text-decoration-line/#article-header-id-0
+
+-}
+overline : Value { provides | overline : Supported }
+overline =
+    Value "overline"
+
+
+{-| The `line-through` [`text-decoration-line`][text-decoration-line] value.
+
+    textDecorationLine lineThrough
+
+[text-decoration-line]: https://css-tricks.com/almanac/properties/t/text-decoration-line/#article-header-id-0
+
+-}
+lineThrough : Value { provides | lineThrough : Supported }
+lineThrough =
+    Value "line-through"
+
+
+{-| Sets [`text-decoration-color`](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-color) property.
+
+    textDecorationColor (hex "#0cf")
+
+-}
+textDecorationColor : BaseValue Color -> Style
+textDecorationColor (Value colorVal) =
+    AppendProperty ("text-decoration-color:" ++ colorVal)
+
+
+{-| Sets the [`text-decoration-thickness`](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-thickness) property.
+
+    textDecorationThickness (pct 10)
+
+-}
+textDecorationThickness :
+    BaseValue
+        ( LengthSupported
+            { pct : Supported
+            , auto : Supported
+            , fromFont : Supported
+            }
         )
+    -> Style
+textDecorationThickness (Value value) =
+    AppendProperty ("text-decoration-thickness:" ++ value)
+
+
+{-| Sets the `from-font` value for usage with [`textDecorationThickness`](#textDecorationThickness).
+
+    textDecorationThickness fromFont
+
+-}
+fromFont : Value { provides | fromFont : Supported }
+fromFont =
+    Value "from-font"
+
+
+{-| Sets [`text-decoration-skip-ink`](https://css-tricks.com/almanac/properties/t/text-decoration-skip-ink/) property.
+
+    textDecorationSkipInk auto
+
+    textDecorationSkipInk all
+
+    textDecorationSkipInk none
+
+-}
+textDecorationSkipInk :
+    Value
+        { auto : Supported
+        , all : Supported
+        , none : Supported
+        }
+    -> Style
+textDecorationSkipInk (Value val) =
+    AppendProperty ("text-decoration-skip-ink:" ++ val)
+
+
+{-| Sets [`text-underline-position`](https://css-tricks.com/almanac/properties/t/text-underline-position/)
+
+    textUnderlinePosition auto
+
+    textUnderlinePosition under
+
+    textUnderlinePosition left_
+
+    textUnderlinePosition right_
+
+-}
+textUnderlinePosition :
+    BaseValue
+        { auto : Supported
+        , under : Supported
+        , left_ : Supported
+        , right_ : Supported
+        }
+    -> Style
+textUnderlinePosition (Value val) =
+    AppendProperty ("text-underline-position:" ++ val)
+
+
+{-| Sets [`text-underline-position`](https://css-tricks.com/almanac/properties/t/text-underline-position/)
+
+    textUnderlinePosition2 under left_
+
+    textUnderlinePosition2 under right_
+
+-}
+textUnderlinePosition2 :
+    Value { under : Supported }
+    ->
+        Value
+            { left_ : Supported
+            , right_ : Supported
+            }
+    -> Style
+textUnderlinePosition2 (Value underVal) (Value val) =
+    AppendProperty ("text-underline-position:" ++ underVal ++ " " ++ val)
+
+
+{-| Sets the [text-underline-offset](https://css-tricks.com/almanac/properties/t/text-underline-offset/) property.
+
+    textUnderlineOffset (pct 5)
+-}
+textUnderlineOffset :
+    BaseValue
+        ( LengthSupported
+            { pct : Supported
+            , auto : Supported
+            }
+        )
+    -> Style
+textUnderlineOffset (Value value) =
+    AppendProperty ("text-underline-offset:" ++ value)
+
+
+{-| Sets the [`text-emphasis`](https://css-tricks.com/almanac/properties/t/text-emphasis/) property.
+
+This is for drawing attention towards textual elements in a way that is commonly
+used in East Asian languages.
+
+    textEmphasis (hex "ff0000")
+
+    textEmphasis sesame
+
+    textEmphasis2 triangle (hex "00ff00")
+
+-}
+textEmphasis :
+    BaseValue
+        (ColorSupported
+            { none : Supported
+            , filled : Supported
+            , open : Supported
+            , dot : Supported
+            , circle_ : Supported
+            , doubleCircle : Supported
+            , triangle : Supported
+            , sesame : Supported
+            , string : Supported
+            }
+        )
+    -> Style
+textEmphasis (Value value) =
+    AppendProperty ("text-emphasis:" ++ value)
+
+
+{-| Sets the [`text-emphasis`](https://css-tricks.com/almanac/properties/t/text-emphasis/) property.
+
+This 2-argument form sets [`text-emphasis-style`](#textEmphasisStyle) and [`textEmphasisColor`](#textEmphasisColor) in a single declaration.
+
+    textEmphasis2 filled (hex "ff0000")
+-}
+textEmphasis2 :
+    BaseValue
+        { none : Supported
+        , filled : Supported
+        , open : Supported
+        , dot : Supported
+        , circle_ : Supported
+        , doubleCircle : Supported
+        , triangle : Supported
+        , sesame : Supported
+        , string : Supported
+        }
+    ->
+        BaseValue
+            (Color)
+    -> Style
+textEmphasis2 (Value value1) (Value value2) =
+    AppendProperty
+        ("text-emphasis:"
+            ++ value1
+            ++ " "
+            ++ value2
+        )
+
+
+{-| Sets the [`text-emphasis-style`](https://developer.mozilla.org/en-US/docs/Web/CSS/text-emphasis-style) property.
+
+    textEmphasisStyle none
+
+    textEmphasisStyle open
+
+    textEmphasisStyle (string "🐯")
+-}
+textEmphasisStyle :
+    BaseValue
+        { none : Supported
+        , filled : Supported
+        , open : Supported
+        , dot : Supported
+        , circle_ : Supported
+        , doubleCircle : Supported
+        , triangle : Supported
+        , sesame : Supported
+        , string : Supported
+        }
+    -> Style
+textEmphasisStyle (Value value) =
+    AppendProperty ("text-emphasis-style:" ++ value)
+
+
+{-| Sets the [`text-emphasis-style`](https://developer.mozilla.org/en-US/docs/Web/CSS/text-emphasis-style) property when you want to use two arguments - one for `filled` or `open`, and one for the shape style.
+
+    textEmphasisStyle filled sesame
+
+    textEmphasisStyle open dot
+-}
+textEmphasisStyle2 :
+    BaseValue
+        { filled : Supported
+        , open : Supported
+        }
+    -> BaseValue
+        { dot : Supported
+        , circle_ : Supported
+        , doubleCircle : Supported
+        , triangle : Supported
+        , sesame : Supported
+        }
+    -> Style
+textEmphasisStyle2 (Value val1) (Value val2) =
+    AppendProperty
+        ("text-emphasis-style:"
+        ++ val1
+        ++ " "
+        ++ val2
+        )
+
+
+{-| Sets the [`text-emphasis-color`](https://developer.mozilla.org/en-US/docs/Web/CSS/text-emphasis-color) property.
+
+    textEmphasisColor currentcolor
+
+    textemphasisColor (hex "0000ff")
+-}
+textEmphasisColor :
+    BaseValue (Color)
+    -> Style
+textEmphasisColor (Value value) =
+    AppendProperty ("text-emphasis-color:" ++ value)
+
+
+{-| Sets the [`text-emphasis-position`](https://developer.mozilla.org/en-US/docs/Web/CSS/text-emphasis-position) property.
+
+This is the one argument version, which is limited to setting global values.
+
+If you want to specify the positions of the text-emphasis, you must use the [2-argument form](#textEmphasisPosition2).
+
+    textEmphasisPosition inherit
+
+    textEmphasisPosition revert
+
+    textEmphasisPosition2 over left_
+
+    textEmphasisPosition2 under right_
+
+-}
+textEmphasisPosition :
+    BaseValue a
+    -> Style
+textEmphasisPosition (Value value) =
+    AppendProperty ("text-emphasis-position:" ++ value)
+
+
+{-| Sets the the [`text-emphasis-position`](https://developer.mozilla.org/en-US/docs/Web/CSS/text-emphasis-position) property.
+
+This is the 2-argument form that lets you specify the positions of the emphasis.
+
+if you want to apply global values, you must use the [1-argument form](#textEmphasisPosition).
+
+    textEmphasisPosition inherit
+
+    textEmphasisPosition revert
+
+    textEmphasisPosition2 over left_
+
+    textEmphasisPosition2 under right_
+
+-}
+textEmphasisPosition2 :
+    BaseValue
+        { over : Supported
+        , under : Supported
+        }
+    -> BaseValue
+        { left_ : Supported
+        , right_ : Supported
+        }
+    -> Style
+textEmphasisPosition2 (Value val1) (Value val2) =
+    AppendProperty
+        ("text-emphasis-position:"
+        ++ val1
+        ++ " "
+        ++ val2
+        )
+
+
+{-| The `filled` value used in [`textEmphasis`](#textEmphasis).
+
+    textEmphasis filled
+
+-}
+filled : Value { provides | filled : Supported }
+filled =
+    Value "filled"
+
+
+{-| The `open` value used in [`textEmphasis`](#textEmphasis).
+
+    textEmphasis open
+
+-}
+open : Value { provides | open : Supported }
+open =
+    Value "open"
+
+
+{-| The `dot` value used in [`textEmphasis`](#textEmphasis).
+
+    textEmphasis dot
+
+-}
+dot : Value { provides | dot : Supported }
+dot =
+    Value "dot"
+
+
+{-| The `doubleCircle` value used in [`textEmphasis`](#textEmphasis).
+
+    textEmphasis doubleCircle
+
+-}
+doubleCircle : Value { provides | doubleCircle : Supported }
+doubleCircle =
+    Value "double-circle"
+
+
+{-| The `triangle` value used in [`textEmphasis`](#textEmphasis).
+
+    textEmphasis triangle
+
+-}
+triangle : Value { provides | triangle : Supported }
+triangle =
+    Value "triangle"
+
+
+{-| The `sesame` value used in [`textEmphasis`](#textEmphasis).
+
+    textEmphasis sesame
+
+-}
+sesame : Value { provides | sesame : Supported }
+sesame =
+    Value "sesame"
+
+
+{-| The `over` value used in [`textEmphasisPosition2`](#textEmphasisPosition2).
+
+    textEmphasisPosition2 over left_
+
+-}
+over : Value { provides | over : Supported }
+over =
+    Value "over"
+
+
+{-| Sets [`text-transform`](https://css-tricks.com/almanac/properties/t/text-transform/).
+
+    textTransform capitalize
+
+    textTransform uppercase
+
+-}
+textTransform :
+    BaseValue
+        { capitalize : Supported
+        , uppercase : Supported
+        , lowercase : Supported
+        , fullWidth : Supported
+        , fullSizeKana : Supported
+        , none : Supported
+        }
+    -> Style
+textTransform (Value str) =
+    AppendProperty ("text-transform:" ++ str)
+
+
+{-| A `capitalize` value for the [`text-transform`](https://developer.mozilla.org/en-US/docs/Web/CSS/text-transform#Syntax) property.
+
+    textTransform capitalize
+
+-}
+capitalize : Value { provides | capitalize : Supported }
+capitalize =
+    Value "capitalize"
+
+
+{-| An `uppercase` value for the [`text-transform`](https://developer.mozilla.org/en-US/docs/Web/CSS/text-transform#Syntax) property.
+
+    textTransform uppercase
+
+-}
+uppercase : Value { provides | uppercase : Supported }
+uppercase =
+    Value "uppercase"
+
+
+{-| A `lowercase` value for the [`text-transform`](https://developer.mozilla.org/en-US/docs/Web/CSS/text-transform#Syntax) property.
+
+    textTransform lowercase
+
+-}
+lowercase : Value { provides | lowercase : Supported }
+lowercase =
+    Value "lowercase"
+
+
+{-| The `full-size-kana` value used by [`textTransform`](#textTransform)
+
+textTransform fullSizeKana
+
+-}
+fullSizeKana : Value { provedes | fullSizeKana : Supported }
+fullSizeKana =
+    Value "full-size-kana"
+
+
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------ TEXT ALIGNMENT AND JUSTIFICATION --------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+
+
+{-| Sets [`text-align`](https://css-tricks.com/almanac/properties/t/text-align/)
+
+    textAlign left_
+
+    textAlign justfy
+
+-}
+textAlign :
+    BaseValue
+        { left_ : Supported
+        , right_ : Supported
+        , center : Supported
+        , justify : Supported
+        , start : Supported
+        , end : Supported
+        , matchParent : Supported
+        }
+    -> Style
+textAlign (Value str) =
+    AppendProperty ("text-align:" ++ str)
+
+
+{-| A `justify` value for the [`text-align`](https://css-tricks.com/almanac/properties/t/text-align/)
+
+    textAlign justify
+
+-}
+justify : Value { provides | justify : Supported }
+justify =
+    Value "justify"
+
+
+
+{-| Sets [`text-justify`](https://css-tricks.com/almanac/properties/t/text-justify/)
+
+    textJustify interWord
+
+    textJustify interCharacter
+
+    textJustify auto
+
+    textJustify none
+
+-}
+textJustify :
+    BaseValue
+        { interWord : Supported
+        , interCharacter : Supported
+        , auto : Supported
+        , none : Supported
+        }
+    -> Style
+textJustify (Value val) =
+    AppendProperty ("text-justify:" ++ val)
+
+
+{-| A `inter-word` value for the [`textJustify`](#textJustify) property.
+
+    textJustify interWord
+
+-}
+interWord : Value { provides | interWord : Supported }
+interWord =
+    Value "inter-word"
+
+
+{-| A `inter-character` value for the [`textJustify`](#textJustify) property.
+
+    textJustify interCharacter
+
+-}
+interCharacter : Value { provides | interCharacter : Supported }
+interCharacter =
+    Value "inter-character"
+
+
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+---------------------------- SCRIPT HANDLING ---------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+
+
+{-| Sets [`direction`](https://css-tricks.com/almanac/properties/d/direction/)
+
+    direction ltr
+
+    direction rtl
+
+-}
+direction :
+    BaseValue
+        { rtl : Supported
+        , ltr : Supported
+        }
+    -> Style
+direction (Value str) =
+    AppendProperty ("direction:" ++ str)
+
+
+{-| A `ltr` value for the [`direction`](https://css-tricks.com/almanac/properties/d/direction/) property.
+
+    direction ltr
+
+-}
+ltr : Value { provides | ltr : Supported }
+ltr =
+    Value "ltr"
+
+
+{-| A `rtl` value for the [`direction`](https://css-tricks.com/almanac/properties/d/direction/) property.
+
+    direction rtl
+
+-}
+rtl : Value { provides | rtl : Supported }
+rtl =
+    Value "rtl"
+
+
+{-| Sets [`writing-mode`](https://css-tricks.com/almanac/properties/w/writing-mode/).
+
+    writingMode horizontalTb
+
+    writingMode verticalRl
+
+    writingMode verticalLr
+
+-}
+writingMode :
+    BaseValue
+        { horizontalTb : Supported
+        , verticalRl : Supported
+        , verticalLr : Supported
+        }
+    -> Style
+writingMode (Value str) =
+    AppendProperty ("writing-mode:" ++ str)
+
+
+{-| Sets `horizontal-tb` value for usage with [`writingMode`](#writingMode).
+
+    writingMode horizontalTb
+
+-}
+horizontalTb : Value { provides | horizontalTb : Supported }
+horizontalTb =
+    Value "horizontal-tb"
+
+
+{-| Sets `vertical-lr` value for usage with [`writingMode`](#writingMode).
+
+    writingMode verticalLr
+
+-}
+verticalLr : Value { provides | verticalLr : Supported }
+verticalLr =
+    Value "vertical-lr"
+
+
+{-| Sets `vertical-rl` value for usage with [`writingMode`](#writingMode).
+
+    writingMode verticalRl
+
+-}
+verticalRl : Value { provides | verticalRl : Supported }
+verticalRl =
+    Value "vertical-rl"
+
+
+{-| Sets [`unicode-bidi`](https://css-tricks.com/almanac/properties/u/unicode-bidi/)
+
+    unicodeBidi normal
+
+    unicodeBidi embed
+
+    unicodeBidi isolate
+
+    unicodeBidi bidiOverride
+
+    unicodeBidi isolateOverride
+
+    unicodeBidi plaintext
+
+-}
+unicodeBidi :
+    BaseValue
+        { normal : Supported
+        , embed : Supported
+        , isolate : Supported
+        , bidiOverride : Supported
+        , isolateOverride : Supported
+        , plaintext : Supported
+        }
+    -> Style
+unicodeBidi (Value val) =
+    AppendProperty ("unicode-bidi:" ++ val)
+
+
+{-| Sets `embed` value for usage with [`unicodeBidi`](#unicodeBidi).
+
+    unicodeBidi embed
+
+-}
+embed : Value { provides | embed : Supported }
+embed =
+    Value "embed"
+
+
+{-| Sets `plaintext` value for usage with [`unicodeBidi`](#unicodeBidi).
+
+    unicodeBidi plaintext
+
+-}
+plaintext : Value { provides | plaintext : Supported }
+plaintext =
+    Value "plaintext"
+
+
+{-| Sets `bidi-override` value for usage with [`unicodeBidi`](#unicodeBidi).
+
+    unicodeBidi bidiOverride
+
+-}
+bidiOverride : Value { provides | bidiOverride : Supported }
+bidiOverride =
+    Value "bidi-override"
+
+
+{-| Sets `isolate-override` value for usage with [`unicodeBidi`](#unicodeBidi).
+
+    unicodeBidi isolateOverride
+
+-}
+isolateOverride : Value { provides | isolateOverride : Supported }
+isolateOverride =
+    Value "isolate-override"
+
+
+{-| Sets [`text-orientation`](https://developer.mozilla.org/en-US/docs/Web/CSS/text-orientation).
+
+    textOrientation sideways
+
+    textOrientation upright
+
+-}
+textOrientation :
+    BaseValue
+        { mixed : Supported
+        , sideways : Supported
+        , sidewaysRight : Supported
+        , upright : Supported
+        , useGlyphOrientation : Supported
+        }
+    -> Style
+textOrientation (Value str) =
+    AppendProperty ("text-orientation:" ++ str)
+
+
+{-| A `mixed` value for the
+[`textOrientation`](#textOrientation) property.
+
+    textOrientation mixed
+
+-}
+mixed : Value { provides | mixed : Supported }
+mixed =
+    Value "mixed"
+
+
+{-| A `sideways` value for the
+[`textOrientation`](#textOrientation) property.
+
+    textOrientation sideways
+
+-}
+sideways : Value { provides | sideways : Supported }
+sideways =
+    Value "sideways"
+
+
+{-| A `sideways-right` value for the
+[`textOrientation`](#textOrientation) property.
+
+    textOrientation sidewaysRight
+
+-}
+sidewaysRight : Value { provides | sidewaysRight : Supported }
+sidewaysRight =
+    Value "sideways-right"
+
+
+{-| A `upright` value for the
+[`textOrientation`](#textOrientation) property.
+
+    textOrientation upright
+
+-}
+upright : Value { provides | upright : Supported }
+upright =
+    Value "upright"
+
+
+{-| A `use-glyph-orientation` value for the
+[`textOrientation`](#textOrientation) property.
+
+    textOrientation useGlyphOrientation
+
+-}
+useGlyphOrientation : Value { provides | useGlyphOrientation : Supported }
+useGlyphOrientation =
+    Value "use-glyph-orientation"
+
+
+{-| Sets the [`quotes`](https://css-tricks.com/almanac/properties/q/quotes/) property.
+
+This one-argument version can only use keyword or global values.
+
+    quotes none
+
+    quotes inherit
+
+    quotes2 (string "\"") (string "\"")
+
+    quotes4 (string "\"") (string "\"") (string "'") (string "'")
+
+-}
+quotes :
+    BaseValue
+        { none : Supported
+        , auto : Supported
+        }
+    -> Style
+quotes (Value val) =
+    AppendProperty ("quotes:" ++ val)
+
+
+{-| Sets the [`quotes`](https://css-tricks.com/almanac/properties/q/quotes/) property.
+
+This 2-argument version sets the starting and closing quotation marks for
+a top-level quote (a quote that is not nested within another quote). It only accepts
+string values.
+
+    quotes auto
+
+    quotes2 (string "\"") (string "\"") -- "Hey, this is a first-level quote."
+
+    quotes2 (string "'") (string "'") -- 'Hey, this is a first-level quote.'
+
+    quotes2 (string "«") (string "»") -- «Hey, this is a first-level quote.»
+
+-}
+quotes2 :
+    Value
+        { string : Supported
+        }
+    ->
+        Value
+            { string : Supported
+            }
+    -> Style
+quotes2 (Value lv1StartQuote) (Value lv1EndQuote) =
+    AppendProperty ("quotes:" ++ lv1StartQuote ++ " " ++ lv1EndQuote)
+
+
+{-| Sets the [`quotes`](https://css-tricks.com/almanac/properties/q/quotes/) property.
+
+This 4-argument version sets the starting and closing quotation marks for both
+a top-level quote and a nested quote. It only accepts
+string values.
+
+    quotes auto
+
+    quotes2 (string "\"") (string "\"")
+
+    -- "Hey, this is a first-level quote."
+
+
+    quotes4 (string "\"") (string "\"") (string "\'") (string "\'")
+
+    {- "Hey, this is a first-level quote.
+    'And this is someone else I made up for
+    a second-level quote!' Yeah, I did that!"
+    -}
+
+    quotes4 (string "«") (string "»") (string "👏") (string "🤔")
+
+    {- «Hey, this is a first-level quote.
+    👏And this is something else I made up for
+    a second-level quote!🤔 Yeah, I did that!»
+    -}
+
+-}
+quotes4 :
+    Value
+        { string : Supported
+        }
+    ->
+        Value
+            { string : Supported
+            }
+    ->
+        Value
+            { string : Supported
+            }
+    ->
+        Value
+            { string : Supported
+            }
+    -> Style
+quotes4 (Value lv1StartQuote) (Value lv1EndQuote) (Value lv2StartQuote) (Value lv2EndQuote) =
+    AppendProperty ("quotes:" ++ lv1StartQuote ++ " " ++ lv1EndQuote ++ " " ++ lv2StartQuote ++ " " ++ lv2EndQuote)
+
+
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+--------------------------- TEXT RENDERING -----------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+
+
+{-| Sets [`text-rendering`](https://css-tricks.com/almanac/properties/t/text-rendering/).
+
+    textRendering geometricPrecision
+
+    textRendering optimizeSpeed
+
+-}
+textRendering :
+    BaseValue
+        { auto : Supported
+        , geometricPrecision : Supported
+        , optimizeLegibility : Supported
+        , optimizeSpeed : Supported
+        }
+    -> Style
+textRendering (Value str) =
+    AppendProperty ("text-rendering:" ++ str)
+
+
+{-| A `geometricPrecision` value for the [`text-rendering`](https://css-tricks.com/almanac/properties/t/text-rendering/) property.
+
+    textRendering geometricPrecision
+
+-}
+geometricPrecision : Value { provides | geometricPrecision : Supported }
+geometricPrecision =
+    Value "geometricPrecision"
+
+
+{-| An `optimizeLegibility` value for the [`text-rendering`](https://css-tricks.com/almanac/properties/t/text-rendering/) property.
+
+    textRendering optimizeLegibility
+
+-}
+optimizeLegibility : Value { provides | optimizeLegibility : Supported }
+optimizeLegibility =
+    Value "optimizeLegibility"
+
+
+{-| An `optimizeSpeed` value for the [`text-rendering`](https://css-tricks.com/almanac/properties/t/text-rendering/) property.
+
+    textRendering optimizeSpeed
+
+-}
+optimizeSpeed : Value { provides | optimizeSpeed : Supported }
+optimizeSpeed =
+    Value "optimizeSpeed"
+
+
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+----------------------------- USER-SELECT ------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+
+
+{-| Sets [`user-select`](https://css-tricks.com/almanac/properties/u/user-select/)
+
+    userSelect none
+
+    userSelect auto
+
+    userSelect text
+
+    userSelect contain_
+
+    userSelect all_
+
+-}
+userSelect :
+    BaseValue
+        { none : Supported
+        , auto : Supported
+        , text : Supported
+        , contain_ : Supported
+        , all_ : Supported
+        }
+    -> Style
+userSelect (Value val) =
+    AppendProperty ("user-select:" ++ val)
+
+
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------ ACCESSIBILITY ---------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+
+
+{-| Sets [`speak`](https://css-tricks.com/almanac/properties/s/speak/)
+
+    speak none
+
+    speak normal
+
+    speak spellOut
+
+-}
+speak :
+    BaseValue
+        { none : Supported
+        , normal : Supported
+        , spellOut : Supported
+        }
+    -> Style
+speak (Value val) =
+    AppendProperty ("speak:" ++ val)
+
+
+{-| Sets `spellOut` value for usage with [`speak`](#speak).
+
+    speak spellOut
+
+-}
+spellOut : Value { provides | spellOut : Supported }
+spellOut =
+    Value "spell-out"
 
 
 ------------------------------------------------------------------------
@@ -13634,1840 +15430,6 @@ and [`listStyleType`](#listStyleType)
 upperRoman : Value { provides | upperRoman : Supported }
 upperRoman =
     Value "upper-roman"
-
-
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
---------------------- TEXT TRANSFORM + DECORATION ----------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-
-
-{-| Sets [`text-transform`](https://css-tricks.com/almanac/properties/t/text-transform/).
-
-    textTransform capitalize
-
-    textTransform uppercase
-
--}
-textTransform :
-    BaseValue
-        { capitalize : Supported
-        , uppercase : Supported
-        , lowercase : Supported
-        , fullWidth : Supported
-        , fullSizeKana : Supported
-        , none : Supported
-        }
-    -> Style
-textTransform (Value str) =
-    AppendProperty ("text-transform:" ++ str)
-
-
-{-| A `capitalize` value for the [`text-transform`](https://developer.mozilla.org/en-US/docs/Web/CSS/text-transform#Syntax) property.
-
-    textTransform capitalize
-
--}
-capitalize : Value { provides | capitalize : Supported }
-capitalize =
-    Value "capitalize"
-
-
-{-| An `uppercase` value for the [`text-transform`](https://developer.mozilla.org/en-US/docs/Web/CSS/text-transform#Syntax) property.
-
-    textTransform uppercase
-
--}
-uppercase : Value { provides | uppercase : Supported }
-uppercase =
-    Value "uppercase"
-
-
-{-| A `lowercase` value for the [`text-transform`](https://developer.mozilla.org/en-US/docs/Web/CSS/text-transform#Syntax) property.
-
-    textTransform lowercase
-
--}
-lowercase : Value { provides | lowercase : Supported }
-lowercase =
-    Value "lowercase"
-
-
-{-| The `full-size-kana` value used by [`textTransform`](#textTransform)
-
-textTransform fullSizeKana
-
--}
-fullSizeKana : Value { provedes | fullSizeKana : Supported }
-fullSizeKana =
-    Value "full-size-kana"
-
-
-{-| Sets [`text-decoration`][text-decoration] shorthand property.
-
-    textDecoration underline
-
-[text-decoration]: https://css-tricks.com/almanac/properties/t/text-decoration/
-
--}
-textDecoration :
-    BaseValue
-        (ColorSupported
-            { none : Supported
-            , underline : Supported
-            , overline : Supported
-            , lineThrough : Supported
-            , solid : Supported
-            , double : Supported
-            , dotted : Supported
-            , dashed : Supported
-            , wavy : Supported
-            }
-        )
-    -> Style
-textDecoration (Value line) =
-    AppendProperty ("text-decoration:" ++ line)
-
-
-{-| Sets [`text-decoration`][text-decoration] property.
-
-    textDecoration2 underline dotted
-
-[text-decoration]: https://css-tricks.com/almanac/properties/t/text-decoration/
-
--}
-textDecoration2 :
-    Value
-        { none : Supported
-        , underline : Supported
-        , overline : Supported
-        , lineThrough : Supported
-        }
-    ->
-        Value
-            { solid : Supported
-            , double : Supported
-            , dotted : Supported
-            , dashed : Supported
-            , wavy : Supported
-            }
-    -> Style
-textDecoration2 (Value line) (Value styleVal) =
-    AppendProperty ("text-decoration:" ++ line ++ " " ++ styleVal)
-
-
-{-| Sets [`text-decoration`][text-decoration] property.
-
-    textDecoration3 underline dotted (hex "#cf0")
-
-[text-decoration]: https://css-tricks.com/almanac/properties/t/text-decoration/
-
--}
-textDecoration3 :
-    Value
-        { none : Supported
-        , underline : Supported
-        , overline : Supported
-        , lineThrough : Supported
-        }
-    ->
-        Value
-            { solid : Supported
-            , double : Supported
-            , dotted : Supported
-            , dashed : Supported
-            , wavy : Supported
-            }
-    -> Value Color
-    -> Style
-textDecoration3 (Value line) (Value styleVal) (Value colorVal) =
-    AppendProperty ("text-decoration:" ++ line ++ " " ++ styleVal ++ " " ++ colorVal)
-
-
-{-| Sets [`text-decoration-line`][text-decoration-line] property.
-
-    textDecorationLine underline
-
-[text-decoration-line]: https://css-tricks.com/almanac/properties/t/text-decoration-line/
-
--}
-textDecorationLine :
-    BaseValue
-        { none : Supported
-        , underline : Supported
-        , overline : Supported
-        , lineThrough : Supported
-        }
-    -> Style
-textDecorationLine (Value line) =
-    AppendProperty ("text-decoration-line:" ++ line)
-
-
-{-| Sets [`text-decoration-line`][text-decoration-line] property.
-
-    textDecorationLine2 underline overline
-
-**Note:** The first and second argument **MUST NOT** be the same.
-
-[text-decoration-line]: https://css-tricks.com/almanac/properties/t/text-decoration-line/
-
--}
-textDecorationLine2 :
-    Value
-        { underline : Supported
-        , overline : Supported
-        , lineThrough : Supported
-        }
-    ->
-        Value
-            { underline : Supported
-            , overline : Supported
-            , lineThrough : Supported
-            }
-    -> Style
-textDecorationLine2 (Value line1) (Value line2) =
-    AppendProperty ("text-decoration-line:" ++ line1 ++ " " ++ line2)
-
-
-{-| Sets [`text-decoration-line`][text-decoration-line] property.
-
-    textDecorationLine3 underline overline lineThrough
-
-[text-decoration-line]: https://css-tricks.com/almanac/properties/t/text-decoration-line/
-
--}
-textDecorationLine3 :
-    Value { underline : Supported }
-    -> Value { overline : Supported }
-    -> Value { lineThrough : Supported }
-    -> Style
-textDecorationLine3 (Value line1) (Value line2) (Value line3) =
-    AppendProperty ("text-decoration-line:" ++ line1 ++ " " ++ line2 ++ " " ++ line3)
-
-
-{-| Sets [`text-decoration-style`][text-decoration-style] property.
-
-    textDecorationStyle wavy
-
-[text-decoration-style]: https://css-tricks.com/almanac/properties/t/text-decoration-style/
-
--}
-textDecorationStyle :
-    BaseValue
-        { solid : Supported
-        , double : Supported
-        , dotted : Supported
-        , dashed : Supported
-        , wavy : Supported
-        }
-    -> Style
-textDecorationStyle (Value styleVal) =
-    AppendProperty ("text-decoration-style:" ++ styleVal)
-
-
-{-| Sets [`text-decoration-color`](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-color) property.
-
-    textDecorationColor (hex "#0cf")
-
--}
-textDecorationColor : BaseValue Color -> Style
-textDecorationColor (Value colorVal) =
-    AppendProperty ("text-decoration-color:" ++ colorVal)
-
-
-{-| Sets the [`text-decoration-thickness`](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-thickness) property.
-
-    textDecorationThickness (pct 10)
-
--}
-textDecorationThickness :
-    BaseValue
-        ( LengthSupported
-            { pct : Supported
-            , auto : Supported
-            , fromFont : Supported
-            }
-        )
-    -> Style
-textDecorationThickness (Value value) =
-    AppendProperty ("text-decoration-thickness:" ++ value)
-
-
-{-| Sets the `from-font` value for usage with [`textDecorationThickness`](#textDecorationThickness).
-
-    textDecorationThickness fromFont
-
--}
-fromFont : Value { provides | fromFont : Supported }
-fromFont =
-    Value "from-font"
-
-
-{-| Sets [`text-decoration-skip`](https://css-tricks.com/almanac/properties/t/text-decoration-skip/) property.
-
-    textDecorationSkip objects
-
-    textDecorationSkip none
-
-    textDecorationSkip spaces
-
-    textDecorationSkip ink
-
-    textDecorationSkip edges
-
-    textDecorationSkip boxDecoration
-
-Note: Using [`textDecorationSkipInk`](#textDecorationSkipInk) is considerered better practice
-instead of `textDecorationSkip ink`.
-
--}
-textDecorationSkip :
-    BaseValue
-        { objects : Supported
-        , none : Supported
-        , spaces : Supported
-        , ink : Supported
-        , edges : Supported
-        , boxDecoration : Supported
-        }
-    -> Style
-textDecorationSkip (Value val) =
-    AppendProperty ("text-decoration-skip:" ++ val)
-
-
-{-| Sets [`text-decoration-skip-ink`](https://css-tricks.com/almanac/properties/t/text-decoration-skip-ink/) property.
-
-    textDecorationSkipInk auto
-
-    textDecorationSkipInk all
-
-    textDecorationSkipInk none
-
--}
-textDecorationSkipInk :
-    Value
-        { auto : Supported
-        , all : Supported
-        , none : Supported
-        }
-    -> Style
-textDecorationSkipInk (Value val) =
-    AppendProperty ("text-decoration-skip-ink:" ++ val)
-
-
-{-| Sets `objects` value for usage with [`textDecorationSkip`](#textDecorationSkip).
-
-    textDecorationSkip objects
-
--}
-objects : Value { provides | objects : Supported }
-objects =
-    Value "objects"
-
-
-{-| Sets `spaces` value for usage with [`textDecorationSkip`](#textDecorationSkip).
-
-    textDecorationSkip spaces
-
--}
-spaces : Value { provides | spaces : Supported }
-spaces =
-    Value "spaces"
-
-
-{-| Sets `ink` value for usage with [`textDecorationSkip`](#textDecorationSkip).
-
-    textDecorationSkip ink
-
--}
-ink : Value { provides | ink : Supported }
-ink =
-    Value "ink"
-
-
-{-| Sets `edges` value for usage with [`textDecorationSkip`](#textDecorationSkip).
-
-    textDecorationSkip edges
-
--}
-edges : Value { provides | edges : Supported }
-edges =
-    Value "edges"
-
-
-{-| Sets `boxDecoration` value for usage with [`textDecorationSkip`](#textDecorationSkip).
-
-    textDecorationSkip boxDecoration
-
--}
-boxDecoration : Value { provides | boxDecoration : Supported }
-boxDecoration =
-    Value "box-decoration"
-
-
-{-| The `wavy` [`text-decoration-style`][text-decoration-style] value.
-
-    textDecorationStyle wavy
-
-[text-decoration-style]: https://css-tricks.com/almanac/properties/t/text-decoration-style/#article-header-id-0
-
--}
-wavy : Value { provides | wavy : Supported }
-wavy =
-    Value "wavy"
-
-
-{-| The `underline` [`text-decoration-line`][text-decoration-line] value.
-
-    textDecorationLine underline
-
-[text-decoration-line]: https://css-tricks.com/almanac/properties/t/text-decoration-line/#article-header-id-0
-
--}
-underline : Value { provides | underline : Supported }
-underline =
-    Value "underline"
-
-
-{-| The `overline` [`text-decoration-line`][text-decoration-line] value.
-
-    textDecorationLine overline
-
-[text-decoration-line]: https://css-tricks.com/almanac/properties/t/text-decoration-line/#article-header-id-0
-
--}
-overline : Value { provides | overline : Supported }
-overline =
-    Value "overline"
-
-
-{-| The `line-through` [`text-decoration-line`][text-decoration-line] value.
-
-    textDecorationLine lineThrough
-
-[text-decoration-line]: https://css-tricks.com/almanac/properties/t/text-decoration-line/#article-header-id-0
-
--}
-lineThrough : Value { provides | lineThrough : Supported }
-lineThrough =
-    Value "line-through"
-
-
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
--------------------------- OTHER TEXT DECORATION -----------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-
-
-{-| Sets [`line-height`](https://css-tricks.com/almanac/properties/l/line-height/)
-
-    lineHeight (pct 150)
-
-    lineHeight (em 2)
-
-    lineHeight (num 1.5)
-
-    lineHeight normal
-
--}
-lineHeight :
-    BaseValue
-        (LengthSupported
-            { pct : Supported
-            , normal : Supported
-            , num : Supported
-            }
-        )
-    -> Style
-lineHeight (Value val) =
-    AppendProperty ("line-height:" ++ val)
-
-
-{-| Sets [`letter-spacing`](https://css-tricks.com/almanac/properties/l/letter-spacing/)
-
-    letterSpacing (pct 150)
-
-    letterSpacing (em 2)
-
-    letterSpacing (num 1.5)
-
-    letterSpacing normal
-
--}
-letterSpacing :
-    BaseValue
-        (LengthSupported
-            { normal : Supported
-            }
-        )
-    -> Style
-letterSpacing (Value val) =
-    AppendProperty ("letter-spacing:" ++ val)
-
-
-{-| The [`text-indent`](https://css-tricks.com/almanac/properties/t/text-indent/) property.
-
-    textIndent (em 1.5)
-
--}
-textIndent : BaseValue (LengthSupported { pct : Supported }) -> Style
-textIndent (Value val) =
-    AppendProperty ("text-indent:" ++ val)
-
-
-{-| The [`text-indent`](https://css-tricks.com/almanac/properties/t/text-indent/) property.
-
-    textIndent2 (em 1.5) hanging
-
--}
-textIndent2 :
-    Value (LengthSupported { pct : Supported })
-    ->
-        Value
-            { hanging : Supported
-            , eachLine : Supported
-            }
-    -> Style
-textIndent2 (Value lengthVal) (Value optionVal) =
-    AppendProperty ("text-indent:" ++ lengthVal ++ " " ++ optionVal)
-
-
-{-| The [`text-indent`](https://css-tricks.com/almanac/properties/t/text-indent/) property.
-
-    textIndent3 (em 1.5) hanging eachLine
-
--}
-textIndent3 :
-    Value (LengthSupported { pct : Supported })
-    -> Value { hanging : Supported }
-    -> Value { eachLine : Supported }
-    -> Style
-textIndent3 (Value lengthVal) (Value hangingVal) (Value eachLineVal) =
-    AppendProperty
-        ("text-indent:"
-            ++ lengthVal
-            ++ " "
-            ++ hangingVal
-            ++ " "
-            ++ eachLineVal
-        )
-
-
-{-| The `hanging` value used for properties such as [`textIdent2`](#textIdent2).
-
-    textIdent2 (px 20) hanging
-
--}
-hanging : Value { provides | hanging : Supported }
-hanging =
-    Value "hanging"
-
-
-{-| The `each-line` value used for properties such as [`textIdent2`](#textIdent2).
-
-    textIdent2 (px 20) eachLine
-
--}
-eachLine : Value { provides | eachLine : Supported }
-eachLine =
-    Value "each-line"
-
-
-{-| Sets the [text-underline-offset](https://css-tricks.com/almanac/properties/t/text-underline-offset/) property.
-
-    textUnderlineOffset (pct 5)
--}
-textUnderlineOffset :
-    BaseValue
-        ( LengthSupported
-            { pct : Supported
-            , auto : Supported
-            }
-        )
-    -> Style
-textUnderlineOffset (Value value) =
-    AppendProperty ("text-underline-offset:" ++ value)
-
-
-{-| Sets the [`text-emphasis`](https://css-tricks.com/almanac/properties/t/text-emphasis/) property.
-
-This is for drawing attention towards textual elements in a way that is commonly
-used in East Asian languages.
-
-    textEmphasis (hex "ff0000")
-
-    textEmphasis sesame
-
-    textEmphasis2 triangle (hex "00ff00")
-
--}
-textEmphasis :
-    BaseValue
-        (ColorSupported
-            { none : Supported
-            , filled : Supported
-            , open : Supported
-            , dot : Supported
-            , circle_ : Supported
-            , doubleCircle : Supported
-            , triangle : Supported
-            , sesame : Supported
-            , string : Supported
-            }
-        )
-    -> Style
-textEmphasis (Value value) =
-    AppendProperty ("text-emphasis:" ++ value)
-
-
-{-| Sets the [`text-emphasis`](https://css-tricks.com/almanac/properties/t/text-emphasis/) property.
-
-This 2-argument form sets [`text-emphasis-style`](#textEmphasisStyle) and [`textEmphasisColor`](#textEmphasisColor) in a single declaration.
-
-    textEmphasis2 filled (hex "ff0000")
--}
-textEmphasis2 :
-    BaseValue
-        { none : Supported
-        , filled : Supported
-        , open : Supported
-        , dot : Supported
-        , circle_ : Supported
-        , doubleCircle : Supported
-        , triangle : Supported
-        , sesame : Supported
-        , string : Supported
-        }
-    ->
-        BaseValue
-            (Color)
-    -> Style
-textEmphasis2 (Value value1) (Value value2) =
-    AppendProperty
-        ("text-emphasis:"
-            ++ value1
-            ++ " "
-            ++ value2
-        )
-
-
-{-| Sets the [`text-emphasis-style`](https://developer.mozilla.org/en-US/docs/Web/CSS/text-emphasis-style) property.
-
-    textEmphasisStyle none
-
-    textEmphasisStyle open
-
-    textEmphasisStyle (string "🐯")
--}
-textEmphasisStyle :
-    BaseValue
-        { none : Supported
-        , filled : Supported
-        , open : Supported
-        , dot : Supported
-        , circle_ : Supported
-        , doubleCircle : Supported
-        , triangle : Supported
-        , sesame : Supported
-        , string : Supported
-        }
-    -> Style
-textEmphasisStyle (Value value) =
-    AppendProperty ("text-emphasis-style:" ++ value)
-
-
-{-| Sets the [`text-emphasis-style`](https://developer.mozilla.org/en-US/docs/Web/CSS/text-emphasis-style) property when you want to use two arguments - one for `filled` or `open`, and one for the shape style.
-
-    textEmphasisStyle filled sesame
-
-    textEmphasisStyle open dot
--}
-textEmphasisStyle2 :
-    BaseValue
-        { filled : Supported
-        , open : Supported
-        }
-    -> BaseValue
-        { dot : Supported
-        , circle_ : Supported
-        , doubleCircle : Supported
-        , triangle : Supported
-        , sesame : Supported
-        }
-    -> Style
-textEmphasisStyle2 (Value val1) (Value val2) =
-    AppendProperty
-        ("text-emphasis-style:"
-        ++ val1
-        ++ " "
-        ++ val2
-        )
-
-
-{-| Sets the [`text-emphasis-color`](https://developer.mozilla.org/en-US/docs/Web/CSS/text-emphasis-color) property.
-
-    textEmphasisColor currentcolor
-
-    textemphasisColor (hex "0000ff")
--}
-textEmphasisColor :
-    BaseValue (Color)
-    -> Style
-textEmphasisColor (Value value) =
-    AppendProperty ("text-emphasis-color:" ++ value)
-
-
-{-| Sets the [`text-emphasis-position`](https://developer.mozilla.org/en-US/docs/Web/CSS/text-emphasis-position) property.
-
-This is the one argument version, which is limited to setting global values.
-
-If you want to specify the positions of the text-emphasis, you must use the [2-argument form](#textEmphasisPosition2).
-
-    textEmphasisPosition inherit
-
-    textEmphasisPosition revert
-
-    textEmphasisPosition2 over left_
-
-    textEmphasisPosition2 under right_
-
--}
-textEmphasisPosition :
-    BaseValue a
-    -> Style
-textEmphasisPosition (Value value) =
-    AppendProperty ("text-emphasis-position:" ++ value)
-
-
-{-| Sets the the [`text-emphasis-position`](https://developer.mozilla.org/en-US/docs/Web/CSS/text-emphasis-position) property.
-
-This is the 2-argument form that lets you specify the positions of the emphasis.
-
-if you want to apply global values, you must use the [1-argument form](#textEmphasisPosition).
-
-    textEmphasisPosition inherit
-
-    textEmphasisPosition revert
-
-    textEmphasisPosition2 over left_
-
-    textEmphasisPosition2 under right_
-
--}
-textEmphasisPosition2 :
-    BaseValue
-        { over : Supported
-        , under : Supported
-        }
-    -> BaseValue
-        { left_ : Supported
-        , right_ : Supported
-        }
-    -> Style
-textEmphasisPosition2 (Value val1) (Value val2) =
-    AppendProperty
-        ("text-emphasis-position:"
-        ++ val1
-        ++ " "
-        ++ val2
-        )
-
-
-{-| The `filled` value used in [`textEmphasis`](#textEmphasis).
-
-    textEmphasis filled
-
--}
-filled : Value { provides | filled : Supported }
-filled =
-    Value "filled"
-
-
-{-| The `open` value used in [`textEmphasis`](#textEmphasis).
-
-    textEmphasis open
-
--}
-open : Value { provides | open : Supported }
-open =
-    Value "open"
-
-
-{-| The `dot` value used in [`textEmphasis`](#textEmphasis).
-
-    textEmphasis dot
-
--}
-dot : Value { provides | dot : Supported }
-dot =
-    Value "dot"
-
-
-{-| The `doubleCircle` value used in [`textEmphasis`](#textEmphasis).
-
-    textEmphasis doubleCircle
-
--}
-doubleCircle : Value { provides | doubleCircle : Supported }
-doubleCircle =
-    Value "double-circle"
-
-
-{-| The `triangle` value used in [`textEmphasis`](#textEmphasis).
-
-    textEmphasis triangle
-
--}
-triangle : Value { provides | triangle : Supported }
-triangle =
-    Value "triangle"
-
-
-{-| The `sesame` value used in [`textEmphasis`](#textEmphasis).
-
-    textEmphasis sesame
-
--}
-sesame : Value { provides | sesame : Supported }
-sesame =
-    Value "sesame"
-
-
-{-| The `over` value used in [`textEmphasisPosition2`](#textEmphasisPosition2).
-
-    textEmphasisPosition2 over left_
-
--}
-over : Value { provides | over : Supported }
-over =
-    Value "over"
-
-
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
---------------------- MORE TEXT STUFF TO REARRANGE ---------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-
-
-{-| Sets [`text-align`](https://css-tricks.com/almanac/properties/t/text-align/)
-
-    textAlign left_
-
-    textAlign justfy
-
--}
-textAlign :
-    BaseValue
-        { left_ : Supported
-        , right_ : Supported
-        , center : Supported
-        , justify : Supported
-        , start : Supported
-        , end : Supported
-        , matchParent : Supported
-        }
-    -> Style
-textAlign (Value str) =
-    AppendProperty ("text-align:" ++ str)
-
-
-{-| A `justify` value for the [`text-align`](https://css-tricks.com/almanac/properties/t/text-align/)
-
-    textAlign justify
-
--}
-justify : Value { provides | justify : Supported }
-justify =
-    Value "justify"
-
-
-{-| Sets [`text-justify`](https://css-tricks.com/almanac/properties/t/text-justify/)
-
-    textJustify interWord
-
-    textJustify interCharacter
-
-    textJustify auto
-
-    textJustify none
-
--}
-textJustify :
-    BaseValue
-        { interWord : Supported
-        , interCharacter : Supported
-        , auto : Supported
-        , none : Supported
-        }
-    -> Style
-textJustify (Value val) =
-    AppendProperty ("text-justify:" ++ val)
-
-
-{-| A `inter-word` value for the [`textJustify`](#textJustify) property.
-
-    textJustify interWord
-
--}
-interWord : Value { provides | interWord : Supported }
-interWord =
-    Value "inter-word"
-
-
-{-| A `inter-character` value for the [`textJustify`](#textJustify) property.
-
-    textJustify interCharacter
-
--}
-interCharacter : Value { provides | interCharacter : Supported }
-interCharacter =
-    Value "inter-character"
-
-
-{-| Sets [`text-underline-position`](https://css-tricks.com/almanac/properties/t/text-underline-position/)
-
-    textUnderlinePosition auto
-
-    textUnderlinePosition under
-
-    textUnderlinePosition left_
-
-    textUnderlinePosition right_
-
--}
-textUnderlinePosition :
-    BaseValue
-        { auto : Supported
-        , under : Supported
-        , left_ : Supported
-        , right_ : Supported
-        }
-    -> Style
-textUnderlinePosition (Value val) =
-    AppendProperty ("text-underline-position:" ++ val)
-
-
-{-| Sets [`text-underline-position`](https://css-tricks.com/almanac/properties/t/text-underline-position/)
-
-    textUnderlinePosition2 under left_
-
-    textUnderlinePosition2 under right_
-
--}
-textUnderlinePosition2 :
-    Value { under : Supported }
-    ->
-        Value
-            { left_ : Supported
-            , right_ : Supported
-            }
-    -> Style
-textUnderlinePosition2 (Value underVal) (Value val) =
-    AppendProperty ("text-underline-position:" ++ underVal ++ " " ++ val)
-
-
-
-{-| Sets [`text-orientation`](https://developer.mozilla.org/en-US/docs/Web/CSS/text-orientation).
-
-    textOrientation sideways
-
-    textOrientation upright
-
--}
-textOrientation :
-    BaseValue
-        { mixed : Supported
-        , sideways : Supported
-        , sidewaysRight : Supported
-        , upright : Supported
-        , useGlyphOrientation : Supported
-        }
-    -> Style
-textOrientation (Value str) =
-    AppendProperty ("text-orientation:" ++ str)
-
-
-{-| A `mixed` value for the
-[`textOrientation`](#textOrientation) property.
-
-    textOrientation mixed
-
--}
-mixed : Value { provides | mixed : Supported }
-mixed =
-    Value "mixed"
-
-
-{-| A `sideways` value for the
-[`textOrientation`](#textOrientation) property.
-
-    textOrientation sideways
-
--}
-sideways : Value { provides | sideways : Supported }
-sideways =
-    Value "sideways"
-
-
-{-| A `sideways-right` value for the
-[`textOrientation`](#textOrientation) property.
-
-    textOrientation sidewaysRight
-
--}
-sidewaysRight : Value { provides | sidewaysRight : Supported }
-sidewaysRight =
-    Value "sideways-right"
-
-
-{-| A `upright` value for the
-[`textOrientation`](#textOrientation) property.
-
-    textOrientation upright
-
--}
-upright : Value { provides | upright : Supported }
-upright =
-    Value "upright"
-
-
-{-| A `use-glyph-orientation` value for the
-[`textOrientation`](#textOrientation) property.
-
-    textOrientation useGlyphOrientation
-
--}
-useGlyphOrientation : Value { provides | useGlyphOrientation : Supported }
-useGlyphOrientation =
-    Value "use-glyph-orientation"
-
-
-{-| Sets [`word-break`](https://css-tricks.com/almanac/properties/w/word-break/)
-
-      wordBreak normal
-      wordBreak breakAll
-      wordBreak keepAll
-      wordBreak breakWord
-
--}
-wordBreak :
-    BaseValue
-        { normal : Supported
-        , breakAll : Supported
-        , keepAll : Supported
-        , breakWord : Supported
-        }
-    -> Style
-wordBreak (Value str) =
-    AppendProperty ("word-break:" ++ str)
-
-
-{-| A `breakAll` value for the [`word-break`](https://css-tricks.com/almanac/properties/w/word-break/) property.
-
-      wordBreak breakAll
-
--}
-breakAll : Value { provides | breakAll : Supported }
-breakAll =
-    Value "break-all"
-
-
-{-| A `keepAll` value for the [`word-break`](https://css-tricks.com/almanac/properties/w/word-break/) property.
-
-      wordBreak keepAll
-
--}
-keepAll : Value { provides | keepAll : Supported }
-keepAll =
-    Value "keep-all"
-
-
-{-| Sets [`word-spacing`](https://css-tricks.com/almanac/properties/w/word-spacing/).
-
-    wordSpacing normal
-
-    wordSpacing zero
-
-    wordSpacing (px 5)
-
--}
-wordSpacing :
-    BaseValue
-        (LengthSupported
-            { normal : Supported
-            , pct : Supported
-            }
-        )
-    -> Style
-wordSpacing (Value str) =
-    AppendProperty ("word-spacing:" ++ str)
-
-
-
-{-| Sets [`tab-size`](https://css-tricks.com/almanac/properties/t/tab-size/)
-**Note:** only positive integer values are allowed.
-
-    tabSize (int 4)
-
--}
-tabSize :
-    BaseValue
-        (LengthSupported
-            { auto : Supported
-            , int : Supported
-            }
-        )
-    -> Style
-tabSize (Value val) =
-    AppendProperty ("tab-size:" ++ val)
-
-
-{-| Sets [`hyphens`](https://css-tricks.com/almanac/properties/h/hyphens/)
-
-    hyphens none
-
-    hyphens manual
-
-    hyphens auto
-
--}
-hyphens :
-    BaseValue
-        { none : Supported
-        , manual : Supported
-        , auto : Supported
-        }
-    -> Style
-hyphens (Value val) =
-    AppendProperty ("hyphens:" ++ val)
-
-
-{-| Sets `manual` value for usage with [`hyphens`](#hyphens).
-
-    hyphens manual
-
--}
-manual : Value { provides | manual : Supported }
-manual =
-    Value "manual"
-
-
-{-| Sets the [`quotes`](https://css-tricks.com/almanac/properties/q/quotes/) property.
-
-This one-argument version can only use keyword or global values.
-
-    quotes none
-
-    quotes inherit
-
-    quotes2 (string "\"") (string "\"")
-
-    quotes4 (string "\"") (string "\"") (string "'") (string "'")
-
--}
-quotes :
-    BaseValue
-        { none : Supported
-        , auto : Supported
-        }
-    -> Style
-quotes (Value val) =
-    AppendProperty ("quotes:" ++ val)
-
-
-{-| Sets the [`quotes`](https://css-tricks.com/almanac/properties/q/quotes/) property.
-
-This 2-argument version sets the starting and closing quotation marks for
-a top-level quote (a quote that is not nested within another quote). It only accepts
-string values.
-
-    quotes auto
-
-    quotes2 (string "\"") (string "\"") -- "Hey, this is a first-level quote."
-
-    quotes2 (string "'") (string "'") -- 'Hey, this is a first-level quote.'
-
-    quotes2 (string "«") (string "»") -- «Hey, this is a first-level quote.»
-
--}
-quotes2 :
-    Value
-        { string : Supported
-        }
-    ->
-        Value
-            { string : Supported
-            }
-    -> Style
-quotes2 (Value lv1StartQuote) (Value lv1EndQuote) =
-    AppendProperty ("quotes:" ++ lv1StartQuote ++ " " ++ lv1EndQuote)
-
-
-{-| Sets the [`quotes`](https://css-tricks.com/almanac/properties/q/quotes/) property.
-
-This 4-argument version sets the starting and closing quotation marks for both
-a top-level quote and a nested quote. It only accepts
-string values.
-
-    quotes auto
-
-    quotes2 (string "\"") (string "\"")
-
-    -- "Hey, this is a first-level quote."
-
-
-    quotes4 (string "\"") (string "\"") (string "\'") (string "\'")
-
-    {- "Hey, this is a first-level quote.
-    'And this is someone else I made up for
-    a second-level quote!' Yeah, I did that!"
-    -}
-
-    quotes4 (string "«") (string "»") (string "👏") (string "🤔")
-
-    {- «Hey, this is a first-level quote.
-    👏And this is something else I made up for
-    a second-level quote!🤔 Yeah, I did that!»
-    -}
-
--}
-quotes4 :
-    Value
-        { string : Supported
-        }
-    ->
-        Value
-            { string : Supported
-            }
-    ->
-        Value
-            { string : Supported
-            }
-    ->
-        Value
-            { string : Supported
-            }
-    -> Style
-quotes4 (Value lv1StartQuote) (Value lv1EndQuote) (Value lv2StartQuote) (Value lv2EndQuote) =
-    AppendProperty ("quotes:" ++ lv1StartQuote ++ " " ++ lv1EndQuote ++ " " ++ lv2StartQuote ++ " " ++ lv2EndQuote)
-
-
-{-| Sets the [`text-overflow`](https://css-tricks.com/almanac/properties/t/text-overflow/) property.
-
-`text-overflow` describes how text that gets cut off is signalled to users.
-
-When the one-argument version is used, it sets the end of text (right end for LTR users) that is cut off.
-
-    textOverflow ellipsis
-
-When the two-argument version is used, it specifies how the
-text cut-off is displayed at the start (left in LTR) and
-the end (right in LTR) of the text.
-
-    textOverflow2 ellipsis ellipsis
-
--}
-textOverflow :
-    BaseValue
-        { clip : Supported
-        , ellipsis : Supported
-        }
-    -> Style
-textOverflow (Value value) =
-    AppendProperty ("text-overflow:" ++ value)
-
-
-{-| Sets the [`text-overflow`](https://css-tricks.com/almanac/properties/t/text-overflow/) property.
-
-`text-overflow` describes how text that gets cut off is signalled to users.
-
-This version specifies how the text cut-off is displayed at the start
-(left in LTR) and at the end (right in LTR) of the text.
-
-    textOverflow2 ellipsis ellipsis
-
--}
-textOverflow2 :
-    Value
-        { clip : Supported
-        , ellipsis : Supported
-        }
-    ->
-        Value
-            { clip : Supported
-            , ellipsis : Supported
-            }
-    -> Style
-textOverflow2 (Value startValue) (Value endValue) =
-    AppendProperty ("text-overflow:" ++ startValue ++ " " ++ endValue)
-
-
-{-| Sets `ellipsis` value for usage with [`textOverflow`](#textOverflow).
-
-    textOverflow ellipsis
-
--}
-ellipsis : Value { provides | ellipsis : Supported }
-ellipsis =
-    Value "ellipsis"
-
-
-{-| Sets the [`lineBreak`](https://css-tricks.com/almanac/properties/l/line-break/) property.
-
-    lineBreak auto
-
-    lineBreak strict
-
--}
-lineBreak :
-    BaseValue
-        { auto : Supported
-        , loose : Supported
-        , normal : Supported
-        , strict : Supported
-        , anywhere : Supported
-        }
-    -> Style
-lineBreak (Value value) =
-    AppendProperty ("line-break:" ++ value)
-
-
-{-| Sets `loose` value for usage with [`lineBreak`](#lineBreak).
-
-    lineBreak loose
-
--}
-loose : Value { provides | loose : Supported }
-loose =
-    Value "loose"
-
-
-{-| Sets [`hanging-punctuation`](https://css-tricks.com/almanac/properties/h/hanging-punctuation/)
-
-    hangingPunctuation none
-
-    hangingPunctuation first
-
-    hangingPunctuation2 first forceEnd
-
-    hangingPunctuation3 first allowEnd last
-
--}
-hangingPunctuation :
-    BaseValue
-        { none : Supported
-        , first : Supported
-        , forceEnd : Supported
-        , allowEnd : Supported
-        , last : Supported
-        }
-    -> Style
-hangingPunctuation (Value val) =
-    AppendProperty ("hanging-punctuation:" ++ val)
-
-
-{-| Sets [`hanging-punctuation`](https://css-tricks.com/almanac/properties/h/hanging-punctuation/)
-
-    hangingPunctuation2 first forceEnd
-
--}
-hangingPunctuation2 :
-    Value
-        { first : Supported
-        , last : Supported
-        }
-    ->
-        Value
-            { first : Supported
-            , forceEnd : Supported
-            , allowEnd : Supported
-            , last : Supported
-            }
-    -> Style
-hangingPunctuation2 (Value val1) (Value val2) =
-    AppendProperty ("hanging-punctuation:" ++ val1 ++ " " ++ val2)
-
-
-{-| Sets [`hanging-punctuation`](https://css-tricks.com/almanac/properties/h/hanging-punctuation/)
-
-    hangingPunctuation3 first allowEnd last
-
--}
-hangingPunctuation3 :
-    Value
-        { first : Supported
-        , last : Supported
-        }
-    ->
-        Value
-            { forceEnd : Supported
-            , allowEnd : Supported
-            }
-    ->
-        Value
-            { first : Supported
-            , last : Supported
-            }
-    -> Style
-hangingPunctuation3 (Value val1) (Value val2) (Value val3) =
-    AppendProperty ("hanging-punctuation:" ++ val1 ++ " " ++ val2 ++ " " ++ val3)
-
-
-{-| Sets `first` value for usage with [`hangingPunctuation`](#hangingPunctuation).
-
-      hangingPunctuation first
-
--}
-first : Value { provides | first : Supported }
-first =
-    Value "first"
-
-
-{-| Sets `last` value for usage with [`hangingPunctuation`](#hangingPunctuation).
-
-      hangingPunctuation last
-
--}
-last : Value { provides | last : Supported }
-last =
-    Value "last"
-
-
-{-| Sets `force-end` value for usage with [`hangingPunctuation`](#hangingPunctuation).
-
-      hangingPunctuation forceEnd
-
--}
-forceEnd : Value { provides | forceEnd : Supported }
-forceEnd =
-    Value "force-end"
-
-
-{-| Sets `allow-end` value for usage with [`hangingPunctuation`](#hangingPunctuation).
-
-      hangingPunctuation allowEnd
-
--}
-allowEnd : Value { provides | allowEnd : Supported }
-allowEnd =
-    Value "allow-end"
-
-
-
-{-| Sets [`white-space`](https://css-tricks.com/almanac/properties/w/whitespace/)
-
-    whiteSpace pre
-
-    whiteSpace nowrap
-
-    whiteSpace preWrap
-
-    whiteSpace preLine
-
--}
-whiteSpace :
-    BaseValue
-        { normal : Supported
-        , nowrap : Supported
-        , pre : Supported
-        , preWrap : Supported
-        , preLine : Supported
-        }
-    -> Style
-whiteSpace (Value str) =
-    AppendProperty ("white-space:" ++ str)
-
-
-{-| A `nowrap` value for the [`white-space`](https://css-tricks.com/almanac/properties/w/whitespace/)
-and [`flex-wrap`](https://css-tricks.com/almanac/properties/f/flex-wrap/) properties.
-
-    whiteSpace nowrap
-
-    flexWrap nowrap
-
--}
-nowrap : Value { provides | nowrap : Supported }
-nowrap =
-    Value "nowrap"
-
-
-{-| A `pre` value for the [`white-space`](https://css-tricks.com/almanac/properties/w/whitespace/) property.
-
-    whiteSpace pre
-
--}
-pre : Value { provides | pre : Supported }
-pre =
-    Value "pre"
-
-
-{-| A `pre-wrap` value for the [`white-space`](https://css-tricks.com/almanac/properties/w/whitespace/) property.
-
-    whiteSpace preWrap
-
--}
-preWrap : Value { provides | preWrap : Supported }
-preWrap =
-    Value "pre-wrap"
-
-
-{-| A `pre-line` value for the [`white-space`](https://css-tricks.com/almanac/properties/w/whitespace/) property.
-
-    whiteSpace preLine
-
--}
-preLine : Value { provides | preLine : Supported }
-preLine =
-    Value "pre-line"
-
-
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
----------------------------- SCRIPT HANDLING ---------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-
-
-{-| Sets [`direction`](https://css-tricks.com/almanac/properties/d/direction/)
-
-    direction ltr
-
-    direction rtl
-
--}
-direction :
-    BaseValue
-        { rtl : Supported
-        , ltr : Supported
-        }
-    -> Style
-direction (Value str) =
-    AppendProperty ("direction:" ++ str)
-
-
-{-| A `ltr` value for the [`direction`](https://css-tricks.com/almanac/properties/d/direction/) property.
-
-    direction ltr
-
--}
-ltr : Value { provides | ltr : Supported }
-ltr =
-    Value "ltr"
-
-
-{-| A `rtl` value for the [`direction`](https://css-tricks.com/almanac/properties/d/direction/) property.
-
-    direction rtl
-
--}
-rtl : Value { provides | rtl : Supported }
-rtl =
-    Value "rtl"
-
-
-{-| Sets [`writing-mode`](https://css-tricks.com/almanac/properties/w/writing-mode/).
-
-    writingMode horizontalTb
-
-    writingMode verticalRl
-
-    writingMode verticalLr
-
--}
-writingMode :
-    BaseValue
-        { horizontalTb : Supported
-        , verticalRl : Supported
-        , verticalLr : Supported
-        }
-    -> Style
-writingMode (Value str) =
-    AppendProperty ("writing-mode:" ++ str)
-
-
-{-| Sets `horizontal-tb` value for usage with [`writingMode`](#writingMode).
-
-    writingMode horizontalTb
-
--}
-horizontalTb : Value { provides | horizontalTb : Supported }
-horizontalTb =
-    Value "horizontal-tb"
-
-
-{-| Sets `vertical-lr` value for usage with [`writingMode`](#writingMode).
-
-    writingMode verticalLr
-
--}
-verticalLr : Value { provides | verticalLr : Supported }
-verticalLr =
-    Value "vertical-lr"
-
-
-{-| Sets `vertical-rl` value for usage with [`writingMode`](#writingMode).
-
-    writingMode verticalRl
-
--}
-verticalRl : Value { provides | verticalRl : Supported }
-verticalRl =
-    Value "vertical-rl"
-
-
-{-| Sets [`unicode-bidi`](https://css-tricks.com/almanac/properties/u/unicode-bidi/)
-
-    unicodeBidi normal
-
-    unicodeBidi embed
-
-    unicodeBidi isolate
-
-    unicodeBidi bidiOverride
-
-    unicodeBidi isolateOverride
-
-    unicodeBidi plaintext
-
--}
-unicodeBidi :
-    BaseValue
-        { normal : Supported
-        , embed : Supported
-        , isolate : Supported
-        , bidiOverride : Supported
-        , isolateOverride : Supported
-        , plaintext : Supported
-        }
-    -> Style
-unicodeBidi (Value val) =
-    AppendProperty ("unicode-bidi:" ++ val)
-
-
-{-| Sets `embed` value for usage with [`unicodeBidi`](#unicodeBidi).
-
-    unicodeBidi embed
-
--}
-embed : Value { provides | embed : Supported }
-embed =
-    Value "embed"
-
-
-{-| Sets `plaintext` value for usage with [`unicodeBidi`](#unicodeBidi).
-
-    unicodeBidi plaintext
-
--}
-plaintext : Value { provides | plaintext : Supported }
-plaintext =
-    Value "plaintext"
-
-
-{-| Sets `bidi-override` value for usage with [`unicodeBidi`](#unicodeBidi).
-
-    unicodeBidi bidiOverride
-
--}
-bidiOverride : Value { provides | bidiOverride : Supported }
-bidiOverride =
-    Value "bidi-override"
-
-
-{-| Sets `isolate-override` value for usage with [`unicodeBidi`](#unicodeBidi).
-
-    unicodeBidi isolateOverride
-
--}
-isolateOverride : Value { provides | isolateOverride : Supported }
-isolateOverride =
-    Value "isolate-override"
-
-
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
---------------------------- TEXT RENDERING -----------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-
-
-{-| Sets [`text-rendering`](https://css-tricks.com/almanac/properties/t/text-rendering/).
-
-    textRendering geometricPrecision
-
-    textRendering optimizeSpeed
-
--}
-textRendering :
-    BaseValue
-        { auto : Supported
-        , geometricPrecision : Supported
-        , optimizeLegibility : Supported
-        , optimizeSpeed : Supported
-        }
-    -> Style
-textRendering (Value str) =
-    AppendProperty ("text-rendering:" ++ str)
-
-
-{-| A `geometricPrecision` value for the [`text-rendering`](https://css-tricks.com/almanac/properties/t/text-rendering/) property.
-
-    textRendering geometricPrecision
-
--}
-geometricPrecision : Value { provides | geometricPrecision : Supported }
-geometricPrecision =
-    Value "geometricPrecision"
-
-
-{-| An `optimizeLegibility` value for the [`text-rendering`](https://css-tricks.com/almanac/properties/t/text-rendering/) property.
-
-    textRendering optimizeLegibility
-
--}
-optimizeLegibility : Value { provides | optimizeLegibility : Supported }
-optimizeLegibility =
-    Value "optimizeLegibility"
-
-
-{-| An `optimizeSpeed` value for the [`text-rendering`](https://css-tricks.com/almanac/properties/t/text-rendering/) property.
-
-    textRendering optimizeSpeed
-
--}
-optimizeSpeed : Value { provides | optimizeSpeed : Supported }
-optimizeSpeed =
-    Value "optimizeSpeed"
-
-
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
------------------------------ USER-SELECT ------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-
-
-{-| Sets [`user-select`](https://css-tricks.com/almanac/properties/u/user-select/)
-
-    userSelect none
-
-    userSelect auto
-
-    userSelect text
-
-    userSelect contain_
-
-    userSelect all_
-
--}
-userSelect :
-    BaseValue
-        { none : Supported
-        , auto : Supported
-        , text : Supported
-        , contain_ : Supported
-        , all_ : Supported
-        }
-    -> Style
-userSelect (Value val) =
-    AppendProperty ("user-select:" ++ val)
-
-
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
------------------------------- ACCESSIBILITY ---------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-
-
-{-| Sets [`speak`](https://css-tricks.com/almanac/properties/s/speak/)
-
-    speak none
-
-    speak normal
-
-    speak spellOut
-
--}
-speak :
-    BaseValue
-        { none : Supported
-        , normal : Supported
-        , spellOut : Supported
-        }
-    -> Style
-speak (Value val) =
-    AppendProperty ("speak:" ++ val)
-
-
-{-| Sets `spellOut` value for usage with [`speak`](#speak).
-
-    speak spellOut
-
--}
-spellOut : Value { provides | spellOut : Supported }
-spellOut =
-    Value "spell-out"
-
 
 
 ------------------------------------------------------------------------

--- a/src/Css.elm
+++ b/src/Css.elm
@@ -94,7 +94,7 @@ module Css exposing
     , flexGrow, flexShrink, flexBasis
     , flexWrap, nowrap, wrap, wrapReverse
     , flex, flex2, flex3, flexFlow, flexFlow2
-    , gridAutoRows, gridAutoColumns
+    , gridAutoRows, gridAutoColumns, gridAutoFlow, gridAutoFlow2, dense
     , wordSpacing
     , tabSize
     , fontDisplay, fallback, swap, optional
@@ -606,7 +606,7 @@ Other values you can use for flex item alignment:
 
 # Grid
 
-@docs gridAutoRows, gridAutoColumns
+@docs gridAutoRows, gridAutoColumns, gridAutoFlow, gridAutoFlow2, dense
 
 
 # Typography
@@ -6895,6 +6895,63 @@ gridAutoRows :
     -> Style
 gridAutoRows (Value val) =
     AppendProperty ("grid-auto-rows:" ++ val)
+
+
+{-| The 1-argument version of the [`grid-auto-flow`](https://css-tricks.com/almanac/properties/g/grid-auto-flow/)
+property.
+
+    gridAutoFlow dense
+    
+    gridAutoFlow column
+
+    gridAutoFlow2 row dense
+-}
+gridAutoFlow :
+    BaseValue (
+        { row : Supported
+        , column : Supported
+        , dense : Supported
+        }
+    )
+    -> Style
+gridAutoFlow (Value val) =
+    AppendProperty ("grid-auto-flow:" ++ val)
+
+
+{-| The 1-argument version of the [`grid-auto-flow`](https://css-tricks.com/almanac/properties/g/grid-auto-flow/)
+property.
+
+    gridAutoFlow2 row dense
+
+(The last argument can only be `dense` but I thought this
+would be the most natural way to make it fit into Elm,
+even if it's a bit redundant.)
+-}
+gridAutoFlow2 :
+    Value
+        { row : Supported
+        , column : Supported
+        }
+    -> Value { dense : Supported }
+    -> Style
+gridAutoFlow2 (Value val1) (Value val2) =
+    AppendProperty <|
+        "grid-auto-flow:"
+        ++ val1
+        ++ " "
+        ++ val2
+
+
+{-| The `dense` value for the [`grid-auto-flow`](#gridAutoFlow) property.
+
+    gridAutoFlow dense
+
+    gridAutoFlow2 row dense
+
+-}
+dense : Value { provides | dense : Supported }
+dense =
+    Value "dense"
 
 
 -- FONT SIZE --

--- a/src/Css.elm
+++ b/src/Css.elm
@@ -6,6 +6,7 @@ module Css exposing
     , unset, initial, inherit
     , all, revert
     , Angle, AngleSupported, Width, WidthSupported
+    , BasicShapeSupported, circle, circleAt, circleAt2, closestSide, farthestSide
     , Length, LengthSupported, zero, px, em, ex, ch, rem, vh, vw, vmin, vmax, mm, cm, q, inches, pt, pc, pct, num, int
     , calc, CalcOperation, minus, plus, times, dividedBy
     , Color, ColorSupported, color, backgroundColor, hex, rgb, rgba, hsl, hsla, currentcolor
@@ -17,8 +18,8 @@ module Css exposing
     , block, inline, start, end, blockStart, blockEnd, inlineStart, inlineEnd
     , x, y, z
     , stretch, center
-    , contentBox, borderBox, paddingBox, fillBox, strokeBox, viewBox
-    , baseline, sub, super, ruby, fullWidth, under, circle
+    , marginBox, borderBox, paddingBox, contentBox, fillBox, strokeBox, viewBox
+    , baseline, sub, super, ruby, fullWidth, under, circle_
     , hidden, visible
     , thin, thick
     , normal, strict, all_, both, always, scroll, column
@@ -203,6 +204,7 @@ module Css exposing
     , objectPosition, objectPosition2, objectPosition4
     , boxDecorationBreak
     , isolation, isolate
+    , clipPath, clipPath2
     , caretColor
     , pointerEvents
     , visiblePainted, visibleFill, visibleStroke, painted
@@ -271,6 +273,9 @@ All CSS properties can have the values `unset`, `initial`, `inherit` and `revert
 
 @docs deg, grad, rad, turn
 
+## Shapes
+
+@docs BasicShapeSupported, circle, circleAt, circleAt2, closestSide, farthestSide
 
 ## URLs
 
@@ -312,13 +317,13 @@ Sometimes these keywords mean other things too.
 
 @docs stretch, center
 
-## Sizing, clip and origin values
+## Geometry box values
 
-@docs contentBox, borderBox, paddingBox,  fillBox, strokeBox, viewBox
+@docs marginBox, borderBox, paddingBox, contentBox, fillBox, strokeBox, viewBox
 
 ## Typographic values
 
-@docs baseline, sub, super, ruby, fullWidth, under, circle
+@docs baseline, sub, super, ruby, fullWidth, under, circle_
 
 ## Visibility
 
@@ -924,7 +929,7 @@ Other values you can use for flex item alignment:
 @docs objectPosition, objectPosition2, objectPosition4
 @docs boxDecorationBreak
 @docs isolation, isolate
-
+@docs clipPath, clipPath2
 
 # Other
 
@@ -1159,6 +1164,18 @@ type alias ImageSupported supported =
         , repeatingRadialGradient : Supported
     }
 
+{-| A type alias used to accept a [basic shape](https://developer.mozilla.org/en-US/docs/Web/CSS/basic-shape).
+-}
+type alias BasicShapeSupported supported =
+    { supported
+        | inset_ : Supported
+        , circle : Supported
+        , circleAt : Supported
+        , circleAt2 : Supported
+        , ellipse : Supported
+        , polygon : Supported
+        , path : Supported
+    }
 
 {-| A type alias used to accept an [image](https://developer.mozilla.org/en-US/docs/Web/CSS/image).
 -}
@@ -1259,6 +1276,132 @@ batch =
     Preprocess.ApplyStyles
 
 
+
+-- SHAPES --
+
+{-| Provides a one-argument `circle()` value.
+
+    clipPath (circle (pct 10))
+
+    clipPath (circle closestSide)
+
+    clipPath (circleAt (pct 10) left)
+
+    clipPath (circleAt closestSide (rem 5))
+
+    clipPath (circleAt2 closestSide (rem 5) (rem 1))
+
+Note: This is not to be confused with [`circle_`](#circle_),
+which is a keyword value for properties such as `listStyleType`.
+
+-}
+circle :
+    Value (
+        LengthSupported
+            { pct : Supported
+            , closestSide : Supported
+            , farthestSide : Supported
+            }
+    )
+    -> Value { provides | circle : Supported }
+circle (Value val) =
+    Value <| "circle(" ++ val ++ ")"
+
+
+{-| Provides a 2-argument `circle(<X> at <Y>)` value.
+
+    clipPath (circleAt (pct 10) left)
+
+    clipPath (circleAt closestSide (rem 5))
+
+    clipPath (circleAt2 closestSide (rem 5) (rem 1))
+-}
+circleAt :
+    Value (
+        LengthSupported
+            { pct : Supported
+            , closestSide : Supported
+            , farthestSide : Supported
+            }
+    )
+    -> Value (
+        LengthSupported
+            { pct : Supported
+            , top : Supported
+            , bottom : Supported
+            , left : Supported
+            , right : Supported
+            , center : Supported
+            }
+    )
+    -> Value { provides | circleAt : Supported }
+circleAt (Value val1) (Value val2) =
+    Value <|
+        "circle("
+        ++ val1
+        ++ " at "
+        ++ val2
+        ++ ")"
+
+
+{-| Provides a 2-argument `circle(<X> at <Y> <Z>)` value.
+
+    clipPath (circleAt2 closestSide (rem 5) (rem 1))
+
+    clipPath (circleAt2 (pct 10) top left)
+-}
+circleAt2 :
+    Value (
+        LengthSupported
+            { pct : Supported
+            , closestSide : Supported
+            , farthestSide : Supported
+            }
+    )
+    -> Value (
+        LengthSupported
+            { pct : Supported
+            , left : Supported
+            , right : Supported
+            , center : Supported
+            }
+    )
+    -> Value (
+        LengthSupported
+            { pct : Supported
+            , top : Supported
+            , bottom : Supported
+            , center : Supported
+            }
+    )
+    -> Value { provides | circleAt2 : Supported }
+circleAt2 (Value val1) (Value val2) (Value val3)=
+    Value <|
+        "circle("
+        ++ val1
+        ++ " at "
+        ++ val2
+        ++ " "
+        ++ val3
+        ++ ")"
+
+{-| The `closest-side` value for use in [circle shapes](#circle).
+
+    clipPath (circle closestSide)
+
+-}
+closestSide : Value { provides | closestSide : Supported }
+closestSide =
+    Value "closest-side"
+
+{-| The `farthest-side` value for use in [circle shapes](#circle).
+
+    clipPath (circleAt farthestSide (pct 20))
+
+-}
+farthestSide : Value { provides | farthestSide : Supported }
+farthestSide =
+    Value "farthest-side"
 
 -- GLOBAL VALUES --
 
@@ -1767,6 +1910,54 @@ center =
     Value "center"
 
 
+{-| The `margin-box` value, used in [`clipPath`](#clipPath).
+
+```
+clipPath marginBox
+```
+-}
+marginBox : Value { provides | marginBox : Supported }
+marginBox =
+    Value "margin-box"
+
+{-| The `border-box` value, used in the following properties:
+
+  - [`boxSizing`](#boxSizing)
+  - [`backgroundClip`](#backgroundClip)
+  - [`backgroundOrigin`](backgroundOrigin)
+  - [`strokeOrigin`](#strokeOrigin)
+
+```
+boxSizing borderBox
+
+backgroundClip borderBox
+
+backgroundOrigin borderBox
+
+strokeOrigin borderBox
+```
+-}
+borderBox : Value { provides | borderBox : Supported }
+borderBox =
+    Value "border-box"
+
+
+{-| The `padding-box` value, used with [`backgroundClip`](#backgroundClip),
+[`backgroundOrigin`](#backgroundOrigin),
+and [`strokeOrigin`](#strokeOrigin).
+
+    backgroundClip paddingBox
+
+    backgroundOrigin paddingBox
+
+    strokeOrigin paddingBox
+
+-}
+paddingBox : Value { provides | paddingBox : Supported }
+paddingBox =
+    Value "padding-box"
+
+
 {-| The `content-box` value, used in the following properties:
 
   - [`boxSizing`](#boxSizing)
@@ -1788,45 +1979,6 @@ strokeOrigin contentBox
 contentBox : Value { provides | contentBox : Supported }
 contentBox =
     Value "content-box"
-
-
-{-| The `border-box` value, used in the following properties:
-
-  - [`boxSizing`](#boxSizing)
-  - [`backgroundClip`](#backgroundClip)
-  - [`backgroundOrigin`](backgroundOrigin)
-  - [`strokeOrigin`](#strokeOrigin)
-
-```
-boxSizing borderBox
-
-backgroundClip borderBox
-
-backgroundOrigin borderBox
-
-strokeOrigin borderBox
-```
-
--}
-borderBox : Value { provides | borderBox : Supported }
-borderBox =
-    Value "border-box"
-
-
-{-| The `padding-box` value, used with [`backgroundClip`](#backgroundClip),
-[`backgroundOrigin`](#backgroundOrigin),
-and [`strokeOrigin`](#strokeOrigin).
-
-    backgroundClip paddingBox
-
-    backgroundOrigin paddingBox
-
-    strokeOrigin paddingBox
-
--}
-paddingBox : Value { provides | paddingBox : Supported }
-paddingBox =
-    Value "padding-box"
 
 
 {-| The `fill-box` value used by [`strokeOrigin`](#strokeOrigin)
@@ -1964,19 +2116,25 @@ under =
 
 
 
+
 {-| The `circle` value used by properties such as [`listStyle`](#listStyle),
 [`listStyleType`](#listStyleType), [`textEmphasis`](#textEmphasis) and [`textEmphasisStyle`](#textEmphasisStyle).
 
-    listStyleType circle
+    listStyleType circle_
 
-    textEmphasis2 circle (hex "ff0000")
+    textEmphasis2 circle_ (hex "ff0000")
 
-    textEmphasisStyle circle
+    textEmphasisStyle circle_
+
+Note: This is not to be confused with [`circle`](#circle),
+[`circleAt`](#circleAt) or [`circleAt2`](#circleAt2), which are
+`<basic-shape>` data types.
 
 -}
-circle : Value { provides | circle : Supported }
-circle =
+circle_ : Value { provides | circle_ : Supported }
+circle_ =
     Value "circle"
+
 
 
 {-| The `hidden` value used for properties such as [`visibility`](https://css-tricks.com/almanac/properties/v/visibility/), [`overflow`](https://css-tricks.com/almanac/properties/o/overflow/) and [`borderStyle`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-style).
@@ -8923,7 +9081,7 @@ type alias ListStyleTypeSupported supported =
         , armenian : Supported
         , bengali : Supported
         , cambodian : Supported
-        , circle : Supported
+        , circle_ : Supported
         , cjkDecimal : Supported
         , cjkEarthlyBranch : Supported
         , cjkHeavenlyStem : Supported
@@ -16349,6 +16507,55 @@ lineClamp (Value val) =
     AppendProperty ("line-clamp:" ++ val)
 
 
+{-| The 1-argument variant of the
+[`clip-path`](https://css-tricks.com/almanac/properties/c/clip-path/) property.
+
+    clipPath marginBox
+
+    clipPath inherit
+
+    clipPath (circle (pct 2))
+
+    clipPath2 marginBox (circleAt2 farthestSide left top)
+-}
+clipPath :
+    BaseValue
+        (BasicShapeSupported
+            { marginBox : Supported
+            , borderBox : Supported
+            , paddingBox : Supported
+            , contentBox : Supported
+            , fillBox : Supported
+            , strokeBox : Supported
+            , viewBox : Supported
+            }
+        )
+    -> Style
+clipPath (Value val) =
+    AppendProperty ("clip-path:" ++ val)
+
+
+{-| The 2-argument variant of the
+[`clip-path`](https://css-tricks.com/almanac/properties/c/clip-path/) property.
+
+    clipPath2 marginBox (circleAt2 farthestSide left top)
+-}
+clipPath2 :
+    Value
+        { marginBox : Supported
+        , borderBox : Supported
+        , paddingBox : Supported
+        , contentBox : Supported
+        , fillBox : Supported
+        , strokeBox : Supported
+        , viewBox : Supported
+        }
+    -> Value (BasicShapeSupported a)
+    -> Style
+clipPath2 (Value val1) (Value val2) =
+    AppendProperty ("clip-path:" ++ val1 ++ " " ++ val2)
+
+
 {-| Sets [`mix-blend-mode`](https://css-tricks.com/almanac/properties/m/mix-blend-mode/)
 
     mixBlendMode multiply
@@ -18025,7 +18232,7 @@ textEmphasis :
             , filled : Supported
             , open : Supported
             , dot : Supported
-            , circle : Supported
+            , circle_ : Supported
             , doubleCircle : Supported
             , triangle : Supported
             , sesame : Supported
@@ -18049,7 +18256,7 @@ textEmphasis2 :
         , filled : Supported
         , open : Supported
         , dot : Supported
-        , circle : Supported
+        , circle_ : Supported
         , doubleCircle : Supported
         , triangle : Supported
         , sesame : Supported
@@ -18082,7 +18289,7 @@ textEmphasisStyle :
         , filled : Supported
         , open : Supported
         , dot : Supported
-        , circle : Supported
+        , circle_ : Supported
         , doubleCircle : Supported
         , triangle : Supported
         , sesame : Supported
@@ -18106,7 +18313,7 @@ textEmphasisStyle2 :
         }
     -> BaseValue
         { dot : Supported
-        , circle : Supported
+        , circle_ : Supported
         , doubleCircle : Supported
         , triangle : Supported
         , sesame : Supported

--- a/src/Css.elm
+++ b/src/Css.elm
@@ -2204,7 +2204,7 @@ pseudoClass pseudoClassName =
 -}
 active : List Style -> Style
 active =
-    Preprocess.ExtendSelector (Structure.PseudoClassSelector "active")
+    pseudoClass "active"
 
 
 {-| A [`:disabled`](https://developer.mozilla.org/en-US/docs/Web/CSS/:disabled)
@@ -2215,7 +2215,7 @@ active =
 -}
 disabled : List Style -> Style
 disabled =
-    Preprocess.ExtendSelector (Structure.PseudoClassSelector "disabled")
+    pseudoClass "disabled"
 
 
 
@@ -2254,7 +2254,7 @@ pseudoElement element =
 -}
 after : List Style -> Style
 after =
-    Preprocess.WithPseudoElement (Structure.PseudoElement "after")
+    pseudoElement "after"
 
 
 {-| A [`::before`](https://css-tricks.com/almanac/selectors/a/after-and-before/)
@@ -2315,7 +2315,7 @@ Be careful when using placeholders as they can compromise accessibility.
     placeholder
         [ opacity (num 1) <| important
         , color (rgb 90 90 90)
-        , fontWeight (int 300)
+        , fontWeight (int 400)
         ]
 ]
 -}

--- a/src/Css.elm
+++ b/src/Css.elm
@@ -118,6 +118,7 @@ module Css exposing
     , wavy, underline, overline, lineThrough
     , textStroke, textStroke2, textStrokeColor, textStrokeWidth
     , textIndent, textIndent2, textIndent3, hanging, eachLine
+    , textUnderlineOffset
     , textEmphasis, textEmphasis2, textEmphasisStyle, textEmphasisStyle2, textEmphasisColor, textEmphasisPosition, textEmphasisPosition2, filled, open, dot, doubleCircle, triangle, sesame, over
     , borderCollapse
     , collapse, separate
@@ -636,6 +637,8 @@ Other values you can use for flex item alignment:
 @docs textStroke, textStroke2, textStrokeColor, textStrokeWidth
 
 @docs textIndent, textIndent2, textIndent3, hanging, eachLine
+
+@docs textUnderlineOffset
 
 @docs textEmphasis, textEmphasis2, textEmphasisStyle, textEmphasisStyle2, textEmphasisColor, textEmphasisPosition, textEmphasisPosition2, filled, open, dot, doubleCircle, triangle, sesame, over
 
@@ -16660,6 +16663,22 @@ eachLine =
     Value "each-line"
 
 
+{-| Sets the [text-underline-offset](https://css-tricks.com/almanac/properties/t/text-underline-offset/) property.
+
+    textUnderlineOffset (pct 5)
+-}
+textUnderlineOffset :
+    BaseValue
+        ( LengthSupported
+            { pct : Supported
+            , auto : Supported
+            }
+        )
+    -> Style
+textUnderlineOffset (Value value) =
+    AppendProperty ("text-underline-offset:" ++ value)
+
+
 {-| Sets the [`text-emphasis`](https://css-tricks.com/almanac/properties/t/text-emphasis/) property.
 
 This is for drawing attention towards textual elements in a way that is commonly
@@ -16747,20 +16766,6 @@ textEmphasisStyle (Value value) =
     AppendProperty ("text-emphasis-style:" ++ value)
 
 
-{-| Sets the [`text-emphasis-color`](https://developer.mozilla.org/en-US/docs/Web/CSS/text-emphasis-color) property.
-
-    textEmphasisColor currentcolor
-
-    textemphasisColor (hex "0000ff")
--}
-textEmphasisColor :
-    BaseValue
-        (ColorSupported a)
-    -> Style
-textEmphasisColor (Value value) =
-    AppendProperty ("text-emphasis-color:" ++ value)
-
-
 {-| Sets the [`text-emphasis-style`](https://developer.mozilla.org/en-US/docs/Web/CSS/text-emphasis-style) property when you want to use two arguments - one for `filled` or `open`, and one for the shape style.
 
     textEmphasisStyle filled sesame
@@ -16787,6 +16792,20 @@ textEmphasisStyle2 (Value val1) (Value val2) =
         ++ " "
         ++ val2
         )
+
+
+{-| Sets the [`text-emphasis-color`](https://developer.mozilla.org/en-US/docs/Web/CSS/text-emphasis-color) property.
+
+    textEmphasisColor currentcolor
+
+    textemphasisColor (hex "0000ff")
+-}
+textEmphasisColor :
+    BaseValue
+        (ColorSupported a)
+    -> Style
+textEmphasisColor (Value value) =
+    AppendProperty ("text-emphasis-color:" ++ value)
 
 
 {-| Sets the [`text-emphasis-position`](https://developer.mozilla.org/en-US/docs/Web/CSS/text-emphasis-position) property.

--- a/src/Css.elm
+++ b/src/Css.elm
@@ -1922,7 +1922,6 @@ values, the block start is set to the first value and the block end is set to th
 
     paddingBlock2 (em 4) (px 2) -- block start = 4em, block end = 2px
 
-
 -}
 paddingBlock :
     BaseValue
@@ -1994,8 +1993,6 @@ paddingBlockEnd (Value value) =
     AppendProperty ("padding-block-end:" ++ value)
 
 
-
-
 {-| Sets [`padding-inline`](https://css-tricks.com/almanac/properties/p/padding-inline/) property.
 
 The `padding-inline` property is a shorthand property for setting `padding-inline-start` and
@@ -2007,7 +2004,6 @@ values, the inline start is set to the first value and the inline end is set to 
     paddingInline (em 4) -- set both inline start and inline end to 4em
 
     paddingInline2 (em 4) (px 2) -- inline start = 4em, inline end = 2px
-
 
 -}
 paddingInline :
@@ -2078,9 +2074,6 @@ paddingInlineEnd :
     -> Style
 paddingInlineEnd (Value value) =
     AppendProperty ("padding-inline-end:" ++ value)
-
-
-
 
 
 
@@ -2312,13 +2305,14 @@ The `margin-block` property is a shorthand property for setting `margin-block-st
 
 If there is only one argument value, it applies to both sides. If there are two
 values, the block start margin is set to the first value and the block end margin
-is set to the second. 
+is set to the second.
 
-    marginBlock (em 4) -- set block start and end margins to 4em
+    marginBlock (em 4) -- set both block margins to 4em
 
     marginBlock2 (em 4) (px 2) -- block start = 4em, block end = 2px
 
 You may want to check out [this article on collapsing margins](https://css-tricks.com/good-ol-margin-collapsing/)!
+
 -}
 marginBlock :
     BaseValue
@@ -2342,6 +2336,7 @@ is set to the second.
     marginBlock2 (em 4) (px 2) -- block start = 4em, block end = 2px
 
 You may want to check out [this article on collapsing margins](https://css-tricks.com/good-ol-margin-collapsing/)!
+
 -}
 marginBlock2 :
     Value
@@ -2402,13 +2397,14 @@ The `margin-inline` property is a shorthand property for setting `margin-inline-
 
 If there is only one argument value, it applies to both sides. If there are two
 values, the inline start margin is set to the first value and the inline end margin
-is set to the second. 
+is set to the second.
 
-    marginInline (em 4) -- set inline start and end margins to 4em
+    marginInline (em 4) -- set both inline margins to 4em
 
     marginInline2 (em 4) (px 2) -- inline start = 4em, inline end = 2px
 
 You may want to check out [this article on collapsing margins](https://css-tricks.com/good-ol-margin-collapsing/)!
+
 -}
 marginInline :
     BaseValue
@@ -2432,6 +2428,7 @@ is set to the second.
     marginInline2 (em 4) (px 2) -- inline start = 4em, inline end = 2px
 
 You may want to check out [this article on collapsing margins](https://css-tricks.com/good-ol-margin-collapsing/)!
+
 -}
 marginInline2 :
     Value
@@ -2450,7 +2447,6 @@ marginInline2 :
     -> Style
 marginInline2 (Value valueStart) (Value valueEnd) =
     AppendProperty ("margin-inline:" ++ valueStart ++ " " ++ valueEnd)
-
 
 
 {-| Sets [`margin-inline-start`](https://developer.mozilla.org/en-US/docs/Web/CSS/margin-inline-start) property.
@@ -2485,6 +2481,8 @@ marginInlineEnd :
     -> Style
 marginInlineEnd (Value value) =
     AppendProperty ("margin-inline-end:" ++ value)
+
+
 
 -- BOX SIZING --
 

--- a/src/Css.elm
+++ b/src/Css.elm
@@ -211,6 +211,8 @@ module Css exposing
     , boxDecorationBreak
     , isolation, isolate
     , clipPath, clipPath2
+    , maskClip, maskClipList, maskComposite, maskMode, maskModeList, maskOrigin, maskOriginList, maskPosition, maskRepeat, maskRepeat2, maskSize, maskSize2, maskType
+    , noClip, add, subtract, intersect, exclude, alpha, luminance, matchSource
     , caretColor
     , pointerEvents
     , visiblePainted, visibleFill, visibleStroke, painted
@@ -955,6 +957,11 @@ Other values you can use for flex item alignment:
 @docs boxDecorationBreak
 @docs isolation, isolate
 @docs clipPath, clipPath2
+
+# Masks
+
+@docs maskClip, maskClipList, maskComposite, maskMode, maskModeList, maskOrigin, maskOriginList, maskPosition, maskRepeat, maskRepeat2, maskSize, maskSize2, maskType
+@docs noClip, add, subtract, intersect, exclude, alpha, luminance, matchSource
 
 # Other
 
@@ -3006,7 +3013,7 @@ rgb red green blue =
 
 -}
 rgba : Int -> Int -> Int -> Float -> Value { provides | rgba : Supported }
-rgba red green blue alpha =
+rgba red green blue alphaVal =
     Value <|
         "rgba("
             ++ String.fromInt red
@@ -3015,7 +3022,7 @@ rgba red green blue alpha =
             ++ ","
             ++ String.fromInt blue
             ++ ","
-            ++ String.fromFloat alpha
+            ++ String.fromFloat alphaVal
             ++ ")"
 
 
@@ -3047,7 +3054,7 @@ The `s` and `l` values are expressed as a number between 0 and 1 and are convert
 
 -}
 hsla : Float -> Float -> Float -> Float -> Value { provides | hsla : Supported }
-hsla hueVal sat lightness alpha =
+hsla hueVal sat lightness alphaVal =
     Value <|
         "hsla("
             ++ String.fromFloat hueVal
@@ -3056,7 +3063,7 @@ hsla hueVal sat lightness alpha =
             ++ "%,"
             ++ String.fromFloat (lightness * 100)
             ++ "%,"
-            ++ String.fromFloat alpha
+            ++ String.fromFloat alphaVal
             ++ ")"
 
 
@@ -16633,6 +16640,449 @@ bleed :
     -> Style
 bleed (Value val) =
     AppendProperty ("bleed:" ++ val)
+
+
+-- MASKS --
+
+
+{-| The 1-argument variant of the [`mask-clip`](https://css-tricks.com/almanac/properties/m/mask-clip/)
+property.
+
+This does not support non-standard keyword values such as `border`.
+
+    maskClip contentBox
+
+    maskClip revert
+
+    maskClipList [contentBox, marginBox, noClip]
+
+-}
+maskClip :
+    BaseValue
+        { contentBox : Supported
+        , paddingBox : Supported
+        , borderBox : Supported
+        , marginBox : Supported
+        , fillBox : Supported
+        , strokeBox : Supported
+        , viewBox : Supported
+        , noClip : Supported
+        }
+    -> Style
+maskClip (Value val) =
+    AppendProperty <| "mask-clip:" ++ val
+
+
+{-| The multi-argument variant of the [`mask-clip`](https://css-tricks.com/almanac/properties/m/mask-clip/)
+property.
+
+This does not support non-standard keyword values such as `border`.
+
+    maskClipList [contentBox, marginBox, noClip]
+    
+-}
+maskClipList :
+    List
+        ( Value
+            { contentBox : Supported
+            , paddingBox : Supported
+            , borderBox : Supported
+            , marginBox : Supported
+            , fillBox : Supported
+            , strokeBox : Supported
+            , viewBox : Supported
+            , noClip : Supported
+            }
+        )
+    -> Style
+maskClipList list =
+    AppendProperty <|
+        "mask-clip:"
+        ++
+        ( list
+        |> List.map (\(Value val) -> val)
+        |> String.join ", "
+        )
+
+
+{-| The [`mask-composite`](https://css-tricks.com/almanac/properties/m/mask-composite/)
+property.
+
+    maskComposite add
+
+    maskComposite revert
+-}
+maskComposite :
+    BaseValue
+        { add : Supported
+        , subtract : Supported
+        , intersect : Supported
+        , exclude : Supported
+        }
+    -> Style
+maskComposite (Value val) =
+    AppendProperty ("mask-composite:" ++ val)
+
+
+{-| The 1-argument variant of the [`mask-mode`](https://css-tricks.com/almanac/properties/m/mask-mode/)
+property.
+
+    maskMode inherit
+
+    maskMode alpha
+
+    maskModeList [alpha, luminance, alpha, matchSource]
+-}
+maskMode :
+    BaseValue
+        { alpha : Supported
+        , luminance : Supported
+        , matchSource : Supported
+        }
+    -> Style
+maskMode (Value val) =
+    AppendProperty ("mask-mode:" ++ val)
+
+
+{-| The multi-argument variant of the [`mask-mode`](https://css-tricks.com/almanac/properties/m/mask-mode/)
+property.
+
+    maskModeList [alpha, luminance, alpha, matchSource]
+-}
+maskModeList :
+    List
+        ( Value
+            { alpha : Supported
+            , luminance : Supported
+            , matchSource : Supported
+            }
+        )
+    -> Style
+maskModeList list =
+    AppendProperty <|
+        "mask-mode:"
+        ++
+        ( list
+        |> List.map (\(Value val) -> val)
+        |> String.join ", "
+        )
+
+
+{-| The 1-argument variant of the [`mask-origin`](https://css-tricks.com/almanac/properties/m/mask-origin/)
+property.
+
+    maskOrigin inherit
+
+    maskOrigin contentBox
+
+    maskOriginList [paddingBox, borderBox]
+-}
+maskOrigin :
+    BaseValue
+        { contentBox : Supported
+        , paddingBox : Supported
+        , borderBox : Supported
+        , marginBox : Supported
+        }
+    -> Style
+maskOrigin (Value val) =
+    AppendProperty ("mask-origin:" ++ val)
+
+
+{-| The multi-argument variant of the [`mask-origin`](https://css-tricks.com/almanac/properties/m/mask-origin/)
+property.
+
+    maskOriginList [paddingBox, borderBox]
+-}
+maskOriginList :
+    List
+        ( Value
+            { contentBox : Supported
+            , paddingBox : Supported
+            , borderBox : Supported
+            , marginBox : Supported
+            }
+        )
+    -> Style
+maskOriginList list =
+    AppendProperty <|
+        "mask-origin:"
+        ++
+        ( list
+        |> List.map (\(Value val) -> val)
+        |> String.join ", "
+        )
+
+
+{-| The 1-argument variant of the [`mask-position`](https://css-tricks.com/almanac/properties/m/mask-position/)
+property.
+
+    maskPosition top_
+
+    maskPosition inherit
+-}
+maskPosition :
+    BaseValue
+        { top_ : Supported
+        , bottom_ : Supported
+        , left_ : Supported
+        , right_ : Supported
+        , center : Supported
+        }
+    -> Style
+maskPosition (Value val) =
+    AppendProperty <| "mask-position:" ++ val
+
+
+{-| The 1-argument variant of the [`mask-repeat`](https://developer.mozilla.org/en-US/docs/Web/CSS/mask-repeat)
+property.
+
+    maskRepeat revert
+
+    maskRepeat repeatX
+
+    maskRepeat Css.round
+
+    maskRepeat2 repeat space
+
+-}
+maskRepeat :
+    BaseValue
+        { repeat : Supported
+        , space : Supported
+        , round : Supported
+        , noRepeat : Supported
+        }
+    -> Style
+maskRepeat (Value val) =
+    AppendProperty <| "mask-repeat:" ++ val
+
+
+{-| The 2-argument variant of the [`mask-repeat`](https://developer.mozilla.org/en-US/docs/Web/CSS/mask-repeat)
+property.
+
+    maskRepeat2 repeat space
+-}
+maskRepeat2 :
+    Value
+        { repeat : Supported
+        , space : Supported
+        , round : Supported
+        , noRepeat : Supported
+        }
+    -> Value
+        { repeat : Supported
+        , space : Supported
+        , round : Supported
+        , noRepeat : Supported
+        }
+    -> Style
+maskRepeat2 (Value valX) (Value valY) =
+    AppendProperty <| "mask-repeat:" ++ valX ++ " " ++ valY
+
+
+-- {-| The multi-argument variant of the [`mask-repeat`](https://developer.mozilla.org/en-US/docs/Web/CSS/mask-repeat)
+-- property.
+
+--     maskRepeatList [repeat, Css.round, space]
+-- -}
+-- maskRepeatList :
+--     List
+--         ( Value
+--             { repeat : Supported
+--             , space : Supported
+--             , round : Supported
+--             , noRepeat : Supported
+--             }
+--         )
+--     -> Style
+-- maskRepeatList list =
+--     AppendProperty <|
+--         "mask-repeat:"
+--         ++
+--         ( list
+--         |> List.map (\(Value val) -> val)
+--         |> String.join ", "
+--         )
+
+
+{-| The 1-argument variant of the [`mask-size`](https://css-tricks.com/almanac/properties/m/mask-size/)
+property.
+
+    maskSize auto
+
+    maskSize (pct 20)
+
+    maskSize (rem 200)
+
+    maskSize2 auto (pct 10)
+
+-}
+maskSize :
+    BaseValue
+        ( LengthSupported
+            { pct : Supported
+            , auto : Supported
+            , cover : Supported
+            , contain : Supported
+            }
+        )
+    -> Style
+maskSize (Value val) =
+    AppendProperty <| "mask-size:" ++ val
+
+
+{-| The 2-argument variant of the [`mask-size`](https://css-tricks.com/almanac/properties/m/mask-size/)
+property.
+
+    maskSize auto
+
+    maskSize (pct 20)
+
+    maskSize (rem 200)
+
+    maskSize2 auto (pct 10)
+
+-}
+maskSize2 :
+    Value
+        ( LengthSupported
+            { pct : Supported
+            , auto : Supported
+            }
+        )
+    -> Value
+        ( LengthSupported
+            { pct : Supported
+            , auto : Supported
+            }
+        )
+    -> Style
+maskSize2 (Value valX) (Value valY) =
+    AppendProperty <| "mask-size:" ++ valX ++ " " ++ valY
+
+
+-- {-|
+-- -}
+-- maskSizeList :
+--     List
+--         ( Value
+--             ( LengthSupported
+--                 { pct : Supported
+--                 , auto : Supported
+--                 }
+--             )
+--         )
+--     -> Style
+-- maskSizeList list =
+--     AppendProperty <|
+--         "mask-size:"
+--         ++
+--         ( list
+--         |> List.map (\(Value val) -> val)
+--         |> String.join ", "
+--         )
+
+{-| Sets the [`mask-type`](https://css-tricks.com/almanac/properties/m/mask-type/)
+property.
+
+    maskType inherit
+
+    maskType luminance
+-}
+maskType :
+    BaseValue
+        { luminance : Supported
+        , alpha : Supported
+        }
+    -> Style
+maskType (Value val) =
+    AppendProperty <| "mask-type:" ++ val
+
+
+{-| Sets `no-clip` value for usage with [`maskClip`](#maskClip).
+
+    maskClip noClip
+
+-}
+noClip : Value { provides | noClip : Supported }
+noClip =
+    Value "no-clip"
+
+
+{-| Sets `add` value for usage with [`maskComposite`](#maskComposite).
+
+    maskComposite add
+
+-}
+add : Value { provides | add : Supported }
+add =
+    Value "add"
+
+
+{-| Sets `subtract` value for usage with [`maskComposite`](#maskComposite).
+
+    maskComposite subtract
+
+-}
+subtract : Value { provides | subtract : Supported }
+subtract =
+    Value "subtract"
+
+
+{-| Sets `intersect` value for usage with [`maskComposite`](#maskComposite).
+
+    maskComposite intersect
+
+-}
+intersect : Value { provides | intersect : Supported }
+intersect =
+    Value "intersect"
+
+
+{-| Sets `exclude` value for usage with [`maskComposite`](#maskComposite).
+
+    maskComposite exclude
+
+-}
+exclude : Value { provides | exclude : Supported }
+exclude =
+    Value "exclude"
+
+
+
+{-| Sets `alpha` value for usage with [`maskMode`](#maskMode) and [`maskType`](#maskType).
+
+    maskMode alpha
+
+    maskType alpha
+
+-}
+alpha : Value { provides | alpha : Supported }
+alpha =
+    Value "alpha"
+
+
+{-| Sets `luminance` value for usage with [`maskMode`](#maskMode) and [`maskType`](#maskType).
+
+    maskMode luminance
+
+    maskType luminance
+
+-}
+luminance : Value { provides | luminance : Supported }
+luminance =
+    Value "luminance"
+
+
+{-| Sets `match-source` value for usage with [`maskMode`](#maskMode).
+
+    maskMode matchSource
+
+-}
+matchSource : Value { provides | matchSource : Supported }
+matchSource =
+    Value "match-source"
 
 
 {-| Sets [`caret-color`](https://css-tricks.com/almanac/properties/c/caret-color/)

--- a/src/Css.elm
+++ b/src/Css.elm
@@ -14102,7 +14102,7 @@ contain3 (Value value1) (Value value2) (Value value3) =
 This version uses all 4 multiple choice values that can be used with this
 property, no values required.
 
-Equivalent to `contain size layout style paint`.
+Equivalent to `contain: size layout style paint;`.
 
     contain4
 

--- a/src/Css.elm
+++ b/src/Css.elm
@@ -83,7 +83,7 @@ module Css exposing
     , auto, none
     , hidden, visible
     , contentBox, borderBox
-    , overflow, overflowX, overflowY
+    , overflow, overflowX, overflowY, clip
     , overflowAnchor
     , overflowWrap
     , breakWord, anywhere
@@ -498,7 +498,7 @@ Multiple CSS properties use these values.
 
 ## Overflow
 
-@docs overflow, overflowX, overflowY
+@docs overflow, overflowX, overflowY, clip
 @docs overflowAnchor
 
 @docs overflowWrap
@@ -1256,6 +1256,7 @@ overflow :
         , hidden : Supported
         , scroll : Supported
         , auto : Supported
+        , clip : Supported
         }
     -> Style
 overflow (Value val) =
@@ -1279,6 +1280,7 @@ overflowX :
         , hidden : Supported
         , scroll : Supported
         , auto : Supported
+        , clip : Supported
         }
     -> Style
 overflowX (Value val) =
@@ -1302,10 +1304,27 @@ overflowY :
         , hidden : Supported
         , scroll : Supported
         , auto : Supported
+        , clip : Supported
         }
     -> Style
 overflowY (Value val) =
     AppendProperty ("overflow-y:" ++ val)
+
+
+{-| The `clip` value used by [`overflow`](#overflow).
+
+    overflow clip
+
+    overflowX clip
+
+    overflowY clip
+
+-}
+clip : Value { provides | clip : Supported }
+clip =
+    Value "clip"
+
+
 
 
 {-| Sets [`overflow-wrap`](https://css-tricks.com/almanac/properties/o/overflow-wrap/)

--- a/src/Css.elm
+++ b/src/Css.elm
@@ -114,7 +114,7 @@ module Css exposing
     , textTransform
     , capitalize, uppercase, lowercase, fullSizeKana
     , textDecoration, textDecoration2, textDecoration3, textDecorationLine, textDecorationLine2, textDecorationLine3, textDecorationStyle, textDecorationColor
-    , textDecorationSkip, objects, spaces, ink, edges, boxDecoration
+    , textDecorationSkip, textDecorationSkipInk, objects, spaces, ink, edges, boxDecoration
     , wavy, underline, overline, lineThrough
     , textStroke, textStroke2, textStrokeColor, textStrokeWidth
     , textIndent, textIndent2, textIndent3, hanging, eachLine
@@ -629,7 +629,7 @@ Other values you can use for flex item alignment:
 # Text Decoration
 
 @docs textDecoration, textDecoration2, textDecoration3, textDecorationLine, textDecorationLine2, textDecorationLine3, textDecorationStyle, textDecorationColor
-@docs textDecorationSkip, objects, spaces, ink, edges, boxDecoration
+@docs textDecorationSkip, textDecorationSkipInk, objects, spaces, ink, edges, boxDecoration
 
 @docs wavy, underline, overline, lineThrough
 
@@ -10728,7 +10728,7 @@ textDecorationColor (Value colorVal) =
     AppendProperty ("text-decoration-color:" ++ colorVal)
 
 
-{-| Sets [`text-decoration-skip`][https://css-tricks.com/almanac/properties/t/text-decoration-skip/] property.
+{-| Sets [`text-decoration-skip`](https://css-tricks.com/almanac/properties/t/text-decoration-skip/) property.
 
     textDecorationSkip objects
 
@@ -10741,6 +10741,9 @@ textDecorationColor (Value colorVal) =
     textDecorationSkip edges
 
     textDecorationSkip boxDecoration
+
+Note: Using [`textDecorationSkipInk`](#textDecorationSkipInk) is considerered better practice
+instead of `textDecorationSkip ink`.
 
 -}
 textDecorationSkip :
@@ -10755,6 +10758,26 @@ textDecorationSkip :
     -> Style
 textDecorationSkip (Value val) =
     AppendProperty ("text-decoration-skip:" ++ val)
+
+
+{-| Sets [`text-decoration-skip-ink`](https://css-tricks.com/almanac/properties/t/text-decoration-skip-ink/) property.
+
+    textDecorationSkipInk auto
+
+    textDecorationSkipInk all
+
+    textDecorationSkipInk none
+
+-}
+textDecorationSkipInk :
+    Value
+        { auto : Supported
+        , all : Supported
+        , none : Supported
+        }
+    -> Style
+textDecorationSkipInk (Value val) =
+    AppendProperty ("text-decoration-skip-ink:" ++ val)
 
 
 {-| Sets `objects` value for usage with [`textDecorationSkip`](#textDecorationSkip).

--- a/src/Css.elm
+++ b/src/Css.elm
@@ -124,6 +124,7 @@ module Css exposing
     , strokeOrigin, fillBox, strokeBox
     , strokeLinejoin, strokeLinejoin2, crop, arcs, miter, bevel
     , strokeDashJustify, compress, dashes, gaps
+    , paintOrder, paintOrder2, paintOrder3, markers
     , columns, columns2, columnWidth, columnCount, columnGap, columnRuleWidth, columnRuleStyle, columnRuleColor, columnRule, columnRule2, columnRule3
     , columnFill, balance, balanceAll
     , columnSpan, all_
@@ -625,6 +626,8 @@ Multiple CSS properties use these values.
 @docs strokeLinejoin, strokeLinejoin2, crop, arcs, miter, bevel
 @docs strokeDashJustify, compress, dashes, gaps
 
+## Other
+@docs paintOrder, paintOrder2, paintOrder3, markers
 
 # Columns
 
@@ -10625,6 +10628,89 @@ gaps =
     Value "gaps"
 
 
+{-| The [`paint-order`](https://css-tricks.com/almanac/properties/p/paint-order/) property.
+
+This one-argument version indicates which parts of text and shape graphics are
+painted first, followed by the other two in their relative default order.
+
+    paintOrder normal -- normal paint order.
+
+    paintOrder2 fill_ stroke  -- fill, stroke, then markers.
+
+    paintOrder3 markers stroke fill_  -- markers, stroke, then fill.
+-}
+paintOrder :
+    BaseValue
+        { normal : Supported
+        , stroke : Supported
+        , markers : Supported
+        }
+    -> Style
+paintOrder (Value val) =
+    AppendProperty ("paint-order:" ++ val)
+
+
+{-| The [`paint-order`](https://css-tricks.com/almanac/properties/p/paint-order/) property.
+
+This two-argument version indicates which parts of text and shape graphics are
+painted first, followed by the other remaining one.
+
+    paintOrder2 fill_ stroke -- fill, stroke, then markers.
+-}
+paintOrder2 :
+    Value
+        { fill_ : Supported
+        , stroke : Supported
+        , markers : Supported
+        }
+    -> Value
+        { fill_ : Supported
+        , stroke : Supported
+        , markers : Supported
+        }
+    -> Style
+paintOrder2 (Value val1) (Value val2) =
+    AppendProperty ("paint-order:" ++ val1 ++ " " ++ val2)
+
+
+{-| The [`paint-order`](https://css-tricks.com/almanac/properties/p/paint-order/) property.
+
+This three-argument version explicitly indicates in which order should all the parts of text
+and shape graphics be painted.
+
+    paintOrder3 markers stroke fill_  -- markers, stroke, then fill.
+-}
+paintOrder3 :
+    Value
+        { fill_ : Supported
+        , stroke : Supported
+        , markers : Supported
+        }
+    -> Value
+        { fill_ : Supported
+        , stroke : Supported
+        , markers : Supported
+        }
+    -> Value
+        { fill_ : Supported
+        , stroke : Supported
+        , markers : Supported
+        }
+    -> Style
+paintOrder3 (Value val1) (Value val2) (Value val3) =
+    AppendProperty ("paint-order:" ++ val1 ++ " " ++ val2 ++ " " ++ val3)
+
+
+{-| Provides the `markers` value for [`paintOrder`](#paintOrder).
+
+    paintOrder markers
+-}
+markers : Value { provides | markers : Supported }
+markers =
+    Value "markers"
+
+
+
 {-| Sets [`column-rule`](https://css-tricks.com/almanac/properties/c/column-rule/).
 This is a shorthand for the [`columnRuleWidth`](#columnRuleWidth),
 [`columnRuleStyle`](#columnRuleStyle), and [`columnRuleColor`](#columnRuleColor)
@@ -12614,12 +12700,14 @@ mixBlendMode (Value val) =
     AppendProperty ("mix-blend-mode:" ++ val)
 
 
-{-| The `fill` value used in properties such as [`objectFit`](#objectFit)
-and [`pointerEvents`](#pointerEvents).
+{-| The `fill` value used in properties such as [`objectFit`](#objectFit),
+ [`pointerEvents`](#pointerEvents) and [`paintOrder`](#paintOrder)
 
     objectFit fill_
 
     pointerEvents fill_
+
+    paintOrder2 fill markers
 
 -}
 fill_ : Value { provides | fill_ : Supported }
@@ -12954,9 +13042,11 @@ painted =
     Value "painted"
 
 
-{-| The `stroke` value used by [`pointerEvents`](#pointerEvents)
+{-| The `stroke` value used by [`pointerEvents`](#pointerEvents) and [`paintOrder`](#paintOrder).
 
     pointerEvents stroke
+
+    paintOrder2 stroke markers
 
 -}
 stroke : Value { provides | stroke : Supported }

--- a/src/Css.elm
+++ b/src/Css.elm
@@ -12995,10 +12995,7 @@ bottom, and left, respectively.
 -}
 scrollMargin :
     BaseValue
-        (LengthSupported
-            { auto : Supported
-            }
-        )
+        Length
     -> Style
 scrollMargin (Value value) =
     AppendProperty ("scroll-margin:" ++ value)
@@ -13017,16 +13014,10 @@ margins are set to the second.
 -}
 scrollMargin2 :
     Value
-        (LengthSupported
-            { auto : Supported
-            }
-        )
+        Length
     ->
         Value
-            (LengthSupported
-                { auto : Supported
-                }
-            )
+            Length
     -> Style
 scrollMargin2 (Value valueTopBottom) (Value valueRightLeft) =
     AppendProperty ("scroll-margin:" ++ valueTopBottom ++ " " ++ valueRightLeft)
@@ -13045,22 +13036,13 @@ second, and the bottom is set to the third.
 -}
 scrollMargin3 :
     Value
-        (LengthSupported
-            { auto : Supported
-            }
-        )
+        Length
     ->
         Value
-            (LengthSupported
-                { auto : Supported
-                }
-            )
+            Length
     ->
         Value
-            (LengthSupported
-                { auto : Supported
-                }
-            )
+            Length
     -> Style
 scrollMargin3 (Value valueTop) (Value valueRightLeft) (Value valueBottom) =
     AppendProperty ("scroll-margin:" ++ valueTop ++ " " ++ valueRightLeft ++ " " ++ valueBottom)
@@ -13078,28 +13060,16 @@ The four values apply to the top, right, bottom, and left margins.
 -}
 scrollMargin4 :
     Value
-        (LengthSupported
-            { auto : Supported
-            }
-        )
+        Length
     ->
         Value
-            (LengthSupported
-                { auto : Supported
-                }
-            )
+            Length
     ->
         Value
-            (LengthSupported
-                { auto : Supported
-                }
-            )
+            Length
     ->
         Value
-            (LengthSupported
-                { auto : Supported
-                }
-            )
+            Length
     -> Style
 scrollMargin4 (Value valueTop) (Value valueRight) (Value valueBottom) (Value valueLeft) =
     AppendProperty ("scroll-margin:" ++ valueTop ++ " " ++ valueRight ++ " " ++ valueBottom ++ " " ++ valueLeft)
@@ -13112,10 +13082,7 @@ scrollMargin4 (Value valueTop) (Value valueRight) (Value valueBottom) (Value val
 -}
 scrollMarginTop :
     BaseValue
-        (LengthSupported
-            { auto : Supported
-            }
-        )
+        Length
     -> Style
 scrollMarginTop (Value value) =
     AppendProperty ("scroll-margin-top:" ++ value)
@@ -13128,10 +13095,7 @@ scrollMarginTop (Value value) =
 -}
 scrollMarginRight :
     BaseValue
-        (LengthSupported
-            { auto : Supported
-            }
-        )
+        Length
     -> Style
 scrollMarginRight (Value value) =
     AppendProperty ("scroll-margin-right:" ++ value)
@@ -13144,10 +13108,7 @@ scrollMarginRight (Value value) =
 -}
 scrollMarginBottom :
     BaseValue
-        (LengthSupported
-            { auto : Supported
-            }
-        )
+        Length
     -> Style
 scrollMarginBottom (Value value) =
     AppendProperty ("scroll-margin-bottom:" ++ value)
@@ -13160,10 +13121,7 @@ scrollMarginBottom (Value value) =
 -}
 scrollMarginLeft :
     BaseValue
-        (LengthSupported
-            { auto : Supported
-            }
-        )
+        Length
     -> Style
 scrollMarginLeft (Value value) =
     AppendProperty ("scroll-margin-left:" ++ value)
@@ -13184,10 +13142,7 @@ set to the second.
 -}
 scrollMarginBlock :
     BaseValue
-        (LengthSupported
-            { auto : Supported
-            }
-        )
+        Length
     -> Style
 scrollMarginBlock (Value value) =
     AppendProperty ("scroll-margin-block:" ++ value)
@@ -13205,16 +13160,10 @@ set to the second.
 -}
 scrollMarginBlock2 :
     Value
-        (LengthSupported
-            { auto : Supported
-            }
-        )
+        Length
     ->
         Value
-            (LengthSupported
-                { auto : Supported
-                }
-            )
+            Length
     -> Style
 scrollMarginBlock2 (Value valueTopBottom) (Value valueRightLeft) =
     AppendProperty ("scroll-margin-block:" ++ valueTopBottom ++ " " ++ valueRightLeft)
@@ -13235,10 +13184,7 @@ set to the second.
 -}
 scrollMarginInline :
     BaseValue
-        (LengthSupported
-            { auto : Supported
-            }
-        )
+        Length
     -> Style
 scrollMarginInline (Value value) =
     AppendProperty ("scroll-margin-inline:" ++ value)
@@ -13256,16 +13202,10 @@ set to the second.
 -}
 scrollMarginInline2 :
     Value
-        (LengthSupported
-            { auto : Supported
-            }
-        )
+        Length
     ->
         Value
-            (LengthSupported
-                { auto : Supported
-                }
-            )
+            Length
     -> Style
 scrollMarginInline2 (Value valueTopBottom) (Value valueRightLeft) =
     AppendProperty ("scroll-margin-inline:" ++ valueTopBottom ++ " " ++ valueRightLeft)

--- a/src/Css.elm
+++ b/src/Css.elm
@@ -21,7 +21,7 @@ module Css exposing
     , backgroundImage, backgroundImages, backgroundPosition, backgroundPosition2, backgroundPosition3, backgroundPosition4, backgroundRepeat, backgroundRepeat2, backgroundSize, backgroundSize2
     , linearGradient, linearGradient2, stop, stop2, stop3, toBottom, toBottomLeft, toBottomRight, toLeft, toRight, toTop, toTopLeft, toTopRight
     , repeat, noRepeat, repeatX, repeatY, space, round
-    , cover, contain
+    , cover, contain_
     , BoxShadowConfig, boxShadow, boxShadows, defaultBoxShadow
     , TextShadowConfig, textShadow, defaultTextShadow
     , LineWidth, LineWidthSupported, LineStyle, LineStyleSupported
@@ -161,6 +161,7 @@ module Css exposing
     , pointerEvents
     , visiblePainted, visibleFill, visibleStroke, painted, stroke
     , resize, horizontal, vertical
+    , contain, contain2, contain3, contain4, strict, size, layout, style, paint
     )
 
 {-| If you need something that `elm-css` does not support right now, the
@@ -260,7 +261,7 @@ All CSS properties can have the values `unset`, `initial`, and `inherit`
 
 @docs repeat, noRepeat, repeatX, repeatY, space, round
 
-@docs cover, contain
+@docs cover, contain_
 
 
 ## Box Shadow
@@ -724,6 +725,8 @@ Multiple CSS properties use these values.
 @docs pointerEvents
 @docs visiblePainted, visibleFill, visibleStroke, painted, stroke
 @docs resize, horizontal, vertical
+@docs contain, contain2, contain3, contain4, strict, size, layout, style, paint
+
 -}
 
 import Css.Preprocess as Preprocess exposing (Style(..))
@@ -3860,9 +3863,16 @@ flexBasis (Value val) =
     AppendProperty ("flex-basis:" ++ val)
 
 
-{-| The `content` [`flex-basis` value](https://developer.mozilla.org/en-US/docs/Web/CSS/flex-basis#Values).
+{-| The `content` value used in:
 
-    flexBasis content
+  - [`flex-basis`](https://developer.mozilla.org/en-US/docs/Web/CSS/flex-basis#Values) (Indicates automatic sizing based on the item's content)
+  - [`contain`](#contain) (Indicates all containment rules apart from `size` and `style` are applied.)
+
+```
+flexBasis content
+
+contain content
+```
 
 -}
 content : Value { provides | content : Supported }
@@ -6076,12 +6086,12 @@ backgroundSize :
             { pct : Supported
             , auto : Supported
             , cover : Supported
-            , contain : Supported
+            , contain_ : Supported
             }
         )
     -> Style
-backgroundSize (Value size) =
-    AppendProperty ("background-size:" ++ size)
+backgroundSize (Value sizeVal) =
+    AppendProperty ("background-size:" ++ sizeVal)
 
 
 {-| Sets [`background-size`](https://css-tricks.com/almanac/properties/b/background-size/) for both width and height (in that order.)
@@ -6113,14 +6123,22 @@ backgroundSize2 (Value widthVal) (Value heightVal) =
 
 
 {-| Sets [`contain`](https://css-tricks.com/almanac/properties/b/background-size/)
-for [`backgroundSize`](#backgroundSize). It always show the whole background
-image, even if it leaves empty spaces on the sides.
+for the following properties:
 
-    backgroundSize contain
+  - [`backgroundSize`](#backgroundSize) (It always show the whole background
+    image, even if it leaves empty spaces on the sides.)
+  - [`objectFit`](#objectFit) (Replaced content is scaled to maintain proportions within the element's content box.)
+  - [`userSelect`](#userSelect) (Lets selection start within the element but that selection will be contained within that element's bounds.)
+
+```
+backgroundSize contain_
+```
+
+The value is called `contain_` instead of `contain` because [`contain`](#contain) is already a function.
 
 -}
-contain : Value { provides | contain : Supported }
-contain =
+contain_ : Value { provides | contain_ : Supported }
+contain_ =
     Value "contain"
 
 
@@ -7219,8 +7237,8 @@ border (Value widthVal) =
 
 -}
 border2 : Value LineWidth -> Value LineStyle -> Style
-border2 (Value widthVal) (Value style) =
-    AppendProperty ("border:" ++ widthVal ++ " " ++ style)
+border2 (Value widthVal) (Value styleVal) =
+    AppendProperty ("border:" ++ widthVal ++ " " ++ styleVal)
 
 
 {-| Sets [`border`](https://css-tricks.com/almanac/properties/b/border/) property.
@@ -7233,8 +7251,8 @@ border2 (Value widthVal) (Value style) =
 
 -}
 border3 : Value LineWidth -> Value LineStyle -> Value Color -> Style
-border3 (Value widthVal) (Value style) (Value colorVal) =
-    AppendProperty ("border:" ++ widthVal ++ " " ++ style ++ " " ++ colorVal)
+border3 (Value widthVal) (Value styleVal) (Value colorVal) =
+    AppendProperty ("border:" ++ widthVal ++ " " ++ styleVal ++ " " ++ colorVal)
 
 
 {-| Sets [`border-top`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-top) property.
@@ -7261,8 +7279,8 @@ borderTop (Value widthVal) =
 
 -}
 borderTop2 : Value LineWidth -> Value LineStyle -> Style
-borderTop2 (Value widthVal) (Value style) =
-    AppendProperty ("border-top:" ++ widthVal ++ " " ++ style)
+borderTop2 (Value widthVal) (Value styleVal) =
+    AppendProperty ("border-top:" ++ widthVal ++ " " ++ styleVal)
 
 
 {-| Sets [`border-top`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-top) property.
@@ -7275,8 +7293,8 @@ borderTop2 (Value widthVal) (Value style) =
 
 -}
 borderTop3 : Value LineWidth -> Value LineStyle -> Value Color -> Style
-borderTop3 (Value widthVal) (Value style) (Value colorVal) =
-    AppendProperty ("border-top:" ++ widthVal ++ " " ++ style ++ " " ++ colorVal)
+borderTop3 (Value widthVal) (Value styleVal) (Value colorVal) =
+    AppendProperty ("border-top:" ++ widthVal ++ " " ++ styleVal ++ " " ++ colorVal)
 
 
 {-| Sets [`border-right`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-right) property.
@@ -7303,8 +7321,8 @@ borderRight (Value widthVal) =
 
 -}
 borderRight2 : Value LineWidth -> Value LineStyle -> Style
-borderRight2 (Value widthVal) (Value style) =
-    AppendProperty ("border-right:" ++ widthVal ++ " " ++ style)
+borderRight2 (Value widthVal) (Value styleVal) =
+    AppendProperty ("border-right:" ++ widthVal ++ " " ++ styleVal)
 
 
 {-| Sets [`border-right`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-right) property.
@@ -7317,8 +7335,8 @@ borderRight2 (Value widthVal) (Value style) =
 
 -}
 borderRight3 : Value LineWidth -> Value LineStyle -> Value Color -> Style
-borderRight3 (Value widthVal) (Value style) (Value colorVal) =
-    AppendProperty ("border-right:" ++ widthVal ++ " " ++ style ++ " " ++ colorVal)
+borderRight3 (Value widthVal) (Value styleVal) (Value colorVal) =
+    AppendProperty ("border-right:" ++ widthVal ++ " " ++ styleVal ++ " " ++ colorVal)
 
 
 {-| Sets [`border-bottom`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-bottom) property.
@@ -7345,8 +7363,8 @@ borderBottom (Value widthVal) =
 
 -}
 borderBottom2 : Value LineWidth -> Value LineStyle -> Style
-borderBottom2 (Value widthVal) (Value style) =
-    AppendProperty ("border-bottom:" ++ widthVal ++ " " ++ style)
+borderBottom2 (Value widthVal) (Value styleVal) =
+    AppendProperty ("border-bottom:" ++ widthVal ++ " " ++ styleVal)
 
 
 {-| Sets [`border-bottom`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-bottom) property.
@@ -7359,8 +7377,8 @@ borderBottom2 (Value widthVal) (Value style) =
 
 -}
 borderBottom3 : Value LineWidth -> Value LineStyle -> Value Color -> Style
-borderBottom3 (Value widthVal) (Value style) (Value colorVal) =
-    AppendProperty ("border-bottom:" ++ widthVal ++ " " ++ style ++ " " ++ colorVal)
+borderBottom3 (Value widthVal) (Value styleVal) (Value colorVal) =
+    AppendProperty ("border-bottom:" ++ widthVal ++ " " ++ styleVal ++ " " ++ colorVal)
 
 
 {-| Sets [`border-left`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-left) property.
@@ -7387,8 +7405,8 @@ borderLeft (Value widthVal) =
 
 -}
 borderLeft2 : Value LineWidth -> Value LineStyle -> Style
-borderLeft2 (Value widthVal) (Value style) =
-    AppendProperty ("border-left:" ++ widthVal ++ " " ++ style)
+borderLeft2 (Value widthVal) (Value styleVal) =
+    AppendProperty ("border-left:" ++ widthVal ++ " " ++ styleVal)
 
 
 {-| Sets [`border-left`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-left) property.
@@ -7401,8 +7419,8 @@ borderLeft2 (Value widthVal) (Value style) =
 
 -}
 borderLeft3 : Value LineWidth -> Value LineStyle -> Value Color -> Style
-borderLeft3 (Value widthVal) (Value style) (Value colorVal) =
-    AppendProperty ("border-left:" ++ widthVal ++ " " ++ style ++ " " ++ colorVal)
+borderLeft3 (Value widthVal) (Value styleVal) (Value colorVal) =
+    AppendProperty ("border-left:" ++ widthVal ++ " " ++ styleVal ++ " " ++ colorVal)
 
 
 {-| Sets [`border-width`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-width) property.
@@ -7521,8 +7539,8 @@ borderLeftWidth (Value widthVal) =
 
 -}
 borderStyle : BaseValue LineStyle -> Style
-borderStyle (Value style) =
-    AppendProperty ("border-style:" ++ style)
+borderStyle (Value styleVal) =
+    AppendProperty ("border-style:" ++ styleVal)
 
 
 {-| Sets [`border-style`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-style) property.
@@ -7561,8 +7579,8 @@ borderStyle4 (Value styleTop) (Value styleRigt) (Value styleBottom) (Value style
 
 -}
 borderTopStyle : BaseValue LineStyle -> Style
-borderTopStyle (Value style) =
-    AppendProperty ("border-top-style:" ++ style)
+borderTopStyle (Value styleVal) =
+    AppendProperty ("border-top-style:" ++ styleVal)
 
 
 {-| Sets [`border-right-style`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-right-style) property.
@@ -7571,8 +7589,8 @@ borderTopStyle (Value style) =
 
 -}
 borderRightStyle : BaseValue LineStyle -> Style
-borderRightStyle (Value style) =
-    AppendProperty ("border-right-style:" ++ style)
+borderRightStyle (Value styleVal) =
+    AppendProperty ("border-right-style:" ++ styleVal)
 
 
 {-| Sets [`border-bottom-style`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-bottom-style) property.
@@ -7581,8 +7599,8 @@ borderRightStyle (Value style) =
 
 -}
 borderBottomStyle : BaseValue LineStyle -> Style
-borderBottomStyle (Value style) =
-    AppendProperty ("border-bottom-style:" ++ style)
+borderBottomStyle (Value styleVal) =
+    AppendProperty ("border-bottom-style:" ++ styleVal)
 
 
 {-| Sets [`border-left-style`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-left-style) property.
@@ -7591,8 +7609,8 @@ borderBottomStyle (Value style) =
 
 -}
 borderLeftStyle : BaseValue LineStyle -> Style
-borderLeftStyle (Value style) =
-    AppendProperty ("border-left-style:" ++ style)
+borderLeftStyle (Value styleVal) =
+    AppendProperty ("border-left-style:" ++ styleVal)
 
 
 {-| Sets [`border-color`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-color) property.
@@ -8795,8 +8813,8 @@ textDecoration2 :
             , wavy : Supported
             }
     -> Style
-textDecoration2 (Value line) (Value style) =
-    AppendProperty ("text-decoration:" ++ line ++ " " ++ style)
+textDecoration2 (Value line) (Value styleVal) =
+    AppendProperty ("text-decoration:" ++ line ++ " " ++ styleVal)
 
 
 {-| Sets [`text-decoration`][text-decoration] property.
@@ -8823,8 +8841,8 @@ textDecoration3 :
             }
     -> Value Color
     -> Style
-textDecoration3 (Value line) (Value style) (Value colorVal) =
-    AppendProperty ("text-decoration:" ++ line ++ " " ++ style ++ " " ++ colorVal)
+textDecoration3 (Value line) (Value styleVal) (Value colorVal) =
+    AppendProperty ("text-decoration:" ++ line ++ " " ++ styleVal ++ " " ++ colorVal)
 
 
 {-| Sets [`text-decoration-line`][text-decoration-line] property.
@@ -8904,8 +8922,8 @@ textDecorationStyle :
         , wavy : Supported
         }
     -> Style
-textDecorationStyle (Value style) =
-    AppendProperty ("text-decoration-style:" ++ style)
+textDecorationStyle (Value styleVal) =
+    AppendProperty ("text-decoration-style:" ++ styleVal)
 
 
 {-| Sets [`text-decoration-color`][text-decoration-color] property.
@@ -9909,8 +9927,8 @@ columnRuleWidth (Value widthVal) =
 
 -}
 columnRuleStyle : BaseValue LineStyle -> Style
-columnRuleStyle (Value style) =
-    AppendProperty ("column-rule-style:" ++ style)
+columnRuleStyle (Value styleVal) =
+    AppendProperty ("column-rule-style:" ++ styleVal)
 
 
 {-| Sets [`column-rule-color`](https://www.w3.org/TR/css-multicol-1/#propdef-column-rule-color)
@@ -10411,8 +10429,8 @@ strokeSize :
             }
         )
     -> Style
-strokeSize (Value size) =
-    AppendProperty ("stroke-size:" ++ size)
+strokeSize (Value sizeVal) =
+    AppendProperty ("stroke-size:" ++ sizeVal)
 
 
 {-| Sets [`stroke-size`](https://www.w3.org/TR/fill-stroke-3/#propdef-stroke-size).
@@ -10462,8 +10480,8 @@ strokeDashCorner :
             }
         )
     -> Style
-strokeDashCorner (Value size) =
-    AppendProperty ("stroke-dash-corner:" ++ size)
+strokeDashCorner (Value sizeVal) =
+    AppendProperty ("stroke-dash-corner:" ++ sizeVal)
 
 
 {-| Sets [`stroke-linejoin`](https://www.w3.org/TR/fill-stroke-3/#propdef-stroke-linejoin).
@@ -10637,8 +10655,8 @@ properties.
 
 -}
 columnRule2 : Value LineWidth -> Value LineStyle -> Style
-columnRule2 (Value widthVal) (Value style) =
-    AppendProperty ("column-rule:" ++ widthVal ++ " " ++ style)
+columnRule2 (Value widthVal) (Value styleVal) =
+    AppendProperty ("column-rule:" ++ widthVal ++ " " ++ styleVal)
 
 
 {-| Sets [`column-rule`](https://css-tricks.com/almanac/properties/c/column-rule/).
@@ -10654,8 +10672,8 @@ properties.
 
 -}
 columnRule3 : Value LineWidth -> Value LineStyle -> Value Color -> Style
-columnRule3 (Value widthVal) (Value style) (Value colorVal) =
-    AppendProperty ("column-rule:" ++ widthVal ++ " " ++ style ++ " " ++ colorVal)
+columnRule3 (Value widthVal) (Value styleVal) (Value colorVal) =
+    AppendProperty ("column-rule:" ++ widthVal ++ " " ++ styleVal ++ " " ++ colorVal)
 
 
 
@@ -11895,8 +11913,8 @@ letterSpacing (Value val) =
 
 -}
 width : BaseValue Width -> Style
-width (Value size) =
-    AppendProperty ("width:" ++ size)
+width (Value sizeVal) =
+    AppendProperty ("width:" ++ sizeVal)
 
 
 {-| Sets [`minWidth`](https://css-tricks.com/almanac/properties/m/min-width/).
@@ -11919,8 +11937,8 @@ minWidth :
             }
         )
     -> Style
-minWidth (Value size) =
-    AppendProperty ("min-width:" ++ size)
+minWidth (Value sizeVal) =
+    AppendProperty ("min-width:" ++ sizeVal)
 
 
 {-| Sets [`maxWidth`](https://css-tricks.com/almanac/properties/m/max-width/).
@@ -11943,8 +11961,8 @@ maxWidth :
             }
         )
     -> Style
-maxWidth (Value size) =
-    AppendProperty ("max-width:" ++ size)
+maxWidth (Value sizeVal) =
+    AppendProperty ("max-width:" ++ sizeVal)
 
 
 {-| The `min-content` value used for properties such as [`width`](#width),
@@ -12623,7 +12641,7 @@ scaleDown =
 
     objectFit fill_
 
-    objectFit contain
+    objectFit contain_
 
     objectFit cover
 
@@ -12635,7 +12653,7 @@ scaleDown =
 objectFit :
     BaseValue
         { fill_ : Supported
-        , contain : Supported
+        , contain_ : Supported
         , cover : Supported
         , none : Supported
         , scaleDown : Supported
@@ -13843,7 +13861,7 @@ unicodeBidi (Value val) =
 
     userSelect text
 
-    userSelect contain
+    userSelect contain_
 
     userSelect all_
 
@@ -13853,7 +13871,7 @@ userSelect :
         { none : Supported
         , auto : Supported
         , text : Supported
-        , contain : Supported
+        , contain_ : Supported
         , all_ : Supported
         }
     -> Style
@@ -13956,7 +13974,7 @@ writingMode (Value str) =
     resize inline
 
 -}
-resize : 
+resize :
     BaseValue
         { none : Supported
         , both : Supported
@@ -13973,6 +13991,7 @@ resize (Value value) =
 {-| The `horizontal` value used by [`resize`](#resize).
 
     resize horizontal
+
 -}
 horizontal : Value { provides | horizontal : Supported }
 horizontal =
@@ -13982,7 +14001,180 @@ horizontal =
 {-| The `vertical` value used by [`resize`](#resize).
 
     resize vertical
+
 -}
 vertical : Value { provides | vertical : Supported }
 vertical =
     Value "vertical"
+
+
+{-| The [`contain`](https://css-tricks.com/almanac/properties/c/contain/) property.
+
+    contain none
+
+    contain content
+
+    contain2 size layout
+
+    contain3 size layout style
+
+    contain4 -- all multiple choice values in use, no value entry needed
+
+-}
+contain :
+    BaseValue
+        { none : Supported
+        , strict : Supported
+        , content : Supported
+        , size : Supported
+        , layout : Supported
+        , style : Supported
+        , paint : Supported
+        }
+    -> Style
+contain (Value value) =
+    AppendProperty ("contain:" ++ value)
+
+
+{-| The [`contain`](https://css-tricks.com/almanac/properties/c/contain/) property.
+
+This two-argument version lets you use 2 of the 4 multiple choice values you
+can use for this property.
+
+    contain2 size layout
+
+-}
+contain2 :
+    Value
+        { size : Supported
+        , layout : Supported
+        , style : Supported
+        , paint : Supported
+        }
+    ->
+        Value
+            { size : Supported
+            , layout : Supported
+            , style : Supported
+            , paint : Supported
+            }
+    -> Style
+contain2 (Value value1) (Value value2) =
+    AppendProperty ("contain:" ++ value1 ++ " " ++ value2)
+
+
+{-| The [`contain`](https://css-tricks.com/almanac/properties/c/contain/) property.
+
+This two-argument version lets you use 3 of the 4 multiple choice values you
+can use for this property.
+
+    contain3 size layout style
+
+-}
+contain3 :
+    Value
+        { size : Supported
+        , layout : Supported
+        , style : Supported
+        , paint : Supported
+        }
+    ->
+        Value
+            { size : Supported
+            , layout : Supported
+            , style : Supported
+            , paint : Supported
+            }
+    ->
+        Value
+            { size : Supported
+            , layout : Supported
+            , style : Supported
+            , paint : Supported
+            }
+    -> Style
+contain3 (Value value1) (Value value2) (Value value3) =
+    AppendProperty ("contain:" ++ value1 ++ " " ++ value2 ++ " " ++ value3)
+
+
+{-| The [`contain`](https://css-tricks.com/almanac/properties/c/contain/) property.
+
+This version uses all 4 multiple choice values that can be used with this
+property, no values required.
+
+Equivalent to `contain size layout style paint`.
+
+    contain4
+
+-}
+contain4 : Style
+contain4 =
+    AppendProperty "contain:size layout style paint"
+
+
+{-| Sets the `strict` value for [`contain`](#contain).
+
+This indicates that all containment rules apart from `style` are applied.
+
+This is equivalent to `contain3 size layout paint`.
+
+    contain strict
+
+-}
+strict : Value { provides | strict : Supported }
+strict =
+    Value "strict"
+
+
+{-| Sets the `size` value for [`contain`](#contain).
+
+This indicates that the element can be sized without
+needing to look at the size of its descendants.
+
+    contain size
+
+-}
+size : Value { provides | size : Supported }
+size =
+    Value "size"
+
+
+{-| Sets the `layout` value for [`contain`](#contain).
+
+This indicates that nothing outside the element
+may affect its internal layout and vice versa.
+
+    contain layout
+
+-}
+layout : Value { provides | layout : Supported }
+layout =
+    Value "layout"
+
+
+{-| Sets the `style` value for [`contain`](#contain).
+
+For properties that can have effects on more than its
+element and descendenants, this indicates that those effects
+are contained by the containing element.
+
+    contain style
+
+-}
+style : Value { provides | style : Supported }
+style =
+    Value "style"
+
+
+{-| Sets the `paint` value for [`contain`](#contain).
+
+Indicates that descendants of the element will not
+display outside its bounds and will not be painted
+by the browser if the containing box is offscreen.
+
+    contain paint
+
+-}
+paint : Value { provides | paint : Supported }
+paint =
+    Value "paint"

--- a/src/Css.elm
+++ b/src/Css.elm
@@ -17,10 +17,10 @@ module Css exposing
     , contentBox, borderBox, paddingBox
     , left_, right_, top_, bottom_, block, inline, start, end
     , x, y
-    , baseline, clip, ruby
+    , clip
     , stretch, center, content, fill_, stroke, text, style
-    , cover, contain_, fullWidth
-    , sub, super
+    , cover, contain_
+    , baseline, sub, super, ruby, fullWidth
     , pseudoClass, active, checked, disabled, empty, enabled
     , firstChild, firstOfType, focus, fullscreen, hover, inRange
     , indeterminate, invalid, lastChild, lastOfType, link, onlyChild
@@ -265,10 +265,10 @@ Many different kinds of CSS properties use these values.
 @docs contentBox, borderBox, paddingBox
 @docs left_, right_, top_, bottom_, block, inline, start, end
 @docs x, y
-@docs baseline, clip, ruby
+@docs clip
 @docs stretch, center, content, fill_, stroke, text, style
-@docs cover, contain_, fullWidth
-@docs sub, super
+@docs cover, contain_
+@docs baseline, sub, super, ruby, fullWidth
 
 
 # Pseudo-Classes
@@ -1371,7 +1371,7 @@ always =
     Value "always"
 
 
-{-| The `hidden` value used for properties such as [`visibility`](https://css-tricks.com/almanac/properties/v/visibility/), [`overflow`](https://css-tricks.com/almanac/properties/o/overflow/) and [`border style`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-style).
+{-| The `hidden` value used for properties such as [`visibility`](https://css-tricks.com/almanac/properties/v/visibility/), [`overflow`](https://css-tricks.com/almanac/properties/o/overflow/) and [`borderStyle`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-style).
 
     visibility hidden
 
@@ -1705,53 +1705,6 @@ y =
     Value "y"
 
 
-{-| The `baseline` value, used in the following properties:
-
-  - [`alignContent`](#alignContent)
-  - [`alignItems`](#alignItems)
-  - [`alignSelf`](#alignSelf)
-  - [`verticalAlign`](#verticalAlign)
-
-```
-alignItems baseline
-
-verticalAlign baseline
-```
-
--}
-baseline : Value { provides | baseline : Supported }
-baseline =
-    Value "baseline"
-
-
-{-| The `clip` value used by [`overflow`](#overflow) and [`textOverflow`](#textOverflow).
-
-    overflow clip
-
-    overflowX clip
-
-    overflowY clip
-
-    textOverflow clip
-
--}
-clip : Value { provides | clip : Supported }
-clip =
-    Value "clip"
-
-
-{-| The `ruby` value used by [`display`](#display) and [`fontVariantEastAsian`](#fontVariantEastAsian).
-
-    display ruby
-
-    fontVariantEastAsian2 ruby jis83
-
--}
-ruby : Value { provides | ruby : Supported }
-ruby =
-    Value "ruby"
-
-
 {-| The `stretch` value used in the following properties:
 
   - [`alignContent`](#alignContent)
@@ -1760,7 +1713,7 @@ ruby =
   - [`justifyContent`](#justifyContent)
   - [`justifyItems`](#justifyItems)
   - [`justifySelf`](#justifySelf)
-  - [\`strokeDashJustify](#strokeDashJustify)
+  - [`strokeDashJustify`](#strokeDashJustify)
 
 ```
 alignContent stretch
@@ -1875,6 +1828,22 @@ style =
     Value "style"
 
 
+{-| The `clip` value used by [`overflow`](#overflow) and [`textOverflow`](#textOverflow).
+
+    overflow clip
+
+    overflowX clip
+
+    overflowY clip
+
+    textOverflow clip
+
+-}
+clip : Value { provides | clip : Supported }
+clip =
+    Value "clip"
+
+
 {-| Sets `contain` for the following properties:
 
   - [`backgroundSize`](#backgroundSize) (It always show the whole background
@@ -1917,26 +1886,23 @@ cover =
     Value "cover"
 
 
-{-| A `full-width` value for:
+{-| The `baseline` value, used in the following properties:
 
+  - [`alignContent`](#alignContent)
+  - [`alignItems`](#alignItems)
+  - [`alignSelf`](#alignSelf)
+  - [`verticalAlign`](#verticalAlign)
 
-### [`textTransform`](#textTransform)
+```
+alignItems baseline
 
-Forces the writing of characters in a square so they can be aligned in East Asian scripts.
-
-
-### [`fontVariantEastAsian`](#fontVariantEastAsian)
-
-Activates the East Asian characters that are roughly be the same width.
-
-    textTransform fullWidth
-
-    fontVariantEastAsian fullWidth
+verticalAlign baseline
+```
 
 -}
-fullWidth : Value { provides | fullWidth : Supported }
-fullWidth =
-    Value "full-width"
+baseline : Value { provides | baseline : Supported }
+baseline =
+    Value "baseline"
 
 
 {-| A `sub` value for the following properties:
@@ -1971,6 +1937,40 @@ sub =
 super : Value { provides | super : Supported }
 super =
     Value "super"
+
+
+{-| The `ruby` value used by [`display`](#display) and [`fontVariantEastAsian`](#fontVariantEastAsian).
+
+    display ruby
+
+    fontVariantEastAsian2 ruby jis83
+
+-}
+ruby : Value { provides | ruby : Supported }
+ruby =
+    Value "ruby"
+
+
+{-| A `full-width` value for:
+
+
+### [`textTransform`](#textTransform)
+
+Forces the writing of characters in a square so they can be aligned in East Asian scripts.
+
+
+### [`fontVariantEastAsian`](#fontVariantEastAsian)
+
+Activates the East Asian characters that are roughly be the same width.
+
+    textTransform fullWidth
+
+    fontVariantEastAsian fullWidth
+
+-}
+fullWidth : Value { provides | fullWidth : Supported }
+fullWidth =
+    Value "full-width"
 
 
 

--- a/src/Css.elm
+++ b/src/Css.elm
@@ -33,7 +33,7 @@ module Css exposing
     , borderBlock, borderBlock2, borderBlock3
     , borderInline, borderInline2, borderInline3
     , borderWidth, borderWidth2, borderWidth3, borderWidth4, borderTopWidth, borderRightWidth, borderBottomWidth, borderLeftWidth
-    , borderBlockWidth, borderInlineWidth
+    , borderBlockWidth, borderBlockStartWidth, borderBlockEndWidth, borderInlineWidth, borderInlineStartWidth, borderInlineEndWidth
     , thin, thick
     , borderStyle, borderStyle2, borderStyle3, borderStyle4, borderTopStyle, borderRightStyle, borderBottomStyle, borderLeftStyle
     , borderBlockStyle, borderBlockStartStyle, borderBlockEndStyle, borderInlineStyle, borderInlineStartStyle, borderInlineEndStyle
@@ -300,7 +300,7 @@ All CSS properties can have the values `unset`, `initial`, and `inherit`
 
 @docs borderWidth, borderWidth2, borderWidth3, borderWidth4, borderTopWidth, borderRightWidth, borderBottomWidth, borderLeftWidth
 
-@docs borderBlockWidth, borderInlineWidth
+@docs borderBlockWidth, borderBlockStartWidth, borderBlockEndWidth, borderInlineWidth, borderInlineStartWidth, borderInlineEndWidth
 
 @docs thin, thick
 
@@ -7613,6 +7613,26 @@ borderBlockWidth (Value widthVal) =
     AppendProperty ("border-block-width:" ++ widthVal)
 
 
+{-| Sets [`border-block-start-width`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-block-start-width) property.
+
+    borderBlockStartWidth (px 1)
+
+-}
+borderBlockStartWidth : BaseValue LineWidth -> Style
+borderBlockStartWidth (Value widthVal) =
+    AppendProperty ("border-block-start-width:" ++ widthVal)
+
+
+{-| Sets [`border-block-end-width`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-block-end-width) property.
+
+    borderBlockEndWidth (px 1)
+
+-}
+borderBlockEndWidth : BaseValue LineWidth -> Style
+borderBlockEndWidth (Value widthVal) =
+    AppendProperty ("border-block-end-width:" ++ widthVal)
+
+
 {-| Sets [`border-inline-width`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-inline-width) property.
 
     borderTopWidth (px 1)
@@ -7621,6 +7641,26 @@ borderBlockWidth (Value widthVal) =
 borderInlineWidth : BaseValue LineWidth -> Style
 borderInlineWidth (Value widthVal) =
     AppendProperty ("border-inline-width:" ++ widthVal)
+
+
+{-| Sets [`border-inline-start-width`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-inline-start-width) property.
+
+    borderInlineStartWidth (px 1)
+
+-}
+borderInlineStartWidth : BaseValue LineWidth -> Style
+borderInlineStartWidth (Value widthVal) =
+    AppendProperty ("border-inline-start-width:" ++ widthVal)
+
+
+{-| Sets [`border-inline-end-width`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-inline-end-width) property.
+
+    borderInlineEndWidth (px 1)
+
+-}
+borderInlineEndWidth : BaseValue LineWidth -> Style
+borderInlineEndWidth (Value widthVal) =
+    AppendProperty ("border-inline-end-width:" ++ widthVal)
 
 
 {-| Sets [`border-style`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-style) property.

--- a/src/Css.elm
+++ b/src/Css.elm
@@ -248,6 +248,8 @@ module Css exposing
     , loose
     , hangingPunctuation, hangingPunctuation2, hangingPunctuation3
     , first, last, forceEnd, allowEnd
+    , whiteSpace
+    , pre, preWrap, preLine
 
     -- script handling
     , direction, ltr, rtl
@@ -356,35 +358,44 @@ module Css exposing
     , columnRuleStyle
     , columnRuleColor
     
-    
-
-    
-    -- ??
-    , lineClamp
-    , LineWidth, LineWidthSupported, LineStyle, LineStyleSupported
-    , verticalAlign
-    , textTop, textBottom, middle
-    , whiteSpace
-    , pre, preWrap, preLine
-
-    , float
-    , clear
-    , visibility
-    , fill
-
-    -- ??
-    , strokeDasharray, strokeDashoffset, strokeWidth, strokeAlign, strokeColor, strokeImage, strokeMiterlimit, strokeOpacity, strokePosition, strokePosition2, strokePosition4, strokeRepeat, strokeRepeat2, strokeSize, strokeSize2, strokeDashCorner
+    -- SVG attributes that can be used as CSS presentation properties.
+    , strokeDasharray
+    , strokeDashoffset
+    , strokeWidth
+    , strokeAlign
+    , strokeColor
+    , strokeImage
+    , strokeMiterlimit
+    , strokeOpacity
+    , strokePosition, strokePosition2, strokePosition4
+    , strokeRepeat, strokeRepeat2
+    , strokeSize, strokeSize2
+    , strokeDashCorner
     , strokeLinecap, butt, square
     , strokeBreak, boundingBox, slice, clone
     , strokeOrigin
     , strokeLinejoin, strokeLinejoin2, crop, arcs, miter, bevel
     , strokeDashJustify, compress, dashes, gaps
 
+
+    
     -- ??
+    , lineClamp
+    , LineWidth, LineWidthSupported, LineStyle, LineStyleSupported
+
+    , verticalAlign
+    , textTop, textBottom, middle
+
+    , float
+
+    , clear
+
+    , visibility
+
+    , fill
+
     , paintOrder, paintOrder2, paintOrder3, markers
 
-
-    -- ??
     , opacity
 
     , zoom
@@ -14681,6 +14692,74 @@ allowEnd =
     Value "allow-end"
 
 
+
+{-| Sets [`white-space`](https://css-tricks.com/almanac/properties/w/whitespace/)
+
+    whiteSpace pre
+
+    whiteSpace nowrap
+
+    whiteSpace preWrap
+
+    whiteSpace preLine
+
+-}
+whiteSpace :
+    BaseValue
+        { normal : Supported
+        , nowrap : Supported
+        , pre : Supported
+        , preWrap : Supported
+        , preLine : Supported
+        }
+    -> Style
+whiteSpace (Value str) =
+    AppendProperty ("white-space:" ++ str)
+
+
+{-| A `nowrap` value for the [`white-space`](https://css-tricks.com/almanac/properties/w/whitespace/)
+and [`flex-wrap`](https://css-tricks.com/almanac/properties/f/flex-wrap/) properties.
+
+    whiteSpace nowrap
+
+    flexWrap nowrap
+
+-}
+nowrap : Value { provides | nowrap : Supported }
+nowrap =
+    Value "nowrap"
+
+
+{-| A `pre` value for the [`white-space`](https://css-tricks.com/almanac/properties/w/whitespace/) property.
+
+    whiteSpace pre
+
+-}
+pre : Value { provides | pre : Supported }
+pre =
+    Value "pre"
+
+
+{-| A `pre-wrap` value for the [`white-space`](https://css-tricks.com/almanac/properties/w/whitespace/) property.
+
+    whiteSpace preWrap
+
+-}
+preWrap : Value { provides | preWrap : Supported }
+preWrap =
+    Value "pre-wrap"
+
+
+{-| A `pre-line` value for the [`white-space`](https://css-tricks.com/almanac/properties/w/whitespace/) property.
+
+    whiteSpace preLine
+
+-}
+preLine : Value { provides | preLine : Supported }
+preLine =
+    Value "pre-line"
+
+
 ------------------------------------------------------------------------
 ------------------------------------------------------------------------
 ------------------------------------------------------------------------
@@ -19581,270 +19660,19 @@ columnRuleColor (Value colorVal) =
     AppendProperty ("column-rule-color:" ++ colorVal)
 
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-{-| Sets [`vertical-align`](https://css-tricks.com/almanac/properties/v/vertical-align/).
-
-    verticalAlign textBottom
-
-    verticalAlign (em 1)
-
--}
-verticalAlign :
-    BaseValue
-        (LengthSupported
-            { baseline : Supported
-            , sub : Supported
-            , super : Supported
-            , textTop : Supported
-            , textBottom : Supported
-            , middle : Supported
-            , top_ : Supported
-            , bottom_ : Supported
-            , pct : Supported
-            }
-        )
-    -> Style
-verticalAlign (Value str) =
-    AppendProperty ("vertical-align:" ++ str)
-
-
-{-| A `textTop` value for the [`vertical-align`](https://css-tricks.com/almanac/properties/v/vertical-align/) property.
-
-    verticalAlign textTop
-
--}
-textTop : Value { provides | textTop : Supported }
-textTop =
-    Value "text-top"
-
-
-{-| A `textBottom` value for the [`vertical-align`](https://css-tricks.com/almanac/properties/v/vertical-align/) property.
-
-    verticalAlign textBottom
-
--}
-textBottom : Value { provides | textBottom : Supported }
-textBottom =
-    Value "text-bottom"
-
-
-{-| A `middle` value for the [`vertical-align`](https://css-tricks.com/almanac/properties/v/vertical-align/) property.
-
-    verticalAlign middle
-
--}
-middle : Value { provides | middle : Supported }
-middle =
-    Value "middle"
-
-
--- WHITE-SPACE --
-
-
-{-| Sets [`white-space`](https://css-tricks.com/almanac/properties/w/whitespace/)
-
-    whiteSpace pre
-
-    whiteSpace nowrap
-
-    whiteSpace preWrap
-
-    whiteSpace preLine
-
--}
-whiteSpace :
-    BaseValue
-        { normal : Supported
-        , nowrap : Supported
-        , pre : Supported
-        , preWrap : Supported
-        , preLine : Supported
-        }
-    -> Style
-whiteSpace (Value str) =
-    AppendProperty ("white-space:" ++ str)
-
-
-{-| A `nowrap` value for the [`white-space`](https://css-tricks.com/almanac/properties/w/whitespace/)
-and [`flex-wrap`](https://css-tricks.com/almanac/properties/f/flex-wrap/) properties.
-
-    whiteSpace nowrap
-
-    flexWrap nowrap
-
--}
-nowrap : Value { provides | nowrap : Supported }
-nowrap =
-    Value "nowrap"
-
-
-{-| A `pre` value for the [`white-space`](https://css-tricks.com/almanac/properties/w/whitespace/) property.
-
-    whiteSpace pre
-
--}
-pre : Value { provides | pre : Supported }
-pre =
-    Value "pre"
-
-
-{-| A `pre-wrap` value for the [`white-space`](https://css-tricks.com/almanac/properties/w/whitespace/) property.
-
-    whiteSpace preWrap
-
--}
-preWrap : Value { provides | preWrap : Supported }
-preWrap =
-    Value "pre-wrap"
-
-
-{-| A `pre-line` value for the [`white-space`](https://css-tricks.com/almanac/properties/w/whitespace/) property.
-
-    whiteSpace preLine
-
--}
-preLine : Value { provides | preLine : Supported }
-preLine =
-    Value "pre-line"
-
-
-
-
--- FLOAT --
-
-
-{-| Sets [`float`](https://css-tricks.com/almanac/properties/f/float/).
-
-    float none
-
-    float left_
-
-    float right_
-
-    float inlineStart
-
--}
-float :
-    BaseValue
-        { none : Supported
-        , left_ : Supported
-        , right_ : Supported
-        , inlineStart : Supported
-        , inlineEnd : Supported
-        }
-    -> Style
-float (Value str) =
-    AppendProperty ("float:" ++ str)
-
-
-
--- VISIBILITY --
-
-
-{-| Sets [`visibility`](https://css-tricks.com/almanac/properties/v/visibility/)
-
-      visibility visible
-      visibility hidden
-      visibility collapse
-
--}
-visibility :
-    BaseValue
-        { visible : Supported
-        , hidden : Supported
-        , collapse : Supported
-        }
-    -> Style
-visibility (Value str) =
-    AppendProperty ("visibility:" ++ str)
-
-
-
--- ORDER --
-
-
-{-| Sets [`order`](https://css-tricks.com/almanac/properties/o/order/)
-
-    order (num 2)
-
-    order (num -2)
-
--}
-order :
-    BaseValue
-        { int : Supported
-        , zero : Supported
-        }
-    -> Style
-order (Value val) =
-    AppendProperty ("order:" ++ val)
-
-
-{-| Sets [`fill`](https://css-tricks.com/almanac/properties/f/fill/)
-**Note:** `fill` also accepts the patterns of SVG shapes that are defined inside of a [`defs`](https://css-tricks.com/snippets/svg/svg-patterns/) element.
-
-    fill (hex "#60b5cc")
-
-    fill (rgb 96 181 204)
-
-    fill (rgba 96 181 204 0.5)
-
-    fill (url "#pattern")
-
--}
-fill :
-    BaseValue
-        (ColorSupported
-            { url : Supported
-            }
-        )
-    -> Style
-fill (Value val) =
-    AppendProperty ("fill:" ++ val)
-
-
-
--- COLUMNS --
-
-
-
--- STROKE --
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+---------------------- SVG STROKE ATTRIBUTES ---------------------------
+--------------- (THAT CAN BE USED AS CSS PROPERTIES) -------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
 
 
 {-| Sets [`stroke-dasharray`](https://css-tricks.com/almanac/properties/s/stroke-dasharray/)
@@ -19889,50 +19717,6 @@ strokeDashoffset :
     -> Style
 strokeDashoffset (Value val) =
     AppendProperty ("stroke-dashoffset:" ++ val)
-
-
-{-| Sets [`stroke-linecap`](https://css-tricks.com/almanac/properties/s/stroke-linecap/)
-
-    strokeLinecap butt
-
-    strokeLinecap square
-
-    strokeLinecap round
-
--}
-strokeLinecap :
-    BaseValue
-        { butt : Supported
-        , square : Supported
-        , round : Supported
-        }
-    -> Style
-strokeLinecap (Value val) =
-    AppendProperty ("stroke-linecap:" ++ val)
-
-
-{-| A `butt` value for the [`strokeLinecap`](#strokeLinecap) property.
-
-    strokeLinecap butt
-
--}
-butt : Value { provides | butt : Supported }
-butt =
-    Value "butt"
-
-
-{-| The `square` value used by properties such as [`strokeLinecap`](#strokeLinecap),
-[`listStyle`](#listStyle),
-and [`listStyleType`](#listStyleType).
-
-    strokeLinecap square
-
-    listStyleType square
-
--}
-square : Value { provides | square : Supported }
-square =
-    Value "square"
 
 
 {-| Sets [`stroke-width`](https://css-tricks.com/almanac/properties/s/stroke-width/)
@@ -19981,58 +19765,6 @@ strokeAlign :
     -> Style
 strokeAlign (Value val) =
     AppendProperty ("stroke-align:" ++ val)
-
-
-{-| Sets [`stroke-break`](https://www.w3.org/TR/fill-stroke-3/#propdef-stroke-break)
-
-      strokeBreak boundingBox
-      strokeBreak slice
-      strokeBreak clone
-
--}
-strokeBreak :
-    BaseValue
-        { boundingBox : Supported
-        , slice : Supported
-        , clone : Supported
-        }
-    -> Style
-strokeBreak (Value val) =
-    AppendProperty ("stroke-break:" ++ val)
-
-
-{-| A `boundingBox` value for the [`strokeBreak`](#strokeBreak) property.
-
-      strokeBreak boundingBox
-
--}
-boundingBox : Value { provides | boundingBox : Supported }
-boundingBox =
-    Value "bounding-box"
-
-
-{-| A `slice` value for the [`strokeBreak`](#strokeBreak) and [`boxDecorationBreak`](#boxDecorationBreak) properties.
-
-      strokeBreak slice
-
-      boxDecorationbreak clone
-
--}
-slice : Value { provides | slice : Supported }
-slice =
-    Value "slice"
-
-
-{-| A `clone` value for the [`strokeBreak`](#strokeBreak) and [`boxDecorationBreak`](#boxDecorationBreak) properties.
-
-      strokeBreak clone
-
-      boxDecorationBreak clone
-
--}
-clone : Value { provides | clone : Supported }
-clone =
-    Value "clone"
 
 
 {-| Sets [`stroke-color`](https://www.w3.org/TR/fill-stroke-3/#propdef-stroke-color)
@@ -20090,36 +19822,6 @@ strokeOpacity :
     -> Style
 strokeOpacity (Value val) =
     AppendProperty ("stroke-opacity:" ++ val)
-
-
-{-| Sets [`stroke-origin`](https://www.w3.org/TR/fill-stroke-3/#propdef-stroke-origin)
-
-    strokeOrign matchParent
-
-    strokeOrign fillBox
-
-    strokeOrign strokeBox
-
-    strokeOrign contentBox
-
-    strokeOrign paddingBox
-
-    strokeOrign borderBox
-
--}
-strokeOrigin :
-    BaseValue
-        { matchParent : Supported
-        , fillBox : Supported
-        , strokeBox : Supported
-        , contentBox : Supported
-        , paddingBox : Supported
-        , borderBox : Supported
-        }
-    -> Style
-strokeOrigin (Value val) =
-    AppendProperty ("stroke-origin:" ++ val)
-
 
 
 {-| Sets [`stroke-position`](https://www.w3.org/TR/fill-stroke-3/#propdef-stroke-position).
@@ -20372,6 +20074,132 @@ strokeDashCorner (Value sizeVal) =
     AppendProperty ("stroke-dash-corner:" ++ sizeVal)
 
 
+{-| Sets [`stroke-linecap`](https://css-tricks.com/almanac/properties/s/stroke-linecap/)
+
+    strokeLinecap butt
+
+    strokeLinecap square
+
+    strokeLinecap round
+
+-}
+strokeLinecap :
+    BaseValue
+        { butt : Supported
+        , square : Supported
+        , round : Supported
+        }
+    -> Style
+strokeLinecap (Value val) =
+    AppendProperty ("stroke-linecap:" ++ val)
+
+
+{-| A `butt` value for the [`strokeLinecap`](#strokeLinecap) property.
+
+    strokeLinecap butt
+
+-}
+butt : Value { provides | butt : Supported }
+butt =
+    Value "butt"
+
+
+{-| The `square` value used by properties such as [`strokeLinecap`](#strokeLinecap),
+[`listStyle`](#listStyle),
+and [`listStyleType`](#listStyleType).
+
+    strokeLinecap square
+
+    listStyleType square
+
+-}
+square : Value { provides | square : Supported }
+square =
+    Value "square"
+
+
+
+{-| Sets [`stroke-break`](https://www.w3.org/TR/fill-stroke-3/#propdef-stroke-break)
+
+      strokeBreak boundingBox
+      strokeBreak slice
+      strokeBreak clone
+
+-}
+strokeBreak :
+    BaseValue
+        { boundingBox : Supported
+        , slice : Supported
+        , clone : Supported
+        }
+    -> Style
+strokeBreak (Value val) =
+    AppendProperty ("stroke-break:" ++ val)
+
+
+{-| A `boundingBox` value for the [`strokeBreak`](#strokeBreak) property.
+
+      strokeBreak boundingBox
+
+-}
+boundingBox : Value { provides | boundingBox : Supported }
+boundingBox =
+    Value "bounding-box"
+
+
+{-| A `slice` value for the [`strokeBreak`](#strokeBreak) and [`boxDecorationBreak`](#boxDecorationBreak) properties.
+
+      strokeBreak slice
+
+      boxDecorationbreak clone
+
+-}
+slice : Value { provides | slice : Supported }
+slice =
+    Value "slice"
+
+
+{-| A `clone` value for the [`strokeBreak`](#strokeBreak) and [`boxDecorationBreak`](#boxDecorationBreak) properties.
+
+      strokeBreak clone
+
+      boxDecorationBreak clone
+
+-}
+clone : Value { provides | clone : Supported }
+clone =
+    Value "clone"
+
+
+{-| Sets [`stroke-origin`](https://www.w3.org/TR/fill-stroke-3/#propdef-stroke-origin)
+
+    strokeOrign matchParent
+
+    strokeOrign fillBox
+
+    strokeOrign strokeBox
+
+    strokeOrign contentBox
+
+    strokeOrign paddingBox
+
+    strokeOrign borderBox
+
+-}
+strokeOrigin :
+    BaseValue
+        { matchParent : Supported
+        , fillBox : Supported
+        , strokeBox : Supported
+        , contentBox : Supported
+        , paddingBox : Supported
+        , borderBox : Supported
+        }
+    -> Style
+strokeOrigin (Value val) =
+    AppendProperty ("stroke-origin:" ++ val)
+
+
 {-| Sets [`stroke-linejoin`](https://www.w3.org/TR/fill-stroke-3/#propdef-stroke-linejoin).
 
     strokeLinejoin crop
@@ -20511,6 +20339,191 @@ dashes =
 gaps : Value { provides | gaps : Supported }
 gaps =
     Value "gaps"
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+{-| Sets [`vertical-align`](https://css-tricks.com/almanac/properties/v/vertical-align/).
+
+    verticalAlign textBottom
+
+    verticalAlign (em 1)
+
+-}
+verticalAlign :
+    BaseValue
+        (LengthSupported
+            { baseline : Supported
+            , sub : Supported
+            , super : Supported
+            , textTop : Supported
+            , textBottom : Supported
+            , middle : Supported
+            , top_ : Supported
+            , bottom_ : Supported
+            , pct : Supported
+            }
+        )
+    -> Style
+verticalAlign (Value str) =
+    AppendProperty ("vertical-align:" ++ str)
+
+
+{-| A `textTop` value for the [`vertical-align`](https://css-tricks.com/almanac/properties/v/vertical-align/) property.
+
+    verticalAlign textTop
+
+-}
+textTop : Value { provides | textTop : Supported }
+textTop =
+    Value "text-top"
+
+
+{-| A `textBottom` value for the [`vertical-align`](https://css-tricks.com/almanac/properties/v/vertical-align/) property.
+
+    verticalAlign textBottom
+
+-}
+textBottom : Value { provides | textBottom : Supported }
+textBottom =
+    Value "text-bottom"
+
+
+{-| A `middle` value for the [`vertical-align`](https://css-tricks.com/almanac/properties/v/vertical-align/) property.
+
+    verticalAlign middle
+
+-}
+middle : Value { provides | middle : Supported }
+middle =
+    Value "middle"
+
+
+
+
+{-| Sets [`float`](https://css-tricks.com/almanac/properties/f/float/).
+
+    float none
+
+    float left_
+
+    float right_
+
+    float inlineStart
+
+-}
+float :
+    BaseValue
+        { none : Supported
+        , left_ : Supported
+        , right_ : Supported
+        , inlineStart : Supported
+        , inlineEnd : Supported
+        }
+    -> Style
+float (Value str) =
+    AppendProperty ("float:" ++ str)
+
+
+
+-- VISIBILITY --
+
+
+{-| Sets [`visibility`](https://css-tricks.com/almanac/properties/v/visibility/)
+
+      visibility visible
+      visibility hidden
+      visibility collapse
+
+-}
+visibility :
+    BaseValue
+        { visible : Supported
+        , hidden : Supported
+        , collapse : Supported
+        }
+    -> Style
+visibility (Value str) =
+    AppendProperty ("visibility:" ++ str)
+
+
+
+-- ORDER --
+
+
+{-| Sets [`order`](https://css-tricks.com/almanac/properties/o/order/)
+
+    order (num 2)
+
+    order (num -2)
+
+-}
+order :
+    BaseValue
+        { int : Supported
+        , zero : Supported
+        }
+    -> Style
+order (Value val) =
+    AppendProperty ("order:" ++ val)
+
+
+{-| Sets [`fill`](https://css-tricks.com/almanac/properties/f/fill/)
+**Note:** `fill` also accepts the patterns of SVG shapes that are defined inside of a [`defs`](https://css-tricks.com/snippets/svg/svg-patterns/) element.
+
+    fill (hex "#60b5cc")
+
+    fill (rgb 96 181 204)
+
+    fill (rgba 96 181 204 0.5)
+
+    fill (url "#pattern")
+
+-}
+fill :
+    BaseValue
+        (ColorSupported
+            { url : Supported
+            }
+        )
+    -> Style
+fill (Value val) =
+    AppendProperty ("fill:" ++ val)
+
+
+
 
 
 {-| The [`paint-order`](https://css-tricks.com/almanac/properties/p/paint-order/) property.

--- a/src/Css.elm
+++ b/src/Css.elm
@@ -180,13 +180,17 @@ module Css exposing
     
     -- grid
     , gridAutoRows, gridAutoColumns, gridAutoFlow, gridAutoFlow2
-    , gridRowStart, gridRowStart2, gridRowStart3
-    , gridRowEnd, gridRowEnd2, gridRowEnd3
-    , gridColumnStart, gridColumnStart2, gridColumnStart3
-    , gridColumnEnd, gridColumnEnd2, gridColumnEnd3
+    , GridLine(..)
+    , gridArea, gridAreaLine, gridArea2Lines, gridArea3Lines, gridArea4Lines
+    , gridRow, gridRowLine, gridRow2Lines
+    , gridRowStart, gridRowStartLine
+    , gridRowEnd, gridRowEndLine
+    , gridColumn, gridColumnLine, gridColumn2Lines
+    , gridColumnStart, gridColumnStartLine
+    , gridColumnEnd, gridColumnEndLine
     , gridTemplateAreas, gridTemplateAreasList
     --
-    , dense, span
+    , dense
 
     -- gaps
     , gap, gap2, rowGap, columnGap
@@ -920,12 +924,16 @@ Other values you can use for flex item alignment:
 # Grid
 
 @docs gridAutoRows, gridAutoColumns, gridAutoFlow, gridAutoFlow2
-@docs gridRowStart, gridRowStart2, gridRowStart3
-@docs gridRowEnd, gridRowEnd2, gridRowEnd3
-@docs gridColumnStart, gridColumnStart2, gridColumnStart3
-@docs gridColumnEnd, gridColumnEnd2, gridColumnEnd3
+@docs GridLine
+@docs gridArea, gridAreaLine, gridArea2Lines, gridArea3Lines, gridArea4Lines
+@docs gridRow, gridRowLine, gridRow2Lines
+@docs gridRowStart, gridRowStartLine
+@docs gridRowEnd, gridRowEndLine
+@docs gridColumn, gridColumnLine, gridColumn2Lines
+@docs gridColumnStart, gridColumnStartLine
+@docs gridColumnEnd, gridColumnEndLine
 @docs gridTemplateAreas, gridTemplateAreasList
-@docs dense, span
+@docs dense
 
 
 ------------------------------------------------------
@@ -10642,6 +10650,340 @@ gridAutoFlow2 (Value val1) (Value val2) =
         ++ val2
 
 
+{-| A type wrapping all of the possibilities of a `<grid-line>`.
+
+No `Int` should be zero - if it's zero, it won't work.
+
+- `GridLineAuto` - `auto`
+- `GridLineIdent` - `<custom-ident>`
+- `GridLineNum` - `<integer>`
+- `GridLineIdentNum` - `<custom-ident> <integer>`
+- `GridLineSpanIdent` - `span <custom-ident>`
+- `GridLineSpanNum` - `span <integer>`
+- `GridLineSpanIdentNum` - `span <custom-ident> <integer>`
+
+```
+    gridArea2Lines
+        (GridLineIdentNum "big-grid" 4)
+        (GridLineSpanIdent "other-grid")
+
+    gridRowStartLine (GridLineSpanIdent "big-grid")
+
+```
+-}
+type GridLine
+    = GridLineAuto
+    | GridLineIdent String
+    | GridLineNum Int
+    | GridLineIdentNum String Int
+    | GridLineSpanIdent String
+    | GridLineSpanNum Int
+    | GridLineSpanIdentNum String Int
+
+
+{-| Internal helper function that turns a `GridLine` into a string
+ready to go in a property.
+-}
+unwrapGridLine : GridLine -> String
+unwrapGridLine gl =
+    case gl of
+        GridLineAuto -> "auto"
+        GridLineIdent str -> str
+        GridLineNum numby -> String.fromInt numby
+        GridLineIdentNum str numby -> str ++ " " ++ String.fromInt numby
+        GridLineSpanIdent str -> "span " ++ str
+        GridLineSpanNum numby -> "span " ++ String.fromInt numby
+        GridLineSpanIdentNum str numby -> "span " ++ str ++ " " ++ String.fromInt numby
+
+
+{-| The [`grid-area`](https://css-tricks.com/almanac/properties/g/grid-area/)
+property.
+
+This variant is for single keyword arguments.
+
+    gridArea auto
+
+    gridArea inherit
+      
+    gridAreaLine (GridLineIdentNum "big-grid" 4)
+
+    gridArea2Lines
+        (GridLineIdentNum "big-grid" 4)
+        (GridLineSpanIdent "other-grid")
+
+    gridArea3Lines
+        (GridLineIdentNum "big-grid" 4)
+        (GridLineSpanIdent "other-grid")
+        (GridLineNum 7)
+
+    gridArea4Lines
+        (GridLineIdentNum "big-grid" 4)
+        (GridLineSpanIdent "other-grid")
+        (GridLineNum 7)
+        (GridLineSpanIdentNum "another-grid" 12)
+
+-}
+gridArea :
+    BaseValue
+        { auto : Supported
+        , customIdent : Supported
+        }
+    -> Style
+gridArea (Value val) =
+    AppendProperty <| "grid-area:" ++ val
+
+
+{-| The [`grid-area`](https://css-tricks.com/almanac/properties/g/grid-area/)
+property.
+
+This variant specifies 1 `<grid-line>` ([`GridLine`](#GridLine)) that determines
+the start and end positions of this grid item.
+
+Numbers used in this should not be zero, else they won't work.
+
+    gridArea auto
+
+    gridArea inherit
+      
+    gridAreaLine (GridLineIdentNum "big-grid" 4)
+
+    gridArea2Lines
+        (GridLineIdentNum "big-grid" 4)
+        (GridLineSpanIdent "other-grid")
+
+    gridArea3Lines
+        (GridLineIdentNum "big-grid" 4)
+        (GridLineSpanIdent "other-grid")
+        (GridLineNum 7)
+
+    gridArea4Lines
+        (GridLineIdentNum "big-grid" 4)
+        (GridLineSpanIdent "other-grid")
+        (GridLineNum 7)
+        (GridLineSpanIdentNum "another-grid" 12)
+
+-}
+gridAreaLine :
+    GridLine
+    -> Style
+gridAreaLine gl =
+    AppendProperty <| "grid-area:" ++ (unwrapGridLine gl)
+
+
+{-| The [`grid-area`](https://css-tricks.com/almanac/properties/g/grid-area/)
+property.
+
+This variant specifies 2 `<grid-line>`s ([`GridLine`](#GridLine)) that determines
+the start and end positions of this grid item.
+
+Numbers used in this should not be zero, else they won't work.
+
+    gridArea auto
+
+    gridArea inherit
+      
+    gridAreaLine (GridLineIdentNum "big-grid" 4)
+
+    gridArea2Lines
+        (GridLineIdentNum "big-grid" 4)
+        (GridLineSpanIdent "other-grid")
+
+    gridArea3Lines
+        (GridLineIdentNum "big-grid" 4)
+        (GridLineSpanIdent "other-grid")
+        (GridLineNum 7)
+
+    gridArea4Lines
+        (GridLineIdentNum "big-grid" 4)
+        (GridLineSpanIdent "other-grid")
+        (GridLineNum 7)
+        (GridLineSpanIdentNum "another-grid" 12)
+
+-}
+gridArea2Lines :
+    GridLine
+    -> GridLine
+    -> Style
+gridArea2Lines gl1 gl2 =
+    AppendProperty <|
+        "grid-area:"
+        ++ (unwrapGridLine gl1)
+        ++ " / "
+        ++ (unwrapGridLine gl2)
+
+
+{-| The [`grid-area`](https://css-tricks.com/almanac/properties/g/grid-area/)
+property.
+
+This variant specifies 3 `<grid-line>`s ([`GridLine`](#GridLine)) that determines
+the start and end positions of this grid item.
+
+Numbers used in this should not be zero, else they won't work.
+
+    gridArea auto
+
+    gridArea inherit
+      
+    gridAreaLine (GridLineIdentNum "big-grid" 4)
+
+    gridArea2Lines
+        (GridLineIdentNum "big-grid" 4)
+        (GridLineSpanIdent "other-grid")
+
+    gridArea3Lines
+        (GridLineIdentNum "big-grid" 4)
+        (GridLineSpanIdent "other-grid")
+        (GridLineNum 7)
+
+    gridArea4Lines
+        (GridLineIdentNum "big-grid" 4)
+        (GridLineSpanIdent "other-grid")
+        (GridLineNum 7)
+        (GridLineSpanIdentNum "another-grid" 12)
+
+-}
+gridArea3Lines :
+    GridLine
+    -> GridLine
+    -> GridLine
+    -> Style
+gridArea3Lines gl1 gl2 gl3 =
+    AppendProperty <|
+        "grid-area:"
+        ++ (unwrapGridLine gl1)
+        ++ " / "
+        ++ (unwrapGridLine gl2)
+        ++ " / "
+        ++ (unwrapGridLine gl3)
+
+
+{-| The [`grid-area`](https://css-tricks.com/almanac/properties/g/grid-area/)
+property.
+
+This variant specifies 4 `<grid-line>`s ([`GridLine`](#GridLine)) that determines
+the start and end positions of this grid item.
+
+Numbers used in this should not be zero, else they won't work.
+
+    gridArea auto
+
+    gridArea inherit
+      
+    gridAreaLine (GridLineIdentNum "big-grid" 4)
+
+    gridArea2Lines
+        (GridLineIdentNum "big-grid" 4)
+        (GridLineSpanIdent "other-grid")
+
+    gridArea3Lines
+        (GridLineIdentNum "big-grid" 4)
+        (GridLineSpanIdent "other-grid")
+        (GridLineNum 7)
+
+    gridArea4Lines
+        (GridLineIdentNum "big-grid" 4)
+        (GridLineSpanIdent "other-grid")
+        (GridLineNum 7)
+        (GridLineSpanIdentNum "another-grid" 12)
+
+-}
+gridArea4Lines :
+    GridLine
+    -> GridLine
+    -> GridLine
+    -> GridLine
+    -> Style
+gridArea4Lines gl1 gl2 gl3 gl4 =
+    AppendProperty <|
+        "grid-area:"
+        ++ (unwrapGridLine gl1)
+        ++ " / "
+        ++ (unwrapGridLine gl2)
+        ++ " / "
+        ++ (unwrapGridLine gl3)
+        ++ " / "
+        ++ (unwrapGridLine gl4)
+
+
+{-| The [`grid-row`](https://css-tricks.com/almanac/properties/g/grid-row/)
+property.
+
+This variant is for single keyword arguments.
+
+    gridRow auto
+
+    gridRow inherit
+
+    gridRowLine (GridLineIdentNum "main-grid" 3)
+    -- grid-row: main-grid 3
+
+    gridRow2Lines GridLineAuto (GridLineSpanIdentNum "grid-thing" 5)
+    -- grid-row: auto / span grid-thing 5
+-}
+gridRow :
+    BaseValue
+        { auto : Supported
+        , customIdent : Supported
+        }
+    -> Style
+gridRow (Value val) =
+    AppendProperty <| "grid-row:" ++ val
+
+
+{-| The [`grid-row`](https://css-tricks.com/almanac/properties/g/grid-row/)
+property.
+
+This variant specifies 1 `<grid-line>` ([`GridLine`](#GridLine)) that determines
+the start and end position of this grid item.
+
+Numbers used in this should not be zero, else they won't work.
+
+    gridRow auto
+
+    gridRow inherit
+
+    gridRowLine (GridLineIdentNum "main-grid" 3)
+    -- grid-row: main-grid 3
+
+    gridRow2Lines GridLineAuto (GridLineSpanIdentNum "grid-thing" 5)
+    -- grid-row: auto / span grid-thing 5
+-}
+gridRowLine :
+    GridLine
+    -> Style
+gridRowLine gl1 =
+    AppendProperty <| "grid-row:" ++ (unwrapGridLine gl1)
+
+
+{-| The [`grid-row`](https://css-tricks.com/almanac/properties/g/grid-row/)
+property.
+
+This variant specifies 2 `<grid-line>`s ([`GridLine`](#GridLine)) that determine
+the start and end position of this grid item.
+
+Numbers used in this should not be zero, else they won't work.
+
+    gridRow auto
+
+    gridRow inherit
+
+    gridRowLine (GridLineIdentNum "main-grid" 3)
+    -- grid-row: main-grid 3
+
+    gridRow2Lines GridLineAuto (GridLineSpanIdentNum "grid-thing" 5)
+    -- grid-row: auto / span grid-thing 5
+-}
+gridRow2Lines :
+    GridLine
+    -> GridLine
+    -> Style
+gridRow2Lines gl1 gl2 =
+    AppendProperty <| "grid-row:"
+        ++ (unwrapGridLine gl1)
+        ++ " / "
+        ++ (unwrapGridLine gl2)
+
+
 {-| The 1-argument version of the [`grid-row-start`](https://css-tricks.com/almanac/properties/g/grid-row-start/)
 property.
 
@@ -10649,11 +10991,11 @@ property.
 
     gridRowStart auto
 
-    gridRowStart2 span (int 3)
+    gridRowStartLine <| GridLineSpanIdent "big-grid"
 
-    gridRowStart2 (customIdent "big-grid") (int 2)
+    gridRowStartLine <| GridLineSpanNum 3
 
-    gridRowStart3 span (customIdent "big-grid") (int 2)
+    gridRowStartLine <| GridLineIdentNum "big-grid" 2
 -}
 gridRowStart :
     BaseValue (
@@ -10667,50 +11009,23 @@ gridRowStart (Value val) =
     AppendProperty ("grid-row-start:" ++ val)
 
 
-{-| The 2-argument version of [`gridRowStart`](#gridRowStart).
+{-| The variant of [`gridRowStart`](#gridRowStart) that accepts a `<grid-line>` ([`GridLine`](#GridLine)) type.
 
-    gridRowStart2 span (customIdent "big-grid")
+    gridRowStart (customIdent "big-grid")
 
-    gridRowStart2 span (int 3)
+    gridRowStart auto
 
-    gridRowStart2 (customIdent "big-grid") (int 2)
+    gridRowStartLine <| GridLineSpanIdent "big-grid"
+
+    gridRowStartLine <| GridLineSpanNum 3
+
+    gridRowStartLine <| GridLineIdentNum "big-grid" 2
 -}
-gridRowStart2 :
-    Value
-        { customIdent : Supported
-        , span : Supported
-        }
-    -> Value
-        { int : Supported
-        , customIdent : Supported
-        }
+gridRowStartLine :
+    GridLine
     -> Style
-gridRowStart2 (Value val1) (Value val2) =
-    AppendProperty ("grid-row-start:" ++ val1 ++ " " ++ val2)
-
-
-{-| The 3-argument version of [`gridRowStart`](#gridRowStart).
-
-    gridRowStart3 span (customIdent "big-grid") (int 2)
--}
-gridRowStart3 :
-    Value
-        { span : Supported
-        }
-    -> Value
-        { customIdent : Supported
-        }
-    -> Value
-        { int : Supported }
-    -> Style
-gridRowStart3 (Value val1) (Value val2) (Value val3) =
-    AppendProperty <|
-        "grid-row-start:"
-        ++ val1
-        ++ " "
-        ++ val2
-        ++ " "
-        ++ val3
+gridRowStartLine gl =
+    AppendProperty ("grid-row-start:" ++ unwrapGridLine gl)
 
 
 {-| The 1-argument version of the [`grid-row-end`](https://css-tricks.com/almanac/properties/g/grid-row-end/)
@@ -10738,50 +11053,102 @@ gridRowEnd (Value val) =
     AppendProperty ("grid-row-end:" ++ val)
 
 
-{-| The 2-argument version of [`gridRowEnd`](#gridRowEnd).
+{-| The variant of [`gridRowEnd`](#gridRowEnd) that accepts a `<grid-line>` ([`GridLine`](#GridLine)) type.
 
-    gridRowEnd2 span (customIdent "big-grid")
+    gridRowEnd (customIdent "big-grid")
 
-    gridRowEnd2 span (int 3)
+    gridRowEnd auto
 
-    gridRowEnd2 (customIdent "big-grid") (int 2)
+    gridRowEndLine <| GridLineSpanIdent "big-grid"
+
+    gridRowEndLine <| GridLineSpanNum 3
+
+    gridRowEndLine <| GridLineIdentNum "big-grid" 2
 -}
-gridRowEnd2 :
-    Value
-        { customIdent : Supported
-        , span : Supported
-        }
-    -> Value
-        { int : Supported
+gridRowEndLine :
+    GridLine
+    -> Style
+gridRowEndLine gl =
+    AppendProperty ("grid-row-end:" ++ unwrapGridLine gl)
+
+
+{-| The [`grid-column`](https://css-tricks.com/almanac/properties/g/grid-column/)
+property.
+
+This variant is for single keyword arguments.
+
+    gridColumn auto
+
+    gridColumn inherit
+
+    gridColumnLine (GridLineIdentNum "main-grid" 3)
+    -- grid-column: main-grid 3
+
+    gridColumn2Lines GridLineAuto (GridLineSpanIdentNum "grid-thing" 5)
+    -- grid-column: auto / span grid-thing 5
+-}
+gridColumn :
+    BaseValue
+        { auto : Supported
         , customIdent : Supported
         }
     -> Style
-gridRowEnd2 (Value val1) (Value val2) =
-    AppendProperty ("grid-row-end:" ++ val1 ++ " " ++ val2)
+gridColumn (Value val) =
+    AppendProperty <| "grid-column:" ++ val
 
 
-{-| The 3-argument version of [`gridRowEnd`](#gridRowEnd).
+{-| The [`grid-column`](https://css-tricks.com/almanac/properties/g/grid-column/)
+property.
 
-    gridRowEnd3 span (customIdent "big-grid") (int 2)
+This variant specifies 1 `<grid-line>` ([`GridLine`](#GridLine)) that determines
+the start and end position of this grid item.
+
+Numbers used in this should not be zero, else they won't work.
+
+    gridColumn auto
+
+    gridColumn inherit
+
+    gridColumnLine (GridLineIdentNum "main-grid" 3)
+    -- grid-column: main-grid 3
+
+    gridColumn2Lines GridLineAuto (GridLineSpanIdentNum "grid-thing" 5)
+    -- grid-column: auto / span grid-thing 5
 -}
-gridRowEnd3 :
-    Value
-        { span : Supported
-        }
-    -> Value
-        { customIdent : Supported
-        }
-    -> Value
-        { int : Supported }
+gridColumnLine :
+    GridLine
     -> Style
-gridRowEnd3 (Value val1) (Value val2) (Value val3) =
-    AppendProperty <|
-        "grid-row-end:"
-        ++ val1
-        ++ " "
-        ++ val2
-        ++ " "
-        ++ val3
+gridColumnLine gl1 =
+    AppendProperty <| "grid-column:" ++ (unwrapGridLine gl1)
+
+
+{-| The [`grid-column`](https://css-tricks.com/almanac/properties/g/grid-column/)
+property.
+
+This variant specifies 2 `<grid-line>`s ([`GridLine`](#GridLine)) that determine
+the start and end position of this grid item.
+
+Numbers used in this should not be zero, else they won't work.
+
+    gridColumn auto
+
+    gridColumn inherit
+
+    gridColumnLine (GridLineIdentNum "main-grid" 3)
+    -- grid-column: main-grid 3
+
+    gridColumn2Lines GridLineAuto (GridLineSpanIdentNum "grid-thing" 5)
+    -- grid-column: auto / span grid-thing 5
+-}
+gridColumn2Lines :
+    GridLine
+    -> GridLine
+    -> Style
+gridColumn2Lines gl1 gl2 =
+    AppendProperty <| "grid-column:"
+        ++ (unwrapGridLine gl1)
+        ++ " / "
+        ++ (unwrapGridLine gl2)
 
 
 {-| The 1-argument version of the [`grid-column-start`](https://css-tricks.com/almanac/properties/g/grid-column-start/)
@@ -10791,11 +11158,11 @@ property.
 
     gridColumnStart auto
 
-    gridColumnStart2 span (int 3)
+    gridColumnStartLine <| GridLineSpanIdent "big-grid"
 
-    gridColumnStart2 (customIdent "big-grid") (int 2)
+    gridColumnStartLine <| GridLineSpanNum 3
 
-    gridColumnStart3 span (customIdent "big-grid") (int 2)
+    gridColumnStartLine <| GridLineIdentNum "big-grid" 2
 -}
 gridColumnStart :
     BaseValue (
@@ -10809,50 +11176,23 @@ gridColumnStart (Value val) =
     AppendProperty ("grid-column-start:" ++ val)
 
 
-{-| The 2-argument version of [`gridColumnStart`](#gridColumnStart).
+{-| The variant of [`gridColumnStart`](#gridColumnStart) that accepts a `<grid-line>` ([`GridLine`](#GridLine)) type.
 
-    gridColumnStart2 span (customIdent "big-grid")
+    gridColumnStart (customIdent "big-grid")
 
-    gridColumnStart2 span (int 3)
+    gridColumnStart auto
 
-    gridColumnStart2 (customIdent "big-grid") (int 2)
+    gridColumnStartLine <| GridLineSpanIdent "big-grid"
+
+    gridColumnStartLine <| GridLineSpanNum 3
+
+    gridColumnStartLine <| GridLineIdentNum "big-grid" 2
 -}
-gridColumnStart2 :
-    Value
-        { customIdent : Supported
-        , span : Supported
-        }
-    -> Value
-        { int : Supported
-        , customIdent : Supported
-        }
+gridColumnStartLine :
+    GridLine
     -> Style
-gridColumnStart2 (Value val1) (Value val2) =
-    AppendProperty ("grid-column-start:" ++ val1 ++ " " ++ val2)
-
-
-{-| The 3-argument version of [`gridColumnStart`](#gridColumnStart).
-
-    gridColumnStart3 span (customIdent "big-grid") (int 2)
--}
-gridColumnStart3 :
-    Value
-        { span : Supported
-        }
-    -> Value
-        { customIdent : Supported
-        }
-    -> Value
-        { int : Supported }
-    -> Style
-gridColumnStart3 (Value val1) (Value val2) (Value val3) =
-    AppendProperty <|
-        "grid-column-start:"
-        ++ val1
-        ++ " "
-        ++ val2
-        ++ " "
-        ++ val3
+gridColumnStartLine gl =
+    AppendProperty ("grid-column-start:" ++ unwrapGridLine gl)
 
 
 {-| The 1-argument version of the [`grid-column-end`](https://css-tricks.com/almanac/properties/g/grid-column-end/)
@@ -10880,51 +11220,24 @@ gridColumnEnd (Value val) =
     AppendProperty ("grid-column-end:" ++ val)
 
 
-{-| The 2-argument version of [`gridColumnEnd`](#gridColumnEnd).
+{-| The variant of [`gridColumnEnd`](#gridColumnEnd) that accepts a `<grid-line>` ([`GridLine`](#GridLine)) type.
 
-    gridColumnEnd2 span (customIdent "big-grid")
+    gridColumnEnd (customIdent "big-grid")
 
-    gridColumnEnd2 span (int 3)
+    gridColumnEnd auto
 
-    gridColumnEnd2 (customIdent "big-grid") (int 2)
+    gridColumnEndLine <| GridLineSpanIdent "big-grid"
+
+    gridColumnEndLine <| GridLineSpanNum 3
+
+    gridColumnEndLine <| GridLineIdentNum "big-grid" 2
 -}
-gridColumnEnd2 :
-    Value
-        { customIdent : Supported
-        , span : Supported
-        }
-    -> Value
-        { int : Supported
-        , customIdent : Supported
-        }
+gridColumnEndLine :
+    GridLine
     -> Style
-gridColumnEnd2 (Value val1) (Value val2) =
-    AppendProperty ("grid-column-end:" ++ val1 ++ " " ++ val2)
+gridColumnEndLine gl =
+    AppendProperty ("grid-column-end:" ++ unwrapGridLine gl)
 
-
-{-| The 3-argument version of [`gridColumnEnd`](#gridColumnEnd).
-
-    gridColumnEnd3 span (customIdent "big-grid") (int 2)
--}
-gridColumnEnd3 :
-    Value
-        { span : Supported
-        }
-    -> Value
-        { customIdent : Supported
-        }
-    -> Value
-        { int : Supported }
-    -> Style
-gridColumnEnd3 (Value val1) (Value val2) (Value val3) =
-    AppendProperty <|
-        "grid-column-end:"
-        ++ val1
-        ++ " "
-        ++ val2
-        ++ " "
-       
-        ++ val3
 
 {-| The [`grid-template-areas`](https://css-tricks.com/almanac/properties/g/grid-template-areas/)
 property. Use the [`gridTemplateAreasList`](#gridTemplateAreasList) function if you want
@@ -10979,24 +11292,6 @@ gridTemplateAreasList listStr =
 dense : Value { provides | dense : Supported }
 dense =
     Value "dense"
-    
-{-| The `span` value for the following properties:
-
--   [`gridRowStart2`](#gridRowStart2)
--   [`gridRowStart3`](#gridRowStart3)
--   [`gridRowEnd2`](#gridRowEnd2)
--   [`gridRowEnd3`](#gridRowEnd3)
--   [`gridColumnStart2`](#gridColumnStart2)
--   [`gridColumnStart3`](#gridColumnStart3)
--   [`gridColumnEnd2`](#gridColumnEnd2)
--   [`gridColumnEnd3`](#gridColumnEnd3)
-```
-    gridColumnEnd3 span (customIdent "big-grid") (int 2)
-```
--}
-span : Value { provides | span : Supported }
-span =
-    Value "span"
 
 
 ------------------------------------------------------------------------

--- a/src/Css.elm
+++ b/src/Css.elm
@@ -17,7 +17,7 @@ module Css exposing
     , block, inline, start, end, blockStart, blockEnd, inlineStart, inlineEnd
     , x, y, z
     , stretch, center
-    , contentBox, borderBox, paddingBox
+    , contentBox, borderBox, paddingBox, fillBox, strokeBox, viewBox
     , baseline, sub, super, ruby, fullWidth, under, circle
     , hidden, visible
     , normal, strict, all_, both, always, scroll, column
@@ -159,14 +159,14 @@ module Css exposing
     , strokeDasharray, strokeDashoffset, strokeWidth, strokeAlign, strokeColor, strokeImage, strokeMiterlimit, strokeOpacity, strokePosition, strokePosition2, strokePosition4, strokeRepeat, strokeRepeat2, strokeSize, strokeSize2, strokeDashCorner
     , strokeLinecap, butt, square
     , strokeBreak, boundingBox, slice, clone
-    , strokeOrigin, fillBox, strokeBox
+    , strokeOrigin
     , strokeLinejoin, strokeLinejoin2, crop, arcs, miter, bevel
     , strokeDashJustify, compress, dashes, gaps
     , paintOrder, paintOrder2, paintOrder3, markers
     , columns, columns2, columnWidth, columnCount, columnRuleWidth, columnRuleStyle, columnRuleColor, columnRule, columnRule2, columnRule3
     , columnFill, balance, balanceAll
     , columnSpan
-    , transform, transforms, transformOrigin, transformOrigin2
+    , transform, transforms, transformOrigin, transformOrigin2, transformBox
     , TransformFunction, TransformFunctionSupported
     , matrix, matrix3d
     , perspective, perspectiveOrigin, perspectiveOrigin2
@@ -313,7 +313,7 @@ Sometimes these keywords mean other things too.
 
 ## Sizing, clip and origin values
 
-@docs contentBox, borderBox, paddingBox
+@docs contentBox, borderBox, paddingBox,  fillBox, strokeBox, viewBox
 
 ## Typographic values
 
@@ -813,7 +813,7 @@ Other values you can use for flex item alignment:
 @docs strokeDasharray, strokeDashoffset, strokeWidth, strokeAlign, strokeColor, strokeImage, strokeMiterlimit, strokeOpacity, strokePosition, strokePosition2, strokePosition4, strokeRepeat, strokeRepeat2, strokeSize, strokeSize2, strokeDashCorner
 @docs strokeLinecap, butt, square
 @docs strokeBreak, boundingBox, slice, clone
-@docs strokeOrigin, fillBox, strokeBox
+@docs strokeOrigin
 @docs strokeLinejoin, strokeLinejoin2, crop, arcs, miter, bevel
 @docs strokeDashJustify, compress, dashes, gaps
 
@@ -832,7 +832,7 @@ Other values you can use for flex item alignment:
 
 # Transformation
 
-@docs transform, transforms, transformOrigin, transformOrigin2
+@docs transform, transforms, transformOrigin, transformOrigin2, transformBox
 @docs TransformFunction, TransformFunctionSupported
 
 
@@ -1825,6 +1825,38 @@ paddingBox =
     Value "padding-box"
 
 
+{-| The `fill-box` value used by [`strokeOrigin`](#strokeOrigin)
+and [`transformBox`](#transformBox).
+
+    strokeOrigin fillBox
+
+    transformBox fillBox
+
+-}
+fillBox : Value { provides | fillBox : Supported }
+fillBox =
+    Value "fill-box"
+
+
+{-| The `stroke-box` value used by [`strokeOrigin`](#strokeOrigin)
+and [`transformBox`](#transformBox).
+
+    strokeOrigin strokeBoxx
+
+    transformBox strokeBox
+-}
+strokeBox : Value { provides | strokeBox : Supported }
+strokeBox =
+    Value "stroke-box"
+
+
+{-| The `view-box` value used by [`transformBox`](#transformBox).
+
+    transformBox viewBox
+-}
+viewBox : Value { provides | viewBox : Supported }
+viewBox =
+    Value "view-box"
 
 
 {-| The `baseline` value, used in the following properties:
@@ -13328,25 +13360,6 @@ strokeOrigin (Value val) =
     AppendProperty ("stroke-origin:" ++ val)
 
 
-{-| A `fillBox` value for the [`strokeOrigin`](#strokeOrigin) property.
-
-      strokeOrigin fillBox
-
--}
-fillBox : Value { provides | fillBox : Supported }
-fillBox =
-    Value "fill-box"
-
-
-{-| A `strokeBox` value for the [`strokeOrigin`](#strokeOrigin) property.
-
-      strokeOrigin strokeBox
-
--}
-strokeBox : Value { provides | strokeBox : Supported }
-strokeBox =
-    Value "stroke-box"
-
 
 {-| Sets [`stroke-position`](https://www.w3.org/TR/fill-stroke-3/#propdef-stroke-position).
 
@@ -18234,6 +18247,26 @@ transformOrigin2 :
     -> Style
 transformOrigin2 (Value vert) (Value horiz) =
     AppendProperty ("transform-origin:" ++ vert ++ " " ++ horiz)
+
+
+{-| Sets the [`transform-box`](https://developer.mozilla.org/en-US/docs/Web/CSS/transform-box) property.
+
+    transformBox contentBox
+
+    transformBox fillBox
+-}
+transformBox :
+    BaseValue
+        { contentBox : Supported
+        , borderBox : Supported
+        , fillBox : Supported
+        , strokeBox : Supported
+        , viewBox : Supported
+        }
+    -> Style
+transformBox (Value val) =
+    AppendProperty ("transform-box:" ++ val)
+
 
 
 

--- a/src/Css.elm
+++ b/src/Css.elm
@@ -36,7 +36,7 @@ module Css exposing
     , thin, thick
     , borderStyle, borderStyle2, borderStyle3, borderStyle4, borderTopStyle, borderRightStyle, borderBottomStyle, borderLeftStyle
     , dotted, dashed, solid, double, groove, ridge, inset, outset
-    , borderColor, borderColor2, borderColor3, borderColor4, borderTopColor, borderRightColor, borderBottomColor, borderLeftColor, borderBlockColor, borderInlineColor
+    , borderColor, borderColor2, borderColor3, borderColor4, borderTopColor, borderRightColor, borderBottomColor, borderLeftColor, borderBlockColor, borderBlockStartColor, borderBlockEndColor, borderInlineColor, borderInlineStartColor, borderInlineEndColor
     , borderRadius, borderRadius2, borderRadius3, borderRadius4, borderTopLeftRadius, borderTopLeftRadius2, borderTopRightRadius, borderTopRightRadius2, borderBottomRightRadius, borderBottomRightRadius2, borderBottomLeftRadius, borderBottomLeftRadius2
     , borderImageOutset, borderImageOutset2, borderImageOutset3, borderImageOutset4
     , borderImageWidth, borderImageWidth2, borderImageWidth3, borderImageWidth4
@@ -314,7 +314,7 @@ All CSS properties can have the values `unset`, `initial`, and `inherit`
 
 @docs borderColor, borderColor2, borderColor3, borderColor4, borderTopColor, borderRightColor, borderBottomColor, borderLeftColor
 
-@docs borderBlockColor, borderInlineColor
+@docs borderBlockColor, borderBlockStartColor, borderBlockEndColor, borderInlineColor, borderInlineStartColor, borderInlineEndColor
 
 
 ## Border Radius
@@ -7804,6 +7804,26 @@ borderBlockColor (Value colorVal) =
     AppendProperty ("border-block-color:" ++ colorVal)
 
 
+{-| Sets [`border-block-start-color`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-block-start-color) property.
+
+    borderBlockStartColor (rgb 0 0 0)
+
+-}
+borderBlockStartColor : BaseValue Color -> Style
+borderBlockStartColor (Value colorVal) =
+    AppendProperty ("border-block-start-color:" ++ colorVal)
+
+
+{-| Sets [`border-block-end-color`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-block-end-color) property.
+
+    borderBlockEndColor (rgb 0 0 0)
+
+-}
+borderBlockEndColor : BaseValue Color -> Style
+borderBlockEndColor (Value colorVal) =
+    AppendProperty ("border-block-end-color:" ++ colorVal)
+
+
 {-| Sets [`border-inline-color`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-inline-color) property.
 
     borderInlineColor (rgb 0 0 0)
@@ -7812,6 +7832,26 @@ borderBlockColor (Value colorVal) =
 borderInlineColor : BaseValue Color -> Style
 borderInlineColor (Value colorVal) =
     AppendProperty ("border-inline-color:" ++ colorVal)
+
+
+{-| Sets [`border-inline-start-color`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-inline-start-color) property.
+
+    borderInlineStartColor (rgb 0 0 0)
+
+-}
+borderInlineStartColor : BaseValue Color -> Style
+borderInlineStartColor (Value colorVal) =
+    AppendProperty ("border-inline-start-color:" ++ colorVal)
+
+
+{-| Sets [`border-inline-end-color`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-inline-end-color) property.
+
+    borderInlineEndColor (rgb 0 0 0)
+
+-}
+borderInlineEndColor : BaseValue Color -> Style
+borderInlineEndColor (Value colorVal) =
+    AppendProperty ("border-inline-end-color:" ++ colorVal)
 
 
 -- BORDER WIDTH --

--- a/src/Css.elm
+++ b/src/Css.elm
@@ -13,6 +13,7 @@ module Css exposing
     , Resolution, ResolutionSupported, dpi, dpcm, dppx
     , Time, TimeSupported, s, ms
     , deg, grad, rad, turn
+    , fr, minmax, fitContentTo
     , url
     , auto, none
     , left_, right_, top_, bottom_
@@ -93,6 +94,7 @@ module Css exposing
     , flexGrow, flexShrink, flexBasis
     , flexWrap, nowrap, wrap, wrapReverse
     , flex, flex2, flex3, flexFlow, flexFlow2
+    , gridAutoRows, gridAutoColumns
     , wordSpacing
     , tabSize
     , fontDisplay, fallback, swap, optional
@@ -281,6 +283,10 @@ All CSS properties can have the values `unset`, `initial`, `inherit` and `revert
 ## Resolution
 
 @docs Resolution, ResolutionSupported, dpi, dpcm, dppx
+
+## Flex
+
+@docs fr, minmax, fitContentTo
 
 ## URLs
 
@@ -596,6 +602,11 @@ Other values you can use for flex item alignment:
 ### Flexbox Shorthands
 
 @docs flex, flex2, flex3, flexFlow, flexFlow2
+
+
+# Grid
+
+@docs gridAutoRows, gridAutoColumns
 
 
 # Typography
@@ -1732,6 +1743,65 @@ dppx : Float -> Value { provides | dppx : Supported }
 dppx val =
     Value <| String.fromFloat val ++ "dppx"
 
+
+-- FLEX VALUES --
+
+{-| [`fr`](https://css-tricks.com/introduction-fr-css-unit/) flex units.
+
+    gridAutoColumns (fr 1)
+-}
+fr : Float -> Value { provides | fr : Supported }
+fr val =
+    Value <| String.fromFloat val ++ "fr"
+
+
+{-| The [`minmax()`](https://css-tricks.com/minmax-function-works/)
+value for grid properties.
+
+    gridAutoRows (minmax (px 2) (pct 100))
+-}
+minmax : 
+    Value (
+        LengthSupported
+            { pct : Supported
+            , fr : Supported
+            , maxContent : Supported
+            , minContent : Supported
+            , auto : Supported
+            }
+    )
+    -> Value (
+        LengthSupported
+            { pct : Supported
+            , fr : Supported
+            , maxContent : Supported
+            , minContent : Supported
+            , auto : Supported
+            }
+    )
+    -> Value { provides | minmax : Supported }
+minmax (Value minBreadth) (Value maxBreadth) =
+    Value <| "minmax(" ++ minBreadth ++ ", " ++ maxBreadth ++ ")"
+
+
+{-| The [`fit-content()`](https://developer.mozilla.org/en-US/docs/Web/CSS/fit-content_function)
+value that can have a length or percentage value that you want the property to be clamped to.
+
+Not to be confused with the [`fitContent`](#fitContent) value for flex properties.
+
+    gridAutoColumns (fitContentTo (pct 100))
+
+    height (fitContentTo (rem 20))
+-}
+fitContentTo :
+    Value (
+        LengthSupported
+            { pct : Supported
+            }
+        )
+    -> Value { provides | fitContentTo : Supported }
+fitContentTo (Value val) =
+    Value <| "fit-content(" ++ val ++ ")"
 
 
 -- SHARED VALUES --
@@ -6765,6 +6835,66 @@ flexFlow2 :
 flexFlow2 (Value direction_) (Value wrapping) =
     AppendProperty ("flex-flow:" ++ direction_ ++ " " ++ wrapping)
 
+
+
+
+
+-- GRID --
+
+{-| The 1-argument version of the [`grid-auto-columns`](https://css-tricks.com/almanac/properties/g/grid-auto-columns/)
+property.
+
+    gridAutoColumns (px 100)
+
+    gridAutoColumns (vmax 30)
+
+    gridAutoColumns (fr 1)
+
+    gridAutoColumns (minmax (fr 2) (pct 20))
+-}
+gridAutoColumns :
+    BaseValue (
+        LengthSupported
+            { auto : Supported
+            , minContent : Supported
+            , maxContent : Supported
+            , pct : Supported
+            , fr : Supported
+            , minmax : Supported
+            , fitContentTo : Supported
+            }
+    )
+    -> Style
+gridAutoColumns (Value val) =
+    AppendProperty ("grid-auto-columns:" ++ val)
+
+
+{-| The 1-argument version of the [`grid-auto-rows`](https://css-tricks.com/almanac/properties/g/grid-auto-rows/)
+ property.
+
+    gridAutoRows (px 100)
+
+    gridAutoRows (vmax 30)
+
+    gridAutoRows (fr 1)
+
+    gridAutoRows (minmax (fr 2) (pct 20))
+-}
+gridAutoRows :
+    BaseValue (
+        LengthSupported
+            { auto : Supported
+            , minContent : Supported
+            , maxContent : Supported
+            , pct : Supported
+            , fr : Supported
+            , minmax : Supported
+            , fitContentTo : Supported
+            }
+    )
+    -> Style
+gridAutoRows (Value val) =
+    AppendProperty ("grid-auto-rows:" ++ val)
 
 
 -- FONT SIZE --

--- a/src/Css.elm
+++ b/src/Css.elm
@@ -33,7 +33,7 @@ module Css exposing
     , borderWidth, borderWidth2, borderWidth3, borderWidth4, borderTopWidth, borderRightWidth, borderBottomWidth, borderLeftWidth
     , thin, thick
     , borderStyle, borderStyle2, borderStyle3, borderStyle4, borderTopStyle, borderRightStyle, borderBottomStyle, borderLeftStyle
-    , dotted, dashed, solid, double, groove, ridge, inset, outset
+    , dotted, dashed, solid, double, groove, ridge, inset_, outset
     , borderColor, borderColor2, borderColor3, borderColor4, borderTopColor, borderRightColor, borderBottomColor, borderLeftColor
     , borderRadius, borderRadius2, borderRadius3, borderRadius4, borderTopLeftRadius, borderTopLeftRadius2, borderTopRightRadius, borderTopRightRadius2, borderBottomRightRadius, borderBottomRightRadius2, borderBottomLeftRadius, borderBottomLeftRadius2
     , borderImageOutset, borderImageOutset2, borderImageOutset3, borderImageOutset4
@@ -41,8 +41,9 @@ module Css exposing
     , outline, outline3, outlineWidth, outlineColor, invert, outlineStyle, outlineOffset
     , display, display2, displayListItem2, displayListItem3
     , block, flex_, flow, flowRoot, grid, contents, listItem, inline, inlineBlock, inlineFlex, inlineTable, inlineGrid, ruby, rubyBase, rubyBaseContainer, rubyText, rubyTextContainer, runIn, table, tableCaption, tableCell, tableColumn, tableColumnGroup, tableFooterGroup, tableHeaderGroup, tableRow, tableRowGroup
-    , position, top, right, bottom, left, zIndex
+    , position, zIndex
     , absolute, fixed, relative, static, sticky
+    , inset, inset2, inset3, inset4, top, right, bottom, left
     , padding, padding2, padding3, padding4, paddingTop, paddingRight, paddingBottom, paddingLeft
     , margin, margin2, margin3, margin4, marginTop, marginRight, marginBottom, marginLeft
     , boxSizing
@@ -298,7 +299,7 @@ All CSS properties can have the values `unset`, `initial`, and `inherit`
 
 @docs borderStyle, borderStyle2, borderStyle3, borderStyle4, borderTopStyle, borderRightStyle, borderBottomStyle, borderLeftStyle
 
-@docs dotted, dashed, solid, double, groove, ridge, inset, outset
+@docs dotted, dashed, solid, double, groove, ridge, inset_, outset
 
 
 ## Border Color
@@ -332,9 +333,16 @@ All CSS properties can have the values `unset`, `initial`, and `inherit`
 
 ## Positions
 
-@docs position, top, right, bottom, left, zIndex
+@docs position, zIndex
 
 @docs absolute, fixed, relative, static, sticky
+
+
+## Inset
+
+@docs inset, inset2, inset3, inset4, top, right, bottom, left
+
+-- @docs insetBlock, insetBlock2, insetInline, insetInline2, insetBlockStart, insetBlockEnd, insetInlineStart, insetInlineEnd
 
 
 ## Paddings
@@ -865,7 +873,7 @@ type alias LineStyleSupported supported =
         , double : Supported
         , groove : Supported
         , ridge : Supported
-        , inset : Supported
+        , inset_ : Supported
         , outset : Supported
     }
 
@@ -1505,6 +1513,148 @@ position :
     -> Style
 position (Value val) =
     AppendProperty ("position:" ++ val)
+
+
+{-| Sets the [`inset`](https://developer.mozilla.org/en-US/docs/Web/CSS/inset) property.
+
+`inset` sets the `top`, `bottom`, `left` and `right` properties.
+
+    inset (px 10) -- top, bottom, left and right are all 10px.
+
+    inset2 (pct 5) (pct 5) -- top & bottom = 5%, left & right = 5%
+
+    inset3 (px 20) (px 20) (px 20) -- top = 20px, left & right = 20px, bottom = 20px
+
+    inset4 (px 20) (px 20) (px 40) (px 20) -- top = 20px, right = 20px, bottom = 40px, left = 20px
+
+-}
+inset :
+    Value
+        (LengthSupported
+            { pct : Supported
+            , auto : Supported
+            }
+        )
+    -> Style
+inset (Value val) =
+    AppendProperty ("inset:" ++ val)
+
+
+{-| Sets the [`inset`](https://developer.mozilla.org/en-US/docs/Web/CSS/inset) property.
+
+`inset` sets the `top`, `bottom`, `left` and `right` properties.
+
+    inset (px 10) -- top, bottom, left and right are all 10px.
+
+    inset2 (pct 5) (pct 5) -- top & bottom = 5%, left & right = 5%
+
+    inset3 (px 20) (px 20) (px 20) -- top = 20px, left & right = 20px, bottom = 20px
+
+    inset4 (px 20) (px 20) (px 40) (px 20) -- top = 20px, right = 20px, bottom = 40px, left = 20px
+
+-}
+inset2 :
+    Value
+        (LengthSupported
+            { pct : Supported
+            , auto : Supported
+            }
+        )
+    ->
+        Value
+            (LengthSupported
+                { pct : Supported
+                , auto : Supported
+                }
+            )
+    -> Style
+inset2 (Value valTopBottom) (Value valRightLeft) =
+    AppendProperty ("inset:" ++ valTopBottom ++ " " ++ valRightLeft)
+
+
+{-| Sets the [`inset`](https://developer.mozilla.org/en-US/docs/Web/CSS/inset) property.
+
+`inset` sets the `top`, `bottom`, `left` and `right` properties.
+
+    inset (px 10) -- top, bottom, left and right are all 10px.
+
+    inset2 (pct 5) (pct 5) -- top & bottom = 5%, left & right = 5%
+
+    inset3 (px 20) (px 20) (px 20) -- top = 20px, left & right = 20px, bottom = 20px
+
+    inset4 (px 20) (px 20) (px 40) (px 20) -- top = 20px, right = 20px, bottom = 40px, left = 20px
+
+-}
+inset3 :
+    Value
+        (LengthSupported
+            { pct : Supported
+            , auto : Supported
+            }
+        )
+    ->
+        Value
+            (LengthSupported
+                { pct : Supported
+                , auto : Supported
+                }
+            )
+    ->
+        Value
+            (LengthSupported
+                { pct : Supported
+                , auto : Supported
+                }
+            )
+    -> Style
+inset3 (Value valTop) (Value valRightLeft) (Value valBottom) =
+    AppendProperty ("inset:" ++ valTop ++ " " ++ valRightLeft ++ " " ++ valBottom)
+
+
+{-| Sets the [`inset`](https://developer.mozilla.org/en-US/docs/Web/CSS/inset) property.
+
+`inset` sets the `top`, `bottom`, `left` and `right` properties.
+
+    inset (px 10) -- top, bottom, left and right are all 10px.
+
+    inset2 (pct 5) (pct 5) -- top & bottom = 5%, left & right = 5%
+
+    inset3 (px 20) (px 20) (px 20) -- top = 20px, left & right = 20px, bottom = 20px
+
+    inset4 (px 20) (px 20) (px 40) (px 20) -- top = 20px, right = 20px, bottom = 40px, left = 20px
+
+-}
+inset4 :
+    Value
+        (LengthSupported
+            { pct : Supported
+            , auto : Supported
+            }
+        )
+    ->
+        Value
+            (LengthSupported
+                { pct : Supported
+                , auto : Supported
+                }
+            )
+    ->
+        Value
+            (LengthSupported
+                { pct : Supported
+                , auto : Supported
+                }
+            )
+    ->
+        Value
+            (LengthSupported
+                { pct : Supported
+                , auto : Supported
+                }
+            )
+    -> Style
+inset4 (Value valTop) (Value valRight) (Value valBottom) (Value valLeft) =
+    AppendProperty ("inset:" ++ valTop ++ " " ++ valRight ++ " " ++ valBottom ++ " " ++ valLeft)
 
 
 {-| Sets the [`top` property](https://css-tricks.com/almanac/properties/t/top/).
@@ -2485,7 +2635,7 @@ type alias BoxShadowConfig =
             )
     , color :
         Maybe (Value Color)
-    , inset : Bool
+    , inset_ : Bool
     }
 
 
@@ -2503,7 +2653,7 @@ defaultBoxShadow =
     , blurRadius = Nothing
     , spreadRadius = Nothing
     , color = Nothing
-    , inset = False
+    , inset_ = False
     }
 
 
@@ -2587,7 +2737,7 @@ boxShadowConfigToString config =
                     ""
 
         insetStr =
-            if config.inset then
+            if config.inset_ then
                 "inset "
 
             else
@@ -7837,19 +7987,19 @@ ridge =
 {-| The `inset` value used by properties such as [`borderStyle`](#borderStyle),
 [`columnRuleStyle`](#columnRuleStyle), and [`textDecorationStyle`](#textDecorationStyle).
 
-    borderStyle inset
+    borderStyle inset_
 
-    columnRuleStyle inset
+    columnRuleStyle inset_
 
-    textDecorationStyle inset
+    textDecorationStyle inset_
 
 Adds a split tone to the line that makes it appear slightly depressed.
 
 Contrast with [`outset`](#outset)
 
 -}
-inset : Value { provides | inset : Supported }
-inset =
+inset_ : Value { provides | inset_ : Supported }
+inset_ =
     Value "inset"
 
 
@@ -7866,7 +8016,7 @@ and [`strokeAlign`](#strokeAlign).
 
     textDecorationStyle outset
 
-Similar to [`inset`](#inset), but reverses the colors in a way that makes it appear slightly raised.
+Similar to [`inset_`](#inset_), but reverses the colors in a way that makes it appear slightly raised.
 
 -}
 outset : Value { provides | outset : Supported }
@@ -10042,14 +10192,14 @@ strokeWidth (Value val) =
 {-| Sets [`stroke-align`](https://www.w3.org/TR/fill-stroke-3/#propdef-stroke-align)
 
       strokeAlign center
-      strokeAlign inset
+      strokeAlign inset_
       strokeAlign outset
 
 -}
 strokeAlign :
     BaseValue
         { center : Supported
-        , inset : Supported
+        , inset_ : Supported
         , outset : Supported
         }
     -> Style

--- a/src/Css.elm
+++ b/src/Css.elm
@@ -36,7 +36,7 @@ module Css exposing
     , thin, thick
     , borderStyle, borderStyle2, borderStyle3, borderStyle4, borderTopStyle, borderRightStyle, borderBottomStyle, borderLeftStyle
     , dotted, dashed, solid, double, groove, ridge, inset, outset
-    , borderColor, borderColor2, borderColor3, borderColor4, borderTopColor, borderRightColor, borderBottomColor, borderLeftColor
+    , borderColor, borderColor2, borderColor3, borderColor4, borderTopColor, borderRightColor, borderBottomColor, borderLeftColor, borderBlockColor, borderInlineColor
     , borderRadius, borderRadius2, borderRadius3, borderRadius4, borderTopLeftRadius, borderTopLeftRadius2, borderTopRightRadius, borderTopRightRadius2, borderBottomRightRadius, borderBottomRightRadius2, borderBottomLeftRadius, borderBottomLeftRadius2
     , borderImageOutset, borderImageOutset2, borderImageOutset3, borderImageOutset4
     , borderImageWidth, borderImageWidth2, borderImageWidth3, borderImageWidth4
@@ -313,6 +313,8 @@ All CSS properties can have the values `unset`, `initial`, and `inherit`
 ## Border Color
 
 @docs borderColor, borderColor2, borderColor3, borderColor4, borderTopColor, borderRightColor, borderBottomColor, borderLeftColor
+
+@docs borderBlockColor, borderInlineColor
 
 
 ## Border Radius
@@ -7791,6 +7793,25 @@ borderLeftColor : BaseValue Color -> Style
 borderLeftColor (Value colorVal) =
     AppendProperty ("border-left-color:" ++ colorVal)
 
+
+{-| Sets [`border-block-color`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-block-color) property.
+
+    borderBlockColor (rgb 0 0 0)
+
+-}
+borderBlockColor : BaseValue Color -> Style
+borderBlockColor (Value colorVal) =
+    AppendProperty ("border-block-color:" ++ colorVal)
+
+
+{-| Sets [`border-inline-color`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-inline-color) property.
+
+    borderInlineColor (rgb 0 0 0)
+
+-}
+borderInlineColor : BaseValue Color -> Style
+borderInlineColor (Value colorVal) =
+    AppendProperty ("border-inline-color:" ++ colorVal)
 
 
 -- BORDER WIDTH --

--- a/src/Css.elm
+++ b/src/Css.elm
@@ -6,7 +6,7 @@ module Css exposing
     , unset, initial, inherit
     , all, revert
     , Angle, AngleSupported, Width, WidthSupported
-    , BasicShapeSupported, circle, circleAt, circleAt2, closestSide, farthestSide
+    , BasicShapeSupported, circle, circleAt, circleAt2, ellipse, ellipseAt, ellipseAt2, closestSide, farthestSide
     , Length, LengthSupported, zero, px, em, ex, ch, rem, vh, vw, vmin, vmax, mm, cm, q, inches, pt, pc, pct, num, int
     , calc, CalcOperation, minus, plus, times, dividedBy
     , Color, ColorSupported, color, backgroundColor, hex, rgb, rgba, hsl, hsla, currentcolor
@@ -275,7 +275,7 @@ All CSS properties can have the values `unset`, `initial`, `inherit` and `revert
 
 ## Shapes
 
-@docs BasicShapeSupported, circle, circleAt, circleAt2, closestSide, farthestSide
+@docs BasicShapeSupported, circle, circleAt, circleAt2, ellipse, ellipseAt, ellipseAt2, closestSide, farthestSide
 
 ## URLs
 
@@ -1173,6 +1173,8 @@ type alias BasicShapeSupported supported =
         , circleAt : Supported
         , circleAt2 : Supported
         , ellipse : Supported
+        , ellipseAt : Supported
+        , ellipseAt2 : Supported
         , polygon : Supported
         , path : Supported
     }
@@ -1308,7 +1310,7 @@ circle (Value val) =
     Value <| "circle(" ++ val ++ ")"
 
 
-{-| Provides a 2-argument `circle(<X> at <Y>)` value.
+{-| Provides a 2-argument `circle(<rad> at <pos>)` value.
 
     clipPath (circleAt (pct 10) left)
 
@@ -1344,7 +1346,7 @@ circleAt (Value val1) (Value val2) =
         ++ ")"
 
 
-{-| Provides a 2-argument `circle(<X> at <Y> <Z>)` value.
+{-| Provides a 3-argument `circle(<rad> at <posX> <posY>)` value.
 
     clipPath (circleAt2 closestSide (rem 5) (rem 1))
 
@@ -1375,33 +1377,172 @@ circleAt2 :
             }
     )
     -> Value { provides | circleAt2 : Supported }
-circleAt2 (Value val1) (Value val2) (Value val3)=
+circleAt2 (Value radius) (Value posX) (Value posY)=
     Value <|
         "circle("
-        ++ val1
+        ++ radius
         ++ " at "
-        ++ val2
+        ++ posX
         ++ " "
-        ++ val3
+        ++ posY
         ++ ")"
 
-{-| The `closest-side` value for use in [circle shapes](#circle).
+
+{-| Provides a one-argument `ellipse()` value.
+
+    clipPath (ellipse (px 20) (px 10))
+
+    clipPath (ellipse closestSide farthestSide)
+
+    clipPath (ellipseAt closestSide (pct 10) left)
+
+    clipPath (ellipseAt (pct 20) (pct 10) (rem 5))
+
+    clipPath (ellipseAt2 (rem 5) closestSide (rem 5) (rem 1))
+
+-}
+ellipse :
+    Value (
+        LengthSupported
+            { pct : Supported
+            , closestSide : Supported
+            , farthestSide : Supported
+            }
+    )
+    -> Value (
+        LengthSupported
+            { pct : Supported
+            , closestSide : Supported
+            , farthestSide : Supported
+            }
+    )
+    -> Value { provides | ellipse : Supported }
+ellipse (Value radx) (Value rady) =
+    Value <|
+        "ellipse("
+        ++ radx
+        ++ " "
+        ++ rady
+        ++ ")"
+
+
+{-| Provides a 3-argument `ellipse(<radiusX> <radiusY> at <pos>)` value.
+
+    clipPath (ellipseAt (pct 50) (pct 10) left)
+
+    clipPath (ellipseAt (rem 5) closestSide (rem 5))
+-}
+ellipseAt :
+    Value (
+        LengthSupported
+            { pct : Supported
+            , closestSide : Supported
+            , farthestSide : Supported
+            }
+    )
+    -> Value (
+        LengthSupported
+            { pct : Supported
+            , closestSide : Supported
+            , farthestSide : Supported
+            }
+    )
+    -> Value (
+        LengthSupported
+            { pct : Supported
+            , top : Supported
+            , bottom : Supported
+            , left : Supported
+            , right : Supported
+            , center : Supported
+            }
+    )
+    -> Value { provides | ellipseAt : Supported }
+ellipseAt (Value radx) (Value rady) (Value pos) =
+    Value <|
+        "ellipse("
+        ++ radx
+        ++ " "
+        ++ rady
+        ++ " at "
+        ++ pos
+        ++ ")"
+
+
+{-| Provides a 4-argument `ellipse(<radiusX> <radiusY> at <posX> <posY>)` value.
+
+    clipPath (ellipseAt2 (rem 6) closestSide (rem 5) (rem 1))
+
+    clipPath (ellipseAt2 farthestSide (pct 10) top left)
+-}
+ellipseAt2 :
+    Value (
+        LengthSupported
+            { pct : Supported
+            , closestSide : Supported
+            , farthestSide : Supported
+            }
+    )
+    -> Value (
+        LengthSupported
+            { pct : Supported
+            , closestSide : Supported
+            , farthestSide : Supported
+            }
+    )
+    -> Value (
+        LengthSupported
+            { pct : Supported
+            , left : Supported
+            , right : Supported
+            , center : Supported
+            }
+    )
+    -> Value (
+        LengthSupported
+            { pct : Supported
+            , top : Supported
+            , bottom : Supported
+            , center : Supported
+            }
+    )
+    -> Value { provides | ellipseAt2 : Supported }
+ellipseAt2 (Value radx) (Value rady) (Value posx) (Value posy) =
+    Value <|
+        "ellipse("
+        ++ radx
+        ++ " "
+        ++ rady
+        ++ " at "
+        ++ posx
+        ++ " "
+        ++ posy
+        ++ ")"
+
+
+{-| The `closest-side` value for use in [circle](#circle) and [ellipse](#ellipse) shapes.
 
     clipPath (circle closestSide)
+
+    clipPath (ellipse farthestSide (px 20))
 
 -}
 closestSide : Value { provides | closestSide : Supported }
 closestSide =
     Value "closest-side"
 
-{-| The `farthest-side` value for use in [circle shapes](#circle).
+
+{-| The `farthest-side` value for use in [circle](#circle) and [ellipse](#ellipse) shapes.
 
     clipPath (circleAt farthestSide (pct 20))
+
+    clipPath (ellipseAt farthestSide (px 2) (pct 20))
 
 -}
 farthestSide : Value { provides | farthestSide : Supported }
 farthestSide =
     Value "farthest-side"
+
 
 -- GLOBAL VALUES --
 

--- a/src/Css.elm
+++ b/src/Css.elm
@@ -344,6 +344,19 @@ module Css exposing
     , show, hide
     , tableLayout
 
+    -- columns
+    , columns, columns2
+    , columnWidth
+    , columnCount
+    , columnFill
+    , balance, balanceAll
+    , columnSpan
+    , columnRule, columnRule2, columnRule3
+    , columnRuleWidth
+    , columnRuleStyle
+    , columnRuleColor
+    
+    
 
     
     -- ??
@@ -370,17 +383,6 @@ module Css exposing
     -- ??
     , paintOrder, paintOrder2, paintOrder3, markers
 
-    -- ??
-    , columns, columns2
-    , columnWidth
-    , columnCount
-    , columnRule, columnRule2, columnRule3
-    , columnRuleWidth
-    , columnRuleStyle
-    , columnRuleColor
-    , columnFill
-    , balance, balanceAll
-    , columnSpan
 
     -- ??
     , opacity
@@ -19342,6 +19344,254 @@ tableLayout (Value str) =
     AppendProperty ("table-layout:" ++ str)
 
 
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------ COLUMNS ---------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+
+
+{-| Sets [`columns`](https://css-tricks.com/almanac/properties/c/columns/)
+
+    columns (px 300)
+
+    columns2 (px 300) (num 2)
+
+-}
+columns :
+    BaseValue
+        (LengthSupported
+            { auto : Supported
+            }
+        )
+    -> Style
+columns (Value widthVal) =
+    AppendProperty ("columns:" ++ widthVal)
+
+
+{-| Sets [`columns`](https://css-tricks.com/almanac/properties/c/columns/)
+
+    columns (px 300)
+
+    columns2 (px 300) (num 2)
+
+-}
+columns2 :
+    Value
+        (LengthSupported
+            { auto : Supported
+            }
+        )
+    ->
+        Value
+            { auto : Supported
+            , num : Supported
+            }
+    -> Style
+columns2 (Value widthVal) (Value count) =
+    AppendProperty ("columns:" ++ widthVal ++ " " ++ count)
+
+
+{-| Sets [`column-width`](https://css-tricks.com/almanac/properties/c/column-width/)
+
+    columnWidth auto
+
+    columnWidth (px 200)
+
+-}
+columnWidth :
+    BaseValue
+        (LengthSupported
+            { auto : Supported
+            }
+        )
+    -> Style
+columnWidth (Value widthVal) =
+    AppendProperty ("column-width:" ++ widthVal)
+
+
+{-| Sets [`column-count`](https://css-tricks.com/almanac/properties/c/column-count/)
+
+    columnCount auto
+
+    columnCount (num 3)
+
+-}
+columnCount :
+    BaseValue
+        { auto : Supported
+        , int : Supported
+        }
+    -> Style
+columnCount (Value count) =
+    AppendProperty ("column-count:" ++ count)
+
+
+{-| Sets [`column-fill`](https://css-tricks.com/almanac/properties/c/column-fill/)
+
+    columnFill auto
+
+    columnFill balance
+
+    columnFill balanceAll
+
+-}
+columnFill :
+    BaseValue
+        { auto : Supported
+        , balance : Supported
+        , balanceAll : Supported
+        }
+    -> Style
+columnFill (Value val) =
+    AppendProperty ("column-fill:" ++ val)
+
+
+{-| A `balance` value used in properties such as [`columnFill`](#columnFill)
+
+    columnFill balance
+
+-}
+balance : Value { provides | balance : Supported }
+balance =
+    Value "balance"
+
+
+{-| A `balance-all` value used in properties such as [`columnFill`](#columnFill)
+
+    columnFill balanceAll
+
+-}
+balanceAll : Value { provides | balanceAll : Supported }
+balanceAll =
+    Value "balance-all"
+
+
+{-| Sets [`column-span`](https://css-tricks.com/almanac/properties/c/column-span/)
+
+    columnSpan all_
+
+    columnSpan none
+
+-}
+columnSpan :
+    BaseValue
+        { none : Supported
+        , all_ : Supported
+        }
+    -> Style
+columnSpan (Value spanVal) =
+    AppendProperty ("column-span:" ++ spanVal)
+
+
+{-| Sets [`column-rule`](https://css-tricks.com/almanac/properties/c/column-rule/).
+This is a shorthand for the [`columnRuleWidth`](#columnRuleWidth),
+[`columnRuleStyle`](#columnRuleStyle), and [`columnRuleColor`](#columnRuleColor)
+properties.
+
+    columnRule thin
+
+    columnRule2 thin solid
+
+    columnRule3 thin solid (hex "#000000")
+
+-}
+columnRule : BaseValue LineWidth -> Style
+columnRule (Value widthVal) =
+    AppendProperty ("column-rule:" ++ widthVal)
+
+
+{-| Sets [`column-rule`](https://css-tricks.com/almanac/properties/c/column-rule/).
+This is a shorthand for the [`columnRuleWidth`](#columnRuleWidth),
+[`columnRuleStyle`](#columnRuleStyle), and [`columnRuleColor`](#columnRuleColor)
+properties.
+
+    columnRule thin
+
+    columnRule2 thin solid
+
+    columnRule3 thin solid (hex "#000000")
+
+-}
+columnRule2 : Value LineWidth -> Value LineStyle -> Style
+columnRule2 (Value widthVal) (Value styleVal) =
+    AppendProperty ("column-rule:" ++ widthVal ++ " " ++ styleVal)
+
+
+{-| Sets [`column-rule`](https://css-tricks.com/almanac/properties/c/column-rule/).
+This is a shorthand for the [`columnRuleWidth`](#columnRuleWidth),
+[`columnRuleStyle`](#columnRuleStyle), and [`columnRuleColor`](#columnRuleColor)
+properties.
+
+    columnRule thin
+
+    columnRule2 thin solid
+
+    columnRule3 thin solid (hex "#000000")
+
+-}
+columnRule3 : Value LineWidth -> Value LineStyle -> Value Color -> Style
+columnRule3 (Value widthVal) (Value styleVal) (Value colorVal) =
+    AppendProperty ("column-rule:" ++ widthVal ++ " " ++ styleVal ++ " " ++ colorVal)
+
+
+{-| Sets [`column-rule-width`](https://www.w3.org/TR/css-multicol-1/#propdef-column-rule-width)
+
+    columnRuleWidth thin
+
+    columnRuleWidth (px 2)
+
+-}
+columnRuleWidth : BaseValue LineWidth -> Style
+columnRuleWidth (Value widthVal) =
+    AppendProperty ("column-rule-width:" ++ widthVal)
+
+
+{-| Sets [`column-rule-style`](https://www.w3.org/TR/css-multicol-1/#propdef-column-rule-style)
+
+    columnRuleStyle solid
+
+    columnRuleStyle dotted
+
+    columnRuleStyle dashed
+
+-}
+columnRuleStyle : BaseValue LineStyle -> Style
+columnRuleStyle (Value styleVal) =
+    AppendProperty ("column-rule-style:" ++ styleVal)
+
+
+{-| Sets [`column-rule-color`](https://www.w3.org/TR/css-multicol-1/#propdef-column-rule-color)
+
+    columnRuleColor (rgb 0 0 0)
+
+    columnRuleColor (hex "#fff")
+
+-}
+columnRuleColor : BaseValue Color -> Style
+columnRuleColor (Value colorVal) =
+    AppendProperty ("column-rule-color:" ++ colorVal)
+
+
+
+
+
+
+
+
+
+
+
+
+
 
 
 
@@ -19592,176 +19842,6 @@ fill (Value val) =
 
 -- COLUMNS --
 
-
-{-| Sets [`columns`](https://css-tricks.com/almanac/properties/c/columns/)
-
-    columns (px 300)
-
-    columns2 (px 300) (num 2)
-
--}
-columns :
-    BaseValue
-        (LengthSupported
-            { auto : Supported
-            }
-        )
-    -> Style
-columns (Value widthVal) =
-    AppendProperty ("columns:" ++ widthVal)
-
-
-{-| Sets [`columns`](https://css-tricks.com/almanac/properties/c/columns/)
-
-    columns (px 300)
-
-    columns2 (px 300) (num 2)
-
--}
-columns2 :
-    Value
-        (LengthSupported
-            { auto : Supported
-            }
-        )
-    ->
-        Value
-            { auto : Supported
-            , num : Supported
-            }
-    -> Style
-columns2 (Value widthVal) (Value count) =
-    AppendProperty ("columns:" ++ widthVal ++ " " ++ count)
-
-
-{-| Sets [`column-width`](https://css-tricks.com/almanac/properties/c/column-width/)
-
-    columnWidth auto
-
-    columnWidth (px 200)
-
--}
-columnWidth :
-    BaseValue
-        (LengthSupported
-            { auto : Supported
-            }
-        )
-    -> Style
-columnWidth (Value widthVal) =
-    AppendProperty ("column-width:" ++ widthVal)
-
-
-{-| Sets [`column-count`](https://css-tricks.com/almanac/properties/c/column-count/)
-
-    columnCount auto
-
-    columnCount (num 3)
-
--}
-columnCount :
-    BaseValue
-        { auto : Supported
-        , int : Supported
-        }
-    -> Style
-columnCount (Value count) =
-    AppendProperty ("column-count:" ++ count)
-
-
-{-| Sets [`column-fill`](https://css-tricks.com/almanac/properties/c/column-fill/)
-
-    columnFill auto
-
-    columnFill balance
-
-    columnFill balanceAll
-
--}
-columnFill :
-    BaseValue
-        { auto : Supported
-        , balance : Supported
-        , balanceAll : Supported
-        }
-    -> Style
-columnFill (Value val) =
-    AppendProperty ("column-fill:" ++ val)
-
-
-{-| A `balance` value used in properties such as [`columnFill`](#columnFill)
-
-    columnFill balance
-
--}
-balance : Value { provides | balance : Supported }
-balance =
-    Value "balance"
-
-
-{-| A `balance-all` value used in properties such as [`columnFill`](#columnFill)
-
-    columnFill balanceAll
-
--}
-balanceAll : Value { provides | balanceAll : Supported }
-balanceAll =
-    Value "balance-all"
-
-
-{-| Sets [`column-span`](https://css-tricks.com/almanac/properties/c/column-span/)
-
-    columnSpan all_
-
-    columnSpan none
-
--}
-columnSpan :
-    BaseValue
-        { none : Supported
-        , all_ : Supported
-        }
-    -> Style
-columnSpan (Value spanVal) =
-    AppendProperty ("column-span:" ++ spanVal)
-
-
-{-| Sets [`column-rule-width`](https://www.w3.org/TR/css-multicol-1/#propdef-column-rule-width)
-
-    columnRuleWidth thin
-
-    columnRuleWidth (px 2)
-
--}
-columnRuleWidth : BaseValue LineWidth -> Style
-columnRuleWidth (Value widthVal) =
-    AppendProperty ("column-rule-width:" ++ widthVal)
-
-
-{-| Sets [`column-rule-style`](https://www.w3.org/TR/css-multicol-1/#propdef-column-rule-style)
-
-    columnRuleStyle solid
-
-    columnRuleStyle dotted
-
-    columnRuleStyle dashed
-
--}
-columnRuleStyle : BaseValue LineStyle -> Style
-columnRuleStyle (Value styleVal) =
-    AppendProperty ("column-rule-style:" ++ styleVal)
-
-
-{-| Sets [`column-rule-color`](https://www.w3.org/TR/css-multicol-1/#propdef-column-rule-color)
-
-    columnRuleColor (rgb 0 0 0)
-
-    columnRuleColor (hex "#fff")
-
--}
-columnRuleColor : BaseValue Color -> Style
-columnRuleColor (Value colorVal) =
-    AppendProperty ("column-rule-color:" ++ colorVal)
 
 
 -- STROKE --
@@ -20520,59 +20600,6 @@ paintOrder3 (Value val1) (Value val2) (Value val3) =
 markers : Value { provides | markers : Supported }
 markers =
     Value "markers"
-
-
-{-| Sets [`column-rule`](https://css-tricks.com/almanac/properties/c/column-rule/).
-This is a shorthand for the [`columnRuleWidth`](#columnRuleWidth),
-[`columnRuleStyle`](#columnRuleStyle), and [`columnRuleColor`](#columnRuleColor)
-properties.
-
-    columnRule thin
-
-    columnRule2 thin solid
-
-    columnRule3 thin solid (hex "#000000")
-
--}
-columnRule : BaseValue LineWidth -> Style
-columnRule (Value widthVal) =
-    AppendProperty ("column-rule:" ++ widthVal)
-
-
-{-| Sets [`column-rule`](https://css-tricks.com/almanac/properties/c/column-rule/).
-This is a shorthand for the [`columnRuleWidth`](#columnRuleWidth),
-[`columnRuleStyle`](#columnRuleStyle), and [`columnRuleColor`](#columnRuleColor)
-properties.
-
-    columnRule thin
-
-    columnRule2 thin solid
-
-    columnRule3 thin solid (hex "#000000")
-
--}
-columnRule2 : Value LineWidth -> Value LineStyle -> Style
-columnRule2 (Value widthVal) (Value styleVal) =
-    AppendProperty ("column-rule:" ++ widthVal ++ " " ++ styleVal)
-
-
-{-| Sets [`column-rule`](https://css-tricks.com/almanac/properties/c/column-rule/).
-This is a shorthand for the [`columnRuleWidth`](#columnRuleWidth),
-[`columnRuleStyle`](#columnRuleStyle), and [`columnRuleColor`](#columnRuleColor)
-properties.
-
-    columnRule thin
-
-    columnRule2 thin solid
-
-    columnRule3 thin solid (hex "#000000")
-
--}
-columnRule3 : Value LineWidth -> Value LineStyle -> Value Color -> Style
-columnRule3 (Value widthVal) (Value styleVal) (Value colorVal) =
-    AppendProperty ("column-rule:" ++ widthVal ++ " " ++ styleVal ++ " " ++ colorVal)
-
-
 
 
 

--- a/src/Css.elm
+++ b/src/Css.elm
@@ -43,8 +43,12 @@ module Css exposing
     , block, flex_, flow, flowRoot, grid, contents, listItem, inline, inlineBlock, inlineFlex, inlineTable, inlineGrid, ruby, rubyBase, rubyBaseContainer, rubyText, rubyTextContainer, runIn, table, tableCaption, tableCell, tableColumn, tableColumnGroup, tableFooterGroup, tableHeaderGroup, tableRow, tableRowGroup
     , position, top, right, bottom, left, zIndex
     , absolute, fixed, relative, static, sticky
-    , padding, padding2, padding3, padding4, paddingTop, paddingRight, paddingBottom, paddingLeft, paddingBlock, paddingBlock2, paddingBlockStart, paddingBlockEnd, paddingInline, paddingInline2, paddingInlineStart, paddingInlineEnd
-    , margin, margin2, margin3, margin4, marginTop, marginRight, marginBottom, marginLeft, marginBlock, marginBlock2, marginBlockStart, marginBlockEnd, marginInline, marginInline2, marginInlineStart, marginInlineEnd
+    , padding, padding2, padding3, padding4, paddingTop, paddingRight, paddingBottom, paddingLeft
+    , paddingBlock, paddingBlock2, paddingBlockStart, paddingBlockEnd
+    , paddingInline, paddingInline2, paddingInlineStart, paddingInlineEnd
+    , margin, margin2, margin3, margin4, marginTop, marginRight, marginBottom, marginLeft
+    , marginBlock, marginBlock2, marginBlockStart, marginBlockEnd
+    , marginInline, marginInline2, marginInlineStart, marginInlineEnd
     , boxSizing
     , alignContent, alignContent2, alignItems, alignItems2, alignSelf, alignSelf2, justifyContent, justifyContent2, justifyItems, justifyItems2, justifySelf, justifySelf2
     , flexDirection, row, rowReverse, column, columnReverse
@@ -342,9 +346,29 @@ All CSS properties can have the values `unset`, `initial`, and `inherit`
 @docs padding, padding2, padding3, padding4, paddingTop, paddingRight, paddingBottom, paddingLeft
 
 
+## Block Paddings
+
+@docs paddingBlock, paddingBlock2, paddingBlockStart, paddingBlockEnd
+
+
+## Inline Paddings
+
+@docs paddingInline, paddingInline2, paddingInlineStart, paddingInlineEnd
+
+
 ## Margins
 
 @docs margin, margin2, margin3, margin4, marginTop, marginRight, marginBottom, marginLeft
+
+
+## Block Margins
+
+@docs marginBlock, marginBlock2, marginBlockStart, marginBlockEnd
+
+
+## Inline Margins
+
+@docs marginInline, marginInline2, marginInlineStart, marginInlineEnd
 
 
 ## Box Sizing
@@ -1895,7 +1919,7 @@ paddingLeft (Value value) =
 
 {-| Sets [`padding-block`](https://css-tricks.com/almanac/properties/p/padding-block/) property.
 The `padding-block` property is a shorthand property for setting `padding-block-start` and
-`padding-block-end` and in a single declaration.
+`padding-block-end` in a single declaration.
 
 If there is only one argument value, it applies to both sides. If there are two
 values, the block start is set to the first value and the block end is set to the second.
@@ -1917,9 +1941,10 @@ paddingBlock (Value value) =
     AppendProperty ("padding-block:" ++ value)
 
 
-{-| Sets [`padding`](https://css-tricks.com/almanac/properties/p/padding/) property.
-The `padding-block` property is a shorthand property for setting `padding-block-start`,
-`padding-block-end` and in a single declaration.
+{-| Sets [`padding-block`](https://css-tricks.com/almanac/properties/p/padding-block/) property.
+
+The `padding-block` property is a shorthand property for setting `padding-block-start` and
+`padding-block-end` in a single declaration.
 
 The block start value is set to the first value and the block end value is set to the second.
 
@@ -1959,7 +1984,7 @@ paddingBlockStart (Value value) =
     AppendProperty ("padding-block-start:" ++ value)
 
 
-{-| Sets [`padding-block-end](https://developer.mozilla.org/en-US/docs/Web/CSS/padding-block-end) property.
+{-| Sets [`padding-block-end`](https://developer.mozilla.org/en-US/docs/Web/CSS/padding-block-end) property.
 
     paddingBlockEnd (px 4)
 
@@ -1978,6 +2003,7 @@ paddingBlockEnd (Value value) =
 
 
 {-| Sets [`padding-inline`](https://css-tricks.com/almanac/properties/p/padding-inline/) property.
+
 The `padding-inline` property is a shorthand property for setting `padding-inline-start` and
 `padding-inline-end` and in a single declaration.
 
@@ -2001,9 +2027,10 @@ paddingInline (Value value) =
     AppendProperty ("padding-inline:" ++ value)
 
 
-{-| Sets [`padding`](https://css-tricks.com/almanac/properties/p/padding/) property.
-The `padding-inline` property is a shorthand property for setting `padding-inline-start`,
-`padding-inline-end` and in a single declaration.
+{-| Sets [`padding-inline`](https://css-tricks.com/almanac/properties/p/padding-inline/) property.
+
+The `padding-inline` property is a shorthand property for setting `padding-inline-start` and
+`padding-inline-end` in a single declaration.
 
 The inline start value is set to the first value and the inline end value is set to the second.
 
@@ -2043,7 +2070,7 @@ paddingInlineStart (Value value) =
     AppendProperty ("padding-inline-start:" ++ value)
 
 
-{-| Sets [`padding-inline-end](https://developer.mozilla.org/en-US/docs/Web/CSS/padding-inline-end) property.
+{-| Sets [`padding-inline-end`](https://developer.mozilla.org/en-US/docs/Web/CSS/padding-inline-end) property.
 
     paddingInlineEnd (px 4)
 
@@ -2289,9 +2316,9 @@ marginLeft (Value value) =
 The `margin-block` property is a shorthand property for setting `margin-block-start` and
 `margin-block-end` in a single declaration.
 
-If there is only one argument value, it applies to all sides. If there are two
-values, the block start margins are set to the first value and the block end margins
-are set to the second. 
+If there is only one argument value, it applies to both sides. If there are two
+values, the block start margin is set to the first value and the block end margin
+is set to the second. 
 
     marginBlock (em 4) -- set block start and end margins to 4em
 
@@ -2315,8 +2342,8 @@ marginBlock (Value value) =
 The `margin-block` property is a shorthand property for setting `margin-block-start` and
 `margin-block-end` in a single declaration.
 
-The block start margins are set to the first value and the block end margins
-are set to the second.
+The block start margin is set to the first value and the block end margin
+is set to the second.
 
     marginBlock2 (em 4) (px 2) -- block start = 4em, block end = 2px
 
@@ -2379,9 +2406,9 @@ marginBlockEnd (Value value) =
 The `margin-inline` property is a shorthand property for setting `margin-inline-start` and
 `margin-inline-end` in a single declaration.
 
-If there is only one argument value, it applies to all sides. If there are two
-values, the inline start margins are set to the first value and the inline end margins
-are set to the second. 
+If there is only one argument value, it applies to both sides. If there are two
+values, the inline start margin is set to the first value and the inline end margin
+is set to the second. 
 
     marginInline (em 4) -- set inline start and end margins to 4em
 
@@ -2405,8 +2432,8 @@ marginInline (Value value) =
 The `margin-inline` property is a shorthand property for setting `margin-inline-start` and
 `margin-inline-end` in a single declaration.
 
-The inline start margins are set to the first value and the inline end margins
-are set to the second.
+The inline start margin is set to the first value and the inline end margin
+is set to the second.
 
     marginInline2 (em 4) (px 2) -- inline start = 4em, inline end = 2px
 

--- a/src/Css.elm
+++ b/src/Css.elm
@@ -10,7 +10,11 @@ module Css exposing
     , calc, CalcOperation, minus, plus, times, dividedBy
     , Color, ColorSupported, color, backgroundColor, hex, rgb, rgba, hsl, hsla, currentcolor
     , Time, TimeSupported, s, ms
-    , pseudoClass, active, disabled
+    , pseudoClass, active, checked, disabled, empty, enabled
+    , firstChild, firstOfType, focus, fullscreen, hover, inRange
+    , indeterminate, invalid, lastChild, lastOfType, link, onlyChild
+    , onlyOfType, outOfRange, readOnly, readWrite, required
+    , root, scope, target, valid, visited
     , pseudoElement, before, after, backdrop, cue, marker, placeholder, selection
     , width, minWidth, maxWidth, height, minHeight, maxHeight
     , minContent, maxContent, fitContent
@@ -225,7 +229,11 @@ All CSS properties can have the values `unset`, `initial`, and `inherit`
 
 ## Pseudo-Classes
 
-@docs pseudoClass, active, disabled
+@docs pseudoClass, active, checked, disabled, empty, enabled
+@docs firstChild, firstOfType, focus, fullscreen, hover, inRange
+@docs indeterminate, invalid, lastChild, lastOfType, link, onlyChild
+@docs onlyOfType, outOfRange, readOnly, readWrite, required
+@docs root, scope, target, valid, visited
 
 
 ## Pseudo-Elements
@@ -2207,6 +2215,20 @@ active =
     pseudoClass "active"
 
 
+{-| A [`:checked`](https://developer.mozilla.org/en-US/docs/Web/CSS/:checked)
+[pseudo-class](https://css-tricks.com/pseudo-class-selectors/).
+
+This pseudo-class is for any checkbox, option or radio input that is checked or toggled on.
+
+    checked
+        [ backgroundColor (rgb 0 0 255)
+        ]
+-}
+checked : List Style -> Style
+checked =
+    pseudoClass "checked"
+
+
 {-| A [`:disabled`](https://developer.mozilla.org/en-US/docs/Web/CSS/:disabled)
 [pseudo-class](https://css-tricks.com/pseudo-class-selectors/).
 
@@ -2217,6 +2239,298 @@ disabled : List Style -> Style
 disabled =
     pseudoClass "disabled"
 
+
+{-| An [`:empty`](https://developer.mozilla.org/en-US/docs/Web/CSS/:empty)
+[pseudo-class](https://css-tricks.com/pseudo-class-selectors/).
+
+    empty
+        [ backgroundColor (rgb 20 20 20)
+        ]
+
+-}
+empty : List Style -> Style
+empty =
+    pseudoClass "empty"
+
+
+{-| An [`:enabled`](https://developer.mozilla.org/en-US/docs/Web/CSS/:enabled)
+[pseudo-class](https://css-tricks.com/pseudo-class-selectors/).
+
+    enabled
+        [ borderColor (rgba 150 150 0 0.5)
+        ]
+-}
+enabled : List Style -> Style
+enabled =
+    pseudoClass "enabled"
+
+
+{-| A [`:first-of-type`](https://developer.mozilla.org/en-US/docs/Web/CSS/:first-child)
+[pseudo-class](https://css-tricks.com/pseudo-class-selectors/).
+
+    firstChild
+        [ fontWeight bold
+        ]
+-}
+firstChild : List Style -> Style
+firstChild =
+    pseudoClass "first-child"
+
+
+{-| A [`:first-of-type`](https://developer.mozilla.org/en-US/docs/Web/CSS/:first-of-type)
+[pseudo-class](https://css-tricks.com/pseudo-class-selectors/).
+
+    firstOfType
+        [ color (rgb 255 0 0)
+        ]
+-}
+firstOfType : List Style -> Style
+firstOfType =
+    pseudoClass "first-of-type"
+
+
+{-| A [`:focus`](https://developer.mozilla.org/en-US/docs/Web/CSS/:focus)
+[pseudo-class](https://css-tricks.com/pseudo-class-selectors/).
+
+    focus
+        [ border3 (px 2) solid (rgb 0 0 0)
+        ]
+-}
+focus : List Style -> Style
+focus =
+    pseudoClass "focus"
+
+
+{-| A [`:fullscreen`](https://developer.mozilla.org/en-US/docs/Web/CSS/:fullscreen)
+[pseudo-class](https://css-tricks.com/pseudo-class-selectors/).
+
+    fullscreen
+        [ backgroundColor (rgb 0 0 0)
+        ]
+-}
+fullscreen : List Style -> Style
+fullscreen =
+    pseudoClass "fullscreen"
+
+
+{-| A [`:hover`](https://developer.mozilla.org/en-US/docs/Web/CSS/:hover)
+[pseudo-class](https://css-tricks.com/pseudo-class-selectors/).
+    
+    hover
+        [ fontWeight bold
+        , color (rgb 255 50 0)
+        ]
+-}
+hover : List Style -> Style
+hover =
+    pseudoClass "hover"
+
+
+{-| An [`:in-range`](https://developer.mozilla.org/en-US/docs/Web/CSS/:in-range)
+[pseudo-class](https://css-tricks.com/pseudo-class-selectors/).
+
+    inRange
+        [ backgroundColor (rgb 0 255 0)
+        ]
+-}
+inRange : List Style -> Style
+inRange =
+    pseudoClass "in-range"
+
+
+{-| An [`:indeterminate`](https://developer.mozilla.org/en-US/docs/Web/CSS/:indeterminate)
+[pseudo-class](https://css-tricks.com/pseudo-class-selectors/).
+
+    indeterminate
+        [ backgroundColor (rgb 100 100 100)
+        ]
+-}
+indeterminate : List Style -> Style
+indeterminate =
+    pseudoClass "indeterminate"
+
+
+{-| An [`:invalid`](https://developer.mozilla.org/en-US/docs/Web/CSS/:invalid)
+[pseudo-class](https://css-tricks.com/pseudo-class-selectors/).
+
+    invalid
+        [ color (rgb 255 0 0)
+        , fontWeight bold
+        ]
+-}
+invalid : List Style -> Style
+invalid =
+    pseudoClass "invalid"
+
+
+{-| A [`:last-child`](https://developer.mozilla.org/en-US/docs/Web/CSS/:last-child)
+[pseudo-class](https://css-tricks.com/pseudo-class-selectors/).
+
+    lastChild
+        [ backgroundColor (rgb 0 0 255)
+        ]
+-}
+lastChild : List Style -> Style
+lastChild =
+    pseudoClass "last-child"
+
+
+{-| A [`:last-of-type`](https://developer.mozilla.org/en-US/docs/Web/CSS/:last-of-type)
+[pseudo-class](https://css-tricks.com/pseudo-class-selectors/).
+
+    lastOfType
+        [ color (rgb 100 100 100)
+        ]
+-}
+lastOfType : List Style -> Style
+lastOfType =
+    pseudoClass "last-of-type"
+
+
+{-| A [`:link`](https://developer.mozilla.org/en-US/docs/Web/CSS/:link)
+[pseudo-class](https://css-tricks.com/pseudo-class-selectors/).
+
+    link
+        [ color (rgb 0 0 255)
+        ]
+-}
+link : List Style -> Style
+link =
+    pseudoClass "link"
+
+
+{-| An [`:only-child`](https://developer.mozilla.org/en-US/docs/Web/CSS/:only-child)
+[pseudo-class](https://css-tricks.com/pseudo-class-selectors/).
+
+    onlyChild
+        [ backgroundColor (rgb 255 255 255)
+        ]
+-}
+onlyChild : List Style -> Style
+onlyChild =
+    pseudoClass "only-child"
+
+
+{-| An [`:only-of-type`](https://developer.mozilla.org/en-US/docs/Web/CSS/:only-of-type)
+[pseudo-class](https://css-tricks.com/pseudo-class-selectors/).
+
+    onlyOfType
+        [ color (rgb 255 0 0)
+        , fontStyle italic
+        ]
+-}
+onlyOfType : List Style -> Style
+onlyOfType =
+    pseudoClass "only-of-type"
+
+
+{-| An [`:out-of-range`](https://developer.mozilla.org/en-US/docs/Web/CSS/:out-of-range)
+[pseudo-class](https://css-tricks.com/pseudo-class-selectors/).
+
+    outOfRange
+        [ color (rgb 255 0 0)
+        ]
+-}
+outOfRange : List Style -> Style
+outOfRange =
+    pseudoClass "out-of-range"
+
+
+{-| A [`:read-only`](https://developer.mozilla.org/en-US/docs/Web/CSS/:read-only)
+[pseudo-class](https://css-tricks.com/pseudo-class-selectors/).
+
+    readOnly
+        [ color (rgb 50 50 50)
+        ]
+-}
+readOnly : List Style -> Style
+readOnly =
+    pseudoClass "read-only"
+
+
+{-| A [`:read-write`](https://developer.mozilla.org/en-US/docs/Web/CSS/:read-write)
+[pseudo-class](https://css-tricks.com/pseudo-class-selectors/).
+
+    readWrite
+        [ backgroundColor (rgb 0 50 150)
+        ]
+-}
+readWrite : List Style -> Style
+readWrite =
+    pseudoClass "read-write"
+
+
+{-| A [`:required`](https://developer.mozilla.org/en-US/docs/Web/CSS/:required)
+[pseudo-class](https://css-tricks.com/pseudo-class-selectors/).
+
+    required
+        [ border (px 2) solid (rgb 100 100 100)
+        ]
+-}
+required : List Style -> Style
+required =
+    pseudoClass "required"
+
+
+{-| A [`:root`](https://developer.mozilla.org/en-US/docs/Web/CSS/:root)
+[pseudo-class](https://css-tricks.com/pseudo-class-selectors/).
+
+    root
+        [ backgroundColor (rgb 0 200 200)
+        ]
+-}
+root : List Style -> Style
+root =
+    pseudoClass "root"
+
+
+{-| A [`:scope`](https://developer.mozilla.org/en-US/docs/Web/CSS/:scope)
+[pseudo-class](https://css-tricks.com/pseudo-class-selectors/).
+
+    scope
+        [ backgroundColor (rgb 0 200 200)
+        ]
+-}
+scope : List Style -> Style
+scope =
+    pseudoClass "scope"
+
+
+{-| A [`:target`](https://developer.mozilla.org/en-US/docs/Web/CSS/:target)
+[pseudo-class](https://css-tricks.com/pseudo-class-selectors/).
+
+    target
+        [ fontWeight bold
+        , border3 (px 2) dotted (rgb 255 0 0)
+        ]
+-}
+target : List Style -> Style
+target =
+    pseudoClass "target"
+
+
+{-| A [`:valid`](https://developer.mozilla.org/en-US/docs/Web/CSS/:valid)
+[pseudo-class](https://css-tricks.com/pseudo-class-selectors/).
+
+    valid
+        [ border3 (px 1) solid (rgb 0 255 0)
+        ]
+-}
+valid : List Style -> Style
+valid =
+    pseudoClass "valid"
+
+
+{-| A [`:visited`](https://developer.mozilla.org/en-US/docs/Web/CSS/:visited)
+[pseudo-class](https://css-tricks.com/pseudo-class-selectors/).
+
+    visited
+        [ color (rgb 150 0 255)
+        ]
+-}
+visited : List Style -> Style
+visited =
+    pseudoClass "visited"
 
 
 -- PSEUDO-ELEMENTS--

--- a/src/Css.elm
+++ b/src/Css.elm
@@ -20,6 +20,7 @@ module Css exposing
     , contentBox, borderBox, paddingBox, fillBox, strokeBox, viewBox
     , baseline, sub, super, ruby, fullWidth, under, circle
     , hidden, visible
+    , thin, thick
     , normal, strict, all_, both, always, scroll, column
     , content, fill_, stroke, text, style
     , clip, cover, contain_
@@ -57,7 +58,6 @@ module Css exposing
     , borderInlineEnd, borderInlineEnd2, borderInlineEnd3
     , borderWidth, borderWidth2, borderWidth3, borderWidth4, borderTopWidth, borderRightWidth, borderBottomWidth, borderLeftWidth
     , borderBlockWidth, borderBlockStartWidth, borderBlockEndWidth, borderInlineWidth, borderInlineStartWidth, borderInlineEndWidth
-    , thin, thick
     , borderStyle, borderStyle2, borderStyle3, borderStyle4, borderTopStyle, borderRightStyle, borderBottomStyle, borderLeftStyle
     , borderBlockStyle, borderBlockStartStyle, borderBlockEndStyle, borderInlineStyle, borderInlineStartStyle, borderInlineEndStyle
     , dotted, dashed, solid, double, groove, ridge, inset_, outset
@@ -179,6 +179,7 @@ module Css exposing
     , EasingFunction, EasingFunctionSupported, linear, ease, easeIn, easeOut, easeInOut, cubicBezier, stepStart, stepEnd, steps, steps2, jumpStart, jumpEnd, jumpNone, jumpBoth, infinite, reverse, alternate, alternateReverse, running, paused, forwards, backwards
     , opacity
     , zoom
+    , scrollbarColor, scrollbarWidth
     , scrollBehavior, smooth, scrollSnapAlign, scrollSnapStop
     , scrollSnapType, scrollSnapType2, mandatory, proximity
     , scrollMargin, scrollMargin2, scrollMargin3, scrollMargin4, scrollMarginTop, scrollMarginLeft, scrollMarginRight, scrollMarginBottom
@@ -323,6 +324,10 @@ Sometimes these keywords mean other things too.
 
 @docs hidden, visible
 
+## Thickness
+
+@docs thin, thick
+
 ## Miscellaneous shared
 
 @docs normal, strict, all_, both, always, scroll, column
@@ -427,8 +432,6 @@ Sometimes these keywords mean other things too.
 @docs borderWidth, borderWidth2, borderWidth3, borderWidth4, borderTopWidth, borderRightWidth, borderBottomWidth, borderLeftWidth
 
 @docs borderBlockWidth, borderBlockStartWidth, borderBlockEndWidth, borderInlineWidth, borderInlineStartWidth, borderInlineEndWidth
-
-@docs thin, thick
 
 
 ## Border Style
@@ -885,6 +888,7 @@ Other values you can use for flex item alignment:
 
 # Scroll
 
+@docs scrollbarColor, scrollbarWidth
 @docs scrollBehavior, smooth, scrollSnapAlign, scrollSnapStop
 @docs scrollSnapType, scrollSnapType2, mandatory, proximity
 @docs scrollMargin, scrollMargin2, scrollMargin3, scrollMargin4, scrollMarginTop, scrollMarginLeft, scrollMarginRight, scrollMarginBottom
@@ -2001,6 +2005,42 @@ hidden =
 visible : Value { provides | visible : Supported }
 visible =
     Value "visible"
+
+
+
+{-| The `thin` value used by various properties.
+
+In [`borderWidth`](#borderWidth) and
+[`columnRuleWidth`](#columnRuleWidth), the value is
+equivalent to 1px.
+
+    borderWidth thin
+
+    columnRuleWidth thin
+
+It's also used in [`scrollbarWidth`](#scrollbarWidth).
+
+    scrollbarWidth thin
+
+-}
+thin : Value { provides | thin : Supported }
+thin =
+    Value "thin"
+
+
+{-| The `thick` value used by properties such as [`borderWidth`](#borderWidth),
+and [`columnRuleWidth`](#columnRuleWidth).
+
+    borderWidth thick
+
+    columnRuleWidth thick
+
+The value is equivalent of 5px.
+
+-}
+thick : Value { provides | thick : Supported }
+thick =
+    Value "thick"
 
 
 {-| The `normal` value, which can be used with such properties as:
@@ -10599,39 +10639,6 @@ borderInlineEndColor (Value colorVal) =
 
 
 
--- BORDER WIDTH --
-
-
-{-| The `thin` value used by properties such as [`borderWidth`](#borderWidth),
-and [`columnRuleWidth`](#columnRuleWidth).
-
-    borderWidth thin
-
-    columnRuleWidth thin
-
-The value is equivalent of 1px.
-
--}
-thin : Value { provides | thin : Supported }
-thin =
-    Value "thin"
-
-
-{-| The `thick` value used by properties such as [`borderWidth`](#borderWidth),
-and [`columnRuleWidth`](#columnRuleWidth).
-
-    borderWidth thick
-
-    columnRuleWidth thick
-
-The value is equivalent of 5px.
-
--}
-thick : Value { provides | thick : Supported }
-thick =
-    Value "thick"
-
-
 
 -- BORDER STYLE --
 
@@ -16848,6 +16855,41 @@ painted =
 smooth : Value { provides | smooth : Supported }
 smooth =
     Value "smooth"
+
+
+{-| Sets the
+[`scrollbar-color`](https://developer.mozilla.org/en-US/docs/Web/CSS/scrollbar-color) property.
+
+    scrollbarColor auto
+
+    scrollbarColor (hex "f35d93")
+-}
+scrollbarColor :
+    BaseValue
+        ( ColorSupported
+            { auto : Supported
+            }
+        )
+    -> Style
+scrollbarColor (Value val) =
+    AppendProperty ("scrollbar-color:" ++ val)
+
+
+{-| Sets the [`scrollbar-width`](https://developer.mozilla.org/en-US/docs/Web/CSS/scrollbar-width) property.
+
+    scrollbarWidth auto
+
+    scrollbarWidth thin
+-}
+scrollbarWidth :
+    BaseValue
+        { auto : Supported
+        , thin : Supported
+        , none : Supported
+        }
+    -> Style
+scrollbarWidth (Value val) =
+    AppendProperty ("scrollbar-width:" ++ val)
 
 
 {-| Sets [`scroll-behavior`](https://css-tricks.com/almanac/properties/s/scroll-behavior/)

--- a/src/Css.elm
+++ b/src/Css.elm
@@ -97,6 +97,7 @@ module Css exposing
     , flex, flex2, flex3, flexFlow, flexFlow2
     , gridAutoRows, gridAutoColumns, gridAutoFlow, gridAutoFlow2, dense
     , gridRowStart, gridRowStart2, gridRowStart3, gridRowEnd, gridRowEnd2, gridRowEnd3, gridColumnStart, gridColumnStart2, gridColumnStart3, gridColumnEnd, gridColumnEnd2, gridColumnEnd3, span
+    , gridTemplateAreas, gridTemplateAreasList
     , wordSpacing
     , tabSize
     , fontDisplay, fallback, swap, optional
@@ -615,7 +616,7 @@ Other values you can use for flex item alignment:
 
 @docs gridAutoRows, gridAutoColumns, gridAutoFlow, gridAutoFlow2, dense
 @docs gridRowStart, gridRowStart2, gridRowStart3, gridRowEnd, gridRowEnd2, gridRowEnd3, gridColumnStart, gridColumnStart2, gridColumnStart3, gridColumnEnd, gridColumnEnd2, gridColumnEnd3, span
-
+@docs gridTemplateAreas, gridTemplateAreasList
 
 # Typography
 
@@ -7283,6 +7284,47 @@ span : Value { provides | span : Supported }
 span =
     Value "span"
 
+{-| The [`grid-template-areas`](https://css-tricks.com/almanac/properties/g/grid-template-areas/)
+property. Use the [`gridTemplateAreasList`](#gridTemplateAreasList) function if you want
+to use a list of strings as a value.
+
+    gridTemplateAreas none
+
+    gridTemplateAreas inherit
+
+    gridTemplateAreasList
+        [ "c a b"
+        , "c d e"
+        ]
+
+-}
+gridTemplateAreas :
+    BaseValue
+        { none : Supported
+        }
+    -> Style
+gridTemplateAreas (Value val) =
+    AppendProperty ("grid-template-areas:" ++ val)
+
+
+{-| A version of [`gridTemplateAreas`](#gridTemplateAreas) that lets you input a list of strings a value.
+
+    gridTemplateAreasList
+        [ "c a b"
+        , "c d e"
+        ]
+-}
+gridTemplateAreasList :
+    List String
+    -> Style
+gridTemplateAreasList listStr =
+    AppendProperty <|
+        "grid-template-areas:"
+        ++
+        ( listStr
+        |> List.map enquoteString
+        |> String.join " "
+        )
 
 -- FONT SIZE --
 
@@ -7662,6 +7704,7 @@ fontFeatureSettings (Value val) =
 
 
 {-| Sets [`font-feature-settings`](https://css-tricks.com/almanac/properties/f/font-feature-settings/)
+in a way that lets you add a list of [`featureTag`](#featureTag)s.
 
     fontFeatureSettingsList featureTag "liga" [ featureTag2 "swsh" 2 ]
 

--- a/src/Css.elm
+++ b/src/Css.elm
@@ -2223,6 +2223,7 @@ This pseudo-class is for any checkbox, option or radio input that is checked or 
     checked
         [ backgroundColor (rgb 0 0 255)
         ]
+
 -}
 checked : List Style -> Style
 checked =
@@ -2259,6 +2260,7 @@ empty =
     enabled
         [ borderColor (rgba 150 150 0 0.5)
         ]
+
 -}
 enabled : List Style -> Style
 enabled =
@@ -2271,6 +2273,7 @@ enabled =
     firstChild
         [ fontWeight bold
         ]
+
 -}
 firstChild : List Style -> Style
 firstChild =
@@ -2283,6 +2286,7 @@ firstChild =
     firstOfType
         [ color (rgb 255 0 0)
         ]
+
 -}
 firstOfType : List Style -> Style
 firstOfType =
@@ -2295,6 +2299,7 @@ firstOfType =
     focus
         [ border3 (px 2) solid (rgb 0 0 0)
         ]
+
 -}
 focus : List Style -> Style
 focus =
@@ -2307,6 +2312,7 @@ focus =
     fullscreen
         [ backgroundColor (rgb 0 0 0)
         ]
+
 -}
 fullscreen : List Style -> Style
 fullscreen =
@@ -2315,11 +2321,12 @@ fullscreen =
 
 {-| A [`:hover`](https://developer.mozilla.org/en-US/docs/Web/CSS/:hover)
 [pseudo-class](https://css-tricks.com/pseudo-class-selectors/).
-    
+
     hover
         [ fontWeight bold
         , color (rgb 255 50 0)
         ]
+
 -}
 hover : List Style -> Style
 hover =
@@ -2332,6 +2339,7 @@ hover =
     inRange
         [ backgroundColor (rgb 0 255 0)
         ]
+
 -}
 inRange : List Style -> Style
 inRange =
@@ -2344,6 +2352,7 @@ inRange =
     indeterminate
         [ backgroundColor (rgb 100 100 100)
         ]
+
 -}
 indeterminate : List Style -> Style
 indeterminate =
@@ -2357,6 +2366,7 @@ indeterminate =
         [ color (rgb 255 0 0)
         , fontWeight bold
         ]
+
 -}
 invalid : List Style -> Style
 invalid =
@@ -2369,6 +2379,7 @@ invalid =
     lastChild
         [ backgroundColor (rgb 0 0 255)
         ]
+
 -}
 lastChild : List Style -> Style
 lastChild =
@@ -2381,6 +2392,7 @@ lastChild =
     lastOfType
         [ color (rgb 100 100 100)
         ]
+
 -}
 lastOfType : List Style -> Style
 lastOfType =
@@ -2393,6 +2405,7 @@ lastOfType =
     link
         [ color (rgb 0 0 255)
         ]
+
 -}
 link : List Style -> Style
 link =
@@ -2405,6 +2418,7 @@ link =
     onlyChild
         [ backgroundColor (rgb 255 255 255)
         ]
+
 -}
 onlyChild : List Style -> Style
 onlyChild =
@@ -2418,6 +2432,7 @@ onlyChild =
         [ color (rgb 255 0 0)
         , fontStyle italic
         ]
+
 -}
 onlyOfType : List Style -> Style
 onlyOfType =
@@ -2430,6 +2445,7 @@ onlyOfType =
     outOfRange
         [ color (rgb 255 0 0)
         ]
+
 -}
 outOfRange : List Style -> Style
 outOfRange =
@@ -2442,6 +2458,7 @@ outOfRange =
     readOnly
         [ color (rgb 50 50 50)
         ]
+
 -}
 readOnly : List Style -> Style
 readOnly =
@@ -2454,6 +2471,7 @@ readOnly =
     readWrite
         [ backgroundColor (rgb 0 50 150)
         ]
+
 -}
 readWrite : List Style -> Style
 readWrite =
@@ -2466,6 +2484,7 @@ readWrite =
     required
         [ border (px 2) solid (rgb 100 100 100)
         ]
+
 -}
 required : List Style -> Style
 required =
@@ -2478,6 +2497,7 @@ required =
     root
         [ backgroundColor (rgb 0 200 200)
         ]
+
 -}
 root : List Style -> Style
 root =
@@ -2490,6 +2510,7 @@ root =
     scope
         [ backgroundColor (rgb 0 200 200)
         ]
+
 -}
 scope : List Style -> Style
 scope =
@@ -2503,6 +2524,7 @@ scope =
         [ fontWeight bold
         , border3 (px 2) dotted (rgb 255 0 0)
         ]
+
 -}
 target : List Style -> Style
 target =
@@ -2515,6 +2537,7 @@ target =
     valid
         [ border3 (px 1) solid (rgb 0 255 0)
         ]
+
 -}
 valid : List Style -> Style
 valid =
@@ -2527,10 +2550,12 @@ valid =
     visited
         [ color (rgb 150 0 255)
         ]
+
 -}
 visited : List Style -> Style
 visited =
     pseudoClass "visited"
+
 
 
 -- PSEUDO-ELEMENTS--
@@ -2590,6 +2615,7 @@ before =
     backdrop
         [ background (rgba 255 0 0 0.25)
         ]
+
 -}
 backdrop : List Style -> Style
 backdrop =
@@ -2603,10 +2629,12 @@ backdrop =
         [ color (rgba 255 255 0 1)
         , fontWeight (int 600)
         ]
+
 -}
 cue : List Style -> Style
 cue =
     pseudoElement "cue"
+
 
 {-| A [`::marker`](https://developer.mozilla.org/en-US/docs/Web/CSS/::marker)
 [pseudo-element](https://developer.mozilla.org/en-US/docs/Web/CSS/Pseudo-elements).
@@ -2615,6 +2643,7 @@ cue =
         [ color (rgba 255 255 0 1)
         , fontWeight (int 600)
         ]
+
 -}
 marker : List Style -> Style
 marker =
@@ -2631,7 +2660,9 @@ Be careful when using placeholders as they can compromise accessibility.
         , color (rgb 90 90 90)
         , fontWeight (int 400)
         ]
+
 ]
+
 -}
 placeholder : List Style -> Style
 placeholder =
@@ -2644,7 +2675,7 @@ placeholder =
     selection
         [ backgroundColor (rgb 200 140 15)
         ]
-    
+
 
 -}
 selection : List Style -> Style
@@ -11476,6 +11507,7 @@ a `num` that will scale the element by both X and Y axes
     scale2 (num 1) (num 3)
 
     scale3 (num 1) (num 3) (num 4)
+
 -}
 scale :
     BaseValue
@@ -11493,14 +11525,16 @@ This two-argument version lets you specify scaling in X and Y axes
 (equivalent to [`scale2_`](#scale2_)).
 
     scale2 (num 1) (num 3)
+
 -}
 scale2 :
     Value
         { num : Supported
         }
-    -> Value
-        { num : Supported
-        }
+    ->
+        Value
+            { num : Supported
+            }
     -> Style
 scale2 (Value xVal) (Value yVal) =
     AppendProperty ("scale:" ++ xVal ++ " " ++ yVal)
@@ -11512,17 +11546,20 @@ This three-argument version lets you specify scaling in X, Y and Z axes
 (equivalent to [`scale3d`](#scale3d)).
 
     scale3 (num 1) (num 3) (num 4)
+
 -}
 scale3 :
     Value
         { num : Supported
         }
-    -> Value
-        { num : Supported
-        }
-    -> Value
-        { num : Supported
-        }
+    ->
+        Value
+            { num : Supported
+            }
+    ->
+        Value
+            { num : Supported
+            }
     -> Style
 scale3 (Value xVal) (Value yVal) (Value zVal) =
     AppendProperty ("scale:" ++ xVal ++ " " ++ yVal ++ " " ++ zVal)
@@ -11533,6 +11570,7 @@ scale3 (Value xVal) (Value yVal) (Value zVal) =
     transform (scale_ 0.7)
 
 This is called `scale_` instead of `scale` because [`scale` is already a function](#scale).
+
 -}
 scale_ : Float -> Value { provides | scale_ : Supported }
 scale_ val =
@@ -11544,6 +11582,7 @@ scale_ val =
     transform (scale2_ 0.7 0.7)
 
 This is called `scale2_` instead of `scale2` because [`scale2` is already a function](#scale2).
+
 -}
 scale2_ : Float -> Float -> Value { provides | scale2_ : Supported }
 scale2_ valX valY =
@@ -11650,6 +11689,7 @@ skewY (Value angle) =
 
 -- ROTATION
 
+
 {-| The [`rotate`](https://css-tricks.com/almanac/properties/r/rotate/) property.
 
 This one-argument version lets you set a global variable, `none`, or angle.
@@ -11665,6 +11705,7 @@ This one-argument version lets you set a global variable, `none`, or angle.
     rotate2 y (deg 100)
 
     rotate2 (vec3 1 2 10) (deg 100)
+
 -}
 rotate :
     BaseValue
@@ -11686,6 +11727,7 @@ This two-argument version lets you set an axis or a vector, then an angle value.
     rotate2 y (deg 100)
 
     rotate2 (vec3 1 2 10) (deg 100)
+
 -}
 rotate2 :
     Value
@@ -11696,7 +11738,7 @@ rotate2 :
         }
     -> Value Angle
     -> Style
-rotate2 (Value axisOrVecVal) (Value angleVal)=
+rotate2 (Value axisOrVecVal) (Value angleVal) =
     AppendProperty ("rotate:" ++ axisOrVecVal ++ " " ++ angleVal)
 
 
@@ -11705,6 +11747,7 @@ rotate2 (Value axisOrVecVal) (Value angleVal)=
     transform (rotate_ (deg 30))
 
 This is called `rotate_` instead of `rotate` because [`rotate` is already a function](#rotate).
+
 -}
 rotate_ :
     Value Angle
@@ -11784,12 +11827,13 @@ Sets the vector values in [`rotate2`](#rotate2).
 vec3 : Float -> Float -> Float -> Value { provides | vec3 : Supported }
 vec3 vec1Val vec2Val vec3Val =
     Value
-        ( String.fromFloat vec1Val
-        ++ " "
-        ++ String.fromFloat vec2Val
-        ++ " "
-        ++ String.fromFloat vec3Val
+        (String.fromFloat vec1Val
+            ++ " "
+            ++ String.fromFloat vec2Val
+            ++ " "
+            ++ String.fromFloat vec3Val
         )
+
 
 {-| Sets `z` value for usage with [`rotate2`](#rotate2).
 
@@ -11799,6 +11843,7 @@ vec3 vec1Val vec2Val vec3Val =
 z : Value { provides | z : Supported }
 z =
     Value "z"
+
 
 
 -- PERSPECTIVE

--- a/src/Css.elm
+++ b/src/Css.elm
@@ -76,6 +76,7 @@ module Css exposing
     , fontStretch, ultraCondensed, extraCondensed, condensed, semiCondensed, normal, semiExpanded, expanded, extraExpanded, ultraExpanded
     , fontFeatureSettings, fontFeatureSettingsList, featureTag, featureTag2
     , fontVariantCaps, smallCaps, allSmallCaps, petiteCaps, allPetiteCaps, unicase, titlingCaps
+    , fontVariantEastAsian, fontVariantEastAsian2, fontVariantEastAsian3, jis78, jis83, jis90, jis04, simplified, traditional, proportionalWidth
     , fontVariantLigatures, commonLigatures, noCommonLigatures, discretionaryLigatures, noDiscretionaryLigatures, historicalLigatures, noHistoricalLigatures, contextual, noContextual
     , fontVariantNumeric, fontVariantNumeric4, ordinal, slashedZero, liningNums, oldstyleNums, proportionalNums, tabularNums, diagonalFractions, stackedFractions
     , stretch, center, start, end, flexStart, flexEnd, selfStart, selfEnd, spaceBetween, spaceAround, spaceEvenly, left_, right_, top_, bottom_, baseline, firstBaseline, lastBaseline, safe, unsafe, legacy, legacyLeft, legacyRight, legacyCenter
@@ -480,6 +481,11 @@ See this [complete guide](https://css-tricks.com/snippets/css/a-guide-to-flexbox
 ## Font Variant Caps
 
 @docs fontVariantCaps, smallCaps, allSmallCaps, petiteCaps, allPetiteCaps, unicase, titlingCaps
+
+
+## Font Variant East Asian
+
+@docs fontVariantEastAsian, fontVariantEastAsian2, fontVariantEastAsian3, jis78, jis83, jis90, jis04, simplified, traditional, proportionalWidth
 
 
 ## Font Variant Ligatures
@@ -5587,6 +5593,201 @@ titlingCaps =
 
 
 
+-- FONT VARIANT EAST ASIAN --
+
+
+{-| The [`font-variant-east-asian`](https://developer.mozilla.org/en-US/docs/Web/CSS/font-variant-east-asian#syntax) property.
+
+This property controls the use of alternative glyphs for East Asian scripts.
+
+    fontVariantEastAsian normal
+
+    fontVariantEastAsian2 ruby jis83
+
+    fontVariantEastAsian3 ruby jis90 fullWidth
+
+-}
+fontVariantEastAsian :
+    BaseValue
+        { normal : Supported
+        , ruby : Supported
+
+        -- variant values
+        , jis78 : Supported
+        , jis83 : Supported
+        , jis90 : Supported
+        , jis04 : Supported
+        , simplified : Supported
+        , traditional : Supported
+
+        -- width values
+        , fullWidth : Supported
+        , proportionalWidth : Supported
+        }
+    -> Style
+fontVariantEastAsian (Value val) =
+    AppendProperty ("font-variant-east-asian:" ++ val)
+
+
+{-| The [`font-variant-east-asian`](https://developer.mozilla.org/en-US/docs/Web/CSS/font-variant-east-asian#syntax) property.
+
+This property controls the use of alternative glyphs for East Asian scripts.
+
+    fontVariantEastAsian2 ruby jis83
+
+-}
+fontVariantEastAsian2 :
+    Value
+        { ruby : Supported
+        , jis78 : Supported
+        , jis83 : Supported
+        , jis90 : Supported
+        , jis04 : Supported
+        , simplified : Supported
+        , traditional : Supported
+        , fullWidth : Supported
+        , proportionalWidth : Supported
+        }
+    ->
+        Value
+            { ruby : Supported
+            , jis78 : Supported
+            , jis83 : Supported
+            , jis90 : Supported
+            , jis04 : Supported
+            , simplified : Supported
+            , traditional : Supported
+            , fullWidth : Supported
+            , proportionalWidth : Supported
+            }
+    -> Style
+fontVariantEastAsian2 (Value val1) (Value val2) =
+    AppendProperty ("font-variant-east-asian:" ++ val1 ++ " " ++ val2)
+
+
+{-| The [`font-variant-east-asian`](https://developer.mozilla.org/en-US/docs/Web/CSS/font-variant-east-asian#syntax) property.
+
+This property controls the use of alternative glyphs for East Asian scripts.
+
+    fontVariantEastAsian3 ruby jis90 fullWidth
+
+-}
+fontVariantEastAsian3 :
+    Value
+        { ruby : Supported
+        }
+    ->
+        Value
+            { jis78 : Supported
+            , jis83 : Supported
+            , jis90 : Supported
+            , jis04 : Supported
+            , simplified : Supported
+            , traditional : Supported
+            }
+    ->
+        Value
+            { fullWidth : Supported
+            , proportionalWidth : Supported
+            }
+    -> Style
+fontVariantEastAsian3 (Value rubyVal) (Value variantVal) (Value widthVal) =
+    AppendProperty ("font-variant-east-asian:" ++ rubyVal ++ " " ++ variantVal ++ " " ++ widthVal)
+
+
+{-| Sets the [`jis78`](https://developer.mozilla.org/en-US/docs/Web/CSS/font-variant-east-asian#syntax) value for [`fontVariantEastAsian`](#fontVariantEastAsian).
+
+This specifies that the JIS X 0208:1978 standard for East Asian logographic glyphs
+should be used.
+
+    fontVariantEastAsian jis78
+
+-}
+jis78 : Value { provides | jis78 : Supported }
+jis78 =
+    Value "jis78"
+
+
+{-| Sets the [`jis83`](https://developer.mozilla.org/en-US/docs/Web/CSS/font-variant-east-asian#syntax) value for [`fontVariantEastAsian`](#fontVariantEastAsian).
+
+This specifies that the JIS X 0208:1983 standard for East Asian logographic glyphs
+should be used.
+
+    fontVariantEastAsian jis83
+
+-}
+jis83 : Value { provides | jis83 : Supported }
+jis83 =
+    Value "jis83"
+
+
+{-| Sets the [`jis90`](https://developer.mozilla.org/en-US/docs/Web/CSS/font-variant-east-asian#syntax) value for [`fontVariantEastAsian`](#fontVariantEastAsian).
+
+This specifies that the JIS X 0208:1990 standard for East Asian logographic glyphs
+should be used.
+
+    fontVariantEastAsian jis90
+
+-}
+jis90 : Value { provides | jis90 : Supported }
+jis90 =
+    Value "jis90"
+
+
+{-| Sets the [`jis04`](https://developer.mozilla.org/en-US/docs/Web/CSS/font-variant-east-asian#syntax) value for [`fontVariantEastAsian`](#fontVariantEastAsian).
+
+This specifies that the JIS X 0208:2004 standard for East Asian logographic glyphs
+should be used.
+
+    fontVariantEastAsian jis04
+
+-}
+jis04 : Value { provides | jis04 : Supported }
+jis04 =
+    Value "jis04"
+
+
+{-| Sets the [`simplified`](https://developer.mozilla.org/en-US/docs/Web/CSS/font-variant-east-asian#syntax) value for [`fontVariantEastAsian`](#fontVariantEastAsian).
+
+This specifies that no particular standard should be used for East Asian logographic glyphs
+apart from them being simplified Chinese glyphs.
+
+    fontVariantEastAsian simplified
+
+-}
+simplified : Value { provides | simplified : Supported }
+simplified =
+    Value "simplified"
+
+
+{-| Sets the [`traditional`](https://developer.mozilla.org/en-US/docs/Web/CSS/font-variant-east-asian#syntax) value for [`fontVariantEastAsian`](#fontVariantEastAsian).
+
+This specifies that no particular standard should be used for East Asian logographic glyphs
+apart from them being traditional Chinese glyphs.
+
+    fontVariantEastAsian traditional
+
+-}
+traditional : Value { provides | traditional : Supported }
+traditional =
+    Value "traditional"
+
+
+{-| Sets the [`proportional-width`](https://developer.mozilla.org/en-US/docs/Web/CSS/font-variant-east-asian#syntax) value for [`fontVariantEastAsian`](#fontVariantEastAsian).
+
+This activates the East Asian characters that vary in width.
+
+(As opposed to [`fullWidth`](#fullWidth), which specifies that they should roughly be the same width.)
+
+    fontVariantEastAsian proportionalWidth
+
+-}
+proportionalWidth : Value { provides | proportionalWidth : Supported }
+proportionalWidth =
+    Value "proportional-width"
+
+
+
 -- FONT VARIANT LIGATURES --
 
 
@@ -9772,9 +9973,18 @@ lowercase =
     Value "lowercase"
 
 
-{-| A `full-width` value for the [`text-transform`](https://developer.mozilla.org/en-US/docs/Web/CSS/text-transform#Syntax) property.
+{-| A `full-width` value for:
+
+### [`textTransform`](#textTransform)
+Forces the writing of characters in a square so they can be aligned in East Asian scripts.
+
+### [`fontVariantEastAsian`](#fontVariantEastAsian)
+Activates the East Asian characters that are roughly be the same width.
+
 
     textTransform fullWidth
+
+    fontVariantEastAsian fullWidth
 
 -}
 fullWidth : Value { provides | fullWidth : Supported }

--- a/src/Css.elm
+++ b/src/Css.elm
@@ -79,6 +79,7 @@ module Css exposing
     , fontVariantEastAsian, fontVariantEastAsian2, fontVariantEastAsian3, jis78, jis83, jis90, jis04, simplified, traditional, proportionalWidth
     , fontVariantLigatures, commonLigatures, noCommonLigatures, discretionaryLigatures, noDiscretionaryLigatures, historicalLigatures, noHistoricalLigatures, contextual, noContextual
     , fontVariantNumeric, fontVariantNumeric4, ordinal, slashedZero, liningNums, oldstyleNums, proportionalNums, tabularNums, diagonalFractions, stackedFractions
+    , fontOpticalSizing
     , stretch, center, start, end, flexStart, flexEnd, selfStart, selfEnd, spaceBetween, spaceAround, spaceEvenly, left_, right_, top_, bottom_, baseline, firstBaseline, lastBaseline, safe, unsafe, legacy, legacyLeft, legacyRight, legacyCenter
     , url
     , CursorKeyword
@@ -496,6 +497,11 @@ See this [complete guide](https://css-tricks.com/snippets/css/a-guide-to-flexbox
 ## Font Variant Numeric
 
 @docs fontVariantNumeric, fontVariantNumeric4, ordinal, slashedZero, liningNums, oldstyleNums, proportionalNums, tabularNums, diagonalFractions, stackedFractions
+
+
+## Font Optical Sizing
+
+@docs fontOpticalSizing
 
 
 # Align Items
@@ -6056,6 +6062,25 @@ stackedFractions =
 
 
 
+-- FONT OPTICAL SIZING --
+
+
+{-| The [`font-optical-sizing`](https://developer.mozilla.org/en-US/docs/Web/CSS/font-optical-sizing) property.
+
+    fontOpticalSizing none
+
+-}
+fontOpticalSizing :
+    BaseValue
+        { none : Supported
+        , auto : Supported
+        }
+    -> Style
+fontOpticalSizing (Value val) =
+    AppendProperty ("font-optical-sizing:" ++ val)
+
+
+
 -- CURSOR --
 
 
@@ -9975,12 +10000,15 @@ lowercase =
 
 {-| A `full-width` value for:
 
+
 ### [`textTransform`](#textTransform)
+
 Forces the writing of characters in a square so they can be aligned in East Asian scripts.
 
-### [`fontVariantEastAsian`](#fontVariantEastAsian)
-Activates the East Asian characters that are roughly be the same width.
 
+### [`fontVariantEastAsian`](#fontVariantEastAsian)
+
+Activates the East Asian characters that are roughly be the same width.
 
     textTransform fullWidth
 

--- a/src/Css.elm
+++ b/src/Css.elm
@@ -149,24 +149,41 @@ module Css exposing
     , resize, horizontal, vertical
 
     -- flex
-    , flex, flex2, flex3, flexDirection
-    , flexGrow, flexShrink, flexBasis
-    , flexWrap, flexFlow, flexFlow2
-    , alignContent, alignContent2, alignItems, alignItems2, alignSelf, alignSelf2
-    , justifyContent, justifyContent2, justifyItems, justifyItems2, justifySelf, justifySelf2
-    , placeContent, placeContent2, placeItems, placeItems2, placeSelf, placeSelf2
-    , flexStart, flexEnd, selfStart, selfEnd, spaceBetween, spaceAround, spaceEvenly
-    , firstBaseline, lastBaseline, safe, unsafe, legacy, legacyLeft, legacyRight, legacyCenter
-    , row, rowReverse, columnReverse
+    , flex, flex2, flex3
+    , flexDirection
+    , flexBasis
+    , flexGrow
+    , flexShrink
+    , flexWrap
+    , flexFlow, flexFlow2
+    , alignContent, alignContent2
+    , alignItems, alignItems2
+    , alignSelf, alignSelf2
+    , justifyContent, justifyContent2
+    , justifyItems, justifyItems2
+    , justifySelf, justifySelf2
+    , placeContent, placeContent2
+    , placeItems, placeItems2
+    , placeSelf, placeSelf2
     , order
+    --
+    , row, rowReverse, columnReverse
+    , flexStart, flexEnd, selfStart, selfEnd
+    , spaceBetween, spaceAround, spaceEvenly
+    , firstBaseline, lastBaseline
+    , safe, unsafe
+    , legacy, legacyLeft, legacyRight, legacyCenter
     , nowrap, wrap, wrapReverse
     
     -- grid
-    , gridAutoRows, gridAutoColumns, gridAutoFlow, gridAutoFlow2, dense
-    , gridRowStart, gridRowStart2, gridRowStart3, gridRowEnd, gridRowEnd2, gridRowEnd3
-    , gridColumnStart, gridColumnStart2, gridColumnStart3, gridColumnEnd, gridColumnEnd2, gridColumnEnd3
-    , span
+    , gridAutoRows, gridAutoColumns, gridAutoFlow, gridAutoFlow2
+    , gridRowStart, gridRowStart2, gridRowStart3
+    , gridRowEnd, gridRowEnd2, gridRowEnd3
+    , gridColumnStart, gridColumnStart2, gridColumnStart3
+    , gridColumnEnd, gridColumnEnd2, gridColumnEnd3
     , gridTemplateAreas, gridTemplateAreasList
+    --
+    , dense, span
 
     -- gaps
     , gap, gap2, rowGap, columnGap
@@ -454,6 +471,7 @@ module Css exposing
 and [`Css.Global.selector`](http://package.elm-lang.org/packages/rtfeldman/elm-css/latest/Css-Global#selector)
 functions let you define custom properties and selectors, respectively.
 
+# Basic stuff
 
 ## CSS Values
 
@@ -475,126 +493,9 @@ functions let you define custom properties and selectors, respectively.
 @docs important
 
 
-# General Values
 
-All CSS properties can have the values `unset`, `initial`, `inherit` and `revert`.
+------------------------------------------------------
 
-@docs unset, initial, inherit
-
-@docs revert
-
-@docs Angle, AngleSupported, Width, WidthSupported
-
-
-## Numeric Units
-
-@docs Length, LengthSupported, zero, px, em, ex, ch, rem, vh, vw, vmin, vmax, mm, cm, q, inch, pt, pc, pct, num, int
-
-
-## Calc
-
-@docs calc, CalcOperation, minus, plus, times, dividedBy
-
-
-## Color
-
-@docs Color, ColorSupported, color, backgroundColor, hex, rgb, rgba, hsl, hsla, currentcolor
-
-
-## Time
-
-@docs Time, TimeSupported, s, ms
-
-
-## Angles
-
-@docs deg, grad, rad, turn
-
-## Shapes
-
-@docs BasicShape, BasicShapeSupported
-@docs circle, circleAt, circleAt2, ellipse, ellipseAt, ellipseAt2, closestSide, farthestSide, polygon, path
-
-## Resolution
-
-@docs Resolution, ResolutionSupported, dpi, dpcm, dppx
-
-## Flex
-
-@docs fr, minmax, fitContentTo
-
-
-## Ident
-
-@docs customIdent
-
-## URLs
-
-@docs url
-
-
-
-
-# Shared/Grouped keyword values
-
-Many different kinds of CSS properties use the same keyword values,
-so they're put in this place for easier understanding.
-
-Some of these keywords are used only in one property but they fit
-into a group of functionality (like Logical Values), so they're also grouped here.
-
-
-## Very common keywords
-
-@docs auto, none
-
-## (usually) Absolute positional values
-
-@docs left_, right_, top_, bottom_
-
-## (usually) Logical Values
-
-Logical values are those that set properties by their relation to the user's reading direction.
-
-Sometimes these keywords mean other things too.
-
-@docs block, inline, start, end, blockStart, blockEnd, inlineStart, inlineEnd
-
-## Content sizing values
-
-@docs minContent, maxContent, fitContent
-
-## Axis values
-
-@docs x, y, z
-
-## Alignment values
-
-@docs stretch, center
-
-## Geometry box values
-
-@docs marginBox, borderBox, paddingBox, contentBox, fillBox, strokeBox, viewBox
-
-## Typographic values
-
-@docs baseline, sub, super, ruby, fullWidth, under, circle_
-
-## Visibility
-
-@docs hidden, visible
-
-## Thickness
-
-@docs thin, thick
-
-## Miscellaneous shared
-
-@docs normal, strict, all_, both, always, scroll, column
-@docs content, fill_, stroke, text, style
-@docs clip, cover, contain_
-@docs repeat, noRepeat, repeatX, repeatY, space, round_
-@docs isolate, matchParent
 
 
 # Pseudo-Classes
@@ -613,197 +514,339 @@ Sometimes these keywords mean other things too.
 @docs before, after, backdrop, cue, marker, placeholder, selection
 
 
+------------------------------------------------------
+
+
+# Value types
+
+## Numerical units
+
+### Lengths
+@docs Length, LengthSupported
+@docs zero, px, em, ex, ch, rem, vh, vw, vmin, vmax, mm, cm, q, inch, pt, pc, pct, num, int
+
+
+### Angles
+@docs Angle, AngleSupported, Width, WidthSupported
+@docs deg, grad, rad, turn
+
+### Time
+@docs Time, TimeSupported, s, ms
+
+### Flex
+@docs fr, minmax, fitContentTo
+
+## Color
+@docs Color, ColorSupported, hex, rgb, rgba, hsl, hsla, currentcolor
+
+## Shapes
+@docs BasicShape, BasicShapeSupported
+@docs circle, circleAt, circleAt2, ellipse, ellipseAt, ellipseAt2, closestSide, farthestSide, polygon, path
+
+## Resolution
+@docs Resolution, ResolutionSupported, dpi, dpcm, dppx
+
+## Ident
+@docs customIdent
+
+## URLs
+@docs url
+
+## Calc
+@docs calc, CalcOperation, minus, plus, times, dividedBy
+
+
+------------------------------------------------------
+
+
+# Shared/Grouped keyword values
+
+Many different kinds of CSS properties use the same keyword values,
+so they're put in this place for easier understanding.
+
+Some of these keywords are used only in one property but they fit
+into a group of functionality (like Logical Values), so they're also grouped here.
+
+
+## General Values
+
+All CSS properties can have the values `unset`, `initial`, `inherit` and `revert`.
+
+@docs unset, initial, inherit, revert
+
+
+## Very common keywords
+
+@docs auto, none
+
+
+## (usually) Absolute positional values
+
+@docs left_, right_, top_, bottom_
+
+
+## (usually) Logical Values
+
+Logical values are those that set properties by their relation to the user's reading direction.
+
+Sometimes these keywords mean other things too.
+
+@docs block, inline, start, end, blockStart, blockEnd, inlineStart, inlineEnd
+
+
+## Content sizing values
+
+@docs minContent, maxContent, fitContent
+
+
+## Axis values
+
+@docs x, y, z
+
+
+## Alignment values
+
+@docs stretch, center
+
+
+## Geometry box values
+
+@docs marginBox, borderBox, paddingBox, contentBox, fillBox, strokeBox, viewBox
+
+
+## Typographic values
+
+@docs baseline, sub, super, ruby, fullWidth, under, circle_
+
+
+## Visibility
+
+@docs hidden, visible
+
+
+## Thickness
+
+@docs thin, thick
+
+
+## Miscellaneous shared
+
+@docs normal, strict, all_, both, always, scroll, column
+@docs content, fill_, stroke, text, style
+@docs clip, cover, contain_
+@docs repeat, noRepeat, repeatX, repeatY, space, round_
+@docs isolate, matchParent
+
+
+------------------------------------------------------
+
+
 # All
 
 @docs all
 
-# Sizing
 
-@docs width, minWidth, maxWidth, height, minHeight, maxHeight
-@docs blockSize, minBlockSize, maxBlockSize, inlineSize, minInlineSize, maxInlineSize
-
-# Backgrounds
-
-
-## Background Attachment
-
-@docs backgroundAttachment, backgroundAttachments, local
-
-
-## Background Blend Mode
-
-@docs backgroundBlendMode, backgroundBlendModes, multiply, screen, overlay, darken, lighten, colorDodge, colorBurn, hardLight, softLight, difference, exclusion, hue, saturation, color_, luminosity
-
-
-## Background Clip and Origin
-
-@docs backgroundClip, backgroundClips, backgroundOrigin, backgroundOrigins
-
-
-## Background Image
-
-@docs ImageSupported, Image
-@docs backgroundImage, backgroundImages, backgroundPosition, backgroundPosition2, backgroundPosition3, backgroundPosition4, backgroundRepeat, backgroundRepeat2, backgroundSize, backgroundSize2
-
-@docs linearGradient, linearGradient2, stop, stop2, stop3, toBottom, toBottomLeft, toBottomRight, toLeft, toRight, toTop, toTopLeft, toTopRight
-
-# Shadows
-
-
-## Box Shadow
-
-@docs BoxShadowConfig, boxShadow, boxShadows, defaultBoxShadow
-
-
-## Text Shadow
-
-@docs TextShadowConfig, textShadow, defaultTextShadow
-
-
-# Borders
-
-@docs LineWidth, LineWidthSupported, LineStyle, LineStyleSupported
-
-@docs border, border2, border3
-
-@docs borderTop, borderTop2, borderTop3
-
-@docs borderRight, borderRight2, borderRight3
-
-@docs borderBottom, borderBottom2, borderBottom3
-
-@docs borderLeft, borderLeft2, borderLeft3
-
-@docs borderBlock, borderBlock2, borderBlock3
-
-@docs borderBlockStart, borderBlockStart2, borderBlockStart3
-
-@docs borderBlockEnd, borderBlockEnd2, borderBlockEnd3
-
-@docs borderInline, borderInline2, borderInline3
-
-@docs borderInlineStart, borderInlineStart2, borderInlineStart3
-
-@docs borderInlineEnd, borderInlineEnd2, borderInlineEnd3
-
-
-## Border Width
-
-@docs borderWidth, borderWidth2, borderWidth3, borderWidth4, borderTopWidth, borderRightWidth, borderBottomWidth, borderLeftWidth
-
-@docs borderBlockWidth, borderBlockStartWidth, borderBlockEndWidth, borderInlineWidth, borderInlineStartWidth, borderInlineEndWidth
-
-
-## Border Style
-
-@docs borderStyle, borderStyle2, borderStyle3, borderStyle4, borderTopStyle, borderRightStyle, borderBottomStyle, borderLeftStyle
-
-@docs borderBlockStyle, borderBlockStartStyle, borderBlockEndStyle, borderInlineStyle, borderInlineStartStyle, borderInlineEndStyle
-
-@docs dotted, dashed, solid, double, groove, ridge, inset_, outset
-
-
-## Border Color
-
-@docs borderColor, borderColor2, borderColor3, borderColor4, borderTopColor, borderRightColor, borderBottomColor, borderLeftColor
-
-@docs borderBlockColor, borderBlockStartColor, borderBlockEndColor, borderInlineColor, borderInlineStartColor, borderInlineEndColor
-
-
-## Border Radius
-
-@docs borderRadius, borderRadius2, borderRadius3, borderRadius4, borderTopLeftRadius, borderTopLeftRadius2, borderTopRightRadius, borderTopRightRadius2, borderBottomRightRadius, borderBottomRightRadius2, borderBottomLeftRadius, borderBottomLeftRadius2
-
-@docs borderStartStartRadius, borderStartStartRadius2, borderStartEndRadius, borderStartEndRadius2, borderEndStartRadius, borderEndStartRadius2, borderEndEndRadius, borderEndEndRadius2
-
-
-## Border Image
-
-@docs borderImageOutset, borderImageOutset2, borderImageOutset3, borderImageOutset4
-
-@docs borderImageWidth, borderImageWidth2, borderImageWidth3, borderImageWidth4
-
-
-# Outline
-
-@docs outline, outline3, outlineWidth, outlineColor, invert, outlineStyle, outlineOffset
+------------------------------------------------------
 
 
 # Display
 
 @docs display, display2, displayListItem2, displayListItem3
+@docs flex_, flow, flowRoot, grid, contents, listItem
+@docs inlineBlock, inlineFlex, inlineTable, inlineGrid
+@docs rubyBase, rubyBaseContainer, rubyText, rubyTextContainer
+@docs runIn, table
+@docs tableCaption, tableCell, tableColumn, tableColumnGroup, tableFooterGroup, tableHeaderGroup, tableRow, tableRowGroup
 
 
-## Display values
-
-You can also use [`block`](#block), [`inline`](#inline) and [`ruby`](#ruby) as values.
-
-@docs flex_, flow, flowRoot, grid, contents, listItem, inlineBlock, inlineFlex, inlineTable, inlineGrid, rubyBase, rubyBaseContainer, rubyText, rubyTextContainer, runIn, table, tableCaption, tableCell, tableColumn, tableColumnGroup, tableFooterGroup, tableHeaderGroup, tableRow, tableRowGroup
+------------------------------------------------------
 
 
-# Positions
+# Position
 
-@docs position, zIndex
-
+@docs position
 @docs absolute, fixed, relative, static, sticky
+
+
+------------------------------------------------------
+
+
+# Stacking contexts & box-sizing
+
+@docs zIndex, isolation, boxSizing
+
+
+------------------------------------------------------
+
+
+# Contain
+
+@docs contain, contain2, contain3, contain4
+@docs size, layout, paint
+
+
+------------------------------------------------------
+
+
+# Sizing
+
+@docs width, minWidth, maxWidth, height, minHeight, maxHeight
+@docs blockSize, minBlockSize, maxBlockSize
+@docs inlineSize, minInlineSize, maxInlineSize
+
+
+------------------------------------------------------
 
 
 # Inset
 
-@docs inset, inset2, inset3, inset4, top, right, bottom, left
+@docs inset, inset2, inset3, inset4
 
-@docs insetBlock, insetBlock2, insetInline, insetInline2, insetBlockStart, insetBlockEnd, insetInlineStart, insetInlineEnd
+## Absolute insets
 
+@docs top, right, bottom, left
 
-# Paddings
+## Logical insets
 
-@docs padding, padding2, padding3, padding4, paddingTop, paddingRight, paddingBottom, paddingLeft
-
-
-## Logical Paddings
-
-@docs paddingBlock, paddingBlock2, paddingBlockStart, paddingBlockEnd
-
-@docs paddingInline, paddingInline2, paddingInlineStart, paddingInlineEnd
+@docs insetBlock, insetBlock2, insetInline, insetInline2
+@docs insetBlockStart, insetBlockEnd, insetInlineStart, insetInlineEnd
 
 
-## Margins
-
-@docs margin, margin2, margin3, margin4, marginTop, marginRight, marginBottom, marginLeft
+------------------------------------------------------
 
 
-# Gaps
+# Margin
 
-@docs gap, gap2, rowGap, columnGap
+@docs margin, margin2, margin3, margin4
 
+## Absolute margin edges
 
-# Box Sizing
-## Logical Margins
+@docs marginTop, marginRight, marginBottom, marginLeft
+
+## Logical margin edges
 
 @docs marginBlock, marginBlock2, marginBlockStart, marginBlockEnd
-
 @docs marginInline, marginInline2, marginInlineStart, marginInlineEnd
 
 
-## Box Sizing
-
-@docs boxSizing
+------------------------------------------------------
 
 
-# Flexbox
+# Padding
+
+@docs padding, padding2, padding3, padding4
+
+## Absolute padding edges
+
+@docs paddingTop, paddingRight, paddingBottom, paddingLeft
+
+## Logical padding edges
+
+@docs paddingBlock, paddingBlock2, paddingBlockStart, paddingBlockEnd
+@docs paddingInline, paddingInline2, paddingInlineStart, paddingInlineEnd
+
+
+------------------------------------------------------
+
+
+# Borders
+
+@docs border, border2, border3
+
+## Absolute border edges
+
+@docs borderTop, borderTop2, borderTop3
+@docs borderRight, borderRight2, borderRight3
+@docs borderBottom, borderBottom2, borderBottom3
+@docs borderLeft, borderLeft2, borderLeft3
+
+## Logical border edges
+
+@docs borderBlock, borderBlock2, borderBlock3
+@docs borderBlockStart, borderBlockStart2, borderBlockStart3
+@docs borderBlockEnd, borderBlockEnd2, borderBlockEnd3
+@docs borderInline, borderInline2, borderInline3
+@docs borderInlineStart, borderInlineStart2, borderInlineStart3
+@docs borderInlineEnd, borderInlineEnd2, borderInlineEnd3
+
+## Border width
+
+@docs borderWidth, borderWidth2, borderWidth3, borderWidth4
+@docs borderTopWidth, borderRightWidth, borderBottomWidth, borderLeftWidth
+@docs borderBlockWidth, borderBlockStartWidth, borderBlockEndWidth
+@docs borderInlineWidth, borderInlineStartWidth, borderInlineEndWidth
+
+## Border style
+
+@docs borderStyle, borderStyle2, borderStyle3, borderStyle4
+@docs borderTopStyle, borderRightStyle, borderBottomStyle, borderLeftStyle
+@docs borderBlockStyle, borderBlockStartStyle, borderBlockEndStyle
+@docs borderInlineStyle, borderInlineStartStyle, borderInlineEndStyle
+@docs dotted, dashed, solid, double, groove, ridge, inset_, outset
+
+## Border color
+
+@docs borderColor, borderColor2, borderColor3, borderColor4
+@docs borderTopColor, borderRightColor, borderBottomColor, borderLeftColor
+@docs borderBlockColor, borderBlockStartColor, borderBlockEndColor
+@docs borderInlineColor, borderInlineStartColor, borderInlineEndColor
+
+## Border radius
+
+@docs borderRadius, borderRadius2, borderRadius3, borderRadius4
+@docs borderTopLeftRadius, borderTopLeftRadius2, borderTopRightRadius, borderTopRightRadius2
+@docs borderBottomRightRadius, borderBottomRightRadius2, borderBottomLeftRadius, borderBottomLeftRadius2
+@docs borderStartStartRadius, borderStartStartRadius2, borderStartEndRadius, borderStartEndRadius2
+@docs borderEndStartRadius, borderEndStartRadius2, borderEndEndRadius, borderEndEndRadius2
+
+## Border image
+
+@docs borderImageOutset, borderImageOutset2, borderImageOutset3, borderImageOutset4
+@docs borderImageWidth, borderImageWidth2, borderImageWidth3, borderImageWidth4
+
+
+------------------------------------------------------
+
+
+# Outlines
+
+@docs outline, outline3, outlineWidth, outlineColor
+@docs invert, outlineStyle, outlineOffset
+
+
+------------------------------------------------------
+
+
+# Overflow and resizing
+
+@docs overflow, overflowX, overflowY, overflowBlock, overflowInline
+@docs overflowWrap, overflowAnchor
+@docs breakWord, anywhere
+@docs resize, horizontal, vertical
+
+
+------------------------------------------------------
+
+
+# Flex
 
 The CSS Flexible Box Layout Module.
 See this [complete guide](https://css-tricks.com/snippets/css/a-guide-to-flexbox/).
 
+## Basics
 
-## Flexbox Alignment
+@docs flex, flex2, flex3
+@docs flexBasis
+@docs flexGrow
+@docs flexShrink
 
-@docs alignContent, alignContent2, alignItems, alignItems2, alignSelf, alignSelf2, justifyContent, justifyContent2, justifyItems, justifyItems2, justifySelf, justifySelf2
+## Layout dynamics
 
-@docs placeContent, placeContent2, placeItems, placeItems2, placeSelf, placeSelf2
+@docs flexDirection
+@docs flexWrap
+@docs flexFlow, flexFlow2
 
-
-### Align Items
+## Alignment
 
 Other values you can use for flex item alignment:
 
@@ -817,42 +860,88 @@ Other values you can use for flex item alignment:
   - [`stretch`](#stretch)
   - [`baseline`](#baseline)
 
-@docs flexStart, flexEnd, selfStart, selfEnd, spaceBetween, spaceAround, spaceEvenly
-@docs firstBaseline, lastBaseline, safe, unsafe, legacy, legacyLeft, legacyRight, legacyCenter
+@docs alignContent, alignContent2
+@docs alignItems, alignItems2
+@docs alignSelf, alignSelf2
 
+## Justify
 
-### Flexbox Direction
+@docs justifyContent, justifyContent2
+@docs justifyItems, justifyItems2
+@docs justifySelf, justifySelf2
 
-@docs flexDirection, row, rowReverse, columnReverse
+## Place
 
+@docs placeContent, placeContent2
+@docs placeItems, placeItems2
+@docs placeSelf, placeSelf2
 
-### Flexbox Order
+## Order
 
 @docs order
 
+## Flex value keywords
 
-### Flexbox Sizing
-
-[`content`](#content) is also a supported value.
-
-@docs flexGrow, flexShrink, flexBasis
-
-
-### Flexbox Wrapping
-
-@docs flexWrap, nowrap, wrap, wrapReverse
+@docs row, rowReverse, columnReverse
+@docs flexStart, flexEnd, selfStart, selfEnd
+@docs spaceBetween, spaceAround, spaceEvenly
+@docs firstBaseline, lastBaseline
+@docs safe, unsafe
+@docs legacy, legacyLeft, legacyRight, legacyCenter
+@docs nowrap, wrap, wrapReverse
 
 
-### Flexbox Shorthands
-
-@docs flex, flex2, flex3, flexFlow, flexFlow2
+------------------------------------------------------
 
 
 # Grid
 
-@docs gridAutoRows, gridAutoColumns, gridAutoFlow, gridAutoFlow2, dense
-@docs gridRowStart, gridRowStart2, gridRowStart3, gridRowEnd, gridRowEnd2, gridRowEnd3, gridColumnStart, gridColumnStart2, gridColumnStart3, gridColumnEnd, gridColumnEnd2, gridColumnEnd3, span
+@docs gridAutoRows, gridAutoColumns, gridAutoFlow, gridAutoFlow2
+@docs gridRowStart, gridRowStart2, gridRowStart3
+@docs gridRowEnd, gridRowEnd2, gridRowEnd3
+@docs gridColumnStart, gridColumnStart2, gridColumnStart3
+@docs gridColumnEnd, gridColumnEnd2, gridColumnEnd3
 @docs gridTemplateAreas, gridTemplateAreasList
+@docs dense, span
+
+
+------------------------------------------------------
+
+
+# Gap
+
+@docs gap, gap2, rowGap, columnGap
+
+
+------------------------------------------------------
+
+
+# Background
+
+@docs backgroundColor
+@docs backgroundAttachment, backgroundAttachments, local
+@docs backgroundBlendMode, backgroundBlendModes
+@docs multiply, screen, overlay, darken, lighten, colorDodge, colorBurn, hardLight, softLight, difference, exclusion, hue, saturation, color_, luminosity
+@docs backgroundClip, backgroundClips, backgroundOrigin, backgroundOrigins
+@docs backgroundImage, backgroundImages
+@docs backgroundPosition, backgroundPosition2, backgroundPosition3, backgroundPosition4
+@docs backgroundRepeat, backgroundRepeat2
+@docs backgroundSize, backgroundSize2
+
+
+------------------------------------------------------
+
+
+
+
+
+
+
+
+
+
+
+
 
 # Typography
 
@@ -961,15 +1050,6 @@ Other values you can use for flex item alignment:
 [`square`](#square) is also a supported value for [`listStyle`](#listStyle) and [`listStyleType`](#listStyleType).
 
 
-# Overflow
-
-@docs overflow, overflowX, overflowY, overflowBlock, overflowInline
-@docs overflowAnchor
-
-@docs overflowWrap
-@docs breakWord, anywhere
-
-
 # Direction
 
 @docs direction, ltr, rtl
@@ -977,7 +1057,7 @@ Other values you can use for flex item alignment:
 
 # Text Align
 
-@docs justify, matchParent, textAlign, textJustify, interWord, interCharacter, textUnderlinePosition, textUnderlinePosition2
+@docs justify, textAlign, textJustify, interWord, interCharacter, textUnderlinePosition, textUnderlinePosition2
 
 
 # Text Orientation
@@ -1186,7 +1266,6 @@ Other values you can use for flex item alignment:
 @docs objectFit, scaleDown
 @docs objectPosition, objectPosition2, objectPosition4
 @docs boxDecorationBreak
-@docs isolation, isolate
 @docs clipPath, clipPath2
 
 # Masks
@@ -1195,13 +1274,17 @@ Other values you can use for flex item alignment:
 @docs maskClip, maskClipList, maskComposite, maskMode, maskModeList, maskOrigin, maskOriginList, maskPosition, maskRepeat, maskRepeat2, maskSize, maskSize2, maskType
 @docs noClip, add, subtract, intersect, exclude, alpha, luminance, matchSource
 
-# Other
+# Other / stuff I'm adding to make the compiled result valid while I work on this rewrite
 
 @docs caretColor
 @docs pointerEvents
 @docs visiblePainted, visibleFill, visibleStroke, painted
-@docs resize, horizontal, vertical
-@docs contain, contain2, contain3, contain4, size, layout, paint
+@docs BoxShadowConfig, boxShadow, boxShadows, defaultBoxShadow, Image, ImageSupported, LineStyle, LineStyleSupported
+@docs LineWidth, LineWidthSupported
+@docs TextShadowConfig, color, defaultTextShadow
+@docs linearGradient, linearGradient2, stop, stop2, stop3, textShadow
+@docs toBottom, toBottomLeft, toBottomRight, toLeft, toRight, toTop, toTopLeft, toTopRight
+
 
 -}
 
@@ -9026,23 +9109,6 @@ flex3 (Value grow) (Value shrink) (Value basis) =
     AppendProperty ("flex:" ++ grow ++ " " ++ shrink ++ " " ++ basis)
 
 
-{-| Sets [`flex-direction`](https://css-tricks.com/almanac/properties/f/flex-direction/).
-
-    flexDirection column
-
--}
-flexDirection :
-    BaseValue
-        { row : Supported
-        , rowReverse : Supported
-        , column : Supported
-        , columnReverse : Supported
-        }
-    -> Style
-flexDirection (Value val) =
-    AppendProperty ("flex-direction:" ++ val)
-
-
 {-| Sets [`flex-basis`](https://css-tricks.com/almanac/properties/f/flex-basis/).
 
     flexBasis (em 10)
@@ -9093,6 +9159,23 @@ flexShrink :
     -> Style
 flexShrink (Value val) =
     AppendProperty ("flex-shrink:" ++ val)
+
+
+{-| Sets [`flex-direction`](https://css-tricks.com/almanac/properties/f/flex-direction/).
+
+    flexDirection column
+
+-}
+flexDirection :
+    BaseValue
+        { row : Supported
+        , rowReverse : Supported
+        , column : Supported
+        , columnReverse : Supported
+        }
+    -> Style
+flexDirection (Value val) =
+    AppendProperty ("flex-direction:" ++ val)
 
 
 {-| Sets [`flex-wrap`](https://css-tricks.com/almanac/properties/f/flex-wrap/).
@@ -9701,6 +9784,23 @@ placeSelf2 (Value alignSelfValue) (Value justifySelfValue) =
     AppendProperty ("place-self:" ++ alignSelfValue ++ " " ++ justifySelfValue)
 
 
+{-| Sets [`order`](https://css-tricks.com/almanac/properties/o/order/)
+
+    order (num 2)
+
+    order (num -2)
+
+-}
+order :
+    BaseValue
+        { int : Supported
+        , zero : Supported
+        }
+    -> Style
+order (Value val) =
+    AppendProperty ("order:" ++ val)
+
+
 {-| The `row` [`flex-direction` value](https://developer.mozilla.org/en-US/docs/Web/CSS/flex-direction#Values).
 
     flexDirection row
@@ -9916,23 +10016,6 @@ wrapReverse =
     Value "wrap-reverse"
 
 
-{-| Sets [`order`](https://css-tricks.com/almanac/properties/o/order/)
-
-    order (num 2)
-
-    order (num -2)
-
--}
-order :
-    BaseValue
-        { int : Supported
-        , zero : Supported
-        }
-    -> Style
-order (Value val) =
-    AppendProperty ("order:" ++ val)
-
-
 ------------------------------------------------------------------------
 ------------------------------------------------------------------------
 ------------------------------------------------------------------------
@@ -10047,19 +10130,6 @@ gridAutoFlow2 (Value val1) (Value val2) =
         ++ val1
         ++ " "
         ++ val2
-
-
-
-{-| The `dense` value for the [`grid-auto-flow`](#gridAutoFlow) property.
-
-    gridAutoFlow dense
-
-    gridAutoFlow2 row dense
-
--}
-dense : Value { provides | dense : Supported }
-dense =
-    Value "dense"
 
 
 {-| The 1-argument version of the [`grid-row-start`](https://css-tricks.com/almanac/properties/g/grid-row-start/)
@@ -10343,26 +10413,8 @@ gridColumnEnd3 (Value val1) (Value val2) (Value val3) =
         ++ " "
         ++ val2
         ++ " "
+       
         ++ val3
-
-
-{-| The `span` value for the following properties:
-
--   [`gridRowStart2`](#gridRowStart2)
--   [`gridRowStart3`](#gridRowStart3)
--   [`gridRowEnd2`](#gridRowEnd2)
--   [`gridRowEnd3`](#gridRowEnd3)
--   [`gridColumnStart2`](#gridColumnStart2)
--   [`gridColumnStart3`](#gridColumnStart3)
--   [`gridColumnEnd2`](#gridColumnEnd2)
--   [`gridColumnEnd3`](#gridColumnEnd3)
-```
-    gridColumnEnd3 span (customIdent "big-grid") (int 2)
-```
--}
-span : Value { provides | span : Supported }
-span =
-    Value "span"
 
 {-| The [`grid-template-areas`](https://css-tricks.com/almanac/properties/g/grid-template-areas/)
 property. Use the [`gridTemplateAreasList`](#gridTemplateAreasList) function if you want
@@ -10405,6 +10457,36 @@ gridTemplateAreasList listStr =
         |> List.map enquoteString
         |> String.join " "
         )
+
+
+{-| The `dense` value for the [`grid-auto-flow`](#gridAutoFlow) property.
+
+    gridAutoFlow dense
+
+    gridAutoFlow2 row dense
+
+-}
+dense : Value { provides | dense : Supported }
+dense =
+    Value "dense"
+    
+{-| The `span` value for the following properties:
+
+-   [`gridRowStart2`](#gridRowStart2)
+-   [`gridRowStart3`](#gridRowStart3)
+-   [`gridRowEnd2`](#gridRowEnd2)
+-   [`gridRowEnd3`](#gridRowEnd3)
+-   [`gridColumnStart2`](#gridColumnStart2)
+-   [`gridColumnStart3`](#gridColumnStart3)
+-   [`gridColumnEnd2`](#gridColumnEnd2)
+-   [`gridColumnEnd3`](#gridColumnEnd3)
+```
+    gridColumnEnd3 span (customIdent "big-grid") (int 2)
+```
+-}
+span : Value { provides | span : Supported }
+span =
+    Value "span"
 
 
 ------------------------------------------------------------------------

--- a/src/Css.elm
+++ b/src/Css.elm
@@ -23,6 +23,8 @@ module Css exposing
     , BasicShape, BasicShapeSupported
     , Length, LengthSupported
     , Color, ColorSupported
+    , LineStyle, LineStyleSupported
+    , LineWidth, LineWidthSupported
     , Resolution, ResolutionSupported
     , Time, TimeSupported
 
@@ -31,7 +33,7 @@ module Css exposing
     , calc, minus, plus, times, dividedBy
 
     -- common value types
-    , zero, px, em, ex, ch, rem, vh, vw, vmin, vmax, mm, cm, q, inches, pt, pc, pct
+    , zero, px, em, ex, ch, rem, vh, vw, vmin, vmax, mm, cm, q, inch, pt, pc, pct
     , fr, minmax, fitContentTo
     , deg, grad, rad, turn
     , s, ms
@@ -76,6 +78,10 @@ module Css exposing
 
     -- stacking contexts + box-sizing
     , zIndex, isolation, boxSizing
+
+    -- contain (DOM)
+    , contain, contain2, contain3, contain4
+    , size, layout, paint
 
     -- sizing
     , width, minWidth, maxWidth, height, minHeight, maxHeight
@@ -136,10 +142,11 @@ module Css exposing
     , outline, outline3, outlineWidth, outlineColor
     , invert, outlineStyle, outlineOffset
 
-    -- overflow
+    -- overflow and resizing
     , overflow, overflowX, overflowY, overflowBlock, overflowInline
     , overflowWrap, overflowAnchor
     , breakWord, anywhere
+    , resize, horizontal, vertical
 
     -- flex
     , flex, flex2, flex3, flexDirection
@@ -180,7 +187,7 @@ module Css exposing
 
     -- font size
     , fontSize
-    , xxSmall, xSmall, small, medium, large, xLarge, xxLarge, smaller, larger, lineHeight, letterSpacing
+    , xxSmall, xSmall, small, medium, large, xLarge, xxLarge, smaller, larger
     , fontSizeAdjust
 
     -- @font-face
@@ -203,7 +210,11 @@ module Css exposing
     , commonLigatures, noCommonLigatures, discretionaryLigatures, noDiscretionaryLigatures, historicalLigatures, noHistoricalLigatures, contextual, noContextual
     , fontVariantNumeric, fontVariantNumeric4
     , ordinal, slashedZero, liningNums, oldstyleNums, proportionalNums, tabularNums, diagonalFractions, stackedFractions
-    , fontKerning, fontLanguageOverride, fontSynthesis, fontSynthesis2, fontSynthesis3, fontOpticalSizing, fontVariantPosition
+    , fontKerning
+    , fontLanguageOverride
+    , fontSynthesis, fontSynthesis2, fontSynthesis3
+    , fontOpticalSizing
+    , fontVariantPosition
     , weight
 
     -- variable fonts (not to be confused with variants)
@@ -211,17 +222,28 @@ module Css exposing
     
     -- list styles
     , ListStyleType, ListStyleTypeSupported
-    , listStyle, listStyle2, listStyle3, listStylePosition, inside, outside, listStyleType, listStyleImage
+    , listStyle, listStyle2, listStyle3, listStylePosition, inside, outside
+    , listStyleType
+    , listStyleImage
     , arabicIndic, armenian, bengali, cambodian, cjkDecimal, cjkEarthlyBranch, cjkHeavenlyStem, cjkIdeographic, decimal, decimalLeadingZero, devanagari, disclosureClosed, disclosureOpen, disc, ethiopicNumeric, georgian, gujarati, gurmukhi, hebrew, hiragana, hiraganaIroha, japaneseFormal, japaneseInformal, kannada, katakana, katakanaIroha, khmer, koreanHangulFormal, koreanHanjaFormal, koreanHanjaInformal, lao, lowerAlpha, lowerArmenian, lowerGreek, lowerLatin, lowerRoman, malayalam, monogolian, myanmar, oriya, persian, simpChineseFormal, simpChineseInformal, tamil, telugu, thai, tibetan, tradChineseFormal, tradChineseInformal, upperAlpha, upperArmenian, upperLatin, upperRoman
 
     -- text transform + decoration
     , textTransform
     , capitalize, uppercase, lowercase, fullSizeKana
-    , textDecoration, textDecoration2, textDecoration3, textDecorationLine, textDecorationLine2, textDecorationLine3, textDecorationStyle, textDecorationColor, textDecorationThickness, fromFont
-    , textDecorationSkip, textDecorationSkipInk, objects, spaces, ink, edges, boxDecoration
+    , textDecoration, textDecoration2, textDecoration3
+    , textDecorationLine, textDecorationLine2, textDecorationLine3
+    , textDecorationStyle
+    , textDecorationColor
+    , textDecorationThickness
+    , fromFont
+    , textDecorationSkip
+    , textDecorationSkipInk
+    , objects, spaces, ink, edges, boxDecoration
     , wavy, underline, overline, lineThrough
 
     -- text decoration (other)
+    , lineHeight
+    , letterSpacing
     , textIndent, textIndent2, textIndent3, hanging, eachLine
     , textUnderlineOffset
     , textEmphasis, textEmphasis2
@@ -260,23 +282,54 @@ module Css exposing
     , textRendering
     , geometricPrecision, optimizeLegibility, optimizeSpeed
 
-    -- cursors
-    , CursorKeyword
-    , cursor, cursor2, cursor4
-    , pointer, default, contextMenu, help, progress, wait, cell
-    , crosshair, verticalText, alias, copy, move, noDrop
-    , notAllowed, allScroll, colResize, rowResize, nResize, eResize, sResize
-    , wResize, neResize, nwResize, seResize, swResize, ewResize, nsResize
-    , neswResize, nwseResize, zoomIn, zoomOut, grab, grabbing
+    -- text selection
+    , userSelect
 
-    -- shadows and gradients
-    , BoxShadowConfig, boxShadow, boxShadows, defaultBoxShadow
-    , TextShadowConfig, textShadow, defaultTextShadow
-    , linearGradient, linearGradient2, stop, stop2, stop3, toBottom, toBottomLeft, toBottomRight, toLeft, toRight, toTop, toTopLeft, toTopRight
+    -- accessibility
+    , speak, spellOut
 
-    -- break (page break)
-    , breakBefore, breakAfter, breakInside, avoid, avoidPage, avoidColumn, page
-    , pageBreakBefore, pageBreakAfter, pageBreakInside
+    -- columns
+    , columns, columns2
+    , columnWidth
+    , columnCount
+    , columnFill
+    , balance, balanceAll
+    , columnSpan
+    , columnRule, columnRule2, columnRule3
+    , columnRuleWidth
+    , columnRuleStyle
+    , columnRuleColor
+    
+    -- tables
+    , borderCollapse
+    , collapse, separate
+    , borderSpacing, borderSpacing2
+    , captionSide
+    , emptyCells
+    , show, hide
+    , tableLayout
+
+    -- content fragmentation
+    , breakBefore
+    , breakAfter
+    , breakInside
+    , avoid, avoidPage, avoidColumn, page
+    , pageBreakBefore
+    , pageBreakAfter
+    , pageBreakInside
+    , orphans, widows
+    , boxDecorationBreak
+
+    -- arranging inline/block stuff
+    , float
+    , clear
+    , verticalAlign
+    , textTop, textBottom, middle
+
+    -- replaced elements
+    , objectFit
+    , scaleDown
+    , objectPosition, objectPosition2, objectPosition4
 
     -- pointer-events
     , pointerEvents
@@ -284,8 +337,11 @@ module Css exposing
 
     -- scrolling
     , scrollbarColor, scrollbarWidth
-    , scrollBehavior, smooth, scrollSnapAlign, scrollSnapStop
-    , scrollSnapType, scrollSnapType2, mandatory, proximity
+    , scrollBehavior, smooth
+    , scrollSnapAlign
+    , scrollSnapStop
+    , scrollSnapType, scrollSnapType2
+    , mandatory, proximity
     , scrollMargin, scrollMargin2, scrollMargin3, scrollMargin4
     , scrollMarginTop, scrollMarginLeft, scrollMarginRight, scrollMarginBottom
     , scrollMarginBlock, scrollMarginBlock2, scrollMarginInline, scrollMarginInline2
@@ -298,9 +354,26 @@ module Css exposing
     , overscrollBehaviorX, overscrollBehaviorY
     , overscrollBehaviorBlock, overscrollBehaviorInline
     
+    -- cursors
+    , CursorKeyword
+    , cursor, cursor2, cursor4
+    , pointer, default, contextMenu, help, progress, wait, cell
+    , crosshair, verticalText, alias, copy, move, noDrop
+    , notAllowed, allScroll, colResize, rowResize, nResize, eResize, sResize
+    , wResize, neResize, nwResize, seResize, swResize, ewResize, nsResize
+    , neswResize, nwseResize, zoomIn, zoomOut, grab, grabbing
+    , caretColor
+
+    -- shadows and gradients
+    , BoxShadowConfig, boxShadow, boxShadows, defaultBoxShadow
+    , TextShadowConfig, textShadow, defaultTextShadow
+    , linearGradient, linearGradient2, stop, stop2, stop3, toBottom, toBottomLeft, toBottomRight, toLeft, toRight, toTop, toTopLeft, toTopRight
+
     -- transformations and perspective
     , TransformFunction, TransformFunctionSupported
-    , transform, transforms, transformOrigin, transformOrigin2, transformBox
+    , transform, transforms
+    , transformOrigin, transformOrigin2
+    , transformBox
     , matrix, matrix3d
     , scale, scale2, scale3, scale_, scale2_, scaleX, scaleY, scaleZ, scale3d
     , skew, skew2, skewX, skewY
@@ -308,6 +381,7 @@ module Css exposing
     , translate, translate2, translateX, translateY, translateZ, translate3d
     , perspective, perspectiveOrigin, perspectiveOrigin2
     , perspective_
+    , backfaceVisibility
     
     -- animation
     , animationName, animationNames
@@ -320,6 +394,14 @@ module Css exposing
     , animationFillMode, animationFillModes
     , EasingFunction, EasingFunctionSupported
     , linear, ease, easeIn, easeOut, easeInOut, cubicBezier, stepStart, stepEnd, steps, steps2, jumpStart, jumpEnd, jumpNone, jumpBoth, infinite, reverse, alternate, alternateReverse, running, paused, forwards, backwards
+
+    -- visual stuff??
+    , opacity
+    , visibility
+    , mixBlendMode
+    , imageRendering
+    , crispEdges, pixelated
+    , clipPath, clipPath2
 
     -- masks
     , maskBorderMode
@@ -337,28 +419,14 @@ module Css exposing
     , maskType
     , noClip, add, subtract, intersect, exclude, alpha, luminance, matchSource
 
-    -- tables
-    , borderCollapse
-    , collapse, separate
-    , borderSpacing, borderSpacing2
-    , captionSide
-    , emptyCells
-    , show, hide
-    , tableLayout
-
-    -- columns
-    , columns, columns2
-    , columnWidth
-    , columnCount
-    , columnFill
-    , balance, balanceAll
-    , columnSpan
-    , columnRule, columnRule2, columnRule3
-    , columnRuleWidth
-    , columnRuleStyle
-    , columnRuleColor
+    -- drawing
+    , paintOrder, paintOrder2, paintOrder3, markers
     
+    -- using a printer
+    , bleed
+
     -- SVG attributes that can be used as CSS presentation properties.
+    , fill
     , strokeDasharray
     , strokeDashoffset
     , strokeWidth
@@ -377,55 +445,8 @@ module Css exposing
     , strokeLinejoin, strokeLinejoin2, crop, arcs, miter, bevel
     , strokeDashJustify, compress, dashes, gaps
 
-
-    
-    -- ??
+    -- WebKit stuff that's standardised for legacy support
     , lineClamp
-    , LineWidth, LineWidthSupported, LineStyle, LineStyleSupported
-
-    , verticalAlign
-    , textTop, textBottom, middle
-
-    , float
-
-    , clear
-
-    , visibility
-
-    , fill
-
-    , paintOrder, paintOrder2, paintOrder3, markers
-
-    , opacity
-
-    
-    , speak, spellOut
-
-    , userSelect
-
-    , bleed
-
-    , orphans, widows
-
-    , mixBlendMode
-
-    , imageRendering, crispEdges, pixelated
-
-    , backfaceVisibility
-
-    , objectFit, scaleDown
-    , objectPosition, objectPosition2, objectPosition4
-
-    , boxDecorationBreak
-
-    , clipPath, clipPath2
-
-    , caretColor
-
-    , resize, horizontal, vertical
-
-    , contain, contain2, contain3, contain4
-    , size, layout, paint
     )
 
 {-| If you need something that `elm-css` does not support right now, the
@@ -467,7 +488,7 @@ All CSS properties can have the values `unset`, `initial`, `inherit` and `revert
 
 ## Numeric Units
 
-@docs Length, LengthSupported, zero, px, em, ex, ch, rem, vh, vw, vmin, vmax, mm, cm, q, inches, pt, pc, pct, num, int
+@docs Length, LengthSupported, zero, px, em, ex, ch, rem, vh, vw, vmin, vmax, mm, cm, q, inch, pt, pc, pct, num, int
 
 
 ## Calc
@@ -2321,13 +2342,13 @@ q value =
 
 {-| [`in`](https://css-tricks.com/the-lengths-of-css/) length units.
 
-    borderWidth (inches 5)
+    borderWidth (inch 5)
 
-(This is `inches` instead of `in` because `in` is a reserved keyword in Elm.)
+(This is `inch` instead of `in` because `in` is a reserved keyword in Elm.)
 
 -}
-inches : Float -> Value { provides | inches : Supported }
-inches value =
+inch : Float -> Value { provides | inch : Supported }
+inch value =
     Value (String.fromFloat value ++ "in")
 
 
@@ -4882,6 +4903,193 @@ boxSizing :
 boxSizing (Value value) =
     AppendProperty ("box-sizing:" ++ value)
 
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------- CONTAIN --------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+
+
+
+{-| The [`contain`](https://css-tricks.com/almanac/properties/c/contain/) property.
+
+    contain none
+
+    contain content
+
+    contain2 size layout
+
+    contain3 size layout style
+
+    contain4 -- all multiple choice values in use, no value entry needed
+
+-}
+contain :
+    BaseValue
+        { none : Supported
+        , strict : Supported
+        , content : Supported
+        , size : Supported
+        , layout : Supported
+        , style : Supported
+        , paint : Supported
+        }
+    -> Style
+contain (Value value) =
+    AppendProperty ("contain:" ++ value)
+
+
+{-| The [`contain`](https://css-tricks.com/almanac/properties/c/contain/) property.
+
+This two-argument version lets you use 2 of the 4 multiple choice values you
+can use for this property.
+
+    contain2 size layout
+
+-}
+contain2 :
+    Value
+        { size : Supported
+        , layout : Supported
+        , style : Supported
+        , paint : Supported
+        }
+    ->
+        Value
+            { size : Supported
+            , layout : Supported
+            , style : Supported
+            , paint : Supported
+            }
+    -> Style
+contain2 (Value value1) (Value value2) =
+    AppendProperty ("contain:" ++ value1 ++ " " ++ value2)
+
+
+{-| The [`contain`](https://css-tricks.com/almanac/properties/c/contain/) property.
+
+This two-argument version lets you use 3 of the 4 multiple choice values you
+can use for this property.
+
+    contain3 size layout style
+
+-}
+contain3 :
+    Value
+        { size : Supported
+        , layout : Supported
+        , style : Supported
+        , paint : Supported
+        }
+    ->
+        Value
+            { size : Supported
+            , layout : Supported
+            , style : Supported
+            , paint : Supported
+            }
+    ->
+        Value
+            { size : Supported
+            , layout : Supported
+            , style : Supported
+            , paint : Supported
+            }
+    -> Style
+contain3 (Value value1) (Value value2) (Value value3) =
+    AppendProperty ("contain:" ++ value1 ++ " " ++ value2 ++ " " ++ value3)
+
+
+{-| The [`contain`](https://css-tricks.com/almanac/properties/c/contain/) property.
+
+This two-argument version lets you use all 4 multiple choice values you
+can use for this property.
+
+    contain4 size layout style paint
+
+**Note: The `style` value is considered at-risk from being depreciated.**
+
+-}
+contain4 :
+    Value
+        { size : Supported
+        , layout : Supported
+        , style : Supported
+        , paint : Supported
+        }
+    ->
+        Value
+            { size : Supported
+            , layout : Supported
+            , style : Supported
+            , paint : Supported
+            }
+    ->
+        Value
+            { size : Supported
+            , layout : Supported
+            , style : Supported
+            , paint : Supported
+            }
+    ->
+        Value
+            { size : Supported
+            , layout : Supported
+            , style : Supported
+            , paint : Supported
+            }
+    -> Style
+contain4 (Value value1) (Value value2) (Value value3) (Value value4) =
+    AppendProperty ("contain:" ++ value1 ++ " " ++ value2 ++ " " ++ value3 ++ " " ++ value4)
+
+
+{-| Sets the `size` value for [`contain`](#contain).
+
+This indicates that the element can be sized without
+needing to look at the size of its descendants.
+
+    contain size
+
+-}
+size : Value { provides | size : Supported }
+size =
+    Value "size"
+
+
+{-| Sets the `layout` value for [`contain`](#contain).
+
+This indicates that nothing outside the element
+may affect its internal layout and vice versa.
+
+    contain layout
+
+-}
+layout : Value { provides | layout : Supported }
+layout =
+    Value "layout"
+
+
+{-| Sets the `paint` value for [`contain`](#contain).
+
+Indicates that descendants of the element will not
+display outside its bounds and will not be painted
+by the browser if the containing box is offscreen.
+
+    contain paint
+
+-}
+paint : Value { provides | paint : Supported }
+paint =
+    Value "paint"
+
 
 ------------------------------------------------------------------------
 ------------------------------------------------------------------------
@@ -5741,8 +5949,6 @@ visited =
     pseudoClass "visited"
 
 
-
-
 ------------------------------------------------------------------------
 ------------------------------------------------------------------------
 ------------------------------------------------------------------------
@@ -5756,7 +5962,6 @@ visited =
 ------------------------------------------------------------------------
 ------------------------------------------------------------------------
 ------------------------------------------------------------------------
-
 
 
 {-| Sets [`margin`](https://css-tricks.com/almanac/properties/m/margin/) property.
@@ -8694,6 +8899,49 @@ anywhere =
     Value "anywhere"
 
 
+{-| The [`resize`](https://css-tricks.com/almanac/properties/r/resize/) property.
+
+    resize none
+
+    resize both
+
+    resize inline
+
+-}
+resize :
+    BaseValue
+        { none : Supported
+        , both : Supported
+        , horizontal : Supported
+        , vertical : Supported
+        , block : Supported
+        , inline : Supported
+        }
+    -> Style
+resize (Value value) =
+    AppendProperty ("resize:" ++ value)
+
+
+{-| The `horizontal` value used by [`resize`](#resize).
+
+    resize horizontal
+
+-}
+horizontal : Value { provides | horizontal : Supported }
+horizontal =
+    Value "horizontal"
+
+
+{-| The `vertical` value used by [`resize`](#resize).
+
+    resize vertical
+
+-}
+vertical : Value { provides | vertical : Supported }
+vertical =
+    Value "vertical"
+
+
 ------------------------------------------------------------------------
 ------------------------------------------------------------------------
 ------------------------------------------------------------------------
@@ -9665,6 +9913,23 @@ wrap =
 wrapReverse : Value { provides | wrapReverse : Supported }
 wrapReverse =
     Value "wrap-reverse"
+
+
+{-| Sets [`order`](https://css-tricks.com/almanac/properties/o/order/)
+
+    order (num 2)
+
+    order (num -2)
+
+-}
+order :
+    BaseValue
+        { int : Supported
+        , zero : Supported
+        }
+    -> Style
+order (Value val) =
+    AppendProperty ("order:" ++ val)
 
 
 ------------------------------------------------------------------------
@@ -13729,6 +13994,52 @@ lineThrough =
 ------------------------------------------------------------------------
 
 
+{-| Sets [`line-height`](https://css-tricks.com/almanac/properties/l/line-height/)
+
+    lineHeight (pct 150)
+
+    lineHeight (em 2)
+
+    lineHeight (num 1.5)
+
+    lineHeight normal
+
+-}
+lineHeight :
+    BaseValue
+        (LengthSupported
+            { pct : Supported
+            , normal : Supported
+            , num : Supported
+            }
+        )
+    -> Style
+lineHeight (Value val) =
+    AppendProperty ("line-height:" ++ val)
+
+
+{-| Sets [`letter-spacing`](https://css-tricks.com/almanac/properties/l/letter-spacing/)
+
+    letterSpacing (pct 150)
+
+    letterSpacing (em 2)
+
+    letterSpacing (num 1.5)
+
+    letterSpacing normal
+
+-}
+letterSpacing :
+    BaseValue
+        (LengthSupported
+            { normal : Supported
+            }
+        )
+    -> Style
+letterSpacing (Value val) =
+    AppendProperty ("letter-spacing:" ++ val)
+
+
 {-| The [`text-indent`](https://css-tricks.com/almanac/properties/t/text-indent/) property.
 
     textIndent (em 1.5)
@@ -14995,7 +15306,7 @@ optimizeSpeed =
 ------------------------------------------------------------------------
 ------------------------------------------------------------------------
 ------------------------------------------------------------------------
--------------------------------- CURSORS -------------------------------
+----------------------------- USER-SELECT ------------------------------
 ------------------------------------------------------------------------
 ------------------------------------------------------------------------
 ------------------------------------------------------------------------
@@ -15004,332 +15315,75 @@ optimizeSpeed =
 ------------------------------------------------------------------------
 
 
-{-| A type alias used for the various [`cursor`](#cursor) properties
--}
-type alias CursorKeyword =
-    { pointer : Supported
-    , auto : Supported
-    , default : Supported
-    , none : Supported
-    , contextMenu : Supported
-    , help : Supported
-    , progress : Supported
-    , wait : Supported
-    , cell : Supported
-    , crosshair : Supported
-    , text : Supported
-    , verticalText : Supported
-    , alias : Supported
-    , copy : Supported
-    , move : Supported
-    , noDrop : Supported
-    , notAllowed : Supported
-    , allScroll : Supported
-    , colResize : Supported
-    , rowResize : Supported
-    , nResize : Supported
-    , eResize : Supported
-    , sResize : Supported
-    , wResize : Supported
-    , neResize : Supported
-    , nwResize : Supported
-    , seResize : Supported
-    , swResize : Supported
-    , ewResize : Supported
-    , nsResize : Supported
-    , neswResize : Supported
-    , nwseResize : Supported
-    , zoomIn : Supported
-    , zoomOut : Supported
-    , grab : Supported
-    , grabbing : Supported
-    }
+{-| Sets [`user-select`](https://css-tricks.com/almanac/properties/u/user-select/)
 
+    userSelect none
 
-{-| The [`cursor`](https://css-tricks.com/almanac/properties/c/cursor/)
-property.
+    userSelect auto
 
-    cursor notAllowed
+    userSelect text
+
+    userSelect contain_
+
+    userSelect all_
 
 -}
-cursor : BaseValue CursorKeyword -> Style
-cursor (Value val) =
-    AppendProperty ("cursor:" ++ val)
-
-
-{-| The [`cursor`](https://css-tricks.com/almanac/properties/c/cursor/)
-property.
-
-    cursor2 (url "https://example.com") move
-
--}
-cursor2 : Value { url : Supported } -> Value CursorKeyword -> Style
-cursor2 (Value urlVal) (Value fallbackVal) =
-    AppendProperty ("cursor:" ++ urlVal ++ "," ++ fallbackVal)
-
-
-{-| The [`cursor`](https://css-tricks.com/almanac/properties/c/cursor/)
-property.
-
-    cursor4 (url "https://example.com") (num 34) zero move
-
--}
-cursor4 :
-    Value { url : Supported }
-    ->
-        Value
-            { num : Supported
-            , zero : Supported
-            }
-    ->
-        Value
-            { num : Supported
-            , zero : Supported
-            }
-    -> Value CursorKeyword
+userSelect :
+    BaseValue
+        { none : Supported
+        , auto : Supported
+        , text : Supported
+        , contain_ : Supported
+        , all_ : Supported
+        }
     -> Style
-cursor4 (Value urlVal) (Value xVal) (Value yVal) (Value fallbackVal) =
-    AppendProperty
-        ("cursor:"
-            ++ urlVal
-            ++ " "
-            ++ xVal
-            ++ " "
-            ++ yVal
-            ++ ","
-            ++ fallbackVal
-        )
+userSelect (Value val) =
+    AppendProperty ("user-select:" ++ val)
 
 
-{-| The `pointer` value for the [`cursor`](#cursor) property.
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------ ACCESSIBILITY ---------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+
+
+{-| Sets [`speak`](https://css-tricks.com/almanac/properties/s/speak/)
+
+    speak none
+
+    speak normal
+
+    speak spellOut
+
 -}
-pointer : Value { provides | pointer : Supported }
-pointer =
-    Value "pointer"
+speak :
+    BaseValue
+        { none : Supported
+        , normal : Supported
+        , spellOut : Supported
+        }
+    -> Style
+speak (Value val) =
+    AppendProperty ("speak:" ++ val)
 
 
-{-| The `default` value for the [`cursor`](#cursor) property.
+{-| Sets `spellOut` value for usage with [`speak`](#speak).
+
+    speak spellOut
+
 -}
-default : Value { provides | default : Supported }
-default =
-    Value "default"
-
-
-{-| The `context-menu` value for the [`cursor`](#cursor) property.
--}
-contextMenu : Value { provides | contextMenu : Supported }
-contextMenu =
-    Value "context-menu"
-
-
-{-| The `help` value for the [`cursor`](#cursor) property.
--}
-help : Value { provides | help : Supported }
-help =
-    Value "help"
-
-
-{-| The `progress` value for the [`cursor`](#cursor) property.
--}
-progress : Value { provides | progress : Supported }
-progress =
-    Value "progress"
-
-
-{-| The `wait` value for the [`cursor`](#cursor) property.
--}
-wait : Value { provides | wait : Supported }
-wait =
-    Value "wait"
-
-
-{-| The `cell` value for the [`cursor`](#cursor) property.
--}
-cell : Value { provides | cell : Supported }
-cell =
-    Value "cell"
-
-
-{-| The `crosshair` value for the [`cursor`](#cursor) property.
--}
-crosshair : Value { provides | crosshair : Supported }
-crosshair =
-    Value "crosshair"
-
-
-{-| The `vertical-text` value for the [`cursor`](#cursor) property.
--}
-verticalText : Value { provides | verticalText : Supported }
-verticalText =
-    Value "vertical-text"
-
-
-{-| The `alias` value for the [`cursor`](#cursor) property.
--}
-alias : Value { provides | alias : Supported }
-alias =
-    Value "alias"
-
-
-{-| The `copy` value for the [`cursor`](#cursor) property.
--}
-copy : Value { provides | copy : Supported }
-copy =
-    Value "copy"
-
-
-{-| The `move` value for the [`cursor`](#cursor) property.
--}
-move : Value { provides | move : Supported }
-move =
-    Value "move"
-
-
-{-| The `no-drop` value for the [`cursor`](#cursor) property.
--}
-noDrop : Value { provides | noDrop : Supported }
-noDrop =
-    Value "no-drop"
-
-
-{-| The `notAllowed` value for the [`cursor`](#cursor) property.
--}
-notAllowed : Value { provides | notAllowed : Supported }
-notAllowed =
-    Value "not-allowed"
-
-
-{-| The `all-scroll` value for the [`cursor`](#cursor) property.
--}
-allScroll : Value { provides | allScroll : Supported }
-allScroll =
-    Value "all-scroll"
-
-
-{-| The `col-resize` value for the [`cursor`](#cursor) property.
--}
-colResize : Value { provides | colResize : Supported }
-colResize =
-    Value "col-resize"
-
-
-{-| The `row-resize` value for the [`cursor`](#cursor) property.
--}
-rowResize : Value { provides | rowResize : Supported }
-rowResize =
-    Value "row-resize"
-
-
-{-| The `n-resize` value for the [`cursor`](#cursor) property.
--}
-nResize : Value { provides | nResize : Supported }
-nResize =
-    Value "n-resize"
-
-
-{-| The `e-resize` value for the [`cursor`](#cursor) property.
--}
-eResize : Value { provides | eResize : Supported }
-eResize =
-    Value "e-resize"
-
-
-{-| The `s-resize` value for the [`cursor`](#cursor) property.
--}
-sResize : Value { provides | sResize : Supported }
-sResize =
-    Value "s-resize"
-
-
-{-| The `w-resize` value for the [`cursor`](#cursor) property.
--}
-wResize : Value { provides | wResize : Supported }
-wResize =
-    Value "w-resize"
-
-
-{-| The `ne-resize` value for the [`cursor`](#cursor) property.
--}
-neResize : Value { provides | neResize : Supported }
-neResize =
-    Value "ne-resize"
-
-
-{-| The `nw-resize` value for the [`cursor`](#cursor) property.
--}
-nwResize : Value { provides | nwResize : Supported }
-nwResize =
-    Value "nw-resize"
-
-
-{-| The `se-resize` value for the [`cursor`](#cursor) property.
--}
-seResize : Value { provides | seResize : Supported }
-seResize =
-    Value "se-resize"
-
-
-{-| The `sw-resize` value for the [`cursor`](#cursor) property.
--}
-swResize : Value { provides | swResize : Supported }
-swResize =
-    Value "sw-resize"
-
-
-{-| The `ew-resize` value for the [`cursor`](#cursor) property.
--}
-ewResize : Value { provides | ewResize : Supported }
-ewResize =
-    Value "ew-resize"
-
-
-{-| The `ns-resize` value for the [`cursor`](#cursor) property.
--}
-nsResize : Value { provides | nsResize : Supported }
-nsResize =
-    Value "ns-resize"
-
-
-{-| The `nesw-resize` value for the [`cursor`](#cursor) property.
--}
-neswResize : Value { provides | neswResize : Supported }
-neswResize =
-    Value "nesw-resize"
-
-
-{-| The `nwse-resize` value for the [`cursor`](#cursor) property.
--}
-nwseResize : Value { provides | nwseResize : Supported }
-nwseResize =
-    Value "nwse-resize"
-
-
-{-| The `zoom-in` value for the [`cursor`](#cursor) property.
--}
-zoomIn : Value { provides | zoomIn : Supported }
-zoomIn =
-    Value "zoom-in"
-
-
-{-| The `zoom-out` value for the [`cursor`](#cursor) property.
--}
-zoomOut : Value { provides | zoomOut : Supported }
-zoomOut =
-    Value "zoom-out"
-
-
-{-| The `grab` value for the [`cursor`](#cursor) property.
--}
-grab : Value { provides | grab : Supported }
-grab =
-    Value "grab"
-
-
-{-| The `grabbing` value for the [`cursor`](#cursor) property.
--}
-grabbing : Value { provides | grabbing : Supported }
-grabbing =
-    Value "grabbing"
+spellOut : Value { provides | spellOut : Supported }
+spellOut =
+    Value "spell-out"
 
 
 
@@ -15339,7 +15393,7 @@ grabbing =
 ------------------------------------------------------------------------
 ------------------------------------------------------------------------
 ------------------------------------------------------------------------
------------------------------- BOX-SHADOW ------------------------------
+------------------------------ COLUMNS ---------------------------------
 ------------------------------------------------------------------------
 ------------------------------------------------------------------------
 ------------------------------------------------------------------------
@@ -15348,514 +15402,226 @@ grabbing =
 ------------------------------------------------------------------------
 
 
-{-| Configuration for [`boxShadow`](#boxShadow).
--}
-type alias BoxShadowConfig =
-    { offsetX :
-        Value
-            (LengthSupported
-                { pct : Supported
-                }
-            )
-    , offsetY :
-        Value
-            (LengthSupported
-                { pct : Supported
-                }
-            )
-    , blurRadius :
-        Maybe
-            (Value
-                (LengthSupported
-                    { pct : Supported
-                    }
-                )
-            )
-    , spreadRadius :
-        Maybe
-            (Value
-                (LengthSupported
-                    { pct : Supported
-                    }
-                )
-            )
-    , color :
-        Maybe (Value Color)
-    , inset : Bool
-    }
+{-| Sets [`columns`](https://css-tricks.com/almanac/properties/c/columns/)
 
+    columns (px 300)
 
-{-| Default [`boxShadow`](#boxShadow) configuration.
-
-It is equivalent to the following CSS:
-
-    box-shadow: 0 0;
+    columns2 (px 300) (num 2)
 
 -}
-defaultBoxShadow : BoxShadowConfig
-defaultBoxShadow =
-    { offsetX = zero
-    , offsetY = zero
-    , blurRadius = Nothing
-    , spreadRadius = Nothing
-    , color = Nothing
-    , inset = False
-    }
-
-
-{-| The [`box-shadow`](https://css-tricks.com/almanac/properties/b/box-shadow/) property.
-
-    boxShadow initial
-
-    boxShadow none
-
-For defining shadows look at [`boxShadows`](#boxShadows).
-
--}
-boxShadow : BaseValue { none : Supported } -> Style
-boxShadow (Value val) =
-    AppendProperty ("box-shadow:" ++ val)
-
-
-{-| Sets [`box-shadow`](https://css-tricks.com/almanac/properties/b/box-shadow/).
-
-    boxShadows [] -- "box-shadow: none"
-
-    -- "box-shadow: 3px 5px #aabbcc"
-    button
-        [ css
-            [ boxShadows
-                [ { defaultBoxShadow
-                    | offsetX = px 3
-                    , offsetY = px 5
-                    , color = Just (hex "#aabbcc")
-                  }
-                ]
-            ]
-        ]
-        [ text "Zap!" ]
-
--}
-boxShadows : List BoxShadowConfig -> Style
-boxShadows configs =
-    let
-        value =
-            case configs of
-                [] ->
-                    "none"
-
-                _ ->
-                    configs
-                        |> List.map boxShadowConfigToString
-                        |> String.join ", "
-    in
-    AppendProperty ("box-shadow:" ++ value)
-
-
-boxShadowConfigToString : BoxShadowConfig -> String
-boxShadowConfigToString config =
-    let
-        (Value offsetX) =
-            config.offsetX
-
-        (Value offsetY) =
-            config.offsetY
-
-        blurRadius =
-            case config.blurRadius of
-                Just (Value value) ->
-                    " " ++ value
-
-                Nothing ->
-                    case config.spreadRadius of
-                        Just _ ->
-                            " 0"
-
-                        Nothing ->
-                            ""
-
-        spreadRadius =
-            case config.spreadRadius of
-                Just (Value value) ->
-                    " " ++ value
-
-                Nothing ->
-                    ""
-
-        insetStr =
-            if config.inset then
-                "inset "
-
-            else
-                ""
-
-        colorVal =
-            config.color
-                |> Maybe.map (unpackValue >> (++) " ")
-                |> Maybe.withDefault ""
-    in
-    insetStr ++ offsetX ++ " " ++ offsetY ++ blurRadius ++ spreadRadius ++ colorVal
-
-
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
------------------------------ TEXT SHADOW ------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-
-
-{-| Configuration for [`textShadow`](#textShadow).
--}
-type alias TextShadowConfig =
-    { offsetX :
-        Value
-            (LengthSupported
-                { pct : Supported
-                }
-            )
-    , offsetY :
-        Value
-            (LengthSupported
-                { pct : Supported
-                }
-            )
-    , blurRadius :
-        Maybe
-            (Value
-                (LengthSupported
-                    { pct : Supported
-                    }
-                )
-            )
-    , color : Maybe (Value Color)
-    }
-
-
-{-| Default [`textShadow`](#textShadow) configuration.
-
-It is equivalent to the following CSS:
-
-    text-shadow: 0 0;
-
--}
-defaultTextShadow : TextShadowConfig
-defaultTextShadow =
-    { offsetX = zero
-    , offsetY = zero
-    , blurRadius = Nothing
-    , color = Nothing
-    }
-
-
-{-| Sets [`text-shadow`](https://css-tricks.com/almanac/properties/t/text-shadow/).
-
-    textShadow [] -- "text-shadow: none"
-
-    -- "text-shadow: 3px 5px #aabbcc"
-    span
-        [ css
-            [ textShadow
-                [ { defaultTextShadow
-                    | offsetX = px 3
-                    , offsetY = px 5
-                    , color = Just (hex "#aabbcc")
-                  }
-                ]
-            ]
-        ]
-        [ text "Zap!" ]
-
--}
-textShadow : List TextShadowConfig -> Style
-textShadow configs =
-    let
-        values =
-            case configs of
-                [] ->
-                    "none"
-
-                _ ->
-                    configs
-                        |> List.map textShadowConfigToString
-                        |> String.join ","
-    in
-    AppendProperty ("text-shadow:" ++ values)
-
-
-textShadowConfigToString : TextShadowConfig -> String
-textShadowConfigToString config =
-    let
-        offsetX =
-            unpackValue config.offsetX
-
-        offsetY =
-            unpackValue config.offsetY
-
-        blurRadius =
-            config.blurRadius
-                |> Maybe.map (unpackValue >> (++) " ")
-                |> Maybe.withDefault ""
-
-        colorSetting =
-            config.color
-                |> Maybe.map (unpackValue >> (++) " ")
-                |> Maybe.withDefault ""
-    in
-    offsetX ++ " " ++ offsetY ++ blurRadius ++ colorSetting
-
-
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
------------------------------- GRADIENTS -------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-
-
-{-| Produces [`linear-gradient()`](https://developer.mozilla.org/en-US/docs/Web/CSS/linear-gradient())
-values used by properties such as [`backgroundImage`](#backgroundImage),
-and [`listStyleImage`](#listStyleImage)
-
-    linearGradient (stop red) (stop blue) []
-
-    linearGradient (stop red) (stop blue) [ stop green ]
-
--}
-linearGradient :
-    Value { colorStop : Supported }
-    -> Value { colorStop : Supported }
-    -> List (Value { colorStop : Supported })
-    -> Value { provides | linearGradient : Supported }
-linearGradient (Value firstStop) (Value secondStop) moreStops =
-    let
-        peeledStops =
-            List.map unpackValue moreStops
-
-        stops =
-            String.join "," (firstStop :: secondStop :: peeledStops)
-    in
-    Value ("linear-gradient(" ++ stops ++ ")")
-
-
-{-| Produces [`linear-gradient()`](https://developer.mozilla.org/en-US/docs/Web/CSS/linear-gradient())
-values used by properties such as [`backgroundImage`](#backgroundImage),
-and [`listStyleImage`](#listStyleImage)
-
-    linearGradient2 toTop (stop red) (stop blue) []
-
-    linearGradient2 toTop (stop red) (stop blue) [ stop green ]
-
--}
-linearGradient2 :
-    Value
-        (AngleSupported
-            { toBottom : Supported
-            , toBottomLeft : Supported
-            , toBottomRight : Supported
-            , toLeft : Supported
-            , toRight : Supported
-            , toTop : Supported
-            , toTopLeft : Supported
-            , toTopRight : Supported
+columns :
+    BaseValue
+        (LengthSupported
+            { auto : Supported
             }
         )
-    -> Value { colorStop : Supported }
-    -> Value { colorStop : Supported }
-    -> List (Value { colorStop : Supported })
-    -> Value { provides | linearGradient : Supported }
-linearGradient2 (Value angle) (Value firstStop) (Value secondStop) moreStops =
-    let
-        peeledStops =
-            List.map unpackValue moreStops
-
-        stops =
-            String.join "," (firstStop :: secondStop :: peeledStops)
-    in
-    Value ("linear-gradient(" ++ angle ++ "," ++ stops ++ ")")
+    -> Style
+columns (Value widthVal) =
+    AppendProperty ("columns:" ++ widthVal)
 
 
-{-| Provides a stop for a [gradient](https://css-tricks.com/snippets/css/css-linear-gradient/).
+{-| Sets [`columns`](https://css-tricks.com/almanac/properties/c/columns/)
 
-    linearGradient toTop (stop red) (stop blue) []
+    columns (px 300)
 
-See also [`stop2`](#stop2) for controlling stop positioning.
+    columns2 (px 300) (num 2)
 
 -}
-stop : Value Color -> Value { provides | colorStop : Supported }
-stop (Value colorVal) =
-    Value colorVal
+columns2 :
+    Value
+        (LengthSupported
+            { auto : Supported
+            }
+        )
+    ->
+        Value
+            { auto : Supported
+            , num : Supported
+            }
+    -> Style
+columns2 (Value widthVal) (Value count) =
+    AppendProperty ("columns:" ++ widthVal ++ " " ++ count)
 
 
-{-| Provides a stop for a [gradient](https://css-tricks.com/snippets/css/css-linear-gradient/).
+{-| Sets [`column-width`](https://css-tricks.com/almanac/properties/c/column-width/)
 
-    linearGradient toTop (stop2 red (px 20)) (stop blue) []
+    columnWidth auto
 
-See also [`stop`](#stop) if you don't need to control the stop position.
-
--}
-stop2 :
-    Value Color
-    -> Value (LengthSupported { pct : Supported })
-    -> Value { provides | colorStop : Supported }
-stop2 (Value colorVal) (Value positionVal) =
-    Value (colorVal ++ " " ++ positionVal)
-
-
-{-| Provides a stop for a [gradient](https://css-tricks.com/snippets/css/css-linear-gradient/).
-
-    linearGradient (stop3 (hex "111") zero (pt 1)) (stop3 (hex "6454") (pt 2) (pct 45))
+    columnWidth (px 200)
 
 -}
-stop3 :
-    Value Color
-    -> Value (LengthSupported { pct : Supported })
-    -> Value (LengthSupported { pct : Supported })
-    -> Value { provides | colorStop : Supported }
-stop3 (Value colorVal) (Value positionStart) (Value positionEnd) =
-    Value (colorVal ++ " " ++ positionStart ++ "," ++ positionEnd)
+columnWidth :
+    BaseValue
+        (LengthSupported
+            { auto : Supported
+            }
+        )
+    -> Style
+columnWidth (Value widthVal) =
+    AppendProperty ("column-width:" ++ widthVal)
 
 
-{-| Provides the [`to bottom` side angle](https://css-tricks.com/snippets/css/css-linear-gradient/) for gradients.
+{-| Sets [`column-count`](https://css-tricks.com/almanac/properties/c/column-count/)
 
-    linearGradient toBottom (stop red) (stop blue) []
+    columnCount auto
 
-If you want your gradient to go to a corner, use [`toBottomLeft`](#toBottomLeft) or [`toBottomRight`](#toBottomRight):
-
-    linearGradient toBottomLeft (stop red) (stop blue) []
-
-    linearGradient toBottomRight (stop red) (stop blue) []
+    columnCount (num 3)
 
 -}
-toBottom : Value { provides | toBottom : Supported }
-toBottom =
-    Value "to bottom"
+columnCount :
+    BaseValue
+        { auto : Supported
+        , int : Supported
+        }
+    -> Style
+columnCount (Value count) =
+    AppendProperty ("column-count:" ++ count)
 
 
-{-| Provides the [`to bottom left` corner angle](https://css-tricks.com/snippets/css/css-linear-gradient/) for gradients.
+{-| Sets [`column-fill`](https://css-tricks.com/almanac/properties/c/column-fill/)
 
-    linearGradient toBottomLeft (stop red) (stop blue) []
+    columnFill auto
 
-If you want your gradient to go to a side, use [`toBottom`](#toBottom) or [`toLeft`](#toLeft) instead:
+    columnFill balance
 
-    linearGradient toBottom (stop red) (stop blue) []
-
-    linearGradient toLeft (stop red) (stop blue) []
-
--}
-toBottomLeft : Value { provides | toBottomLeft : Supported }
-toBottomLeft =
-    Value "to bottom left"
-
-
-{-| Provides the [`to bottom right` corner angle](https://css-tricks.com/snippets/css/css-linear-gradient/) for gradients.
-
-    linearGradient toBottomRight (stop red) (stop blue) []
-
-If you want your gradient to go to a side, use [`toBottom`](#toBottom) or [`toRight`](#toRight) instead:
-
-    linearGradient toBottom (stop red) (stop blue) []
-
-    linearGradient toRight (stop red) (stop blue) []
+    columnFill balanceAll
 
 -}
-toBottomRight : Value { provides | toBottomRight : Supported }
-toBottomRight =
-    Value "to bottom right"
+columnFill :
+    BaseValue
+        { auto : Supported
+        , balance : Supported
+        , balanceAll : Supported
+        }
+    -> Style
+columnFill (Value val) =
+    AppendProperty ("column-fill:" ++ val)
 
 
-{-| Provides the [`to left` side angle](https://css-tricks.com/snippets/css/css-linear-gradient/) for gradients.
+{-| A `balance` value used in properties such as [`columnFill`](#columnFill)
 
-    linearGradient toLeft (stop red) (stop blue) []
-
-If you want your gradient to go to a corner, use [`toTopLeft`](#toTopLeft) or [`toBottomLeft`](#toBottomLeft):
-
-    linearGradient toTopLeft (stop red) (stop blue) []
-
-    linearGradient toBottomLeft (stop red) (stop blue) []
-
--}
-toLeft : Value { provides | toLeft : Supported }
-toLeft =
-    Value "to left"
-
-
-{-| Provides the [`to right` side angle](https://css-tricks.com/snippets/css/css-linear-gradient/) for gradients.
-
-    linearGradient toRight (stop red) (stop blue) []
-
-If you want your gradient to go to a corner, use [`toTopRight`](#toTopRight) or [`toBottomRight`](#toBottomRight):
-
-    linearGradient toTopRight (stop red) (stop blue) []
-
-    linearGradient toBottomRight (stop red) (stop blue) []
+    columnFill balance
 
 -}
-toRight : Value { provides | toRight : Supported }
-toRight =
-    Value "to right"
+balance : Value { provides | balance : Supported }
+balance =
+    Value "balance"
 
 
-{-| Provides the [`to top` side angle](https://css-tricks.com/snippets/css/css-linear-gradient/) for gradients.
+{-| A `balance-all` value used in properties such as [`columnFill`](#columnFill)
 
-    linearGradient toTop (stop red) (stop blue) []
-
-If you want your gradient to go to a corner, use [`toTopLeft`](#toTopLeft) or [`toTopRight`](#toTopRight):
-
-    linearGradient toTopLeft (stop red) (stop blue) []
-
-    linearGradient toTopRight (stop red) (stop blue) []
+    columnFill balanceAll
 
 -}
-toTop : Value { provides | toTop : Supported }
-toTop =
-    Value "to top"
+balanceAll : Value { provides | balanceAll : Supported }
+balanceAll =
+    Value "balance-all"
 
 
-{-| Provides the [`to top left` corner angle](https://css-tricks.com/snippets/css/css-linear-gradient/) for gradients.
+{-| Sets [`column-span`](https://css-tricks.com/almanac/properties/c/column-span/)
 
-    linearGradient toTopLeft (stop red) (stop blue) []
+    columnSpan all_
 
-If you want your gradient to go to a side, use [`toTop`](#toTop) or [`toLeft`](#toLeft) instead:
-
-    linearGradient toTop (stop red) (stop blue) []
-
-    linearGradient toLeft (stop red) (stop blue) []
+    columnSpan none
 
 -}
-toTopLeft : Value { provides | toTopLeft : Supported }
-toTopLeft =
-    Value "to top left"
+columnSpan :
+    BaseValue
+        { none : Supported
+        , all_ : Supported
+        }
+    -> Style
+columnSpan (Value spanVal) =
+    AppendProperty ("column-span:" ++ spanVal)
 
 
-{-| Provides the [`to top right` corner angle](https://css-tricks.com/snippets/css/css-linear-gradient/) for gradients.
+{-| Sets [`column-rule`](https://css-tricks.com/almanac/properties/c/column-rule/).
+This is a shorthand for the [`columnRuleWidth`](#columnRuleWidth),
+[`columnRuleStyle`](#columnRuleStyle), and [`columnRuleColor`](#columnRuleColor)
+properties.
 
-    linearGradient toTopRight (stop red) (stop blue) []
+    columnRule thin
 
-If you want your gradient to go to a side, use [`toTop`](#toTop) or [`toRight`](#toRight) instead:
+    columnRule2 thin solid
 
-    linearGradient toTop (stop red) (stop blue) []
-
-    linearGradient toRight (stop red) (stop blue) []
+    columnRule3 thin solid (hex "#000000")
 
 -}
-toTopRight : Value { provides | toTopRight : Supported }
-toTopRight =
-    Value "to top right"
+columnRule : BaseValue LineWidth -> Style
+columnRule (Value widthVal) =
+    AppendProperty ("column-rule:" ++ widthVal)
+
+
+{-| Sets [`column-rule`](https://css-tricks.com/almanac/properties/c/column-rule/).
+This is a shorthand for the [`columnRuleWidth`](#columnRuleWidth),
+[`columnRuleStyle`](#columnRuleStyle), and [`columnRuleColor`](#columnRuleColor)
+properties.
+
+    columnRule thin
+
+    columnRule2 thin solid
+
+    columnRule3 thin solid (hex "#000000")
+
+-}
+columnRule2 : Value LineWidth -> Value LineStyle -> Style
+columnRule2 (Value widthVal) (Value styleVal) =
+    AppendProperty ("column-rule:" ++ widthVal ++ " " ++ styleVal)
+
+
+{-| Sets [`column-rule`](https://css-tricks.com/almanac/properties/c/column-rule/).
+This is a shorthand for the [`columnRuleWidth`](#columnRuleWidth),
+[`columnRuleStyle`](#columnRuleStyle), and [`columnRuleColor`](#columnRuleColor)
+properties.
+
+    columnRule thin
+
+    columnRule2 thin solid
+
+    columnRule3 thin solid (hex "#000000")
+
+-}
+columnRule3 : Value LineWidth -> Value LineStyle -> Value Color -> Style
+columnRule3 (Value widthVal) (Value styleVal) (Value colorVal) =
+    AppendProperty ("column-rule:" ++ widthVal ++ " " ++ styleVal ++ " " ++ colorVal)
+
+
+{-| Sets [`column-rule-width`](https://www.w3.org/TR/css-multicol-1/#propdef-column-rule-width)
+
+    columnRuleWidth thin
+
+    columnRuleWidth (px 2)
+
+-}
+columnRuleWidth : BaseValue LineWidth -> Style
+columnRuleWidth (Value widthVal) =
+    AppendProperty ("column-rule-width:" ++ widthVal)
+
+
+{-| Sets [`column-rule-style`](https://www.w3.org/TR/css-multicol-1/#propdef-column-rule-style)
+
+    columnRuleStyle solid
+
+    columnRuleStyle dotted
+
+    columnRuleStyle dashed
+
+-}
+columnRuleStyle : BaseValue LineStyle -> Style
+columnRuleStyle (Value styleVal) =
+    AppendProperty ("column-rule-style:" ++ styleVal)
+
+
+{-| Sets [`column-rule-color`](https://www.w3.org/TR/css-multicol-1/#propdef-column-rule-color)
+
+    columnRuleColor (rgb 0 0 0)
+
+    columnRuleColor (hex "#fff")
+
+-}
+columnRuleColor : BaseValue Color -> Style
+columnRuleColor (Value colorVal) =
+    AppendProperty ("column-rule-color:" ++ colorVal)
 
 
 ------------------------------------------------------------------------
@@ -15864,7 +15630,164 @@ toTopRight =
 ------------------------------------------------------------------------
 ------------------------------------------------------------------------
 ------------------------------------------------------------------------
--------------------------- BREAK (PAGE BREAK) --------------------------
+------------------------------- TABLES ---------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+
+
+{-| Sets [`border-collapse`](https://css-tricks.com/almanac/properties/b/border-collapse/).
+
+    borderCollapse collapse
+
+    borderCollapse separate
+
+-}
+borderCollapse :
+    BaseValue
+        { collapse : Supported
+        , separate : Supported
+        }
+    -> Style
+borderCollapse (Value str) =
+    AppendProperty ("border-collapse:" ++ str)
+
+
+{-| A `collapse` value for the [`border-collapse`](https://css-tricks.com/almanac/properties/b/border-collapse/) and
+[`visibility`](https://css-tricks.com/almanac/properties/v/visibility/) property.
+
+    borderCollapse collapse
+
+    visibility collapse
+
+-}
+collapse : Value { provides | collapse : Supported }
+collapse =
+    Value "collapse"
+
+
+{-| A `separate` value for the [`border-separate`](https://css-tricks.com/almanac/properties/b/border-collapse/) property.
+
+    borderCollapse separate
+
+-}
+separate : Value { provides | separate : Supported }
+separate =
+    Value "separate"
+
+
+{-| Sets [`border-spacing`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-spacing).
+
+    borderSpacing zero
+
+    borderSpacing (px 5)
+
+-}
+borderSpacing : BaseValue Length -> Style
+borderSpacing (Value str) =
+    AppendProperty ("border-spacing:" ++ str)
+
+
+{-| Sets [`border-spacing`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-spacing), defining horizontal and vertical spacing separately.
+
+    borderSpacing2 (cm 1) (em 2)
+
+-}
+borderSpacing2 : Value Length -> Value Length -> Style
+borderSpacing2 (Value valHorizontal) (Value valVertical) =
+    AppendProperty ("border-spacing:" ++ valHorizontal ++ " " ++ valVertical)
+
+
+{-| Sets [`caption-side`](https://css-tricks.com/almanac/properties/c/caption-side/).
+
+    captionSide top_
+
+    captionSide bottom_
+
+    captionSide blockStart
+
+    captionSide inlineEnd
+
+-}
+captionSide :
+    BaseValue
+        { top_ : Supported
+        , bottom_ : Supported
+        , blockStart : Supported
+        , blockEnd : Supported
+        , inlineStart : Supported
+        , inlineEnd : Supported
+        }
+    -> Style
+captionSide (Value str) =
+    AppendProperty ("caption-side:" ++ str)
+
+
+{-| Sets [`empty-cells`](https://css-tricks.com/almanac/properties/e/empty-cells/).
+
+    emptyCells show
+
+    emptyCells hide
+
+-}
+emptyCells :
+    BaseValue
+        { show : Supported
+        , hide : Supported
+        }
+    -> Style
+emptyCells (Value str) =
+    AppendProperty ("empty-cells:" ++ str)
+
+
+{-| A `show` value for the [`empty-cells`](https://css-tricks.com/almanac/properties/e/empty-cells/) property.
+
+    emptyCells show
+
+-}
+show : Value { provides | show : Supported }
+show =
+    Value "show"
+
+
+{-| A `hide` value for the [`empty-cells`](https://css-tricks.com/almanac/properties/e/empty-cells/) property.
+
+    emptyCells hide
+
+-}
+hide : Value { provides | hide : Supported }
+hide =
+    Value "hide"
+
+
+{-| Sets [`table-layout`](https://css-tricks.com/almanac/properties/t/table-layout/).
+
+    tableLayout auto
+
+    tableLayout fixed
+
+-}
+tableLayout :
+    BaseValue
+        { auto : Supported
+        , fixed : Supported
+        }
+    -> Style
+tableLayout (Value str) =
+    AppendProperty ("table-layout:" ++ str)
+
+
+
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+----------------------- CONTENT FRAGMENTATION --------------------------
 ------------------------------------------------------------------------
 ------------------------------------------------------------------------
 ------------------------------------------------------------------------
@@ -16077,6 +16000,350 @@ pageBreakInside (Value val) =
     AppendProperty ("page-break-inside:" ++ val)
 
 
+{-| Sets [`orphans`](https://css-tricks.com/almanac/properties/o/orphans/)
+**Note:** This function accepts only positive integers.
+
+    orphans (int 2)
+
+-}
+orphans :
+    BaseValue
+        { int : Supported
+        }
+    -> Style
+orphans (Value val) =
+    AppendProperty ("orphans:" ++ val)
+
+
+{-| Sets [`widows`](https://css-tricks.com/almanac/properties/w/widows/)
+**Note:** This function accepts only positive integers.
+
+    widows (int 2)
+
+-}
+widows :
+    BaseValue
+        { int : Supported
+        }
+    -> Style
+widows (Value val) =
+    AppendProperty ("widows:" ++ val)
+
+
+{-| Sets [`box-decoration-break`](https://css-tricks.com/almanac/properties/b/box-decoration-break/)
+
+    boxDecorationBreak slice
+
+    boxDecorationBreak clone
+
+-}
+boxDecorationBreak :
+    BaseValue
+        { slice : Supported
+        , clone : Supported
+        }
+    -> Style
+boxDecorationBreak (Value val) =
+    AppendProperty ("box-decoration-break:" ++ val)
+
+
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+--------------------- ARRANGING BLOCK/INLINE STUFF ---------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+
+
+{-| Sets [`float`](https://css-tricks.com/almanac/properties/f/float/).
+
+    float none
+
+    float left_
+
+    float right_
+
+    float inlineStart
+
+-}
+float :
+    BaseValue
+        { none : Supported
+        , left_ : Supported
+        , right_ : Supported
+        , inlineStart : Supported
+        , inlineEnd : Supported
+        }
+    -> Style
+float (Value str) =
+    AppendProperty ("float:" ++ str)
+
+
+{-| Sets [`clear`](https://css-tricks.com/almanac/properties/c/clear/) property.
+
+    clear none
+
+    clear both
+
+    clear left_
+
+    clear right_
+
+    clear inlineStart
+
+    clear inlineEnd
+
+-}
+clear :
+    BaseValue
+        { none : Supported
+        , left_ : Supported
+        , right_ : Supported
+        , both : Supported
+        , inlineStart : Supported
+        , inlineEnd : Supported
+        }
+    -> Style
+clear (Value val) =
+    AppendProperty ("clear:" ++ val)
+
+
+{-| Sets [`vertical-align`](https://css-tricks.com/almanac/properties/v/vertical-align/).
+
+    verticalAlign textBottom
+
+    verticalAlign (em 1)
+
+-}
+verticalAlign :
+    BaseValue
+        (LengthSupported
+            { baseline : Supported
+            , sub : Supported
+            , super : Supported
+            , textTop : Supported
+            , textBottom : Supported
+            , middle : Supported
+            , top_ : Supported
+            , bottom_ : Supported
+            , pct : Supported
+            }
+        )
+    -> Style
+verticalAlign (Value str) =
+    AppendProperty ("vertical-align:" ++ str)
+
+
+{-| A `textTop` value for the [`vertical-align`](https://css-tricks.com/almanac/properties/v/vertical-align/) property.
+
+    verticalAlign textTop
+
+-}
+textTop : Value { provides | textTop : Supported }
+textTop =
+    Value "text-top"
+
+
+{-| A `textBottom` value for the [`vertical-align`](https://css-tricks.com/almanac/properties/v/vertical-align/) property.
+
+    verticalAlign textBottom
+
+-}
+textBottom : Value { provides | textBottom : Supported }
+textBottom =
+    Value "text-bottom"
+
+
+{-| A `middle` value for the [`vertical-align`](https://css-tricks.com/almanac/properties/v/vertical-align/) property.
+
+    verticalAlign middle
+
+-}
+middle : Value { provides | middle : Supported }
+middle =
+    Value "middle"
+
+
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------ REPLACED ELEMENTS -----------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+
+
+{-| Sets [`object-fit`](https://css-tricks.com/almanac/properties/o/object-fit/)
+
+    objectFit fill_
+
+    objectFit contain_
+
+    objectFit cover
+
+    objectFit scaleDown
+
+    objectFit none
+
+-}
+objectFit :
+    BaseValue
+        { fill_ : Supported
+        , contain_ : Supported
+        , cover : Supported
+        , none : Supported
+        , scaleDown : Supported
+        }
+    -> Style
+objectFit (Value val) =
+    AppendProperty ("object-fit:" ++ val)
+
+
+{-| Sets `scale-down` value for usage with [`objectFit`](#objectFit).
+
+    objectFit scaleDown
+
+-}
+scaleDown : Value { provides | scaleDown : Supported }
+scaleDown =
+    Value "scale-down"
+
+
+{-| Sets [`object-position`](https://css-tricks.com/almanac/properties/o/object-position/).
+
+    objectPosition left_
+
+    objectPosition (px 45)
+
+`objectPosition` sets the horizontal direction. If you need the vertical
+direction instead, use [`objectPosition2`](#objectPosition2) like this:
+
+    objectPosition zero (px 45)
+
+If you need to set the offsets from the right or bottom, use
+[`objectPosition4`](#objectPosition4) like this:
+
+    objectPosition4 right_ (px 20) bottom_ (pct 25)
+
+-}
+objectPosition :
+    BaseValue
+        (LengthSupported
+            { left_ : Supported
+            , right_ : Supported
+            , center : Supported
+            , pct : Supported
+            }
+        )
+    -> Style
+objectPosition (Value horiz) =
+    AppendProperty ("object-position:" ++ horiz)
+
+
+{-| Sets [`object-position`](https://css-tricks.com/almanac/properties/o/object-position/).
+
+    objectPosition2 left_ top_
+
+    objectPosition2 (px 45) (pct 50)
+
+`objectPosition2` sets both the horizontal and vertical directions (in that
+order, same as CSS.) If you need only the horizontal, you can use
+[`objectPosition`](#objectPosition) instead:
+
+    objectPosition left_
+
+If you need to set the offsets from the right or bottom, use
+[`objectPosition4`](#objectPosition4) like this:
+
+    objectPosition4 right_ (px 20) bottom_ (pct 25)
+
+-}
+objectPosition2 :
+    Value
+        (LengthSupported
+            { left_ : Supported
+            , right_ : Supported
+            , center : Supported
+            , pct : Supported
+            }
+        )
+    ->
+        Value
+            (LengthSupported
+                { top_ : Supported
+                , bottom_ : Supported
+                , center : Supported
+                , pct : Supported
+                }
+            )
+    -> Style
+objectPosition2 (Value horiz) (Value vert) =
+    AppendProperty ("object-position:" ++ horiz ++ " " ++ vert)
+
+
+{-| Sets [`object-position`](https://css-tricks.com/almanac/properties/o/object-position/).
+
+    objectPosition4 right_ (px 20) bottom_ (pct 30)
+
+The four-argument form of object position alternates sides and offets. So the
+example above would position the object image 20px from the right, and 30%
+from the bottom.
+
+See also [`objectPosition`](#objectPosition) for horizontal alignment and
+[`objectPosition2`](#objectPosition2) for horizontal (from left) and
+vertical (from top) alignment.
+
+-}
+objectPosition4 :
+    Value
+        { left_ : Supported
+        , right_ : Supported
+        }
+    ->
+        Value
+            (LengthSupported
+                { pct : Supported
+                }
+            )
+    ->
+        Value
+            { top_ : Supported
+            , bottom_ : Supported
+            }
+    ->
+        Value
+            (LengthSupported
+                { pct : Supported
+                }
+            )
+    -> Style
+objectPosition4 (Value horiz) (Value horizAmount) (Value vert) (Value vertAmount) =
+    AppendProperty
+        ("object-position:"
+            ++ horiz
+            ++ " "
+            ++ horizAmount
+            ++ " "
+            ++ vert
+            ++ " "
+            ++ vertAmount
+        )
+
+
+
 ------------------------------------------------------------------------
 ------------------------------------------------------------------------
 ------------------------------------------------------------------------
@@ -16232,6 +16499,111 @@ scrollBehavior :
     -> Style
 scrollBehavior (Value val) =
     AppendProperty ("scroll-behavior:" ++ val)
+
+
+{-| Sets [`scroll-snap-align`](https://css-tricks.com/almanac/properties/s/scroll-snap-align/)
+
+    scrollSnapAlign none
+
+    scrollSnapAlign start
+
+    scrollSnapAlign center
+
+    scrollSnapAlign end
+
+-}
+scrollSnapAlign :
+    BaseValue
+        { none : Supported
+        , start : Supported
+        , center : Supported
+        , end : Supported
+        }
+    -> Style
+scrollSnapAlign (Value val) =
+    AppendProperty ("scroll-snap-align:" ++ val)
+
+
+{-| Sets [`scroll-snap-stop`](https://css-tricks.com/almanac/properties/s/scroll-snap-stop/)
+
+    scrollSnapStop normal
+
+    scrollSnapStop always
+
+-}
+scrollSnapStop :
+    BaseValue
+        { normal : Supported
+        , always : Supported
+        }
+    -> Style
+scrollSnapStop (Value val) =
+    AppendProperty ("scroll-snap-stop:" ++ val)
+
+
+{-| Sets [`scroll-snap-type`](https://css-tricks.com/almanac/properties/s/scroll-snap-type/)
+
+    scrollSnapType none
+
+-}
+scrollSnapType :
+    BaseValue
+        { none : Supported
+        , x : Supported
+        , y : Supported
+        , block : Supported
+        , inline : Supported
+        , both : Supported
+        }
+    -> Style
+scrollSnapType (Value val) =
+    AppendProperty ("scroll-snap-type:" ++ val)
+
+
+
+{-| Sets [`scroll-snap-type`](https://css-tricks.com/almanac/properties/s/scroll-snap-type/)
+
+    scrollSnapType2 x mandatory
+
+    scrollSnapType2 both proximity
+
+-}
+scrollSnapType2 :
+    Value
+        { x : Supported
+        , y : Supported
+        , block : Supported
+        , inline : Supported
+        , both : Supported
+        }
+    ->
+        Value
+            { mandatory : Supported
+            , proximity : Supported
+            }
+    -> Style
+scrollSnapType2 (Value val1) (Value val2) =
+    AppendProperty ("scroll-snap-type:" ++ val1 ++ " " ++ val2)
+
+
+{-| Sets `mandatory` value for usage with [`scrollSnapType2`](#scrollSnapType2).
+
+    scrollSnapType2 x mandatory
+
+-}
+mandatory : Value { provides | mandatory : Supported }
+mandatory =
+    Value "mandatory"
+
+
+{-| Sets `proximity` value for usage with [`scrollSnapType2`](#scrollSnapType2).
+
+    scrollSnapType2 x proximity
+
+-}
+proximity : Value { provides | proximity : Supported }
+proximity =
+    Value "proximity"
 
 
 {-| Sets [`scroll-margin`](https://css-tricks.com/almanac/properties/s/scroll-margin/) property.
@@ -16924,7 +17296,7 @@ This property is a shorthand for setting both `overscroll-behavior-x` and `overs
 overscrollBehavior :
     BaseValue
         { auto : Supported
-        , contain : Supported
+        , contain_ : Supported
         , none : Supported
         }
     -> Style
@@ -16936,19 +17308,19 @@ overscrollBehavior (Value value) =
 
 This property is a shorthand for setting both `overscroll-behavior-x` and `overscroll-behavior-y`.
 
-    overscrollBehavior2 auto contain -- X = auto, Y = contain.
+    overscrollBehavior2 auto contain_ -- X = auto, Y = contain.
 
 -}
 overscrollBehavior2 :
     Value
         { auto : Supported
-        , contain : Supported
+        , contain_ : Supported
         , none : Supported
         }
     ->
         Value
             { auto : Supported
-            , contain : Supported
+            , contain_ : Supported
             , none : Supported
             }
     -> Style
@@ -16960,13 +17332,13 @@ overscrollBehavior2 (Value xValue) (Value yValue) =
 
     overscrollBehaviorX auto
 
-    overscrollBehaviorX contain
+    overscrollBehaviorX contain_
 
 -}
 overscrollBehaviorX :
     BaseValue
         { auto : Supported
-        , contain : Supported
+        , contain_ : Supported
         , none : Supported
         }
     -> Style
@@ -16978,13 +17350,13 @@ overscrollBehaviorX (Value value) =
 
     overscrollBehaviorY auto
 
-    overscrollBehaviorY contain
+    overscrollBehaviorY contain_
 
 -}
 overscrollBehaviorY :
     BaseValue
         { auto : Supported
-        , contain : Supported
+        , contain_ : Supported
         , none : Supported
         }
     -> Style
@@ -16996,13 +17368,13 @@ overscrollBehaviorY (Value value) =
 
     overscrollBehaviorBlock auto
 
-    overscrollBehaviorBlock contain
+    overscrollBehaviorBlock contain_
 
 -}
 overscrollBehaviorBlock :
     BaseValue
         { auto : Supported
-        , contain : Supported
+        , contain_ : Supported
         , none : Supported
         }
     -> Style
@@ -17014,19 +17386,907 @@ overscrollBehaviorBlock (Value value) =
 
     overscrollBehaviorInline auto
 
-    overscrollBehaviorInline contain
+    overscrollBehaviorInline contain_
 
 -}
 overscrollBehaviorInline :
     BaseValue
         { auto : Supported
-        , contain : Supported
+        , contain_ : Supported
         , none : Supported
         }
     -> Style
 overscrollBehaviorInline (Value value) =
     AppendProperty ("overscroll-behavior-inline:" ++ value)
 
+
+
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+-------------------------------- CURSORS -------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+
+
+{-| A type alias used for the various [`cursor`](#cursor) properties
+-}
+type alias CursorKeyword =
+    { pointer : Supported
+    , auto : Supported
+    , default : Supported
+    , none : Supported
+    , contextMenu : Supported
+    , help : Supported
+    , progress : Supported
+    , wait : Supported
+    , cell : Supported
+    , crosshair : Supported
+    , text : Supported
+    , verticalText : Supported
+    , alias : Supported
+    , copy : Supported
+    , move : Supported
+    , noDrop : Supported
+    , notAllowed : Supported
+    , allScroll : Supported
+    , colResize : Supported
+    , rowResize : Supported
+    , nResize : Supported
+    , eResize : Supported
+    , sResize : Supported
+    , wResize : Supported
+    , neResize : Supported
+    , nwResize : Supported
+    , seResize : Supported
+    , swResize : Supported
+    , ewResize : Supported
+    , nsResize : Supported
+    , neswResize : Supported
+    , nwseResize : Supported
+    , zoomIn : Supported
+    , zoomOut : Supported
+    , grab : Supported
+    , grabbing : Supported
+    }
+
+
+{-| The [`cursor`](https://css-tricks.com/almanac/properties/c/cursor/)
+property.
+
+    cursor notAllowed
+
+-}
+cursor : BaseValue CursorKeyword -> Style
+cursor (Value val) =
+    AppendProperty ("cursor:" ++ val)
+
+
+{-| The [`cursor`](https://css-tricks.com/almanac/properties/c/cursor/)
+property.
+
+    cursor2 (url "https://example.com") move
+
+-}
+cursor2 : Value { url : Supported } -> Value CursorKeyword -> Style
+cursor2 (Value urlVal) (Value fallbackVal) =
+    AppendProperty ("cursor:" ++ urlVal ++ "," ++ fallbackVal)
+
+
+{-| The [`cursor`](https://css-tricks.com/almanac/properties/c/cursor/)
+property.
+
+    cursor4 (url "https://example.com") (num 34) zero move
+
+-}
+cursor4 :
+    Value { url : Supported }
+    ->
+        Value
+            { num : Supported
+            , zero : Supported
+            }
+    ->
+        Value
+            { num : Supported
+            , zero : Supported
+            }
+    -> Value CursorKeyword
+    -> Style
+cursor4 (Value urlVal) (Value xVal) (Value yVal) (Value fallbackVal) =
+    AppendProperty
+        ("cursor:"
+            ++ urlVal
+            ++ " "
+            ++ xVal
+            ++ " "
+            ++ yVal
+            ++ ","
+            ++ fallbackVal
+        )
+
+
+{-| The `pointer` value for the [`cursor`](#cursor) property.
+-}
+pointer : Value { provides | pointer : Supported }
+pointer =
+    Value "pointer"
+
+
+{-| The `default` value for the [`cursor`](#cursor) property.
+-}
+default : Value { provides | default : Supported }
+default =
+    Value "default"
+
+
+{-| The `context-menu` value for the [`cursor`](#cursor) property.
+-}
+contextMenu : Value { provides | contextMenu : Supported }
+contextMenu =
+    Value "context-menu"
+
+
+{-| The `help` value for the [`cursor`](#cursor) property.
+-}
+help : Value { provides | help : Supported }
+help =
+    Value "help"
+
+
+{-| The `progress` value for the [`cursor`](#cursor) property.
+-}
+progress : Value { provides | progress : Supported }
+progress =
+    Value "progress"
+
+
+{-| The `wait` value for the [`cursor`](#cursor) property.
+-}
+wait : Value { provides | wait : Supported }
+wait =
+    Value "wait"
+
+
+{-| The `cell` value for the [`cursor`](#cursor) property.
+-}
+cell : Value { provides | cell : Supported }
+cell =
+    Value "cell"
+
+
+{-| The `crosshair` value for the [`cursor`](#cursor) property.
+-}
+crosshair : Value { provides | crosshair : Supported }
+crosshair =
+    Value "crosshair"
+
+
+{-| The `vertical-text` value for the [`cursor`](#cursor) property.
+-}
+verticalText : Value { provides | verticalText : Supported }
+verticalText =
+    Value "vertical-text"
+
+
+{-| The `alias` value for the [`cursor`](#cursor) property.
+-}
+alias : Value { provides | alias : Supported }
+alias =
+    Value "alias"
+
+
+{-| The `copy` value for the [`cursor`](#cursor) property.
+-}
+copy : Value { provides | copy : Supported }
+copy =
+    Value "copy"
+
+
+{-| The `move` value for the [`cursor`](#cursor) property.
+-}
+move : Value { provides | move : Supported }
+move =
+    Value "move"
+
+
+{-| The `no-drop` value for the [`cursor`](#cursor) property.
+-}
+noDrop : Value { provides | noDrop : Supported }
+noDrop =
+    Value "no-drop"
+
+
+{-| The `notAllowed` value for the [`cursor`](#cursor) property.
+-}
+notAllowed : Value { provides | notAllowed : Supported }
+notAllowed =
+    Value "not-allowed"
+
+
+{-| The `all-scroll` value for the [`cursor`](#cursor) property.
+-}
+allScroll : Value { provides | allScroll : Supported }
+allScroll =
+    Value "all-scroll"
+
+
+{-| The `col-resize` value for the [`cursor`](#cursor) property.
+-}
+colResize : Value { provides | colResize : Supported }
+colResize =
+    Value "col-resize"
+
+
+{-| The `row-resize` value for the [`cursor`](#cursor) property.
+-}
+rowResize : Value { provides | rowResize : Supported }
+rowResize =
+    Value "row-resize"
+
+
+{-| The `n-resize` value for the [`cursor`](#cursor) property.
+-}
+nResize : Value { provides | nResize : Supported }
+nResize =
+    Value "n-resize"
+
+
+{-| The `e-resize` value for the [`cursor`](#cursor) property.
+-}
+eResize : Value { provides | eResize : Supported }
+eResize =
+    Value "e-resize"
+
+
+{-| The `s-resize` value for the [`cursor`](#cursor) property.
+-}
+sResize : Value { provides | sResize : Supported }
+sResize =
+    Value "s-resize"
+
+
+{-| The `w-resize` value for the [`cursor`](#cursor) property.
+-}
+wResize : Value { provides | wResize : Supported }
+wResize =
+    Value "w-resize"
+
+
+{-| The `ne-resize` value for the [`cursor`](#cursor) property.
+-}
+neResize : Value { provides | neResize : Supported }
+neResize =
+    Value "ne-resize"
+
+
+{-| The `nw-resize` value for the [`cursor`](#cursor) property.
+-}
+nwResize : Value { provides | nwResize : Supported }
+nwResize =
+    Value "nw-resize"
+
+
+{-| The `se-resize` value for the [`cursor`](#cursor) property.
+-}
+seResize : Value { provides | seResize : Supported }
+seResize =
+    Value "se-resize"
+
+
+{-| The `sw-resize` value for the [`cursor`](#cursor) property.
+-}
+swResize : Value { provides | swResize : Supported }
+swResize =
+    Value "sw-resize"
+
+
+{-| The `ew-resize` value for the [`cursor`](#cursor) property.
+-}
+ewResize : Value { provides | ewResize : Supported }
+ewResize =
+    Value "ew-resize"
+
+
+{-| The `ns-resize` value for the [`cursor`](#cursor) property.
+-}
+nsResize : Value { provides | nsResize : Supported }
+nsResize =
+    Value "ns-resize"
+
+
+{-| The `nesw-resize` value for the [`cursor`](#cursor) property.
+-}
+neswResize : Value { provides | neswResize : Supported }
+neswResize =
+    Value "nesw-resize"
+
+
+{-| The `nwse-resize` value for the [`cursor`](#cursor) property.
+-}
+nwseResize : Value { provides | nwseResize : Supported }
+nwseResize =
+    Value "nwse-resize"
+
+
+{-| The `zoom-in` value for the [`cursor`](#cursor) property.
+-}
+zoomIn : Value { provides | zoomIn : Supported }
+zoomIn =
+    Value "zoom-in"
+
+
+{-| The `zoom-out` value for the [`cursor`](#cursor) property.
+-}
+zoomOut : Value { provides | zoomOut : Supported }
+zoomOut =
+    Value "zoom-out"
+
+
+{-| The `grab` value for the [`cursor`](#cursor) property.
+-}
+grab : Value { provides | grab : Supported }
+grab =
+    Value "grab"
+
+
+{-| The `grabbing` value for the [`cursor`](#cursor) property.
+-}
+grabbing : Value { provides | grabbing : Supported }
+grabbing =
+    Value "grabbing"
+
+
+{-| Sets [`caret-color`](https://css-tricks.com/almanac/properties/c/caret-color/)
+
+    caretColor (hex "#60b5cc")
+
+    caretColor (rgb 96 181 204)
+
+    caretColor (rgba 96 181 204 0.5)
+
+-}
+caretColor :
+    BaseValue
+        (ColorSupported
+            { auto : Supported
+            }
+        )
+    -> Style
+caretColor (Value val) =
+    AppendProperty ("caret-color:" ++ val)
+
+
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------ BOX-SHADOW ------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+
+
+{-| Configuration for [`boxShadow`](#boxShadow).
+-}
+type alias BoxShadowConfig =
+    { offsetX :
+        Value
+            (LengthSupported
+                { pct : Supported
+                }
+            )
+    , offsetY :
+        Value
+            (LengthSupported
+                { pct : Supported
+                }
+            )
+    , blurRadius :
+        Maybe
+            (Value
+                (LengthSupported
+                    { pct : Supported
+                    }
+                )
+            )
+    , spreadRadius :
+        Maybe
+            (Value
+                (LengthSupported
+                    { pct : Supported
+                    }
+                )
+            )
+    , color :
+        Maybe (Value Color)
+    , inset : Bool
+    }
+
+
+{-| Default [`boxShadow`](#boxShadow) configuration.
+
+It is equivalent to the following CSS:
+
+    box-shadow: 0 0;
+
+-}
+defaultBoxShadow : BoxShadowConfig
+defaultBoxShadow =
+    { offsetX = zero
+    , offsetY = zero
+    , blurRadius = Nothing
+    , spreadRadius = Nothing
+    , color = Nothing
+    , inset = False
+    }
+
+
+{-| The [`box-shadow`](https://css-tricks.com/almanac/properties/b/box-shadow/) property.
+
+    boxShadow initial
+
+    boxShadow none
+
+For defining shadows look at [`boxShadows`](#boxShadows).
+
+-}
+boxShadow : BaseValue { none : Supported } -> Style
+boxShadow (Value val) =
+    AppendProperty ("box-shadow:" ++ val)
+
+
+{-| Sets [`box-shadow`](https://css-tricks.com/almanac/properties/b/box-shadow/).
+
+    boxShadows [] -- "box-shadow: none"
+
+    -- "box-shadow: 3px 5px #aabbcc"
+    button
+        [ css
+            [ boxShadows
+                [ { defaultBoxShadow
+                    | offsetX = px 3
+                    , offsetY = px 5
+                    , color = Just (hex "#aabbcc")
+                  }
+                ]
+            ]
+        ]
+        [ text "Zap!" ]
+
+-}
+boxShadows : List BoxShadowConfig -> Style
+boxShadows configs =
+    let
+        value =
+            case configs of
+                [] ->
+                    "none"
+
+                _ ->
+                    configs
+                        |> List.map boxShadowConfigToString
+                        |> String.join ", "
+    in
+    AppendProperty ("box-shadow:" ++ value)
+
+
+boxShadowConfigToString : BoxShadowConfig -> String
+boxShadowConfigToString config =
+    let
+        (Value offsetX) =
+            config.offsetX
+
+        (Value offsetY) =
+            config.offsetY
+
+        blurRadius =
+            case config.blurRadius of
+                Just (Value value) ->
+                    " " ++ value
+
+                Nothing ->
+                    case config.spreadRadius of
+                        Just _ ->
+                            " 0"
+
+                        Nothing ->
+                            ""
+
+        spreadRadius =
+            case config.spreadRadius of
+                Just (Value value) ->
+                    " " ++ value
+
+                Nothing ->
+                    ""
+
+        insetStr =
+            if config.inset then
+                "inset "
+
+            else
+                ""
+
+        colorVal =
+            config.color
+                |> Maybe.map (unpackValue >> (++) " ")
+                |> Maybe.withDefault ""
+    in
+    insetStr ++ offsetX ++ " " ++ offsetY ++ blurRadius ++ spreadRadius ++ colorVal
+
+
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+----------------------------- TEXT SHADOW ------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+
+
+{-| Configuration for [`textShadow`](#textShadow).
+-}
+type alias TextShadowConfig =
+    { offsetX :
+        Value
+            (LengthSupported
+                { pct : Supported
+                }
+            )
+    , offsetY :
+        Value
+            (LengthSupported
+                { pct : Supported
+                }
+            )
+    , blurRadius :
+        Maybe
+            (Value
+                (LengthSupported
+                    { pct : Supported
+                    }
+                )
+            )
+    , color : Maybe (Value Color)
+    }
+
+
+{-| Default [`textShadow`](#textShadow) configuration.
+
+It is equivalent to the following CSS:
+
+    text-shadow: 0 0;
+
+-}
+defaultTextShadow : TextShadowConfig
+defaultTextShadow =
+    { offsetX = zero
+    , offsetY = zero
+    , blurRadius = Nothing
+    , color = Nothing
+    }
+
+
+{-| Sets [`text-shadow`](https://css-tricks.com/almanac/properties/t/text-shadow/).
+
+    textShadow [] -- "text-shadow: none"
+
+    -- "text-shadow: 3px 5px #aabbcc"
+    span
+        [ css
+            [ textShadow
+                [ { defaultTextShadow
+                    | offsetX = px 3
+                    , offsetY = px 5
+                    , color = Just (hex "#aabbcc")
+                  }
+                ]
+            ]
+        ]
+        [ text "Zap!" ]
+
+-}
+textShadow : List TextShadowConfig -> Style
+textShadow configs =
+    let
+        values =
+            case configs of
+                [] ->
+                    "none"
+
+                _ ->
+                    configs
+                        |> List.map textShadowConfigToString
+                        |> String.join ","
+    in
+    AppendProperty ("text-shadow:" ++ values)
+
+
+textShadowConfigToString : TextShadowConfig -> String
+textShadowConfigToString config =
+    let
+        offsetX =
+            unpackValue config.offsetX
+
+        offsetY =
+            unpackValue config.offsetY
+
+        blurRadius =
+            config.blurRadius
+                |> Maybe.map (unpackValue >> (++) " ")
+                |> Maybe.withDefault ""
+
+        colorSetting =
+            config.color
+                |> Maybe.map (unpackValue >> (++) " ")
+                |> Maybe.withDefault ""
+    in
+    offsetX ++ " " ++ offsetY ++ blurRadius ++ colorSetting
+
+
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------ GRADIENTS -------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+
+
+{-| Produces [`linear-gradient()`](https://developer.mozilla.org/en-US/docs/Web/CSS/linear-gradient())
+values used by properties such as [`backgroundImage`](#backgroundImage),
+and [`listStyleImage`](#listStyleImage)
+
+    linearGradient (stop red) (stop blue) []
+
+    linearGradient (stop red) (stop blue) [ stop green ]
+
+-}
+linearGradient :
+    Value { colorStop : Supported }
+    -> Value { colorStop : Supported }
+    -> List (Value { colorStop : Supported })
+    -> Value { provides | linearGradient : Supported }
+linearGradient (Value firstStop) (Value secondStop) moreStops =
+    let
+        peeledStops =
+            List.map unpackValue moreStops
+
+        stops =
+            String.join "," (firstStop :: secondStop :: peeledStops)
+    in
+    Value ("linear-gradient(" ++ stops ++ ")")
+
+
+{-| Produces [`linear-gradient()`](https://developer.mozilla.org/en-US/docs/Web/CSS/linear-gradient())
+values used by properties such as [`backgroundImage`](#backgroundImage),
+and [`listStyleImage`](#listStyleImage)
+
+    linearGradient2 toTop (stop red) (stop blue) []
+
+    linearGradient2 toTop (stop red) (stop blue) [ stop green ]
+
+-}
+linearGradient2 :
+    Value
+        (AngleSupported
+            { toBottom : Supported
+            , toBottomLeft : Supported
+            , toBottomRight : Supported
+            , toLeft : Supported
+            , toRight : Supported
+            , toTop : Supported
+            , toTopLeft : Supported
+            , toTopRight : Supported
+            }
+        )
+    -> Value { colorStop : Supported }
+    -> Value { colorStop : Supported }
+    -> List (Value { colorStop : Supported })
+    -> Value { provides | linearGradient : Supported }
+linearGradient2 (Value angle) (Value firstStop) (Value secondStop) moreStops =
+    let
+        peeledStops =
+            List.map unpackValue moreStops
+
+        stops =
+            String.join "," (firstStop :: secondStop :: peeledStops)
+    in
+    Value ("linear-gradient(" ++ angle ++ "," ++ stops ++ ")")
+
+
+{-| Provides a stop for a [gradient](https://css-tricks.com/snippets/css/css-linear-gradient/).
+
+    linearGradient toTop (stop red) (stop blue) []
+
+See also [`stop2`](#stop2) for controlling stop positioning.
+
+-}
+stop : Value Color -> Value { provides | colorStop : Supported }
+stop (Value colorVal) =
+    Value colorVal
+
+
+{-| Provides a stop for a [gradient](https://css-tricks.com/snippets/css/css-linear-gradient/).
+
+    linearGradient toTop (stop2 red (px 20)) (stop blue) []
+
+See also [`stop`](#stop) if you don't need to control the stop position.
+
+-}
+stop2 :
+    Value Color
+    -> Value (LengthSupported { pct : Supported })
+    -> Value { provides | colorStop : Supported }
+stop2 (Value colorVal) (Value positionVal) =
+    Value (colorVal ++ " " ++ positionVal)
+
+
+{-| Provides a stop for a [gradient](https://css-tricks.com/snippets/css/css-linear-gradient/).
+
+    linearGradient (stop3 (hex "111") zero (pt 1)) (stop3 (hex "6454") (pt 2) (pct 45))
+
+-}
+stop3 :
+    Value Color
+    -> Value (LengthSupported { pct : Supported })
+    -> Value (LengthSupported { pct : Supported })
+    -> Value { provides | colorStop : Supported }
+stop3 (Value colorVal) (Value positionStart) (Value positionEnd) =
+    Value (colorVal ++ " " ++ positionStart ++ "," ++ positionEnd)
+
+
+{-| Provides the [`to bottom` side angle](https://css-tricks.com/snippets/css/css-linear-gradient/) for gradients.
+
+    linearGradient toBottom (stop red) (stop blue) []
+
+If you want your gradient to go to a corner, use [`toBottomLeft`](#toBottomLeft) or [`toBottomRight`](#toBottomRight):
+
+    linearGradient toBottomLeft (stop red) (stop blue) []
+
+    linearGradient toBottomRight (stop red) (stop blue) []
+
+-}
+toBottom : Value { provides | toBottom : Supported }
+toBottom =
+    Value "to bottom"
+
+
+{-| Provides the [`to bottom left` corner angle](https://css-tricks.com/snippets/css/css-linear-gradient/) for gradients.
+
+    linearGradient toBottomLeft (stop red) (stop blue) []
+
+If you want your gradient to go to a side, use [`toBottom`](#toBottom) or [`toLeft`](#toLeft) instead:
+
+    linearGradient toBottom (stop red) (stop blue) []
+
+    linearGradient toLeft (stop red) (stop blue) []
+
+-}
+toBottomLeft : Value { provides | toBottomLeft : Supported }
+toBottomLeft =
+    Value "to bottom left"
+
+
+{-| Provides the [`to bottom right` corner angle](https://css-tricks.com/snippets/css/css-linear-gradient/) for gradients.
+
+    linearGradient toBottomRight (stop red) (stop blue) []
+
+If you want your gradient to go to a side, use [`toBottom`](#toBottom) or [`toRight`](#toRight) instead:
+
+    linearGradient toBottom (stop red) (stop blue) []
+
+    linearGradient toRight (stop red) (stop blue) []
+
+-}
+toBottomRight : Value { provides | toBottomRight : Supported }
+toBottomRight =
+    Value "to bottom right"
+
+
+{-| Provides the [`to left` side angle](https://css-tricks.com/snippets/css/css-linear-gradient/) for gradients.
+
+    linearGradient toLeft (stop red) (stop blue) []
+
+If you want your gradient to go to a corner, use [`toTopLeft`](#toTopLeft) or [`toBottomLeft`](#toBottomLeft):
+
+    linearGradient toTopLeft (stop red) (stop blue) []
+
+    linearGradient toBottomLeft (stop red) (stop blue) []
+
+-}
+toLeft : Value { provides | toLeft : Supported }
+toLeft =
+    Value "to left"
+
+
+{-| Provides the [`to right` side angle](https://css-tricks.com/snippets/css/css-linear-gradient/) for gradients.
+
+    linearGradient toRight (stop red) (stop blue) []
+
+If you want your gradient to go to a corner, use [`toTopRight`](#toTopRight) or [`toBottomRight`](#toBottomRight):
+
+    linearGradient toTopRight (stop red) (stop blue) []
+
+    linearGradient toBottomRight (stop red) (stop blue) []
+
+-}
+toRight : Value { provides | toRight : Supported }
+toRight =
+    Value "to right"
+
+
+{-| Provides the [`to top` side angle](https://css-tricks.com/snippets/css/css-linear-gradient/) for gradients.
+
+    linearGradient toTop (stop red) (stop blue) []
+
+If you want your gradient to go to a corner, use [`toTopLeft`](#toTopLeft) or [`toTopRight`](#toTopRight):
+
+    linearGradient toTopLeft (stop red) (stop blue) []
+
+    linearGradient toTopRight (stop red) (stop blue) []
+
+-}
+toTop : Value { provides | toTop : Supported }
+toTop =
+    Value "to top"
+
+
+{-| Provides the [`to top left` corner angle](https://css-tricks.com/snippets/css/css-linear-gradient/) for gradients.
+
+    linearGradient toTopLeft (stop red) (stop blue) []
+
+If you want your gradient to go to a side, use [`toTop`](#toTop) or [`toLeft`](#toLeft) instead:
+
+    linearGradient toTop (stop red) (stop blue) []
+
+    linearGradient toLeft (stop red) (stop blue) []
+
+-}
+toTopLeft : Value { provides | toTopLeft : Supported }
+toTopLeft =
+    Value "to top left"
+
+
+{-| Provides the [`to top right` corner angle](https://css-tricks.com/snippets/css/css-linear-gradient/) for gradients.
+
+    linearGradient toTopRight (stop red) (stop blue) []
+
+If you want your gradient to go to a side, use [`toTop`](#toTop) or [`toRight`](#toRight) instead:
+
+    linearGradient toTop (stop red) (stop blue) []
+
+    linearGradient toRight (stop red) (stop blue) []
+
+-}
+toTopRight : Value { provides | toTopRight : Supported }
+toTopRight =
+    Value "to top right"
 
 
 ------------------------------------------------------------------------
@@ -17141,7 +18401,79 @@ plusListToString head rest =
 
 
 
--- MATRIX TRANSFORMATION
+{-| Sets [`transform-origin`](https://css-tricks.com/almanac/properties/t/transform-origin/).
+
+    transformOrigin top_
+
+    transformOrigin center
+
+    transformOrigin bottom
+
+    transformOrigin (pct 50)
+
+-}
+transformOrigin :
+    BaseValue
+        { top_ : Supported
+        , center : Supported
+        , bottom_ : Supported
+        , pct : Supported
+        , calc : Supported
+        }
+    -> Style
+transformOrigin (Value vert) =
+    AppendProperty ("transform-origin:" ++ vert)
+
+
+{-| Sets [`transform-origin`](https://css-tricks.com/almanac/properties/t/transform-origin/).
+
+    transformOrigin2 top_ left
+
+    transformOrigin2 center right_
+
+    transformOrigin2 bottom_ right_
+
+    transformOrigin2 (pct 50) (pct 50)
+
+-}
+transformOrigin2 :
+    Value
+        { top_ : Supported
+        , center : Supported
+        , bottom_ : Supported
+        , pct : Supported
+        , calc : Supported
+        }
+    ->
+        Value
+            { left_ : Supported
+            , center : Supported
+            , right_ : Supported
+            , pct : Supported
+            , calc : Supported
+            }
+    -> Style
+transformOrigin2 (Value vert) (Value horiz) =
+    AppendProperty ("transform-origin:" ++ vert ++ " " ++ horiz)
+
+
+{-| Sets the [`transform-box`](https://developer.mozilla.org/en-US/docs/Web/CSS/transform-box) property.
+
+    transformBox contentBox
+
+    transformBox fillBox
+-}
+transformBox :
+    BaseValue
+        { contentBox : Supported
+        , borderBox : Supported
+        , fillBox : Supported
+        , strokeBox : Supported
+        , viewBox : Supported
+        }
+    -> Style
+transformBox (Value val) =
+    AppendProperty ("transform-box:" ++ val)
 
 
 {-| Sets `matrix` value for usage with [`transform`](#transform).
@@ -17774,6 +19106,22 @@ perspective_ (Value length) =
     Value ("perspective(" ++ length ++ ")")
 
 
+{-| Sets [`backface-visibility`](https://css-tricks.com/almanac/properties/b/backface-visibility/)
+
+    backfaceVisibility visible
+
+    backfaceVisibility hidden
+
+-}
+backfaceVisibility :
+    BaseValue
+        { visible : Supported
+        , hidden : Supported
+        }
+    -> Style
+backfaceVisibility (Value val) =
+    AppendProperty ("backface-visibility" ++ val)
+
 
 ------------------------------------------------------------------------
 ------------------------------------------------------------------------
@@ -18325,6 +19673,179 @@ backwards : Value { provides | backwards : Supported }
 backwards =
     Value "backwards"
 
+
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+----------------------------- VISUAL STUFF? ----------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+
+
+{-| Sets [`opacity`](https://css-tricks.com/almanac/properties/o/opacity/)
+
+    opacity (num 0.5)
+
+    opacity (num 1.0)
+
+    opacity zero
+
+-}
+opacity :
+    BaseValue
+        { num : Supported
+        , zero : Supported
+        , calc : Supported
+        , pct : Supported
+        }
+    -> Style
+opacity (Value val) =
+    AppendProperty ("opacity:" ++ val)
+
+
+{-| Sets [`visibility`](https://css-tricks.com/almanac/properties/v/visibility/)
+
+      visibility visible
+      visibility hidden
+      visibility collapse
+
+-}
+visibility :
+    BaseValue
+        { visible : Supported
+        , hidden : Supported
+        , collapse : Supported
+        }
+    -> Style
+visibility (Value str) =
+    AppendProperty ("visibility:" ++ str)
+
+
+{-| Sets [`mix-blend-mode`](https://css-tricks.com/almanac/properties/m/mix-blend-mode/)
+
+    mixBlendMode multiply
+
+    mixBlendMode saturation
+
+-}
+mixBlendMode :
+    BaseValue
+        { normal : Supported
+        , multiply : Supported
+        , screen : Supported
+        , overlay : Supported
+        , darken : Supported
+        , lighten : Supported
+        , colorDodge : Supported
+        , colorBurn : Supported
+        , hardLight : Supported
+        , softLight : Supported
+        , difference : Supported
+        , exclusion : Supported
+        , hue : Supported
+        , saturation : Supported
+        , color_ : Supported
+        , luminosity : Supported
+        }
+    -> Style
+mixBlendMode (Value val) =
+    AppendProperty ("mix-blend-mode:" ++ val)
+
+
+{-| Sets [`image-rendering`](https://css-tricks.com/almanac/properties/i/image-rendering/)
+
+    imageRendering auto
+
+    imageRendering crispEdges
+
+    imageRendering pixelated
+
+-}
+imageRendering :
+    BaseValue
+        { auto : Supported
+        , crispEdges : Supported
+        , pixelated : Supported
+        }
+    -> Style
+imageRendering (Value val) =
+    AppendProperty ("image-rendering:" ++ val)
+
+
+{-| Sets `pixelated` value for usage with [`imageRendering`](#imageRendering).
+
+    imageRendering pixelated
+
+-}
+pixelated : Value { provides | pixelated : Supported }
+pixelated =
+    Value "pixelated"
+
+
+{-| Sets `crisp-edges` value for usage with [`imageRendering`](#imageRendering).
+
+    imageRendering crispEdges
+
+-}
+crispEdges : Value { provides | crispEdges : Supported }
+crispEdges =
+    Value "crisp-edges"
+
+
+{-| The 1-argument variant of the
+[`clip-path`](https://css-tricks.com/almanac/properties/c/clip-path/) property.
+
+    clipPath marginBox
+
+    clipPath inherit
+
+    clipPath (circle (pct 2))
+
+    clipPath2 marginBox (circleAt2 farthestSide left top)
+-}
+clipPath :
+    BaseValue
+        (BasicShapeSupported
+            { marginBox : Supported
+            , borderBox : Supported
+            , paddingBox : Supported
+            , contentBox : Supported
+            , fillBox : Supported
+            , strokeBox : Supported
+            , viewBox : Supported
+            }
+        )
+    -> Style
+clipPath (Value val) =
+    AppendProperty ("clip-path:" ++ val)
+
+
+{-| The 2-argument variant of the
+[`clip-path`](https://css-tricks.com/almanac/properties/c/clip-path/) property.
+
+    clipPath2 marginBox (circleAt2 farthestSide left top)
+-}
+clipPath2 :
+    Value
+        { marginBox : Supported
+        , borderBox : Supported
+        , paddingBox : Supported
+        , contentBox : Supported
+        , fillBox : Supported
+        , strokeBox : Supported
+        , viewBox : Supported
+        }
+    -> Value (BasicShapeSupported a)
+    -> Style
+clipPath2 (Value val1) (Value val2) =
+    AppendProperty ("clip-path:" ++ val1 ++ " " ++ val2)
 
 
 ------------------------------------------------------------------------
@@ -19081,7 +20602,7 @@ maskSize :
             { pct : Supported
             , auto : Supported
             , cover : Supported
-            , contain : Supported
+            , contain_ : Supported
             }
         )
     -> Style
@@ -19251,7 +20772,7 @@ matchSource =
 ------------------------------------------------------------------------
 ------------------------------------------------------------------------
 ------------------------------------------------------------------------
-------------------------------- TABLES ---------------------------------
+------------------------------- DRAWING --------------------------------
 ------------------------------------------------------------------------
 ------------------------------------------------------------------------
 ------------------------------------------------------------------------
@@ -19260,398 +20781,126 @@ matchSource =
 ------------------------------------------------------------------------
 
 
-{-| Sets [`border-collapse`](https://css-tricks.com/almanac/properties/b/border-collapse/).
+{-| The [`paint-order`](https://css-tricks.com/almanac/properties/p/paint-order/) property.
 
-    borderCollapse collapse
+This one-argument version indicates which parts of text and shape graphics are
+painted first, followed by the other two in their relative default order.
 
-    borderCollapse separate
+    paintOrder normal -- normal paint order.
+
+    paintOrder2 fill_ stroke -- fill, stroke, then markers.
+
+    paintOrder3 markers stroke fill_ -- markers, stroke, then fill.
 
 -}
-borderCollapse :
+paintOrder :
     BaseValue
-        { collapse : Supported
-        , separate : Supported
+        { normal : Supported
+        , stroke : Supported
+        , markers : Supported
         }
     -> Style
-borderCollapse (Value str) =
-    AppendProperty ("border-collapse:" ++ str)
+paintOrder (Value val) =
+    AppendProperty ("paint-order:" ++ val)
 
 
-{-| A `collapse` value for the [`border-collapse`](https://css-tricks.com/almanac/properties/b/border-collapse/) and
-[`visibility`](https://css-tricks.com/almanac/properties/v/visibility/) property.
+{-| The [`paint-order`](https://css-tricks.com/almanac/properties/p/paint-order/) property.
 
-    borderCollapse collapse
+This two-argument version indicates which parts of text and shape graphics are
+painted first, followed by the other remaining one.
 
-    visibility collapse
-
--}
-collapse : Value { provides | collapse : Supported }
-collapse =
-    Value "collapse"
-
-
-{-| A `separate` value for the [`border-separate`](https://css-tricks.com/almanac/properties/b/border-collapse/) property.
-
-    borderCollapse separate
+    paintOrder2 fill_ stroke -- fill, stroke, then markers.
 
 -}
-separate : Value { provides | separate : Supported }
-separate =
-    Value "separate"
-
-
-
--- BORDER SPACING --
-
-
-{-| Sets [`border-spacing`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-spacing).
-
-    borderSpacing zero
-
-    borderSpacing (px 5)
-
--}
-borderSpacing : BaseValue Length -> Style
-borderSpacing (Value str) =
-    AppendProperty ("border-spacing:" ++ str)
-
-
-{-| Sets [`border-spacing`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-spacing), defining horizontal and vertical spacing separately.
-
-    borderSpacing2 (cm 1) (em 2)
-
--}
-borderSpacing2 : Value Length -> Value Length -> Style
-borderSpacing2 (Value valHorizontal) (Value valVertical) =
-    AppendProperty ("border-spacing:" ++ valHorizontal ++ " " ++ valVertical)
-
-
-
--- CAPTION SIDE --
-
-
-{-| Sets [`caption-side`](https://css-tricks.com/almanac/properties/c/caption-side/).
-
-    captionSide top_
-
-    captionSide bottom_
-
-    captionSide blockStart
-
-    captionSide inlineEnd
-
--}
-captionSide :
-    BaseValue
-        { top_ : Supported
-        , bottom_ : Supported
-        , blockStart : Supported
-        , blockEnd : Supported
-        , inlineStart : Supported
-        , inlineEnd : Supported
-        }
-    -> Style
-captionSide (Value str) =
-    AppendProperty ("caption-side:" ++ str)
-
-
-
--- EMPTY CELLS --
-
-
-{-| Sets [`empty-cells`](https://css-tricks.com/almanac/properties/e/empty-cells/).
-
-    emptyCells show
-
-    emptyCells hide
-
--}
-emptyCells :
-    BaseValue
-        { show : Supported
-        , hide : Supported
-        }
-    -> Style
-emptyCells (Value str) =
-    AppendProperty ("empty-cells:" ++ str)
-
-
-{-| A `show` value for the [`empty-cells`](https://css-tricks.com/almanac/properties/e/empty-cells/) property.
-
-    emptyCells show
-
--}
-show : Value { provides | show : Supported }
-show =
-    Value "show"
-
-
-{-| A `hide` value for the [`empty-cells`](https://css-tricks.com/almanac/properties/e/empty-cells/) property.
-
-    emptyCells hide
-
--}
-hide : Value { provides | hide : Supported }
-hide =
-    Value "hide"
-
-
-
--- TABLE LAYOUT --
-
-
-{-| Sets [`table-layout`](https://css-tricks.com/almanac/properties/t/table-layout/).
-
-    tableLayout auto
-
-    tableLayout fixed
-
--}
-tableLayout :
-    BaseValue
-        { auto : Supported
-        , fixed : Supported
-        }
-    -> Style
-tableLayout (Value str) =
-    AppendProperty ("table-layout:" ++ str)
-
-
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
------------------------------- COLUMNS ---------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-
-
-{-| Sets [`columns`](https://css-tricks.com/almanac/properties/c/columns/)
-
-    columns (px 300)
-
-    columns2 (px 300) (num 2)
-
--}
-columns :
-    BaseValue
-        (LengthSupported
-            { auto : Supported
-            }
-        )
-    -> Style
-columns (Value widthVal) =
-    AppendProperty ("columns:" ++ widthVal)
-
-
-{-| Sets [`columns`](https://css-tricks.com/almanac/properties/c/columns/)
-
-    columns (px 300)
-
-    columns2 (px 300) (num 2)
-
--}
-columns2 :
+paintOrder2 :
     Value
-        (LengthSupported
-            { auto : Supported
-            }
-        )
+        { fill_ : Supported
+        , stroke : Supported
+        , markers : Supported
+        }
     ->
         Value
-            { auto : Supported
-            , num : Supported
+            { fill_ : Supported
+            , stroke : Supported
+            , markers : Supported
             }
     -> Style
-columns2 (Value widthVal) (Value count) =
-    AppendProperty ("columns:" ++ widthVal ++ " " ++ count)
+paintOrder2 (Value val1) (Value val2) =
+    AppendProperty ("paint-order:" ++ val1 ++ " " ++ val2)
 
 
-{-| Sets [`column-width`](https://css-tricks.com/almanac/properties/c/column-width/)
+{-| The [`paint-order`](https://css-tricks.com/almanac/properties/p/paint-order/) property.
 
-    columnWidth auto
+This three-argument version explicitly indicates in which order should all the parts of text
+and shape graphics be painted.
 
-    columnWidth (px 200)
+    paintOrder3 markers stroke fill_ -- markers, stroke, then fill.
 
 -}
-columnWidth :
+paintOrder3 :
+    Value
+        { fill_ : Supported
+        , stroke : Supported
+        , markers : Supported
+        }
+    ->
+        Value
+            { fill_ : Supported
+            , stroke : Supported
+            , markers : Supported
+            }
+    ->
+        Value
+            { fill_ : Supported
+            , stroke : Supported
+            , markers : Supported
+            }
+    -> Style
+paintOrder3 (Value val1) (Value val2) (Value val3) =
+    AppendProperty ("paint-order:" ++ val1 ++ " " ++ val2 ++ " " ++ val3)
+
+
+{-| Provides the `markers` value for [`paintOrder`](#paintOrder).
+
+    paintOrder markers
+
+-}
+markers : Value { provides | markers : Supported }
+markers =
+    Value "markers"
+
+
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+--------------------------- USING A PRINTER ----------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+
+
+{-| Sets [`bleed`](https://css-tricks.com/almanac/properties/b/bleed/)
+
+    bleed auto
+
+    bleed (pt 10)
+
+-}
+bleed :
     BaseValue
         (LengthSupported
             { auto : Supported
             }
         )
     -> Style
-columnWidth (Value widthVal) =
-    AppendProperty ("column-width:" ++ widthVal)
-
-
-{-| Sets [`column-count`](https://css-tricks.com/almanac/properties/c/column-count/)
-
-    columnCount auto
-
-    columnCount (num 3)
-
--}
-columnCount :
-    BaseValue
-        { auto : Supported
-        , int : Supported
-        }
-    -> Style
-columnCount (Value count) =
-    AppendProperty ("column-count:" ++ count)
-
-
-{-| Sets [`column-fill`](https://css-tricks.com/almanac/properties/c/column-fill/)
-
-    columnFill auto
-
-    columnFill balance
-
-    columnFill balanceAll
-
--}
-columnFill :
-    BaseValue
-        { auto : Supported
-        , balance : Supported
-        , balanceAll : Supported
-        }
-    -> Style
-columnFill (Value val) =
-    AppendProperty ("column-fill:" ++ val)
-
-
-{-| A `balance` value used in properties such as [`columnFill`](#columnFill)
-
-    columnFill balance
-
--}
-balance : Value { provides | balance : Supported }
-balance =
-    Value "balance"
-
-
-{-| A `balance-all` value used in properties such as [`columnFill`](#columnFill)
-
-    columnFill balanceAll
-
--}
-balanceAll : Value { provides | balanceAll : Supported }
-balanceAll =
-    Value "balance-all"
-
-
-{-| Sets [`column-span`](https://css-tricks.com/almanac/properties/c/column-span/)
-
-    columnSpan all_
-
-    columnSpan none
-
--}
-columnSpan :
-    BaseValue
-        { none : Supported
-        , all_ : Supported
-        }
-    -> Style
-columnSpan (Value spanVal) =
-    AppendProperty ("column-span:" ++ spanVal)
-
-
-{-| Sets [`column-rule`](https://css-tricks.com/almanac/properties/c/column-rule/).
-This is a shorthand for the [`columnRuleWidth`](#columnRuleWidth),
-[`columnRuleStyle`](#columnRuleStyle), and [`columnRuleColor`](#columnRuleColor)
-properties.
-
-    columnRule thin
-
-    columnRule2 thin solid
-
-    columnRule3 thin solid (hex "#000000")
-
--}
-columnRule : BaseValue LineWidth -> Style
-columnRule (Value widthVal) =
-    AppendProperty ("column-rule:" ++ widthVal)
-
-
-{-| Sets [`column-rule`](https://css-tricks.com/almanac/properties/c/column-rule/).
-This is a shorthand for the [`columnRuleWidth`](#columnRuleWidth),
-[`columnRuleStyle`](#columnRuleStyle), and [`columnRuleColor`](#columnRuleColor)
-properties.
-
-    columnRule thin
-
-    columnRule2 thin solid
-
-    columnRule3 thin solid (hex "#000000")
-
--}
-columnRule2 : Value LineWidth -> Value LineStyle -> Style
-columnRule2 (Value widthVal) (Value styleVal) =
-    AppendProperty ("column-rule:" ++ widthVal ++ " " ++ styleVal)
-
-
-{-| Sets [`column-rule`](https://css-tricks.com/almanac/properties/c/column-rule/).
-This is a shorthand for the [`columnRuleWidth`](#columnRuleWidth),
-[`columnRuleStyle`](#columnRuleStyle), and [`columnRuleColor`](#columnRuleColor)
-properties.
-
-    columnRule thin
-
-    columnRule2 thin solid
-
-    columnRule3 thin solid (hex "#000000")
-
--}
-columnRule3 : Value LineWidth -> Value LineStyle -> Value Color -> Style
-columnRule3 (Value widthVal) (Value styleVal) (Value colorVal) =
-    AppendProperty ("column-rule:" ++ widthVal ++ " " ++ styleVal ++ " " ++ colorVal)
-
-
-{-| Sets [`column-rule-width`](https://www.w3.org/TR/css-multicol-1/#propdef-column-rule-width)
-
-    columnRuleWidth thin
-
-    columnRuleWidth (px 2)
-
--}
-columnRuleWidth : BaseValue LineWidth -> Style
-columnRuleWidth (Value widthVal) =
-    AppendProperty ("column-rule-width:" ++ widthVal)
-
-
-{-| Sets [`column-rule-style`](https://www.w3.org/TR/css-multicol-1/#propdef-column-rule-style)
-
-    columnRuleStyle solid
-
-    columnRuleStyle dotted
-
-    columnRuleStyle dashed
-
--}
-columnRuleStyle : BaseValue LineStyle -> Style
-columnRuleStyle (Value styleVal) =
-    AppendProperty ("column-rule-style:" ++ styleVal)
-
-
-{-| Sets [`column-rule-color`](https://www.w3.org/TR/css-multicol-1/#propdef-column-rule-color)
-
-    columnRuleColor (rgb 0 0 0)
-
-    columnRuleColor (hex "#fff")
-
--}
-columnRuleColor : BaseValue Color -> Style
-columnRuleColor (Value colorVal) =
-    AppendProperty ("column-rule-color:" ++ colorVal)
+bleed (Value val) =
+    AppendProperty ("bleed:" ++ val)
 
 
 ------------------------------------------------------------------------
@@ -19667,6 +20916,29 @@ columnRuleColor (Value colorVal) =
 ------------------------------------------------------------------------
 ------------------------------------------------------------------------
 ------------------------------------------------------------------------
+
+
+{-| Sets [`fill`](https://css-tricks.com/almanac/properties/f/fill/)
+**Note:** `fill` also accepts the patterns of SVG shapes that are defined inside of a [`defs`](https://css-tricks.com/snippets/svg/svg-patterns/) element.
+
+    fill (hex "#60b5cc")
+
+    fill (rgb 96 181 204)
+
+    fill (rgba 96 181 204 0.5)
+
+    fill (url "#pattern")
+
+-}
+fill :
+    BaseValue
+        (ColorSupported
+            { url : Supported
+            }
+        )
+    -> Style
+fill (Value val) =
+    AppendProperty ("fill:" ++ val)
 
 
 {-| Sets [`stroke-dasharray`](https://css-tricks.com/almanac/properties/s/stroke-dasharray/)
@@ -20335,1110 +21607,19 @@ gaps =
     Value "gaps"
 
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-{-| Sets [`vertical-align`](https://css-tricks.com/almanac/properties/v/vertical-align/).
-
-    verticalAlign textBottom
-
-    verticalAlign (em 1)
-
--}
-verticalAlign :
-    BaseValue
-        (LengthSupported
-            { baseline : Supported
-            , sub : Supported
-            , super : Supported
-            , textTop : Supported
-            , textBottom : Supported
-            , middle : Supported
-            , top_ : Supported
-            , bottom_ : Supported
-            , pct : Supported
-            }
-        )
-    -> Style
-verticalAlign (Value str) =
-    AppendProperty ("vertical-align:" ++ str)
-
-
-{-| A `textTop` value for the [`vertical-align`](https://css-tricks.com/almanac/properties/v/vertical-align/) property.
-
-    verticalAlign textTop
-
--}
-textTop : Value { provides | textTop : Supported }
-textTop =
-    Value "text-top"
-
-
-{-| A `textBottom` value for the [`vertical-align`](https://css-tricks.com/almanac/properties/v/vertical-align/) property.
-
-    verticalAlign textBottom
-
--}
-textBottom : Value { provides | textBottom : Supported }
-textBottom =
-    Value "text-bottom"
-
-
-{-| A `middle` value for the [`vertical-align`](https://css-tricks.com/almanac/properties/v/vertical-align/) property.
-
-    verticalAlign middle
-
--}
-middle : Value { provides | middle : Supported }
-middle =
-    Value "middle"
-
-
-
-
-{-| Sets [`float`](https://css-tricks.com/almanac/properties/f/float/).
-
-    float none
-
-    float left_
-
-    float right_
-
-    float inlineStart
-
--}
-float :
-    BaseValue
-        { none : Supported
-        , left_ : Supported
-        , right_ : Supported
-        , inlineStart : Supported
-        , inlineEnd : Supported
-        }
-    -> Style
-float (Value str) =
-    AppendProperty ("float:" ++ str)
-
-
-
--- VISIBILITY --
-
-
-{-| Sets [`visibility`](https://css-tricks.com/almanac/properties/v/visibility/)
-
-      visibility visible
-      visibility hidden
-      visibility collapse
-
--}
-visibility :
-    BaseValue
-        { visible : Supported
-        , hidden : Supported
-        , collapse : Supported
-        }
-    -> Style
-visibility (Value str) =
-    AppendProperty ("visibility:" ++ str)
-
-
-
--- ORDER --
-
-
-{-| Sets [`order`](https://css-tricks.com/almanac/properties/o/order/)
-
-    order (num 2)
-
-    order (num -2)
-
--}
-order :
-    BaseValue
-        { int : Supported
-        , zero : Supported
-        }
-    -> Style
-order (Value val) =
-    AppendProperty ("order:" ++ val)
-
-
-{-| Sets [`fill`](https://css-tricks.com/almanac/properties/f/fill/)
-**Note:** `fill` also accepts the patterns of SVG shapes that are defined inside of a [`defs`](https://css-tricks.com/snippets/svg/svg-patterns/) element.
-
-    fill (hex "#60b5cc")
-
-    fill (rgb 96 181 204)
-
-    fill (rgba 96 181 204 0.5)
-
-    fill (url "#pattern")
-
--}
-fill :
-    BaseValue
-        (ColorSupported
-            { url : Supported
-            }
-        )
-    -> Style
-fill (Value val) =
-    AppendProperty ("fill:" ++ val)
-
-
-
-
-
-{-| The [`paint-order`](https://css-tricks.com/almanac/properties/p/paint-order/) property.
-
-This one-argument version indicates which parts of text and shape graphics are
-painted first, followed by the other two in their relative default order.
-
-    paintOrder normal -- normal paint order.
-
-    paintOrder2 fill_ stroke -- fill, stroke, then markers.
-
-    paintOrder3 markers stroke fill_ -- markers, stroke, then fill.
-
--}
-paintOrder :
-    BaseValue
-        { normal : Supported
-        , stroke : Supported
-        , markers : Supported
-        }
-    -> Style
-paintOrder (Value val) =
-    AppendProperty ("paint-order:" ++ val)
-
-
-{-| The [`paint-order`](https://css-tricks.com/almanac/properties/p/paint-order/) property.
-
-This two-argument version indicates which parts of text and shape graphics are
-painted first, followed by the other remaining one.
-
-    paintOrder2 fill_ stroke -- fill, stroke, then markers.
-
--}
-paintOrder2 :
-    Value
-        { fill_ : Supported
-        , stroke : Supported
-        , markers : Supported
-        }
-    ->
-        Value
-            { fill_ : Supported
-            , stroke : Supported
-            , markers : Supported
-            }
-    -> Style
-paintOrder2 (Value val1) (Value val2) =
-    AppendProperty ("paint-order:" ++ val1 ++ " " ++ val2)
-
-
-{-| The [`paint-order`](https://css-tricks.com/almanac/properties/p/paint-order/) property.
-
-This three-argument version explicitly indicates in which order should all the parts of text
-and shape graphics be painted.
-
-    paintOrder3 markers stroke fill_ -- markers, stroke, then fill.
-
--}
-paintOrder3 :
-    Value
-        { fill_ : Supported
-        , stroke : Supported
-        , markers : Supported
-        }
-    ->
-        Value
-            { fill_ : Supported
-            , stroke : Supported
-            , markers : Supported
-            }
-    ->
-        Value
-            { fill_ : Supported
-            , stroke : Supported
-            , markers : Supported
-            }
-    -> Style
-paintOrder3 (Value val1) (Value val2) (Value val3) =
-    AppendProperty ("paint-order:" ++ val1 ++ " " ++ val2 ++ " " ++ val3)
-
-
-{-| Provides the `markers` value for [`paintOrder`](#paintOrder).
-
-    paintOrder markers
-
--}
-markers : Value { provides | markers : Supported }
-markers =
-    Value "markers"
-
-
-
-
-
-
-
-{-| Sets [`clear`](https://css-tricks.com/almanac/properties/c/clear/) property.
-
-    clear none
-
-    clear both
-
-    clear left_
-
-    clear right_
-
-    clear inlineStart
-
-    clear inlineEnd
-
--}
-clear :
-    BaseValue
-        { none : Supported
-        , left_ : Supported
-        , right_ : Supported
-        , both : Supported
-        , inlineStart : Supported
-        , inlineEnd : Supported
-        }
-    -> Style
-clear (Value val) =
-    AppendProperty ("clear:" ++ val)
-
-
-{-| Sets [`opacity`](https://css-tricks.com/almanac/properties/o/opacity/)
-
-    opacity (num 0.5)
-
-    opacity (num 1.0)
-
-    opacity zero
-
--}
-opacity :
-    BaseValue
-        { num : Supported
-        , zero : Supported
-        , calc : Supported
-        , pct : Supported
-        }
-    -> Style
-opacity (Value val) =
-    AppendProperty ("opacity:" ++ val)
-
-
-{-| Sets [`line-height`](https://css-tricks.com/almanac/properties/l/line-height/)
-
-    lineHeight (pct 150)
-
-    lineHeight (em 2)
-
-    lineHeight (num 1.5)
-
-    lineHeight normal
-
--}
-lineHeight :
-    BaseValue
-        (LengthSupported
-            { pct : Supported
-            , normal : Supported
-            , num : Supported
-            }
-        )
-    -> Style
-lineHeight (Value val) =
-    AppendProperty ("line-height:" ++ val)
-
-
-{-| Sets [`letter-spacing`](https://css-tricks.com/almanac/properties/l/letter-spacing/)
-
-    letterSpacing (pct 150)
-
-    letterSpacing (em 2)
-
-    letterSpacing (num 1.5)
-
-    letterSpacing normal
-
--}
-letterSpacing :
-    BaseValue
-        (LengthSupported
-            { normal : Supported
-            }
-        )
-    -> Style
-letterSpacing (Value val) =
-    AppendProperty ("letter-spacing:" ++ val)
-
-
-
-{-| Sets [`backface-visibility`](https://css-tricks.com/almanac/properties/b/backface-visibility/)
-
-    backfaceVisibility visible
-
-    backfaceVisibility hidden
-
--}
-backfaceVisibility :
-    BaseValue
-        { visible : Supported
-        , hidden : Supported
-        }
-    -> Style
-backfaceVisibility (Value val) =
-    AppendProperty ("backface-visibility" ++ val)
-
-
-{-| Sets [`bleed`](https://css-tricks.com/almanac/properties/b/bleed/)
-
-    bleed auto
-
-    bleed (pt 10)
-
--}
-bleed :
-    BaseValue
-        (LengthSupported
-            { auto : Supported
-            }
-        )
-    -> Style
-bleed (Value val) =
-    AppendProperty ("bleed:" ++ val)
-
-
-
-
-
-
-{-| Sets [`caret-color`](https://css-tricks.com/almanac/properties/c/caret-color/)
-
-    caretColor (hex "#60b5cc")
-
-    caretColor (rgb 96 181 204)
-
-    caretColor (rgba 96 181 204 0.5)
-
--}
-caretColor :
-    BaseValue
-        (ColorSupported
-            { auto : Supported
-            }
-        )
-    -> Style
-caretColor (Value val) =
-    AppendProperty ("caret-color:" ++ val)
-
-
-
-
-{-| Sets [`box-decoration-break`](https://css-tricks.com/almanac/properties/b/box-decoration-break/)
-
-    boxDecorationBreak slice
-
-    boxDecorationBreak clone
-
--}
-boxDecorationBreak :
-    BaseValue
-        { slice : Supported
-        , clone : Supported
-        }
-    -> Style
-boxDecorationBreak (Value val) =
-    AppendProperty ("box-decoration-break:" ++ val)
-
-
-
-
-
-
-{-| Sets [`object-position`](https://css-tricks.com/almanac/properties/o/object-position/).
-
-    objectPosition left_
-
-    objectPosition (px 45)
-
-`objectPosition` sets the horizontal direction. If you need the vertical
-direction instead, use [`objectPosition2`](#objectPosition2) like this:
-
-    objectPosition zero (px 45)
-
-If you need to set the offsets from the right or bottom, use
-[`objectPosition4`](#objectPosition4) like this:
-
-    objectPosition4 right_ (px 20) bottom_ (pct 25)
-
--}
-objectPosition :
-    BaseValue
-        (LengthSupported
-            { left_ : Supported
-            , right_ : Supported
-            , center : Supported
-            , pct : Supported
-            }
-        )
-    -> Style
-objectPosition (Value horiz) =
-    AppendProperty ("object-position:" ++ horiz)
-
-
-{-| Sets [`object-position`](https://css-tricks.com/almanac/properties/o/object-position/).
-
-    objectPosition2 left_ top_
-
-    objectPosition2 (px 45) (pct 50)
-
-`objectPosition2` sets both the horizontal and vertical directions (in that
-order, same as CSS.) If you need only the horizontal, you can use
-[`objectPosition`](#objectPosition) instead:
-
-    objectPosition left_
-
-If you need to set the offsets from the right or bottom, use
-[`objectPosition4`](#objectPosition4) like this:
-
-    objectPosition4 right_ (px 20) bottom_ (pct 25)
-
--}
-objectPosition2 :
-    Value
-        (LengthSupported
-            { left_ : Supported
-            , right_ : Supported
-            , center : Supported
-            , pct : Supported
-            }
-        )
-    ->
-        Value
-            (LengthSupported
-                { top_ : Supported
-                , bottom_ : Supported
-                , center : Supported
-                , pct : Supported
-                }
-            )
-    -> Style
-objectPosition2 (Value horiz) (Value vert) =
-    AppendProperty ("object-position:" ++ horiz ++ " " ++ vert)
-
-
-{-| Sets [`object-position`](https://css-tricks.com/almanac/properties/o/object-position/).
-
-    objectPosition4 right_ (px 20) bottom_ (pct 30)
-
-The four-argument form of object position alternates sides and offets. So the
-example above would position the object image 20px from the right, and 30%
-from the bottom.
-
-See also [`objectPosition`](#objectPosition) for horizontal alignment and
-[`objectPosition2`](#objectPosition2) for horizontal (from left) and
-vertical (from top) alignment.
-
--}
-objectPosition4 :
-    Value
-        { left_ : Supported
-        , right_ : Supported
-        }
-    ->
-        Value
-            (LengthSupported
-                { pct : Supported
-                }
-            )
-    ->
-        Value
-            { top_ : Supported
-            , bottom_ : Supported
-            }
-    ->
-        Value
-            (LengthSupported
-                { pct : Supported
-                }
-            )
-    -> Style
-objectPosition4 (Value horiz) (Value horizAmount) (Value vert) (Value vertAmount) =
-    AppendProperty
-        ("object-position:"
-            ++ horiz
-            ++ " "
-            ++ horizAmount
-            ++ " "
-            ++ vert
-            ++ " "
-            ++ vertAmount
-        )
-
-
-{-| Sets [`scroll-snap-align`](https://css-tricks.com/almanac/properties/s/scroll-snap-align/)
-
-    scrollSnapAlign none
-
-    scrollSnapAlign start
-
-    scrollSnapAlign center
-
-    scrollSnapAlign end
-
--}
-scrollSnapAlign :
-    BaseValue
-        { none : Supported
-        , start : Supported
-        , center : Supported
-        , end : Supported
-        }
-    -> Style
-scrollSnapAlign (Value val) =
-    AppendProperty ("scroll-snap-align:" ++ val)
-
-
-{-| Sets [`scroll-snap-stop`](https://css-tricks.com/almanac/properties/s/scroll-snap-stop/)
-
-    scrollSnapStop normal
-
-    scrollSnapStop always
-
--}
-scrollSnapStop :
-    BaseValue
-        { normal : Supported
-        , always : Supported
-        }
-    -> Style
-scrollSnapStop (Value val) =
-    AppendProperty ("scroll-snap-stop:" ++ val)
-
-
-{-| Sets [`scroll-snap-type`](https://css-tricks.com/almanac/properties/s/scroll-snap-type/)
-
-    scrollSnapType none
-
--}
-scrollSnapType :
-    BaseValue
-        { none : Supported
-        , x : Supported
-        , y : Supported
-        , block : Supported
-        , inline : Supported
-        , both : Supported
-        }
-    -> Style
-scrollSnapType (Value val) =
-    AppendProperty ("scroll-snap-type:" ++ val)
-
-
-{-| Sets `mandatory` value for usage with [`scrollSnapType2`](#scrollSnapType2).
-
-    scrollSnapType2 x mandatory
-
--}
-mandatory : Value { provides | mandatory : Supported }
-mandatory =
-    Value "mandatory"
-
-
-{-| Sets `proximity` value for usage with [`scrollSnapType2`](#scrollSnapType2).
-
-    scrollSnapType2 x proximity
-
--}
-proximity : Value { provides | proximity : Supported }
-proximity =
-    Value "proximity"
-
-
-{-| Sets [`scroll-snap-type`](https://css-tricks.com/almanac/properties/s/scroll-snap-type/)
-
-    scrollSnapType2 x mandatory
-
-    scrollSnapType2 both proximity
-
--}
-scrollSnapType2 :
-    Value
-        { x : Supported
-        , y : Supported
-        , block : Supported
-        , inline : Supported
-        , both : Supported
-        }
-    ->
-        Value
-            { mandatory : Supported
-            , proximity : Supported
-            }
-    -> Style
-scrollSnapType2 (Value val1) (Value val2) =
-    AppendProperty ("scroll-snap-type:" ++ val1 ++ " " ++ val2)
-
-
-{-| Sets `spellOut` value for usage with [`speak`](#speak).
-
-    speak spellOut
-
--}
-spellOut : Value { provides | spellOut : Supported }
-spellOut =
-    Value "spell-out"
-
-
-{-| Sets [`speak`](https://css-tricks.com/almanac/properties/s/speak/)
-
-    speak none
-
-    speak normal
-
-    speak spellOut
-
--}
-speak :
-    BaseValue
-        { none : Supported
-        , normal : Supported
-        , spellOut : Supported
-        }
-    -> Style
-speak (Value val) =
-    AppendProperty ("speak:" ++ val)
-
-
-{-| Sets [`transform-origin`](https://css-tricks.com/almanac/properties/t/transform-origin/).
-
-    transformOrigin top_
-
-    transformOrigin center
-
-    transformOrigin bottom
-
-    transformOrigin (pct 50)
-
--}
-transformOrigin :
-    BaseValue
-        { top_ : Supported
-        , center : Supported
-        , bottom_ : Supported
-        , pct : Supported
-        , calc : Supported
-        }
-    -> Style
-transformOrigin (Value vert) =
-    AppendProperty ("transform-origin:" ++ vert)
-
-
-{-| Sets [`transform-origin`](https://css-tricks.com/almanac/properties/t/transform-origin/).
-
-    transformOrigin2 top_ left
-
-    transformOrigin2 center right_
-
-    transformOrigin2 bottom_ right_
-
-    transformOrigin2 (pct 50) (pct 50)
-
--}
-transformOrigin2 :
-    Value
-        { top_ : Supported
-        , center : Supported
-        , bottom_ : Supported
-        , pct : Supported
-        , calc : Supported
-        }
-    ->
-        Value
-            { left_ : Supported
-            , center : Supported
-            , right_ : Supported
-            , pct : Supported
-            , calc : Supported
-            }
-    -> Style
-transformOrigin2 (Value vert) (Value horiz) =
-    AppendProperty ("transform-origin:" ++ vert ++ " " ++ horiz)
-
-
-{-| Sets the [`transform-box`](https://developer.mozilla.org/en-US/docs/Web/CSS/transform-box) property.
-
-    transformBox contentBox
-
-    transformBox fillBox
--}
-transformBox :
-    BaseValue
-        { contentBox : Supported
-        , borderBox : Supported
-        , fillBox : Supported
-        , strokeBox : Supported
-        , viewBox : Supported
-        }
-    -> Style
-transformBox (Value val) =
-    AppendProperty ("transform-box:" ++ val)
-
-
-
-
---- unicode-bidi ---
-
-
-
-{-| Sets [`user-select`](https://css-tricks.com/almanac/properties/u/user-select/)
-
-    userSelect none
-
-    userSelect auto
-
-    userSelect text
-
-    userSelect contain_
-
-    userSelect all_
-
--}
-userSelect :
-    BaseValue
-        { none : Supported
-        , auto : Supported
-        , text : Supported
-        , contain_ : Supported
-        , all_ : Supported
-        }
-    -> Style
-userSelect (Value val) =
-    AppendProperty ("user-select:" ++ val)
-
-
-{-| Sets [`widows`](https://css-tricks.com/almanac/properties/w/widows/)
-**Note:** This function accepts only positive integers.
-
-    widows (int 2)
-
--}
-widows :
-    BaseValue
-        { int : Supported
-        }
-    -> Style
-widows (Value val) =
-    AppendProperty ("widows:" ++ val)
-
-
-{-| The [`resize`](https://css-tricks.com/almanac/properties/r/resize/) property.
-
-    resize none
-
-    resize both
-
-    resize inline
-
--}
-resize :
-    BaseValue
-        { none : Supported
-        , both : Supported
-        , horizontal : Supported
-        , vertical : Supported
-        , block : Supported
-        , inline : Supported
-        }
-    -> Style
-resize (Value value) =
-    AppendProperty ("resize:" ++ value)
-
-
-{-| The `horizontal` value used by [`resize`](#resize).
-
-    resize horizontal
-
--}
-horizontal : Value { provides | horizontal : Supported }
-horizontal =
-    Value "horizontal"
-
-
-{-| The `vertical` value used by [`resize`](#resize).
-
-    resize vertical
-
--}
-vertical : Value { provides | vertical : Supported }
-vertical =
-    Value "vertical"
-
-
-{-| The [`contain`](https://css-tricks.com/almanac/properties/c/contain/) property.
-
-    contain none
-
-    contain content
-
-    contain2 size layout
-
-    contain3 size layout style
-
-    contain4 -- all multiple choice values in use, no value entry needed
-
--}
-contain :
-    BaseValue
-        { none : Supported
-        , strict : Supported
-        , content : Supported
-        , size : Supported
-        , layout : Supported
-        , style : Supported
-        , paint : Supported
-        }
-    -> Style
-contain (Value value) =
-    AppendProperty ("contain:" ++ value)
-
-
-{-| The [`contain`](https://css-tricks.com/almanac/properties/c/contain/) property.
-
-This two-argument version lets you use 2 of the 4 multiple choice values you
-can use for this property.
-
-    contain2 size layout
-
--}
-contain2 :
-    Value
-        { size : Supported
-        , layout : Supported
-        , style : Supported
-        , paint : Supported
-        }
-    ->
-        Value
-            { size : Supported
-            , layout : Supported
-            , style : Supported
-            , paint : Supported
-            }
-    -> Style
-contain2 (Value value1) (Value value2) =
-    AppendProperty ("contain:" ++ value1 ++ " " ++ value2)
-
-
-{-| The [`contain`](https://css-tricks.com/almanac/properties/c/contain/) property.
-
-This two-argument version lets you use 3 of the 4 multiple choice values you
-can use for this property.
-
-    contain3 size layout style
-
--}
-contain3 :
-    Value
-        { size : Supported
-        , layout : Supported
-        , style : Supported
-        , paint : Supported
-        }
-    ->
-        Value
-            { size : Supported
-            , layout : Supported
-            , style : Supported
-            , paint : Supported
-            }
-    ->
-        Value
-            { size : Supported
-            , layout : Supported
-            , style : Supported
-            , paint : Supported
-            }
-    -> Style
-contain3 (Value value1) (Value value2) (Value value3) =
-    AppendProperty ("contain:" ++ value1 ++ " " ++ value2 ++ " " ++ value3)
-
-
-{-| The [`contain`](https://css-tricks.com/almanac/properties/c/contain/) property.
-
-This two-argument version lets you use all 4 multiple choice values you
-can use for this property.
-
-    contain4 size layout style paint
-
-**Note: The `style` value is considered at-risk from being depreciated.**
-
--}
-contain4 :
-    Value
-        { size : Supported
-        , layout : Supported
-        , style : Supported
-        , paint : Supported
-        }
-    ->
-        Value
-            { size : Supported
-            , layout : Supported
-            , style : Supported
-            , paint : Supported
-            }
-    ->
-        Value
-            { size : Supported
-            , layout : Supported
-            , style : Supported
-            , paint : Supported
-            }
-    ->
-        Value
-            { size : Supported
-            , layout : Supported
-            , style : Supported
-            , paint : Supported
-            }
-    -> Style
-contain4 (Value value1) (Value value2) (Value value3) (Value value4) =
-    AppendProperty ("contain:" ++ value1 ++ " " ++ value2 ++ " " ++ value3 ++ " " ++ value4)
-
-
-{-| Sets the `size` value for [`contain`](#contain).
-
-This indicates that the element can be sized without
-needing to look at the size of its descendants.
-
-    contain size
-
--}
-size : Value { provides | size : Supported }
-size =
-    Value "size"
-
-
-{-| Sets the `layout` value for [`contain`](#contain).
-
-This indicates that nothing outside the element
-may affect its internal layout and vice versa.
-
-    contain layout
-
--}
-layout : Value { provides | layout : Supported }
-layout =
-    Value "layout"
-
-
-{-| Sets the `paint` value for [`contain`](#contain).
-
-Indicates that descendants of the element will not
-display outside its bounds and will not be painted
-by the browser if the containing box is offscreen.
-
-    contain paint
-
--}
-paint : Value { provides | paint : Supported }
-paint =
-    Value "paint"
-
-
-{-| Sets [`orphans`](https://css-tricks.com/almanac/properties/o/orphans/)
-**Note:** This function accepts only positive integers.
-
-    orphans (int 2)
-
--}
-orphans :
-    BaseValue
-        { int : Supported
-        }
-    -> Style
-orphans (Value val) =
-    AppendProperty ("orphans:" ++ val)
-
-
-
-{-| Sets [`image-rendering`](https://css-tricks.com/almanac/properties/i/image-rendering/)
-
-    imageRendering auto
-
-    imageRendering crispEdges
-
-    imageRendering pixelated
-
--}
-imageRendering :
-    BaseValue
-        { auto : Supported
-        , crispEdges : Supported
-        , pixelated : Supported
-        }
-    -> Style
-imageRendering (Value val) =
-    AppendProperty ("image-rendering:" ++ val)
-
-
-{-| Sets `pixelated` value for usage with [`imageRendering`](#imageRendering).
-
-    imageRendering pixelated
-
--}
-pixelated : Value { provides | pixelated : Supported }
-pixelated =
-    Value "pixelated"
-
-
-{-| Sets `crisp-edges` value for usage with [`imageRendering`](#imageRendering).
-
-    imageRendering crispEdges
-
--}
-crispEdges : Value { provides | crispEdges : Supported }
-crispEdges =
-    Value "crisp-edges"
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------ WEBKIT STUFF THAT'S STANDARDISED --------------------
+-------------------------- FOR LEGACY SUPPORT --------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
 
 
 {-| Sets [`lineClamp`](https://css-tricks.com/almanac/properties/l/line-clamp/)
@@ -21459,120 +21640,4 @@ lineClamp :
     -> Style
 lineClamp (Value val) =
     AppendProperty ("line-clamp:" ++ val)
-
-
-{-| The 1-argument variant of the
-[`clip-path`](https://css-tricks.com/almanac/properties/c/clip-path/) property.
-
-    clipPath marginBox
-
-    clipPath inherit
-
-    clipPath (circle (pct 2))
-
-    clipPath2 marginBox (circleAt2 farthestSide left top)
--}
-clipPath :
-    BaseValue
-        (BasicShapeSupported
-            { marginBox : Supported
-            , borderBox : Supported
-            , paddingBox : Supported
-            , contentBox : Supported
-            , fillBox : Supported
-            , strokeBox : Supported
-            , viewBox : Supported
-            }
-        )
-    -> Style
-clipPath (Value val) =
-    AppendProperty ("clip-path:" ++ val)
-
-
-{-| The 2-argument variant of the
-[`clip-path`](https://css-tricks.com/almanac/properties/c/clip-path/) property.
-
-    clipPath2 marginBox (circleAt2 farthestSide left top)
--}
-clipPath2 :
-    Value
-        { marginBox : Supported
-        , borderBox : Supported
-        , paddingBox : Supported
-        , contentBox : Supported
-        , fillBox : Supported
-        , strokeBox : Supported
-        , viewBox : Supported
-        }
-    -> Value (BasicShapeSupported a)
-    -> Style
-clipPath2 (Value val1) (Value val2) =
-    AppendProperty ("clip-path:" ++ val1 ++ " " ++ val2)
-
-
-{-| Sets [`mix-blend-mode`](https://css-tricks.com/almanac/properties/m/mix-blend-mode/)
-
-    mixBlendMode multiply
-
-    mixBlendMode saturation
-
--}
-mixBlendMode :
-    BaseValue
-        { normal : Supported
-        , multiply : Supported
-        , screen : Supported
-        , overlay : Supported
-        , darken : Supported
-        , lighten : Supported
-        , colorDodge : Supported
-        , colorBurn : Supported
-        , hardLight : Supported
-        , softLight : Supported
-        , difference : Supported
-        , exclusion : Supported
-        , hue : Supported
-        , saturation : Supported
-        , color_ : Supported
-        , luminosity : Supported
-        }
-    -> Style
-mixBlendMode (Value val) =
-    AppendProperty ("mix-blend-mode:" ++ val)
-
-
-{-| Sets `scale-down` value for usage with [`objectFit`](#objectFit).
-
-    objectFit scaleDown
-
--}
-scaleDown : Value { provides | scaleDown : Supported }
-scaleDown =
-    Value "scale-down"
-
-
-{-| Sets [`object-fit`](https://css-tricks.com/almanac/properties/o/object-fit/)
-
-    objectFit fill_
-
-    objectFit contain_
-
-    objectFit cover
-
-    objectFit scaleDown
-
-    objectFit none
-
--}
-objectFit :
-    BaseValue
-        { fill_ : Supported
-        , contain_ : Supported
-        , cover : Supported
-        , none : Supported
-        , scaleDown : Supported
-        }
-    -> Style
-objectFit (Value val) =
-    AppendProperty ("object-fit:" ++ val)
 

--- a/src/Css.elm
+++ b/src/Css.elm
@@ -61,7 +61,7 @@ module Css exposing
     , tabSize
     , fontDisplay, fallback, swap, optional
     , writingMode, verticalLr, verticalRl, horizontalTb
-    , hyphens, quotes, quotes2, quotes4, textOverflow, textOverflow2, ellipsis, manual
+    , hyphens, quotes, quotes2, quotes4, textOverflow, textOverflow2, lineBreak, manual, ellipsis, strict, loose
     , hangingPunctuation, first, last, forceEnd, allowEnd
     , lineClamp
     , fontSize, xxSmall, xSmall, small, medium, large, xLarge, xxLarge, smaller, larger, lineHeight, letterSpacing
@@ -426,7 +426,7 @@ See this [complete guide](https://css-tricks.com/snippets/css/a-guide-to-flexbox
 
 @docs fontDisplay, fallback, swap, optional
 @docs writingMode, verticalLr, verticalRl, horizontalTb
-@docs hyphens, quotes, quotes2, quotes4, textOverflow, textOverflow2, ellipsis, manual
+@docs hyphens, quotes, quotes2, quotes4, textOverflow, textOverflow2, lineBreak, manual, ellipsis, strict, loose
 @docs hangingPunctuation, first, last, forceEnd, allowEnd
 @docs lineClamp
 
@@ -1428,9 +1428,11 @@ breakWord =
     Value "break-word"
 
 
-{-| The `anywhere` value used by [`overflowWrap`](#overflowWrap)
+{-| The `anywhere` value used by [`overflowWrap`](#overflowWrap) and [`lineBreak`](#lineBreak).
 
     overflowWrap anywhere
+
+    lineBreak anywhere
 
 -}
 anywhere : Value { provides | anywhere : Supported }
@@ -5041,14 +5043,17 @@ fontVariantCaps (Value str) =
     AppendProperty ("font-variant-caps:" ++ str)
 
 
-{-| The `normal` value, which can be used with such properties as
-[`fontVariantCaps`](#fontVariantCaps),
-[`whiteSpace`](#whiteSpace),
-[`wordBreak`](#wordBreak),
-[`columnGap`](#columnGap),
-[`zoom`](#zoom),
-[`animationDirection`](#animationDirection),
-and [`alignItems`](#alignItems).
+{-| The `normal` value, which can be used with such properties as:
+
+- [`fontVariantCaps`](#fontVariantCaps)
+- [`whiteSpace`](#whiteSpace)
+- [`wordBreak`](#wordBreak)
+- [`columnGap`](#columnGap)
+- [`zoom`](#zoom)
+- [`animationDirection`](#animationDirection)
+- [`alignItems`](#alignItems)
+- [`lineBreak`](#lineBreak)
+
 
     alignItems normal
 
@@ -13252,15 +13257,6 @@ hangingPunctuation (Value val) =
     AppendProperty ("hanging-punctuation:" ++ val)
 
 
-{-| Sets `manual` value for usage with [`hyphens`](#hyphens).
-
-    hyphens manual
-
--}
-manual : Value { provides | manual : Supported }
-manual =
-    Value "manual"
-
 
 {-| Sets [`hyphens`](https://css-tricks.com/almanac/properties/h/hyphens/)
 
@@ -13432,6 +13428,35 @@ textOverflow2 (Value startValue) (Value endValue) =
     AppendProperty ("text-overflow:" ++ startValue ++ " " ++ endValue)
 
 
+{-| Sets the [`lineBreak`](https://css-tricks.com/almanac/properties/l/line-break/) property.
+
+    lineBreak auto
+
+    lineBreak strict
+-}
+lineBreak :
+    BaseValue
+        { auto : Supported
+        , loose : Supported
+        , normal : Supported
+        , strict : Supported
+        , anywhere : Supported
+        }
+    -> Style
+lineBreak (Value value) =
+    AppendProperty ("line-break:" ++ "value")
+
+
+{-| Sets `manual` value for usage with [`hyphens`](#hyphens).
+
+    hyphens manual
+
+-}
+manual : Value { provides | manual : Supported }
+manual =
+    Value "manual"
+
+
 {-| Sets `ellipsis` value for usage with [`textOverflow`](#textOverflow).
 
     textOverflow ellipsis
@@ -13441,6 +13466,23 @@ ellipsis : Value { provides | ellipsis : Supported }
 ellipsis =
     Value "ellipsis"
 
+
+{-| Sets `strict` value for usage with [`lineBreak`](#lineBreak).
+
+    lineBreak strict
+-}
+strict : Value { provides | strict : Supported }
+strict =
+    Value "strict"
+
+
+{-| Sets `loose` value for usage with [`lineBreak`](#lineBreak).
+
+    lineBreak loose
+-}
+loose : Value { provides | loose : Supported }
+loose =
+    Value "loose"
 
 {-| Sets `pixelated` value for usage with [`imageRendering`](#imageRendering).
 

--- a/src/Css.elm
+++ b/src/Css.elm
@@ -11,6 +11,8 @@ module Css exposing
     , indeterminate, invalid, lastChild, lastOfType, link, onlyChild
     , onlyOfType, outOfRange, readOnly, readWrite, required
     , root, scope, target, valid, visited
+
+    -- pseudo-elements
     , pseudoElement
     , before, after, backdrop, cue, marker, placeholder, selection
 
@@ -20,11 +22,13 @@ module Css exposing
     , Angle, AngleSupported, Width, WidthSupported
     , BasicShape, BasicShapeSupported
     , Length, LengthSupported
-    , calc, CalcOperation
-    , minus, plus, times, dividedBy
     , Color, ColorSupported
     , Resolution, ResolutionSupported
     , Time, TimeSupported
+
+    -- calc
+    , CalcOperation
+    , calc, minus, plus, times, dividedBy
 
     -- common value types
     , zero, px, em, ex, ch, rem, vh, vw, vmin, vmax, mm, cm, q, inches, pt, pc, pct
@@ -56,10 +60,25 @@ module Css exposing
     -- all
     , all
 
+    -- display
+    , display, display2, displayListItem2, displayListItem3
+    , flex_, flow, flowRoot, grid, contents, listItem, inlineBlock, inlineFlex, inlineTable, inlineGrid, rubyBase, rubyBaseContainer, rubyText, rubyTextContainer, runIn, table, tableCaption, tableCell, tableColumn, tableColumnGroup, tableFooterGroup, tableHeaderGroup, tableRow, tableRowGroup
+    
+    -- position
+    , position
+    , absolute, fixed, relative, static, sticky
+
+    -- z-index + box-sizing
+    , zIndex, boxSizing
+
     -- sizing
     , width, minWidth, maxWidth, height, minHeight, maxHeight
     , blockSize, minBlockSize, maxBlockSize
     , inlineSize, minInlineSize, maxInlineSize
+
+    -- insets
+    , inset, inset2, inset3, inset4, top, right, bottom, left
+    , insetBlock, insetBlock2, insetInline, insetInline2, insetBlockStart, insetBlockEnd, insetInlineStart, insetInlineEnd
 
     -- margins
     , margin, margin2, margin3, margin4
@@ -105,24 +124,38 @@ module Css exposing
     , outline, outline3, outlineWidth, outlineColor
     , invert, outlineStyle, outlineOffset
 
-    -- ??
-    , display, display2, displayListItem2, displayListItem3
-    , flex_, flow, flowRoot, grid, contents, listItem, inlineBlock, inlineFlex, inlineTable, inlineGrid, rubyBase, rubyBaseContainer, rubyText, rubyTextContainer, runIn, table, tableCaption, tableCell, tableColumn, tableColumnGroup, tableFooterGroup, tableHeaderGroup, tableRow, tableRowGroup
-    , position
-    , absolute, fixed, relative, static, sticky
-    , zIndex
+    -- overflow
+    , overflow, overflowX, overflowY, overflowBlock, overflowInline
+    , overflowAnchor
+    , overflowWrap
+    , breakWord, anywhere
 
-    -- insets
-    , inset, inset2, inset3, inset4, top, right, bottom, left
-    , insetBlock, insetBlock2, insetInline, insetInline2, insetBlockStart, insetBlockEnd, insetInlineStart, insetInlineEnd
+    -- flex
+    , flex, flex2, flex3, flexDirection
+    , flexGrow, flexShrink, flexBasis
+    , flexWrap, flexFlow, flexFlow2
+    , alignContent, alignContent2, alignItems, alignItems2, alignSelf, alignSelf2
+    , justifyContent, justifyContent2, justifyItems, justifyItems2, justifySelf, justifySelf2
+    , placeContent, placeContent2, placeItems, placeItems2, placeSelf, placeSelf2
+    , flexStart, flexEnd, selfStart, selfEnd, spaceBetween, spaceAround, spaceEvenly
+    , firstBaseline, lastBaseline, safe, unsafe, legacy, legacyLeft, legacyRight, legacyCenter
+    , row, rowReverse, columnReverse
+    , order
+    , nowrap, wrap, wrapReverse
+    
+    -- grid
+    , gridAutoRows, gridAutoColumns, gridAutoFlow, gridAutoFlow2, dense
+    , gridRowStart, gridRowStart2, gridRowStart3, gridRowEnd, gridRowEnd2, gridRowEnd3, gridColumnStart, gridColumnStart2, gridColumnStart3, gridColumnEnd, gridColumnEnd2, gridColumnEnd3, span
+    , gridTemplateAreas, gridTemplateAreasList
 
     -- gaps
     , gap, gap2, rowGap, columnGap
 
     -- color
-    , color, backgroundColor
+    , color
 
-    -- ??
+    -- backgrounds
+    , backgroundColor
     , backgroundAttachment, backgroundAttachments, local
     , backgroundBlendMode, backgroundBlendModes, multiply, screen, overlay, darken, lighten, colorDodge, colorBurn, hardLight, softLight, difference, exclusion, hue, saturation, color_, luminosity
     , backgroundClip, backgroundClips, backgroundOrigin, backgroundOrigins
@@ -132,33 +165,6 @@ module Css exposing
     , BoxShadowConfig, boxShadow, boxShadows, defaultBoxShadow
     , TextShadowConfig, textShadow, defaultTextShadow
     , LineWidth, LineWidthSupported, LineStyle, LineStyleSupported
-
-    
-    -- ??
-    , boxSizing
-    , alignContent, alignContent2, alignItems, alignItems2, alignSelf, alignSelf2, justifyContent, justifyContent2, justifyItems, justifyItems2, justifySelf, justifySelf2
-    , placeContent, placeContent2, placeItems, placeItems2, placeSelf, placeSelf2
-    , flexStart, flexEnd, selfStart, selfEnd, spaceBetween, spaceAround, spaceEvenly
-    , firstBaseline, lastBaseline, safe, unsafe, legacy, legacyLeft, legacyRight, legacyCenter
-    , flexDirection, row, rowReverse, columnReverse
-    , order
-    , flexGrow, flexShrink, flexBasis
-    , flexWrap, nowrap, wrap, wrapReverse
-    , flex, flex2, flex3, flexFlow, flexFlow2
-
-    -- grid
-    , gridAutoRows, gridAutoColumns, gridAutoFlow, gridAutoFlow2, dense
-    , gridRowStart, gridRowStart2, gridRowStart3, gridRowEnd, gridRowEnd2, gridRowEnd3, gridColumnStart, gridColumnStart2, gridColumnStart3, gridColumnEnd, gridColumnEnd2, gridColumnEnd3, span
-    , gridTemplateAreas, gridTemplateAreasList
-
-    -- ??
-    , wordSpacing
-    , tabSize
-    , fontDisplay, fallback, swap, optional
-    , writingMode, verticalLr, verticalRl, horizontalTb
-    , hyphens, quotes, quotes2, quotes4, textOverflow, textOverflow2, lineBreak, manual, ellipsis, loose
-    , hangingPunctuation, hangingPunctuation2, hangingPunctuation3, first, last, forceEnd, allowEnd
-    , lineClamp
 
     -- fonts
     , fontSize
@@ -176,6 +182,15 @@ module Css exposing
     , fontVariantNumeric, fontVariantNumeric4, ordinal, slashedZero, liningNums, oldstyleNums, proportionalNums, tabularNums, diagonalFractions, stackedFractions
     , fontKerning, fontLanguageOverride, fontSynthesis, fontSynthesis2, fontSynthesis3, fontOpticalSizing, fontVariantPosition, weight
     
+    -- ??
+    , wordSpacing
+    , tabSize
+    , fontDisplay, fallback, swap, optional
+    , writingMode, verticalLr, verticalRl, horizontalTb
+    , hyphens, quotes, quotes2, quotes4, textOverflow, textOverflow2, lineBreak, manual, ellipsis, loose
+    , hangingPunctuation, hangingPunctuation2, hangingPunctuation3, first, last, forceEnd, allowEnd
+    , lineClamp
+
     -- cursors
     , CursorKeyword
     , cursor, cursor2, cursor4
@@ -189,12 +204,7 @@ module Css exposing
     , ListStyleType, ListStyleTypeSupported
     , listStyle, listStyle2, listStyle3, listStylePosition, inside, outside, listStyleType, listStyleImage
     , arabicIndic, armenian, bengali, cambodian, cjkDecimal, cjkEarthlyBranch, cjkHeavenlyStem, cjkIdeographic, decimal, decimalLeadingZero, devanagari, disclosureClosed, disclosureOpen, disc, ethiopicNumeric, georgian, gujarati, gurmukhi, hebrew, hiragana, hiraganaIroha, japaneseFormal, japaneseInformal, kannada, katakana, katakanaIroha, khmer, koreanHangulFormal, koreanHanjaFormal, koreanHanjaInformal, lao, lowerAlpha, lowerArmenian, lowerGreek, lowerLatin, lowerRoman, malayalam, monogolian, myanmar, oriya, persian, simpChineseFormal, simpChineseInformal, tamil, telugu, thai, tibetan, tradChineseFormal, tradChineseInformal, upperAlpha, upperArmenian, upperLatin, upperRoman
-    
-    -- overflow
-    , overflow, overflowX, overflowY, overflowBlock, overflowInline
-    , overflowAnchor
-    , overflowWrap
-    , breakWord, anywhere
+
 
     -- ??
     , direction, ltr, rtl
@@ -244,16 +254,18 @@ module Css exposing
     , transform, transforms, transformOrigin, transformOrigin2, transformBox
     , TransformFunction, TransformFunctionSupported
     , matrix, matrix3d
-    , perspective, perspectiveOrigin, perspectiveOrigin2
-    , perspective_
-    , rotate, rotate2, rotate_, rotateX, rotateY, rotateZ, rotate3d, vec3
     , scale, scale2, scale3, scale_, scale2_, scaleX, scaleY, scaleZ, scale3d
     , skew, skew2, skewX, skewY
+    , rotate, rotate2, rotate_, rotateX, rotateY, rotateZ, rotate3d, vec3
     , translate, translate2, translateX, translateY, translateZ, translate3d
+    , perspective, perspectiveOrigin, perspectiveOrigin2
+    , perspective_
     
-    -- ??
+    -- animation?
     , animationName, animationNames, animationDuration, animationDurations, animationTimingFunction, animationTimingFunctions, animationIterationCount, animationIterationCounts, animationDirection, animationDirections, animationPlayState, animationPlayStates, animationDelay, animationDelays, animationFillMode, animationFillModes
     , EasingFunction, EasingFunctionSupported, linear, ease, easeIn, easeOut, easeInOut, cubicBezier, stepStart, stepEnd, steps, steps2, jumpStart, jumpEnd, jumpNone, jumpBoth, infinite, reverse, alternate, alternateReverse, running, paused, forwards, backwards
+
+    -- ??
     , opacity
     , zoom
 
@@ -270,7 +282,8 @@ module Css exposing
     , scrollPaddingBlock, scrollPaddingBlock2, scrollPaddingInline, scrollPaddingInline2
     , scrollPaddingBlockStart, scrollPaddingBlockEnd, scrollPaddingInlineStart, scrollPaddingInlineEnd
     , overscrollBehavior, overscrollBehavior2
-    , overscrollBehaviorX, overscrollBehaviorY, overscrollBehaviorBlock, overscrollBehaviorInline
+    , overscrollBehaviorX, overscrollBehaviorY
+    , overscrollBehaviorBlock, overscrollBehaviorInline
     
     -- ??
     , speak, spellOut
@@ -1519,6 +1532,142 @@ readOnly =
 ------------------------------------------------------------------------
 ------------------------------------------------------------------------
 ------------------------------------------------------------------------
+--------------------------- PSEUDO-ELEMENTS ----------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+
+
+{-| Define a custom [pseudo-element](https://developer.mozilla.org/en-US/docs/Web/CSS/Pseudo-elements).
+
+    textarea
+        [ css [ pseudoElement "-webkit-scrollbar" [ display none ] ] ]
+        []
+
+...outputs
+
+    <textarea class="d84ff7"></textarea>
+
+    <style>
+        .d84ff7::-webkit-scrollbar {
+            display: none;
+        }
+    </style>
+
+-}
+pseudoElement : String -> List Style -> Style
+pseudoElement element =
+    Preprocess.WithPseudoElement (Structure.PseudoElement element)
+
+
+{-| An [`::after`](https://css-tricks.com/almanac/selectors/a/after-and-before/)
+[pseudo-element](https://developer.mozilla.org/en-US/docs/Web/CSS/Pseudo-elements).
+
+    div [ after [ content "hi!" ] ]
+
+--TODO : Introduce a way to do [`content`](https://developer.mozilla.org/en-US/docs/Web/CSS/content) - lots of options there, not just text. Also it's overloaded with `flexBasis content`.
+
+-}
+after : List Style -> Style
+after =
+    pseudoElement "after"
+
+
+{-| A [`::before`](https://css-tricks.com/almanac/selectors/a/after-and-before/)
+[pseudo-element](https://developer.mozilla.org/en-US/docs/Web/CSS/Pseudo-elements).
+
+    div [ before [ content "hi!" ] ]
+
+--TODO : Introduce a way to do [`content`](https://developer.mozilla.org/en-US/docs/Web/CSS/content) - lots of options there, not just text. Also it's overloaded with `flexBasis content`.
+
+-}
+before : List Style -> Style
+before =
+    pseudoElement "before"
+
+
+{-| A [`::backdrop`](https://developer.mozilla.org/en-US/docs/Web/CSS/::backdrop)
+[pseudo-element](https://developer.mozilla.org/en-US/docs/Web/CSS/Pseudo-elements).
+
+    backdrop
+        [ background (rgba 255 0 0 0.25)
+        ]
+
+-}
+backdrop : List Style -> Style
+backdrop =
+    pseudoElement "backdrop"
+
+
+{-| A [`::cue`](https://developer.mozilla.org/en-US/docs/Web/CSS/::cue)
+[pseudo-element](https://developer.mozilla.org/en-US/docs/Web/CSS/Pseudo-elements).
+
+    cue
+        [ color (rgba 255 255 0 1)
+        , fontWeight (int 600)
+        ]
+
+-}
+cue : List Style -> Style
+cue =
+    pseudoElement "cue"
+
+
+{-| A [`::marker`](https://developer.mozilla.org/en-US/docs/Web/CSS/::marker)
+[pseudo-element](https://developer.mozilla.org/en-US/docs/Web/CSS/Pseudo-elements).
+
+    marker
+        [ color (rgba 255 255 0 1)
+        , fontWeight (int 600)
+        ]
+
+-}
+marker : List Style -> Style
+marker =
+    pseudoElement "marker"
+
+
+{-| A [`::placeholder`](https://developer.mozilla.org/en-US/docs/Web/CSS/::placeholder)
+[pseudo-element](https://developer.mozilla.org/en-US/docs/Web/CSS/Pseudo-elements).
+
+Be careful when using placeholders as they can negatively impact accessibility.
+
+    placeholder
+        [ opacity (num 1) <| important
+        , color (rgb 90 90 90)
+        , fontWeight (int 400)
+        ]
+
+]
+
+-}
+placeholder : List Style -> Style
+placeholder =
+    pseudoElement "placeholder"
+
+
+{-| A [`::selection`](https://developer.mozilla.org/en-US/docs/Web/CSS/::selection)
+[pseudo-element](https://developer.mozilla.org/en-US/docs/Web/CSS/Pseudo-elements).
+
+    selection
+        [ backgroundColor (rgb 200 140 15)
+        ]
+
+-}
+selection : List Style -> Style
+selection =
+    pseudoElement "selection"
+
+
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
 -------------------------- VALUE TYPE GROUPS ---------------------------
 ------------------------------------------------------------------------
 ------------------------------------------------------------------------
@@ -1752,6 +1901,155 @@ type alias Time =
     TimeSupported {}
 
 
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------- Calc --------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+
+
+{-| Either [`plus`](#plus) or [`minus`](#minus).
+
+See [`calc`](#calc) for how to use this.
+
+-}
+type CalcOperation
+    = CalcOperation String
+
+
+getCalcExpression : String -> String
+getCalcExpression str =
+    if String.startsWith "calc(" str then
+        String.dropLeft 4 str
+
+    else
+        str
+
+
+{-| The css [`calc`](https://css-tricks.com/a-couple-of-use-cases-for-calc) function.
+
+    almostPct100 =
+        calc (pct 100) (minus (px 2))
+
+    -- The following compiles to: calc(100vh - (2px + 2rem))
+    screenMinusBorderAndFooter =
+        calc (vh 100) (minus (calc (px 2) (plus (rem 2))))
+
+    myWidth =
+        width almostPct100
+
+    myHeight =
+        height screenMinusBorderAndFooter
+
+**CAUTION:** `calc` can easily be used to create invalid CSS values! For example,
+`zIndex (calc (pct 100) (minus (px 5)))` compiles to `z-index: calc(100% - 5px);`
+which is invalid. According to the spec, `calc` may return values that have no
+relation to its arguments, so unfortunately there's not much `elm-css` can do
+to make `calc` more reliable. Use with caution!
+
+-}
+calc :
+    Value
+        (LengthSupported
+            { pct : Supported
+            , num : Supported
+            , int : Supported
+            }
+        )
+    -> CalcOperation
+    -> Value { provides | calc : Supported }
+calc (Value head) (CalcOperation operation) =
+    Value
+        ("calc("
+            ++ getCalcExpression head
+            ++ operation
+            ++ ")"
+        )
+
+
+{-| Use with [`calc`](#calc) to subtract one value from another.
+
+    calc (pct 100) (minus (px 2))
+    -- calc: (100% - 2px)
+
+-}
+minus :
+    Value
+        (LengthSupported
+            { pct : Supported
+            , num : Supported
+            , int : Supported
+            }
+        )
+    -> CalcOperation
+minus (Value second) =
+    -- The calc `-` operator MUST be surrounded by whitespace.
+    CalcOperation (" - " ++ getCalcExpression second)
+
+
+{-| Use with [`calc`](#calc) to add one numeric value to another.
+
+    calc (pct 100) (plus (px 2))
+    -- calc: (100% + 2px)
+
+-}
+plus :
+    Value
+        (LengthSupported
+            { pct : Supported
+            , num : Supported
+            , int : Supported
+            }
+        )
+    -> CalcOperation
+plus (Value second) =
+    -- The calc `+` operator MUST be surrounded by whitespace.
+    CalcOperation (" + " ++ getCalcExpression second)
+
+
+{-| Use with [`calc`](#calc) to multiply a value by a unitless number.
+
+    calc (pct 100) (times (int 2))
+    -- calc: (100% * 2px)
+
+-}
+times :
+    Value
+        { num : Supported
+        , int : Supported
+        , zero : Supported
+        }
+    -> CalcOperation
+times (Value second) =
+    -- The calc `*` operator does not need to be surrounded by whitespace.
+    CalcOperation (" * " ++ getCalcExpression second)
+
+
+{-| Use with [`calc`](#calc) to divide a value by a unitless number.
+
+    calc (pct 100) (dividedBy (int 2))
+    -- calc: (100% / 2px)
+
+-}
+dividedBy :
+    Value
+        { num : Supported
+        , int : Supported
+        , zero : Supported
+        }
+    -> CalcOperation
+dividedBy (Value second) =
+    -- The calc `/` operator does not need to be surrounded by whitespace.
+    CalcOperation (" / " ++ getCalcExpression second)
+
 
 ------------------------------------------------------------------------
 ------------------------------------------------------------------------
@@ -1766,7 +2064,6 @@ type alias Time =
 ------------------------------------------------------------------------
 ------------------------------------------------------------------------
 ------------------------------------------------------------------------
-
 
 
 {-| Compiles to a `0` value with no units.
@@ -3817,7 +4114,537 @@ all (Value val) =
 ------------------------------------------------------------------------
 ------------------------------------------------------------------------
 ------------------------------------------------------------------------
-------------------------------- SIZING --------------------------------
+------------------------------- DISPLAY --------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+
+
+{-| Sets [`display`](https://css-tricks.com/almanac/properties/d/display/).
+
+    display block
+
+**Note:** This function accepts `flex_` rather than `flex` because [`flex` is already a property function](#flex).
+
+-}
+display :
+    BaseValue
+        { block : Supported
+        , flex_ : Supported
+        , flow : Supported
+        , flowRoot : Supported
+        , grid : Supported
+        , listItem : Supported
+        , inline : Supported
+        , inlineBlock : Supported
+        , inlineFlex : Supported
+        , inlineGrid : Supported
+        , inlineTable : Supported
+        , none : Supported
+        , contents : Supported
+        , ruby : Supported
+        , rubyBase : Supported
+        , rubyBaseContainer : Supported
+        , rubyText : Supported
+        , rubyTextContainer : Supported
+        , runIn : Supported
+        , table : Supported
+        , tableCaption : Supported
+        , tableCell : Supported
+        , tableColumn : Supported
+        , tableColumnGroup : Supported
+        , tableFooterGroup : Supported
+        , tableHeaderGroup : Supported
+        , tableRow : Supported
+        , tableRowGroup : Supported
+        }
+    -> Style
+display (Value val) =
+    AppendProperty ("display:" ++ val)
+
+
+{-| Sets [`display`](https://css-tricks.com/almanac/properties/d/display/).
+
+    display2 block flex_
+
+**Note:** This function accepts `flex_` rather than `flex` because [`flex` is already a property function](#flex).
+For `display: inline list-item` and similar property values that include `list-item`
+look at [`displayListItem2`](#displayListItem2) and [`displayListItem3`](#displayListItem3).
+
+-}
+display2 :
+    Value
+        { block : Supported
+        , inline : Supported
+        , runIn : Supported
+        }
+    ->
+        Value
+            { flow : Supported
+            , flowRoot : Supported
+            , table : Supported
+            , flex_ : Supported
+            , grid : Supported
+            , ruby : Supported
+            }
+    -> Style
+display2 (Value displayOutside) (Value displayInside) =
+    AppendProperty ("display:" ++ displayOutside ++ " " ++ displayInside)
+
+
+{-| The [`display`](https://css-tricks.com/almanac/properties/d/display/) property.
+This function is used to generate complex `display: list-item` properties
+such as `display: block list-item`.
+
+    displayListItem2 block
+
+-}
+displayListItem2 :
+    Value
+        { block : Supported
+        , inline : Supported
+        , runIn : Supported
+        , flow : Supported
+        , flowRoot : Supported
+        }
+    -> Style
+displayListItem2 (Value val) =
+    AppendProperty ("display:list-item " ++ val)
+
+
+{-| The [`display`](https://css-tricks.com/almanac/properties/d/display/) property.
+This function is used to generate complex `display: list-item` properties
+such as `display: block flow-root list-item`.
+
+    displayListItem3 block flowRoot
+
+-}
+displayListItem3 :
+    Value
+        { block : Supported
+        , inline : Supported
+        , runIn : Supported
+        }
+    ->
+        Value
+            { flow : Supported
+            , flowRoot : Supported
+            }
+    -> Style
+displayListItem3 (Value displayOutside) (Value displayFlow) =
+    AppendProperty ("display:list-item " ++ displayOutside ++ " " ++ displayFlow)
+
+
+{-| The `flex` value used by [`display`](#display).
+
+    display flex_
+
+The value is called `flex_` instead of `flex` because [`flex` is already a property function](#flex).
+
+-}
+flex_ : Value { provides | flex_ : Supported }
+flex_ =
+    Value "flex"
+
+
+{-| The `flow` value used by [`display`](#display).
+
+    display flow
+
+-}
+flow : Value { provides | flow : Supported }
+flow =
+    Value "flow"
+
+
+{-| The `flow-root` value used by [`display`](#display).
+
+    display flowRoot
+
+-}
+flowRoot : Value { provides | flowRoot : Supported }
+flowRoot =
+    Value "flow-root"
+
+
+{-| The `grid` value used by [`display`](#display).
+
+    display grid
+
+-}
+grid : Value { provides | grid : Supported }
+grid =
+    Value "grid"
+
+
+{-| The `contents` value used by [`display`](#display).
+
+    display contents
+
+-}
+contents : Value { provides | contents : Supported }
+contents =
+    Value "contents"
+
+
+{-| The `inline-block` value used by [`display`](#display).
+
+    display inlineBlock
+
+-}
+inlineBlock : Value { provides | inlineBlock : Supported }
+inlineBlock =
+    Value "inline-block"
+
+
+{-| The `inline-flex` value used by [`display`](#display).
+
+    display inlineFlex
+
+-}
+inlineFlex : Value { provides | inlineFlex : Supported }
+inlineFlex =
+    Value "inline-flex"
+
+
+{-| The `list-item` value used by [`display`](#display).
+
+    display listItem
+
+-}
+listItem : Value { provides | listItem : Supported }
+listItem =
+    Value "list-item"
+
+
+{-| The `inline-table` value used by [`display`](#display).
+
+    display inlineTable
+
+-}
+inlineTable : Value { provides | inlineTable : Supported }
+inlineTable =
+    Value "inline-table"
+
+
+{-| The `inline-grid` value used by [`display`](#display).
+
+    display inlineGrid
+
+-}
+inlineGrid : Value { provides | inlineGrid : Supported }
+inlineGrid =
+    Value "inline-grid"
+
+
+{-| The `ruby-base` value used by [`display`](#display).
+
+    display rubyBase
+
+-}
+rubyBase : Value { provides | rubyBase : Supported }
+rubyBase =
+    Value "ruby-base"
+
+
+{-| The `ruby-base-container` value used by [`display`](#display).
+
+    display rubyBaseContainer
+
+-}
+rubyBaseContainer : Value { provides | rubyBaseContainer : Supported }
+rubyBaseContainer =
+    Value "ruby-base-container"
+
+
+{-| The `ruby-text` value used by [`display`](#display).
+
+    display rubyText
+
+-}
+rubyText : Value { provides | rubyText : Supported }
+rubyText =
+    Value "ruby-text"
+
+
+{-| The `ruby-text-container` value used by [`display`](#display).
+
+    display rubyTextContainer
+
+-}
+rubyTextContainer : Value { provides | rubyTextContainer : Supported }
+rubyTextContainer =
+    Value "ruby-text-container"
+
+
+{-| The `run-in` value used by [`display`](#display).
+
+    display runIn
+
+-}
+runIn : Value { provides | runIn : Supported }
+runIn =
+    Value "run-in"
+
+
+{-| The `table` value used by [`display`](#display).
+
+    display table
+
+-}
+table : Value { provides | table : Supported }
+table =
+    Value "table"
+
+
+{-| The `table-caption` value used by [`display`](#display).
+
+    display tableCaption
+
+-}
+tableCaption : Value { provides | tableCaption : Supported }
+tableCaption =
+    Value "table-caption"
+
+
+{-| The `table-cell` value used by [`display`](#display).
+
+    display tableCell
+
+-}
+tableCell : Value { provides | tableCell : Supported }
+tableCell =
+    Value "table-cell"
+
+
+{-| The `table-column` value used by [`display`](#display).
+
+    display tableColumn
+
+-}
+tableColumn : Value { provides | tableColumn : Supported }
+tableColumn =
+    Value "table-column"
+
+
+{-| The `table-column-group` value used by [`display`](#display).
+
+    display tableColumnGroup
+
+-}
+tableColumnGroup : Value { provides | tableColumnGroup : Supported }
+tableColumnGroup =
+    Value "table-column-group"
+
+
+{-| The `table-footer-group` value used by [`display`](#display).
+
+    display tableFooterGroup
+
+-}
+tableFooterGroup : Value { provides | tableFooterGroup : Supported }
+tableFooterGroup =
+    Value "table-footer-group"
+
+
+{-| The `table-header-group` value used by [`display`](#display).
+
+    display tableHeaderGroup
+
+-}
+tableHeaderGroup : Value { provides | tableHeaderGroup : Supported }
+tableHeaderGroup =
+    Value "table-header-group"
+
+
+{-| The `table-row` value used by [`display`](#display).
+
+    display tableRow
+
+-}
+tableRow : Value { provides | tableRow : Supported }
+tableRow =
+    Value "table-row"
+
+
+{-| The `table-row-group` value used by [`display`](#display).
+
+    display tableRowGroup
+
+-}
+tableRowGroup : Value { provides | tableRowGroup : Supported }
+tableRowGroup =
+    Value "table-row-group"
+
+
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------- POSITION -------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+
+
+{-| Sets the [`position`](https://css-tricks.com/almanac/properties/p/position/) of an element.
+
+    position absolute
+
+    position relative
+
+-}
+position :
+    BaseValue
+        { absolute : Supported
+        , fixed : Supported
+        , relative : Supported
+        , static : Supported
+        , sticky : Supported
+        }
+    -> Style
+position (Value val) =
+    AppendProperty ("position:" ++ val)
+
+
+{-| An [`absolute` `position`](https://developer.mozilla.org/en-US/docs/Web/CSS/position#relative).
+
+    position absolute
+
+The default `position` value is [`static`](#static). See also [`position: sticky`](#sticky), and [the differences between absolute, relative, and fixed positioning](<https://css-tricks.com/absolute-relative-fixed-positioining-how-do-they-differ/>
+
+-}
+absolute : Value { provides | absolute : Supported }
+absolute =
+    Value "absolute"
+
+
+{-| A [`fixed` `position`](https://developer.mozilla.org/en-US/docs/Web/CSS/position#Values)
+or [`fixed` `background-attachment`](https://developer.mozilla.org/en-US/docs/Web/CSS/background-attachment#Values)
+or [`fixed` `table-layout`](https://css-tricks.com/almanac/properties/t/table-layout/).
+
+    position fixed
+
+    backgroundAttachment fixed
+
+    tableLayout fixed
+
+The default `position` value is [`static`](#static). See also [`position: sticky`](#sticky), and [the differences between absolute, relative, and fixed positioning](https://css-tricks.com/absolute-relative-fixed-positioining-how-do-they-differ/)
+
+-}
+fixed : Value { provides | fixed : Supported }
+fixed =
+    Value "fixed"
+
+
+{-| A [`relative` `position`](https://developer.mozilla.org/en-US/docs/Web/CSS/position#Values).
+
+    position relative
+
+The default `position` value is [`static`](#static). See also [`position: sticky`](#sticky), and [the differences between absolute, relative, and fixed positioning](https://css-tricks.com/absolute-relative-fixed-positioining-how-do-they-differ/).
+
+-}
+relative : Value { provides | relative : Supported }
+relative =
+    Value "relative"
+
+
+{-| A [`static` `position`](https://developer.mozilla.org/en-US/docs/Web/CSS/position#Values).
+
+    position static
+
+This is the default `position` value. See also [`position: sticky`](#sticky), and [the differences between absolute, relative, and fixed positioning](https://css-tricks.com/absolute-relative-fixed-positioining-how-do-they-differ/).
+
+-}
+static : Value { provides | static : Supported }
+static =
+    Value "static"
+
+
+{-| A [`sticky` `position`](https://css-tricks.com/position-sticky-2/)
+
+    position sticky
+
+The default `position` value is [`static`](#static). See also [the differences between absolute, relative, and fixed positioning](https://css-tricks.com/absolute-relative-fixed-positioining-how-do-they-differ/).
+
+-}
+sticky : Value { provides | sticky : Supported }
+sticky =
+    Value "sticky"
+
+
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------ Z-INDEX, BOX-SIZING ---------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+
+
+{-| Sets [`z-index`](https://css-tricks.com/almanac/properties/z/z-index/)
+
+    zIndex (int 10)
+
+    zIndex auto
+
+**NOTE:** Z-index is not as simple as it looks! Make sure to read about
+[stacking contexts](https://css-tricks.com/css-stacking-contexts/) 
+if you're not already familiar with them.
+
+-}
+zIndex :
+    BaseValue
+        { int : Supported
+        , auto : Supported
+        }
+    -> Style
+zIndex (Value val) =
+    AppendProperty ("z-index:" ++ val)
+
+
+
+-- BOX SIZING --
+
+
+{-| Sets [`box-sizing`](https://css-tricks.com/almanac/properties/b/box-sizing/) property.
+
+    boxSizing contentBox
+
+    boxSizing borderBox
+
+-}
+boxSizing :
+    BaseValue
+        { contentBox : Supported
+        , borderBox : Supported
+        }
+    -> Style
+boxSizing (Value value) =
+    AppendProperty ("box-sizing:" ++ value)
+
+
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------- SIZING ---------------------------------
 ------------------------------------------------------------------------
 ------------------------------------------------------------------------
 ------------------------------------------------------------------------
@@ -4078,6 +4905,597 @@ maxInlineSize :
     -> Style
 maxInlineSize (Value val) =
     AppendProperty ("max-inline-size:" ++ val)
+
+
+
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------- INSETS --------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+
+
+{-| Sets the [`inset`](https://developer.mozilla.org/en-US/docs/Web/CSS/inset) property.
+
+`inset` sets the `top`, `bottom`, `left` and `right` properties.
+
+    inset (px 10) -- top, bottom, left and right are all 10px.
+
+    inset2 (pct 5) (pct 5) -- top & bottom = 5%, left & right = 5%
+
+    inset3 (px 20) (px 20) (px 20) -- top = 20px, left & right = 20px, bottom = 20px
+
+    inset4 (px 20) (px 20) (px 40) (px 20) -- top = 20px, right = 20px, bottom = 40px, left = 20px
+
+-}
+inset :
+    BaseValue
+        (LengthSupported
+            { pct : Supported
+            , auto : Supported
+            }
+        )
+    -> Style
+inset (Value val) =
+    AppendProperty ("inset:" ++ val)
+
+
+{-| Sets the [`inset`](https://developer.mozilla.org/en-US/docs/Web/CSS/inset) property.
+
+`inset` sets the `top`, `bottom`, `left` and `right` properties.
+
+    inset (px 10) -- top, bottom, left and right are all 10px.
+
+    inset2 (pct 5) (pct 5) -- top & bottom = 5%, left & right = 5%
+
+    inset3 (px 20) (px 20) (px 20) -- top = 20px, left & right = 20px, bottom = 20px
+
+    inset4 (px 20) (px 20) (px 40) (px 20) -- top = 20px, right = 20px, bottom = 40px, left = 20px
+
+-}
+inset2 :
+    Value
+        (LengthSupported
+            { pct : Supported
+            , auto : Supported
+            }
+        )
+    ->
+        Value
+            (LengthSupported
+                { pct : Supported
+                , auto : Supported
+                }
+            )
+    -> Style
+inset2 (Value valTopBottom) (Value valRightLeft) =
+    AppendProperty ("inset:" ++ valTopBottom ++ " " ++ valRightLeft)
+
+
+{-| Sets the [`inset`](https://developer.mozilla.org/en-US/docs/Web/CSS/inset) property.
+
+`inset` sets the `top`, `bottom`, `left` and `right` properties.
+
+    inset (px 10) -- top, bottom, left and right are all 10px.
+
+    inset2 (pct 5) (pct 5) -- top & bottom = 5%, left & right = 5%
+
+    inset3 (px 20) (px 20) (px 20) -- top = 20px, left & right = 20px, bottom = 20px
+
+    inset4 (px 20) (px 20) (px 40) (px 20) -- top = 20px, right = 20px, bottom = 40px, left = 20px
+
+-}
+inset3 :
+    Value
+        (LengthSupported
+            { pct : Supported
+            , auto : Supported
+            }
+        )
+    ->
+        Value
+            (LengthSupported
+                { pct : Supported
+                , auto : Supported
+                }
+            )
+    ->
+        Value
+            (LengthSupported
+                { pct : Supported
+                , auto : Supported
+                }
+            )
+    -> Style
+inset3 (Value valTop) (Value valRightLeft) (Value valBottom) =
+    AppendProperty ("inset:" ++ valTop ++ " " ++ valRightLeft ++ " " ++ valBottom)
+
+
+{-| Sets the [`inset`](https://developer.mozilla.org/en-US/docs/Web/CSS/inset) property.
+
+`inset` sets the `top`, `bottom`, `left` and `right` properties.
+
+    inset (px 10) -- top, bottom, left and right are all 10px.
+
+    inset2 (pct 5) (pct 5) -- top & bottom = 5%, left & right = 5%
+
+    inset3 (px 20) (px 20) (px 20) -- top = 20px, left & right = 20px, bottom = 20px
+
+    inset4 (px 20) (px 20) (px 40) (px 20) -- top = 20px, right = 20px, bottom = 40px, left = 20px
+
+-}
+inset4 :
+    Value
+        (LengthSupported
+            { pct : Supported
+            , auto : Supported
+            }
+        )
+    ->
+        Value
+            (LengthSupported
+                { pct : Supported
+                , auto : Supported
+                }
+            )
+    ->
+        Value
+            (LengthSupported
+                { pct : Supported
+                , auto : Supported
+                }
+            )
+    ->
+        Value
+            (LengthSupported
+                { pct : Supported
+                , auto : Supported
+                }
+            )
+    -> Style
+inset4 (Value valTop) (Value valRight) (Value valBottom) (Value valLeft) =
+    AppendProperty ("inset:" ++ valTop ++ " " ++ valRight ++ " " ++ valBottom ++ " " ++ valLeft)
+
+
+{-| Sets the [`top`](https://css-tricks.com/almanac/properties/t/top/) property.
+
+    top (px 10)
+
+    top (pct 50)
+
+    top auto
+
+    top zero
+
+If you need to use `top` as a CSS _value_ instead of as a _property_,
+for example in `vertical-align: top`, use [`top_`](#top_) instead of this.
+
+-}
+top :
+    BaseValue
+        (LengthSupported
+            { pct : Supported
+            , auto : Supported
+            }
+        )
+    -> Style
+top (Value val) =
+    AppendProperty ("top:" ++ val)
+
+
+{-| Sets the [`bottom`](https://css-tricks.com/almanac/properties/b/bottom/) property.
+
+    bottom (px 10)
+
+    bottom (pct 50)
+
+    bottom auto
+
+    bottom zero
+
+If you need to use `bottom` as a CSS _value_ instead of as a _property_,
+for example in `vertical-align: bottom`, use [`bottom_`](#bottom_) instead of this.
+
+-}
+bottom :
+    BaseValue
+        (LengthSupported
+            { pct : Supported
+            , auto : Supported
+            }
+        )
+    -> Style
+bottom (Value val) =
+    AppendProperty ("bottom:" ++ val)
+
+
+{-| Sets the [`left`](https://css-tricks.com/almanac/properties/l/left/) property.
+
+    left (px 10)
+
+    left (pct 50)
+
+    left auto
+
+    left zero
+
+If you need to use `left` as a CSS _value_ instead of as a _property_,
+for example in `float: left`, use [`left_`](#left_) instead of this.
+
+-}
+left :
+    BaseValue
+        (LengthSupported
+            { pct : Supported
+            , auto : Supported
+            }
+        )
+    -> Style
+left (Value val) =
+    AppendProperty ("left:" ++ val)
+
+
+{-| Sets the [`right`](https://css-tricks.com/almanac/properties/r/right) property.
+
+    right (px 10)
+
+    right (pct 50)
+
+    right auto
+
+    right zero
+
+If you need to use `right` as a CSS _value_ instead of as a _property_,
+for example in `float: right`, use [`right_`](#right_) instead of this.
+
+-}
+right :
+    BaseValue
+        (LengthSupported
+            { pct : Supported
+            , auto : Supported
+            }
+        )
+    -> Style
+right (Value val) =
+    AppendProperty ("right:" ++ val)
+
+
+{-| Sets the [`inset-block`](https://css-tricks.com/almanac/properties/i/inset-block/) property.
+
+`inset-block` sets the `inset-block-start` and `inset-block-end` properties.
+
+    insetBlock (px 10) -- block start and block end are both 10px.
+
+    insetBlock2 (pct 5) (pct 5) -- block start = 5%, block end = 5%
+
+-}
+insetBlock :
+    BaseValue
+        (LengthSupported
+            { pct : Supported
+            , auto : Supported
+            }
+        )
+    -> Style
+insetBlock (Value val) =
+    AppendProperty ("inset-block:" ++ val)
+
+
+{-| Sets the [`inset-block`](https://css-tricks.com/almanac/properties/i/inset-block/) property.
+
+`inset-block` sets the `inset-block-start` and `inset-block-end` properties.
+
+    insetBlock (px 10) -- block start and block end are both 10px.
+
+    insetBlock2 (pct 5) (pct 5) -- block start = 5%, block end = 5%
+
+-}
+insetBlock2 :
+    Value
+        (LengthSupported
+            { pct : Supported
+            , auto : Supported
+            }
+        )
+    ->
+        Value
+            (LengthSupported
+                { pct : Supported
+                , auto : Supported
+                }
+            )
+    -> Style
+insetBlock2 (Value valStart) (Value valEnd) =
+    AppendProperty ("inset-block:" ++ valStart ++ " " ++ valEnd)
+
+
+{-| Sets the [`inset-inline`](https://css-tricks.com/almanac/properties/i/inset-inline) property.
+
+`inset-inline` sets the `inset-inline-start` and `inset-inline-end` properties.
+
+    insetInline (px 10) -- inline start and inline end are both 10px.
+
+    insetInline2 (pct 5) (pct 5) -- inline start = 5%, inline end = 5%
+
+-}
+insetInline :
+    BaseValue
+        (LengthSupported
+            { pct : Supported
+            , auto : Supported
+            }
+        )
+    -> Style
+insetInline (Value val) =
+    AppendProperty ("inset-inline:" ++ val)
+
+
+{-| Sets the [`inset-inline`](https://css-tricks.com/almanac/properties/i/inset-inline) property.
+
+`inset-inline` sets the `inset-inline-start` and `inset-inline-end` properties.
+
+    insetInline (px 10) -- inline start and inline end are both 10px.
+
+    insetInline2 (pct 5) (pct 5) -- inline start = 5%, inline end = 5%
+
+-}
+insetInline2 :
+    Value
+        (LengthSupported
+            { pct : Supported
+            , auto : Supported
+            }
+        )
+    ->
+        Value
+            (LengthSupported
+                { pct : Supported
+                , auto : Supported
+                }
+            )
+    -> Style
+insetInline2 (Value valStart) (Value valEnd) =
+    AppendProperty ("inset-inline:" ++ valStart ++ " " ++ valEnd)
+
+
+{-| Sets the [`inset-block-start`](https://developer.mozilla.org/en-US/docs/Web/CSS/inset-block-start) property.
+
+    insetBlockStart (px 10)
+
+    insetBlockStart (pct 50)
+
+    insetBlockStart auto
+
+    insetBlockStart zero
+
+-}
+insetBlockStart :
+    BaseValue
+        (LengthSupported
+            { pct : Supported
+            , auto : Supported
+            }
+        )
+    -> Style
+insetBlockStart (Value val) =
+    AppendProperty ("inset-block-start:" ++ val)
+
+
+{-| Sets the [`inset-block-end`](https://developer.mozilla.org/en-US/docs/Web/CSS/inset-block-end) property.
+
+    insetBlockEnd (px 10)
+
+    insetBlockEnd (pct 50)
+
+    insetBlockEnd auto
+
+    insetBlockEnd zero
+
+-}
+insetBlockEnd :
+    BaseValue
+        (LengthSupported
+            { pct : Supported
+            , auto : Supported
+            }
+        )
+    -> Style
+insetBlockEnd (Value val) =
+    AppendProperty ("inset-block-end:" ++ val)
+
+
+{-| Sets the [`inset-inline-start`](https://developer.mozilla.org/en-US/docs/Web/CSS/inset-inline-start) property.
+
+    insetInlineStart (px 10)
+
+    insetInlineStart (pct 50)
+
+    insetInlineStart auto
+
+    insetInlineStart zero
+
+-}
+insetInlineStart :
+    BaseValue
+        (LengthSupported
+            { pct : Supported
+            , auto : Supported
+            }
+        )
+    -> Style
+insetInlineStart (Value val) =
+    AppendProperty ("inset-inline-start:" ++ val)
+
+
+{-| Sets the [`inset-inline-end`](https://developer.mozilla.org/en-US/docs/Web/CSS/inset-inline-end) property.
+
+    insetInlineEnd (px 10)
+
+    insetInlineEnd (pct 50)
+
+    insetInlineEnd auto
+
+    insetInlineEnd zero
+
+-}
+insetInlineEnd :
+    BaseValue
+        (LengthSupported
+            { pct : Supported
+            , auto : Supported
+            }
+        )
+    -> Style
+insetInlineEnd (Value val) =
+    AppendProperty ("inset-inline-end:" ++ val)
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+{-| A [`:read-write`](https://developer.mozilla.org/en-US/docs/Web/CSS/:read-write)
+[pseudo-class](https://css-tricks.com/pseudo-class-selectors/).
+
+    readWrite
+        [ backgroundColor (rgb 0 50 150)
+        ]
+
+-}
+readWrite : List Style -> Style
+readWrite =
+    pseudoClass "read-write"
+
+
+{-| A [`:required`](https://developer.mozilla.org/en-US/docs/Web/CSS/:required)
+[pseudo-class](https://css-tricks.com/pseudo-class-selectors/).
+
+    required
+        [ border (px 2) solid (rgb 100 100 100)
+        ]
+
+-}
+required : List Style -> Style
+required =
+    pseudoClass "required"
+
+
+{-| A [`:root`](https://developer.mozilla.org/en-US/docs/Web/CSS/:root)
+[pseudo-class](https://css-tricks.com/pseudo-class-selectors/).
+
+    root
+        [ backgroundColor (rgb 0 200 200)
+        ]
+
+-}
+root : List Style -> Style
+root =
+    pseudoClass "root"
+
+
+{-| A [`:scope`](https://developer.mozilla.org/en-US/docs/Web/CSS/:scope)
+[pseudo-class](https://css-tricks.com/pseudo-class-selectors/).
+
+    scope
+        [ backgroundColor (rgb 0 200 200)
+        ]
+
+-}
+scope : List Style -> Style
+scope =
+    pseudoClass "scope"
+
+
+{-| A [`:target`](https://developer.mozilla.org/en-US/docs/Web/CSS/:target)
+[pseudo-class](https://css-tricks.com/pseudo-class-selectors/).
+
+    target
+        [ fontWeight bold
+        , border3 (px 2) dotted (rgb 255 0 0)
+        ]
+
+-}
+target : List Style -> Style
+target =
+    pseudoClass "target"
+
+
+{-| A [`:valid`](https://developer.mozilla.org/en-US/docs/Web/CSS/:valid)
+[pseudo-class](https://css-tricks.com/pseudo-class-selectors/).
+
+    valid
+        [ border3 (px 1) solid (rgb 0 255 0)
+        ]
+
+-}
+valid : List Style -> Style
+valid =
+    pseudoClass "valid"
+
+
+{-| A [`:visited`](https://developer.mozilla.org/en-US/docs/Web/CSS/:visited)
+[pseudo-class](https://css-tricks.com/pseudo-class-selectors/).
+
+    visited
+        [ color (rgb 150 0 255)
+        ]
+
+-}
+visited : List Style -> Style
+visited =
+    pseudoClass "visited"
+
+
 
 
 ------------------------------------------------------------------------
@@ -7020,7 +8438,7 @@ anywhere =
 ------------------------------------------------------------------------
 ------------------------------------------------------------------------
 ------------------------------------------------------------------------
-------------------------------- DISPLAY --------------------------------
+--------------------------------- FLEX ---------------------------------
 ------------------------------------------------------------------------
 ------------------------------------------------------------------------
 ------------------------------------------------------------------------
@@ -7029,1743 +8447,216 @@ anywhere =
 ------------------------------------------------------------------------
 
 
-{-| Sets [`display`](https://css-tricks.com/almanac/properties/d/display/).
+{-| The [`flex`](https://css-tricks.com/almanac/properties/f/flex/) shorthand property.
 
-    display block
+    flex none
 
-**Note:** This function accepts `flex_` rather than `flex` because [`flex` is already a property function](#flex).
+    flex auto
+
+    flex (num 1)
 
 -}
-display :
+flex :
     BaseValue
-        { block : Supported
-        , flex_ : Supported
-        , flow : Supported
-        , flowRoot : Supported
-        , grid : Supported
-        , listItem : Supported
-        , inline : Supported
-        , inlineBlock : Supported
-        , inlineFlex : Supported
-        , inlineGrid : Supported
-        , inlineTable : Supported
-        , none : Supported
-        , contents : Supported
-        , ruby : Supported
-        , rubyBase : Supported
-        , rubyBaseContainer : Supported
-        , rubyText : Supported
-        , rubyTextContainer : Supported
-        , runIn : Supported
-        , table : Supported
-        , tableCaption : Supported
-        , tableCell : Supported
-        , tableColumn : Supported
-        , tableColumnGroup : Supported
-        , tableFooterGroup : Supported
-        , tableHeaderGroup : Supported
-        , tableRow : Supported
-        , tableRowGroup : Supported
-        }
-    -> Style
-display (Value val) =
-    AppendProperty ("display:" ++ val)
-
-
-{-| Sets [`display`](https://css-tricks.com/almanac/properties/d/display/).
-
-    display2 block flex_
-
-**Note:** This function accepts `flex_` rather than `flex` because [`flex` is already a property function](#flex).
-For `display: inline list-item` and similar property values that include `list-item`
-look at [`displayListItem2`](#displayListItem2) and [`displayListItem3`](#displayListItem3).
-
--}
-display2 :
-    Value
-        { block : Supported
-        , inline : Supported
-        , runIn : Supported
-        }
-    ->
-        Value
-            { flow : Supported
-            , flowRoot : Supported
-            , table : Supported
-            , flex_ : Supported
-            , grid : Supported
-            , ruby : Supported
-            }
-    -> Style
-display2 (Value displayOutside) (Value displayInside) =
-    AppendProperty ("display:" ++ displayOutside ++ " " ++ displayInside)
-
-
-{-| The [`display`](https://css-tricks.com/almanac/properties/d/display/) property.
-This function is used to generate complex `display: list-item` properties
-such as `display: block list-item`.
-
-    displayListItem2 block
-
--}
-displayListItem2 :
-    Value
-        { block : Supported
-        , inline : Supported
-        , runIn : Supported
-        , flow : Supported
-        , flowRoot : Supported
-        }
-    -> Style
-displayListItem2 (Value val) =
-    AppendProperty ("display:list-item " ++ val)
-
-
-{-| The [`display`](https://css-tricks.com/almanac/properties/d/display/) property.
-This function is used to generate complex `display: list-item` properties
-such as `display: block flow-root list-item`.
-
-    displayListItem3 block flowRoot
-
--}
-displayListItem3 :
-    Value
-        { block : Supported
-        , inline : Supported
-        , runIn : Supported
-        }
-    ->
-        Value
-            { flow : Supported
-            , flowRoot : Supported
-            }
-    -> Style
-displayListItem3 (Value displayOutside) (Value displayFlow) =
-    AppendProperty ("display:list-item " ++ displayOutside ++ " " ++ displayFlow)
-
-
-{-| The `flex` value used by [`display`](#display).
-
-    display flex_
-
-The value is called `flex_` instead of `flex` because [`flex` is already a property function](#flex).
-
--}
-flex_ : Value { provides | flex_ : Supported }
-flex_ =
-    Value "flex"
-
-
-{-| The `flow` value used by [`display`](#display).
-
-    display flow
-
--}
-flow : Value { provides | flow : Supported }
-flow =
-    Value "flow"
-
-
-{-| The `flow-root` value used by [`display`](#display).
-
-    display flowRoot
-
--}
-flowRoot : Value { provides | flowRoot : Supported }
-flowRoot =
-    Value "flow-root"
-
-
-{-| The `grid` value used by [`display`](#display).
-
-    display grid
-
--}
-grid : Value { provides | grid : Supported }
-grid =
-    Value "grid"
-
-
-{-| The `contents` value used by [`display`](#display).
-
-    display contents
-
--}
-contents : Value { provides | contents : Supported }
-contents =
-    Value "contents"
-
-
-{-| The `inline-block` value used by [`display`](#display).
-
-    display inlineBlock
-
--}
-inlineBlock : Value { provides | inlineBlock : Supported }
-inlineBlock =
-    Value "inline-block"
-
-
-{-| The `inline-flex` value used by [`display`](#display).
-
-    display inlineFlex
-
--}
-inlineFlex : Value { provides | inlineFlex : Supported }
-inlineFlex =
-    Value "inline-flex"
-
-
-{-| The `list-item` value used by [`display`](#display).
-
-    display listItem
-
--}
-listItem : Value { provides | listItem : Supported }
-listItem =
-    Value "list-item"
-
-
-{-| The `inline-table` value used by [`display`](#display).
-
-    display inlineTable
-
--}
-inlineTable : Value { provides | inlineTable : Supported }
-inlineTable =
-    Value "inline-table"
-
-
-{-| The `inline-grid` value used by [`display`](#display).
-
-    display inlineGrid
-
--}
-inlineGrid : Value { provides | inlineGrid : Supported }
-inlineGrid =
-    Value "inline-grid"
-
-
-{-| The `ruby-base` value used by [`display`](#display).
-
-    display rubyBase
-
--}
-rubyBase : Value { provides | rubyBase : Supported }
-rubyBase =
-    Value "ruby-base"
-
-
-{-| The `ruby-base-container` value used by [`display`](#display).
-
-    display rubyBaseContainer
-
--}
-rubyBaseContainer : Value { provides | rubyBaseContainer : Supported }
-rubyBaseContainer =
-    Value "ruby-base-container"
-
-
-{-| The `ruby-text` value used by [`display`](#display).
-
-    display rubyText
-
--}
-rubyText : Value { provides | rubyText : Supported }
-rubyText =
-    Value "ruby-text"
-
-
-{-| The `ruby-text-container` value used by [`display`](#display).
-
-    display rubyTextContainer
-
--}
-rubyTextContainer : Value { provides | rubyTextContainer : Supported }
-rubyTextContainer =
-    Value "ruby-text-container"
-
-
-{-| The `run-in` value used by [`display`](#display).
-
-    display runIn
-
--}
-runIn : Value { provides | runIn : Supported }
-runIn =
-    Value "run-in"
-
-
-{-| The `table` value used by [`display`](#display).
-
-    display table
-
--}
-table : Value { provides | table : Supported }
-table =
-    Value "table"
-
-
-{-| The `table-caption` value used by [`display`](#display).
-
-    display tableCaption
-
--}
-tableCaption : Value { provides | tableCaption : Supported }
-tableCaption =
-    Value "table-caption"
-
-
-{-| The `table-cell` value used by [`display`](#display).
-
-    display tableCell
-
--}
-tableCell : Value { provides | tableCell : Supported }
-tableCell =
-    Value "table-cell"
-
-
-{-| The `table-column` value used by [`display`](#display).
-
-    display tableColumn
-
--}
-tableColumn : Value { provides | tableColumn : Supported }
-tableColumn =
-    Value "table-column"
-
-
-{-| The `table-column-group` value used by [`display`](#display).
-
-    display tableColumnGroup
-
--}
-tableColumnGroup : Value { provides | tableColumnGroup : Supported }
-tableColumnGroup =
-    Value "table-column-group"
-
-
-{-| The `table-footer-group` value used by [`display`](#display).
-
-    display tableFooterGroup
-
--}
-tableFooterGroup : Value { provides | tableFooterGroup : Supported }
-tableFooterGroup =
-    Value "table-footer-group"
-
-
-{-| The `table-header-group` value used by [`display`](#display).
-
-    display tableHeaderGroup
-
--}
-tableHeaderGroup : Value { provides | tableHeaderGroup : Supported }
-tableHeaderGroup =
-    Value "table-header-group"
-
-
-{-| The `table-row` value used by [`display`](#display).
-
-    display tableRow
-
--}
-tableRow : Value { provides | tableRow : Supported }
-tableRow =
-    Value "table-row"
-
-
-{-| The `table-row-group` value used by [`display`](#display).
-
-    display tableRowGroup
-
--}
-tableRowGroup : Value { provides | tableRowGroup : Supported }
-tableRowGroup =
-    Value "table-row-group"
-
-
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------- POSITION -------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-
-
-{-| Sets the [`position`](https://css-tricks.com/almanac/properties/p/position/) of an element.
-
-    position absolute
-
-    position relative
-
--}
-position :
-    BaseValue
-        { absolute : Supported
-        , fixed : Supported
-        , relative : Supported
-        , static : Supported
-        , sticky : Supported
-        }
-    -> Style
-position (Value val) =
-    AppendProperty ("position:" ++ val)
-
-
-{-| An [`absolute` `position`](https://developer.mozilla.org/en-US/docs/Web/CSS/position#relative).
-
-    position absolute
-
-The default `position` value is [`static`](#static). See also [`position: sticky`](#sticky), and [the differences between absolute, relative, and fixed positioning](<https://css-tricks.com/absolute-relative-fixed-positioining-how-do-they-differ/>
-
--}
-absolute : Value { provides | absolute : Supported }
-absolute =
-    Value "absolute"
-
-
-{-| A [`fixed` `position`](https://developer.mozilla.org/en-US/docs/Web/CSS/position#Values)
-or [`fixed` `background-attachment`](https://developer.mozilla.org/en-US/docs/Web/CSS/background-attachment#Values)
-or [`fixed` `table-layout`](https://css-tricks.com/almanac/properties/t/table-layout/).
-
-    position fixed
-
-    backgroundAttachment fixed
-
-    tableLayout fixed
-
-The default `position` value is [`static`](#static). See also [`position: sticky`](#sticky), and [the differences between absolute, relative, and fixed positioning](https://css-tricks.com/absolute-relative-fixed-positioining-how-do-they-differ/)
-
--}
-fixed : Value { provides | fixed : Supported }
-fixed =
-    Value "fixed"
-
-
-{-| A [`relative` `position`](https://developer.mozilla.org/en-US/docs/Web/CSS/position#Values).
-
-    position relative
-
-The default `position` value is [`static`](#static). See also [`position: sticky`](#sticky), and [the differences between absolute, relative, and fixed positioning](https://css-tricks.com/absolute-relative-fixed-positioining-how-do-they-differ/).
-
--}
-relative : Value { provides | relative : Supported }
-relative =
-    Value "relative"
-
-
-{-| A [`static` `position`](https://developer.mozilla.org/en-US/docs/Web/CSS/position#Values).
-
-    position static
-
-This is the default `position` value. See also [`position: sticky`](#sticky), and [the differences between absolute, relative, and fixed positioning](https://css-tricks.com/absolute-relative-fixed-positioining-how-do-they-differ/).
-
--}
-static : Value { provides | static : Supported }
-static =
-    Value "static"
-
-
-{-| A [`sticky` `position`](https://css-tricks.com/position-sticky-2/)
-
-    position sticky
-
-The default `position` value is [`static`](#static). See also [the differences between absolute, relative, and fixed positioning](https://css-tricks.com/absolute-relative-fixed-positioining-how-do-they-differ/).
-
--}
-sticky : Value { provides | sticky : Supported }
-sticky =
-    Value "sticky"
-
-
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------- INSETS --------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-
-
-{-| Sets the [`inset`](https://developer.mozilla.org/en-US/docs/Web/CSS/inset) property.
-
-`inset` sets the `top`, `bottom`, `left` and `right` properties.
-
-    inset (px 10) -- top, bottom, left and right are all 10px.
-
-    inset2 (pct 5) (pct 5) -- top & bottom = 5%, left & right = 5%
-
-    inset3 (px 20) (px 20) (px 20) -- top = 20px, left & right = 20px, bottom = 20px
-
-    inset4 (px 20) (px 20) (px 40) (px 20) -- top = 20px, right = 20px, bottom = 40px, left = 20px
-
--}
-inset :
-    BaseValue
-        (LengthSupported
-            { pct : Supported
-            , auto : Supported
-            }
-        )
-    -> Style
-inset (Value val) =
-    AppendProperty ("inset:" ++ val)
-
-
-{-| Sets the [`inset`](https://developer.mozilla.org/en-US/docs/Web/CSS/inset) property.
-
-`inset` sets the `top`, `bottom`, `left` and `right` properties.
-
-    inset (px 10) -- top, bottom, left and right are all 10px.
-
-    inset2 (pct 5) (pct 5) -- top & bottom = 5%, left & right = 5%
-
-    inset3 (px 20) (px 20) (px 20) -- top = 20px, left & right = 20px, bottom = 20px
-
-    inset4 (px 20) (px 20) (px 40) (px 20) -- top = 20px, right = 20px, bottom = 40px, left = 20px
-
--}
-inset2 :
-    Value
-        (LengthSupported
-            { pct : Supported
-            , auto : Supported
-            }
-        )
-    ->
-        Value
-            (LengthSupported
-                { pct : Supported
-                , auto : Supported
-                }
-            )
-    -> Style
-inset2 (Value valTopBottom) (Value valRightLeft) =
-    AppendProperty ("inset:" ++ valTopBottom ++ " " ++ valRightLeft)
-
-
-{-| Sets the [`inset`](https://developer.mozilla.org/en-US/docs/Web/CSS/inset) property.
-
-`inset` sets the `top`, `bottom`, `left` and `right` properties.
-
-    inset (px 10) -- top, bottom, left and right are all 10px.
-
-    inset2 (pct 5) (pct 5) -- top & bottom = 5%, left & right = 5%
-
-    inset3 (px 20) (px 20) (px 20) -- top = 20px, left & right = 20px, bottom = 20px
-
-    inset4 (px 20) (px 20) (px 40) (px 20) -- top = 20px, right = 20px, bottom = 40px, left = 20px
-
--}
-inset3 :
-    Value
-        (LengthSupported
-            { pct : Supported
-            , auto : Supported
-            }
-        )
-    ->
-        Value
-            (LengthSupported
-                { pct : Supported
-                , auto : Supported
-                }
-            )
-    ->
-        Value
-            (LengthSupported
-                { pct : Supported
-                , auto : Supported
-                }
-            )
-    -> Style
-inset3 (Value valTop) (Value valRightLeft) (Value valBottom) =
-    AppendProperty ("inset:" ++ valTop ++ " " ++ valRightLeft ++ " " ++ valBottom)
-
-
-{-| Sets the [`inset`](https://developer.mozilla.org/en-US/docs/Web/CSS/inset) property.
-
-`inset` sets the `top`, `bottom`, `left` and `right` properties.
-
-    inset (px 10) -- top, bottom, left and right are all 10px.
-
-    inset2 (pct 5) (pct 5) -- top & bottom = 5%, left & right = 5%
-
-    inset3 (px 20) (px 20) (px 20) -- top = 20px, left & right = 20px, bottom = 20px
-
-    inset4 (px 20) (px 20) (px 40) (px 20) -- top = 20px, right = 20px, bottom = 40px, left = 20px
-
--}
-inset4 :
-    Value
-        (LengthSupported
-            { pct : Supported
-            , auto : Supported
-            }
-        )
-    ->
-        Value
-            (LengthSupported
-                { pct : Supported
-                , auto : Supported
-                }
-            )
-    ->
-        Value
-            (LengthSupported
-                { pct : Supported
-                , auto : Supported
-                }
-            )
-    ->
-        Value
-            (LengthSupported
-                { pct : Supported
-                , auto : Supported
-                }
-            )
-    -> Style
-inset4 (Value valTop) (Value valRight) (Value valBottom) (Value valLeft) =
-    AppendProperty ("inset:" ++ valTop ++ " " ++ valRight ++ " " ++ valBottom ++ " " ++ valLeft)
-
-
-{-| Sets the [`top`](https://css-tricks.com/almanac/properties/t/top/) property.
-
-    top (px 10)
-
-    top (pct 50)
-
-    top auto
-
-    top zero
-
-If you need to use `top` as a CSS _value_ instead of as a _property_,
-for example in `vertical-align: top`, use [`top_`](#top_) instead of this.
-
--}
-top :
-    BaseValue
-        (LengthSupported
-            { pct : Supported
-            , auto : Supported
-            }
-        )
-    -> Style
-top (Value val) =
-    AppendProperty ("top:" ++ val)
-
-
-{-| Sets the [`bottom`](https://css-tricks.com/almanac/properties/b/bottom/) property.
-
-    bottom (px 10)
-
-    bottom (pct 50)
-
-    bottom auto
-
-    bottom zero
-
-If you need to use `bottom` as a CSS _value_ instead of as a _property_,
-for example in `vertical-align: bottom`, use [`bottom_`](#bottom_) instead of this.
-
--}
-bottom :
-    BaseValue
-        (LengthSupported
-            { pct : Supported
-            , auto : Supported
-            }
-        )
-    -> Style
-bottom (Value val) =
-    AppendProperty ("bottom:" ++ val)
-
-
-{-| Sets the [`left`](https://css-tricks.com/almanac/properties/l/left/) property.
-
-    left (px 10)
-
-    left (pct 50)
-
-    left auto
-
-    left zero
-
-If you need to use `left` as a CSS _value_ instead of as a _property_,
-for example in `float: left`, use [`left_`](#left_) instead of this.
-
--}
-left :
-    BaseValue
-        (LengthSupported
-            { pct : Supported
-            , auto : Supported
-            }
-        )
-    -> Style
-left (Value val) =
-    AppendProperty ("left:" ++ val)
-
-
-{-| Sets the [`right`](https://css-tricks.com/almanac/properties/r/right) property.
-
-    right (px 10)
-
-    right (pct 50)
-
-    right auto
-
-    right zero
-
-If you need to use `right` as a CSS _value_ instead of as a _property_,
-for example in `float: right`, use [`right_`](#right_) instead of this.
-
--}
-right :
-    BaseValue
-        (LengthSupported
-            { pct : Supported
-            , auto : Supported
-            }
-        )
-    -> Style
-right (Value val) =
-    AppendProperty ("right:" ++ val)
-
-
-{-| Sets the [`inset-block`](https://css-tricks.com/almanac/properties/i/inset-block/) property.
-
-`inset-block` sets the `inset-block-start` and `inset-block-end` properties.
-
-    insetBlock (px 10) -- block start and block end are both 10px.
-
-    insetBlock2 (pct 5) (pct 5) -- block start = 5%, block end = 5%
-
--}
-insetBlock :
-    BaseValue
-        (LengthSupported
-            { pct : Supported
-            , auto : Supported
-            }
-        )
-    -> Style
-insetBlock (Value val) =
-    AppendProperty ("inset-block:" ++ val)
-
-
-{-| Sets the [`inset-block`](https://css-tricks.com/almanac/properties/i/inset-block/) property.
-
-`inset-block` sets the `inset-block-start` and `inset-block-end` properties.
-
-    insetBlock (px 10) -- block start and block end are both 10px.
-
-    insetBlock2 (pct 5) (pct 5) -- block start = 5%, block end = 5%
-
--}
-insetBlock2 :
-    Value
-        (LengthSupported
-            { pct : Supported
-            , auto : Supported
-            }
-        )
-    ->
-        Value
-            (LengthSupported
-                { pct : Supported
-                , auto : Supported
-                }
-            )
-    -> Style
-insetBlock2 (Value valStart) (Value valEnd) =
-    AppendProperty ("inset-block:" ++ valStart ++ " " ++ valEnd)
-
-
-{-| Sets the [`inset-inline`](https://css-tricks.com/almanac/properties/i/inset-inline) property.
-
-`inset-inline` sets the `inset-inline-start` and `inset-inline-end` properties.
-
-    insetInline (px 10) -- inline start and inline end are both 10px.
-
-    insetInline2 (pct 5) (pct 5) -- inline start = 5%, inline end = 5%
-
--}
-insetInline :
-    BaseValue
-        (LengthSupported
-            { pct : Supported
-            , auto : Supported
-            }
-        )
-    -> Style
-insetInline (Value val) =
-    AppendProperty ("inset-inline:" ++ val)
-
-
-{-| Sets the [`inset-inline`](https://css-tricks.com/almanac/properties/i/inset-inline) property.
-
-`inset-inline` sets the `inset-inline-start` and `inset-inline-end` properties.
-
-    insetInline (px 10) -- inline start and inline end are both 10px.
-
-    insetInline2 (pct 5) (pct 5) -- inline start = 5%, inline end = 5%
-
--}
-insetInline2 :
-    Value
-        (LengthSupported
-            { pct : Supported
-            , auto : Supported
-            }
-        )
-    ->
-        Value
-            (LengthSupported
-                { pct : Supported
-                , auto : Supported
-                }
-            )
-    -> Style
-insetInline2 (Value valStart) (Value valEnd) =
-    AppendProperty ("inset-inline:" ++ valStart ++ " " ++ valEnd)
-
-
-{-| Sets the [`inset-block-start`](https://developer.mozilla.org/en-US/docs/Web/CSS/inset-block-start) property.
-
-    insetBlockStart (px 10)
-
-    insetBlockStart (pct 50)
-
-    insetBlockStart auto
-
-    insetBlockStart zero
-
--}
-insetBlockStart :
-    BaseValue
-        (LengthSupported
-            { pct : Supported
-            , auto : Supported
-            }
-        )
-    -> Style
-insetBlockStart (Value val) =
-    AppendProperty ("inset-block-start:" ++ val)
-
-
-{-| Sets the [`inset-block-end`](https://developer.mozilla.org/en-US/docs/Web/CSS/inset-block-end) property.
-
-    insetBlockEnd (px 10)
-
-    insetBlockEnd (pct 50)
-
-    insetBlockEnd auto
-
-    insetBlockEnd zero
-
--}
-insetBlockEnd :
-    BaseValue
-        (LengthSupported
-            { pct : Supported
-            , auto : Supported
-            }
-        )
-    -> Style
-insetBlockEnd (Value val) =
-    AppendProperty ("inset-block-end:" ++ val)
-
-
-{-| Sets the [`inset-inline-start`](https://developer.mozilla.org/en-US/docs/Web/CSS/inset-inline-start) property.
-
-    insetInlineStart (px 10)
-
-    insetInlineStart (pct 50)
-
-    insetInlineStart auto
-
-    insetInlineStart zero
-
--}
-insetInlineStart :
-    BaseValue
-        (LengthSupported
-            { pct : Supported
-            , auto : Supported
-            }
-        )
-    -> Style
-insetInlineStart (Value val) =
-    AppendProperty ("inset-inline-start:" ++ val)
-
-
-{-| Sets the [`inset-inline-end`](https://developer.mozilla.org/en-US/docs/Web/CSS/inset-inline-end) property.
-
-    insetInlineEnd (px 10)
-
-    insetInlineEnd (pct 50)
-
-    insetInlineEnd auto
-
-    insetInlineEnd zero
-
--}
-insetInlineEnd :
-    BaseValue
-        (LengthSupported
-            { pct : Supported
-            , auto : Supported
-            }
-        )
-    -> Style
-insetInlineEnd (Value val) =
-    AppendProperty ("inset-inline-end:" ++ val)
-
-
-{-| Sets [`z-index`](https://css-tricks.com/almanac/properties/z/z-index/)
-
-    zIndex (int 10)
-
-    zIndex auto
-
-**NOTE:** Z-index is not as simple as it looks! Make sure to read about [stacking contexts](https://css-tricks.com/css-stacking-contexts/) if you're not already familiar with them.
-
--}
-zIndex :
-    BaseValue
-        { int : Supported
-        , auto : Supported
-        }
-    -> Style
-zIndex (Value val) =
-    AppendProperty ("z-index:" ++ val)
-
-
-
--- BOX SIZING --
-
-
-{-| Sets [`box-sizing`](https://css-tricks.com/almanac/properties/b/box-sizing/) property.
-
-    boxSizing contentBox
-
-    boxSizing borderBox
-
--}
-boxSizing :
-    BaseValue
-        { contentBox : Supported
-        , borderBox : Supported
-        }
-    -> Style
-boxSizing (Value value) =
-    AppendProperty ("box-sizing:" ++ value)
-
-
-
-{-| A [`:read-write`](https://developer.mozilla.org/en-US/docs/Web/CSS/:read-write)
-[pseudo-class](https://css-tricks.com/pseudo-class-selectors/).
-
-    readWrite
-        [ backgroundColor (rgb 0 50 150)
-        ]
-
--}
-readWrite : List Style -> Style
-readWrite =
-    pseudoClass "read-write"
-
-
-{-| A [`:required`](https://developer.mozilla.org/en-US/docs/Web/CSS/:required)
-[pseudo-class](https://css-tricks.com/pseudo-class-selectors/).
-
-    required
-        [ border (px 2) solid (rgb 100 100 100)
-        ]
-
--}
-required : List Style -> Style
-required =
-    pseudoClass "required"
-
-
-{-| A [`:root`](https://developer.mozilla.org/en-US/docs/Web/CSS/:root)
-[pseudo-class](https://css-tricks.com/pseudo-class-selectors/).
-
-    root
-        [ backgroundColor (rgb 0 200 200)
-        ]
-
--}
-root : List Style -> Style
-root =
-    pseudoClass "root"
-
-
-{-| A [`:scope`](https://developer.mozilla.org/en-US/docs/Web/CSS/:scope)
-[pseudo-class](https://css-tricks.com/pseudo-class-selectors/).
-
-    scope
-        [ backgroundColor (rgb 0 200 200)
-        ]
-
--}
-scope : List Style -> Style
-scope =
-    pseudoClass "scope"
-
-
-{-| A [`:target`](https://developer.mozilla.org/en-US/docs/Web/CSS/:target)
-[pseudo-class](https://css-tricks.com/pseudo-class-selectors/).
-
-    target
-        [ fontWeight bold
-        , border3 (px 2) dotted (rgb 255 0 0)
-        ]
-
--}
-target : List Style -> Style
-target =
-    pseudoClass "target"
-
-
-{-| A [`:valid`](https://developer.mozilla.org/en-US/docs/Web/CSS/:valid)
-[pseudo-class](https://css-tricks.com/pseudo-class-selectors/).
-
-    valid
-        [ border3 (px 1) solid (rgb 0 255 0)
-        ]
-
--}
-valid : List Style -> Style
-valid =
-    pseudoClass "valid"
-
-
-{-| A [`:visited`](https://developer.mozilla.org/en-US/docs/Web/CSS/:visited)
-[pseudo-class](https://css-tricks.com/pseudo-class-selectors/).
-
-    visited
-        [ color (rgb 150 0 255)
-        ]
-
--}
-visited : List Style -> Style
-visited =
-    pseudoClass "visited"
-
-
-
--- PSEUDO-ELEMENTS--
-
-
-{-| Define a custom [pseudo-element](https://developer.mozilla.org/en-US/docs/Web/CSS/Pseudo-elements).
-
-    textarea
-        [ css [ pseudoElement "-webkit-scrollbar" [ display none ] ] ]
-        []
-
-...outputs
-
-    <textarea class="d84ff7"></textarea>
-
-    <style>
-        .d84ff7::-webkit-scrollbar {
-            display: none;
-        }
-    </style>
-
--}
-pseudoElement : String -> List Style -> Style
-pseudoElement element =
-    Preprocess.WithPseudoElement (Structure.PseudoElement element)
-
-
-{-| An [`::after`](https://css-tricks.com/almanac/selectors/a/after-and-before/)
-[pseudo-element](https://developer.mozilla.org/en-US/docs/Web/CSS/Pseudo-elements).
-
-    div [ after [ content "hi!" ] ]
-
---TODO : Introduce a way to do [`content`](https://developer.mozilla.org/en-US/docs/Web/CSS/content) - lots of options there, not just text. Also it's overloaded with `flexBasis content`.
-
--}
-after : List Style -> Style
-after =
-    pseudoElement "after"
-
-
-{-| A [`::before`](https://css-tricks.com/almanac/selectors/a/after-and-before/)
-[pseudo-element](https://developer.mozilla.org/en-US/docs/Web/CSS/Pseudo-elements).
-
-    div [ before [ content "hi!" ] ]
-
---TODO : Introduce a way to do [`content`](https://developer.mozilla.org/en-US/docs/Web/CSS/content) - lots of options there, not just text. Also it's overloaded with `flexBasis content`.
-
--}
-before : List Style -> Style
-before =
-    pseudoElement "before"
-
-
-{-| A [`::backdrop`](https://developer.mozilla.org/en-US/docs/Web/CSS/::backdrop)
-[pseudo-element](https://developer.mozilla.org/en-US/docs/Web/CSS/Pseudo-elements).
-
-    backdrop
-        [ background (rgba 255 0 0 0.25)
-        ]
-
--}
-backdrop : List Style -> Style
-backdrop =
-    pseudoElement "backdrop"
-
-
-{-| A [`::cue`](https://developer.mozilla.org/en-US/docs/Web/CSS/::cue)
-[pseudo-element](https://developer.mozilla.org/en-US/docs/Web/CSS/Pseudo-elements).
-
-    cue
-        [ color (rgba 255 255 0 1)
-        , fontWeight (int 600)
-        ]
-
--}
-cue : List Style -> Style
-cue =
-    pseudoElement "cue"
-
-
-{-| A [`::marker`](https://developer.mozilla.org/en-US/docs/Web/CSS/::marker)
-[pseudo-element](https://developer.mozilla.org/en-US/docs/Web/CSS/Pseudo-elements).
-
-    marker
-        [ color (rgba 255 255 0 1)
-        , fontWeight (int 600)
-        ]
-
--}
-marker : List Style -> Style
-marker =
-    pseudoElement "marker"
-
-
-{-| A [`::placeholder`](https://developer.mozilla.org/en-US/docs/Web/CSS/::placeholder)
-[pseudo-element](https://developer.mozilla.org/en-US/docs/Web/CSS/Pseudo-elements).
-
-Be careful when using placeholders as they can negatively impact accessibility.
-
-    placeholder
-        [ opacity (num 1) <| important
-        , color (rgb 90 90 90)
-        , fontWeight (int 400)
-        ]
-
-]
-
--}
-placeholder : List Style -> Style
-placeholder =
-    pseudoElement "placeholder"
-
-
-{-| A [`::selection`](https://developer.mozilla.org/en-US/docs/Web/CSS/::selection)
-[pseudo-element](https://developer.mozilla.org/en-US/docs/Web/CSS/Pseudo-elements).
-
-    selection
-        [ backgroundColor (rgb 200 140 15)
-        ]
-
--}
-selection : List Style -> Style
-selection =
-    pseudoElement "selection"
-
-
-
--- BOX SHADOW --
-
-
-{-| Configuration for [`boxShadow`](#boxShadow).
--}
-type alias BoxShadowConfig =
-    { offsetX :
-        Value
-            (LengthSupported
-                { pct : Supported
-                }
-            )
-    , offsetY :
-        Value
-            (LengthSupported
-                { pct : Supported
-                }
-            )
-    , blurRadius :
-        Maybe
-            (Value
-                (LengthSupported
-                    { pct : Supported
-                    }
-                )
-            )
-    , spreadRadius :
-        Maybe
-            (Value
-                (LengthSupported
-                    { pct : Supported
-                    }
-                )
-            )
-    , color :
-        Maybe (Value Color)
-    , inset : Bool
-    }
-
-
-{-| Default [`boxShadow`](#boxShadow) configuration.
-
-It is equivalent to the following CSS:
-
-    box-shadow: 0 0;
-
--}
-defaultBoxShadow : BoxShadowConfig
-defaultBoxShadow =
-    { offsetX = zero
-    , offsetY = zero
-    , blurRadius = Nothing
-    , spreadRadius = Nothing
-    , color = Nothing
-    , inset = False
-    }
-
-
-{-| The [`box-shadow`](https://css-tricks.com/almanac/properties/b/box-shadow/) property.
-
-    boxShadow initial
-
-    boxShadow none
-
-For defining shadows look at [`boxShadows`](#boxShadows).
-
--}
-boxShadow : BaseValue { none : Supported } -> Style
-boxShadow (Value val) =
-    AppendProperty ("box-shadow:" ++ val)
-
-
-{-| Sets [`box-shadow`](https://css-tricks.com/almanac/properties/b/box-shadow/).
-
-    boxShadows [] -- "box-shadow: none"
-
-    -- "box-shadow: 3px 5px #aabbcc"
-    button
-        [ css
-            [ boxShadows
-                [ { defaultBoxShadow
-                    | offsetX = px 3
-                    , offsetY = px 5
-                    , color = Just (hex "#aabbcc")
-                  }
-                ]
-            ]
-        ]
-        [ text "Zap!" ]
-
--}
-boxShadows : List BoxShadowConfig -> Style
-boxShadows configs =
-    let
-        value =
-            case configs of
-                [] ->
-                    "none"
-
-                _ ->
-                    configs
-                        |> List.map boxShadowConfigToString
-                        |> String.join ", "
-    in
-    AppendProperty ("box-shadow:" ++ value)
-
-
-boxShadowConfigToString : BoxShadowConfig -> String
-boxShadowConfigToString config =
-    let
-        (Value offsetX) =
-            config.offsetX
-
-        (Value offsetY) =
-            config.offsetY
-
-        blurRadius =
-            case config.blurRadius of
-                Just (Value value) ->
-                    " " ++ value
-
-                Nothing ->
-                    case config.spreadRadius of
-                        Just _ ->
-                            " 0"
-
-                        Nothing ->
-                            ""
-
-        spreadRadius =
-            case config.spreadRadius of
-                Just (Value value) ->
-                    " " ++ value
-
-                Nothing ->
-                    ""
-
-        insetStr =
-            if config.inset then
-                "inset "
-
-            else
-                ""
-
-        colorVal =
-            config.color
-                |> Maybe.map (unpackValue >> (++) " ")
-                |> Maybe.withDefault ""
-    in
-    insetStr ++ offsetX ++ " " ++ offsetY ++ blurRadius ++ spreadRadius ++ colorVal
-
-
-
--- TEXT SHADOW --
-
-
-{-| Configuration for [`textShadow`](#textShadow).
--}
-type alias TextShadowConfig =
-    { offsetX :
-        Value
-            (LengthSupported
-                { pct : Supported
-                }
-            )
-    , offsetY :
-        Value
-            (LengthSupported
-                { pct : Supported
-                }
-            )
-    , blurRadius :
-        Maybe
-            (Value
-                (LengthSupported
-                    { pct : Supported
-                    }
-                )
-            )
-    , color : Maybe (Value Color)
-    }
-
-
-{-| Default [`textShadow`](#textShadow) configuration.
-
-It is equivalent to the following CSS:
-
-    text-shadow: 0 0;
-
--}
-defaultTextShadow : TextShadowConfig
-defaultTextShadow =
-    { offsetX = zero
-    , offsetY = zero
-    , blurRadius = Nothing
-    , color = Nothing
-    }
-
-
-{-| Sets [`text-shadow`](https://css-tricks.com/almanac/properties/t/text-shadow/).
-
-    textShadow [] -- "text-shadow: none"
-
-    -- "text-shadow: 3px 5px #aabbcc"
-    span
-        [ css
-            [ textShadow
-                [ { defaultTextShadow
-                    | offsetX = px 3
-                    , offsetY = px 5
-                    , color = Just (hex "#aabbcc")
-                  }
-                ]
-            ]
-        ]
-        [ text "Zap!" ]
-
--}
-textShadow : List TextShadowConfig -> Style
-textShadow configs =
-    let
-        values =
-            case configs of
-                [] ->
-                    "none"
-
-                _ ->
-                    configs
-                        |> List.map textShadowConfigToString
-                        |> String.join ","
-    in
-    AppendProperty ("text-shadow:" ++ values)
-
-
-textShadowConfigToString : TextShadowConfig -> String
-textShadowConfigToString config =
-    let
-        offsetX =
-            unpackValue config.offsetX
-
-        offsetY =
-            unpackValue config.offsetY
-
-        blurRadius =
-            config.blurRadius
-                |> Maybe.map (unpackValue >> (++) " ")
-                |> Maybe.withDefault ""
-
-        colorSetting =
-            config.color
-                |> Maybe.map (unpackValue >> (++) " ")
-                |> Maybe.withDefault ""
-    in
-    offsetX ++ " " ++ offsetY ++ blurRadius ++ colorSetting
-
-
-
--- CALC --
-
-
-{-| The css [`calc`](https://css-tricks.com/a-couple-of-use-cases-for-calc) function.
-
-    almostPct100 =
-        calc (pct 100) (minus (px 2))
-
-    -- The following compiles to: calc(100vh - (2px + 2rem))
-    screenMinusBorderAndFooter =
-        calc (vh 100) (minus (calc (px 2) (plus (rem 2))))
-
-    myWidth =
-        width almostPct100
-
-    myHeight =
-        height screenMinusBorderAndFooter
-
-**CAUTION:** `calc` can easily be used to create invalid CSS values! For example,
-`zIndex (calc (pct 100) (minus (px 5)))` compiles to `z-index: calc(100% - 5px);`
-which is invalid. According to the spec, `calc` may return values that have no
-relation to its arguments, so unfortunately there's not much `elm-css` can do
-to make `calc` more reliable. Use with caution!
-
--}
-calc :
-    Value
-        (LengthSupported
-            { pct : Supported
+        (WidthSupported
+            { none : Supported
+            , content : Supported
             , num : Supported
-            , int : Supported
             }
         )
-    -> CalcOperation
-    -> Value { provides | calc : Supported }
-calc (Value head) (CalcOperation operation) =
-    Value
-        ("calc("
-            ++ getCalcExpression head
-            ++ operation
-            ++ ")"
-        )
+    -> Style
+flex (Value growOrBasis) =
+    AppendProperty ("flex:" ++ growOrBasis)
 
 
-{-| Either [`plus`](#plus) or [`minus`](#minus).
+{-| The [`flex`](https://css-tricks.com/almanac/properties/f/flex/) shorthand property.
 
-See [`calc`](#calc) for how to use this.
+    flex2 zero auto
 
 -}
-type CalcOperation
-    = CalcOperation String
-
-
-getCalcExpression : String -> String
-getCalcExpression str =
-    if String.startsWith "calc(" str then
-        String.dropLeft 4 str
-
-    else
-        str
-
-
-{-| Use with [`calc`](#calc) to subtract one value from another.
-
-    calc (pct 100) (minus (px 2))
-    -- calc: (100% - 2px)
-
--}
-minus :
-    Value
-        (LengthSupported
-            { pct : Supported
-            , num : Supported
-            , int : Supported
-            }
-        )
-    -> CalcOperation
-minus (Value second) =
-    -- The calc `-` operator MUST be surrounded by whitespace.
-    CalcOperation (" - " ++ getCalcExpression second)
-
-
-{-| Use with [`calc`](#calc) to add one numeric value to another.
-
-    calc (pct 100) (plus (px 2))
-    -- calc: (100% + 2px)
-
--}
-plus :
-    Value
-        (LengthSupported
-            { pct : Supported
-            , num : Supported
-            , int : Supported
-            }
-        )
-    -> CalcOperation
-plus (Value second) =
-    -- The calc `+` operator MUST be surrounded by whitespace.
-    CalcOperation (" + " ++ getCalcExpression second)
-
-
-{-| Use with [`calc`](#calc) to multiply a value by a unitless number.
-
-    calc (pct 100) (times (int 2))
-    -- calc: (100% * 2px)
-
--}
-times :
+flex2 :
     Value
         { num : Supported
-        , int : Supported
         , zero : Supported
+        , calc : Supported
         }
-    -> CalcOperation
-times (Value second) =
-    -- The calc `*` operator does not need to be surrounded by whitespace.
-    CalcOperation (" * " ++ getCalcExpression second)
+    ->
+        Value
+            (WidthSupported
+                { content : Supported
+                , num : Supported
+                }
+            )
+    -> Style
+flex2 (Value grow) (Value shrinkOrBasis) =
+    AppendProperty ("flex:" ++ grow ++ " " ++ shrinkOrBasis)
 
 
-{-| Use with [`calc`](#calc) to divide a value by a unitless number.
+{-| The [`flex`](https://css-tricks.com/almanac/properties/f/flex/) shorthand property.
 
-    calc (pct 100) (dividedBy (int 2))
-    -- calc: (100% / 2px)
+    flex3 (num 1) zero (pct 50)
 
 -}
-dividedBy :
+flex3 :
     Value
         { num : Supported
-        , int : Supported
         , zero : Supported
+        , calc : Supported
         }
-    -> CalcOperation
-dividedBy (Value second) =
-    -- The calc `/` operator does not need to be surrounded by whitespace.
-    CalcOperation (" / " ++ getCalcExpression second)
+    ->
+        Value
+            { num : Supported
+            , zero : Supported
+            , calc : Supported
+            }
+    -> Value (WidthSupported { content : Supported })
+    -> Style
+flex3 (Value grow) (Value shrink) (Value basis) =
+    AppendProperty ("flex:" ++ grow ++ " " ++ shrink ++ " " ++ basis)
 
 
+{-| Sets [`flex-direction`](https://css-tricks.com/almanac/properties/f/flex-direction/).
 
--- DISPLAY --
-
-
--- ALIGN-ITEMS VALUES --
-
-
-{-| The `flex-start` value used by [`alignItems`](#alignItems),
-[`justifyContent`](#justifyContent),
-and [`alignContent`](#alignContent).
-
-    alignItems flexStart
-
-    justifyContent flexStart
-
-    alignContent flexStart
+    flexDirection column
 
 -}
-flexStart : Value { provides | flexStart : Supported }
-flexStart =
-    Value "flex-start"
+flexDirection :
+    BaseValue
+        { row : Supported
+        , rowReverse : Supported
+        , column : Supported
+        , columnReverse : Supported
+        }
+    -> Style
+flexDirection (Value val) =
+    AppendProperty ("flex-direction:" ++ val)
 
 
-{-| The `flex-end` value used by [`alignItems`](#alignItems),
-[`justifyContent`](#justifyContent),
-and [`alignContent`](#alignContent).
+{-| Sets [`flex-basis`](https://css-tricks.com/almanac/properties/f/flex-basis/).
 
-    alignItems flexEnd
+    flexBasis (em 10)
 
-    justifyContent flexEnd
+    flexBasis (px 3)
 
-    alignContent flexEnd
+    flexBasis (pct 100)
 
--}
-flexEnd : Value { provides | flexEnd : Supported }
-flexEnd =
-    Value "flex-end"
-
-
-{-| -}
-selfStart : Value { provides | selfStart : Supported }
-selfStart =
-    Value "self-start"
-
-
-{-| -}
-selfEnd : Value { provides | selfEnd : Supported }
-selfEnd =
-    Value "self-end"
-
-
-{-| The `space-between` value used by [`justifyContent`](#justifyContent)
-and [`alignContent`](#alignContent).
-
-    justifyContent spaceBetween
-
-    alignContent spaceBetween
+    flexBasis auto
 
 -}
-spaceBetween : Value { provides | spaceBetween : Supported }
-spaceBetween =
-    Value "space-between"
+flexBasis : BaseValue (WidthSupported { content : Supported }) -> Style
+flexBasis (Value val) =
+    AppendProperty ("flex-basis:" ++ val)
 
 
-{-| The `space-around` value used by [`justifyContent`](#justifyContent)
-and [`alignContent`](#alignContent).
+{-| Sets [`flex-grow`](https://css-tricks.com/almanac/properties/f/flex-grow/).
 
-    justifyContent spaceAround
+    flexGrow (num 3)
 
-    alignContent spaceAround
-
--}
-spaceAround : Value { provides | spaceAround : Supported }
-spaceAround =
-    Value "space-around"
-
-
-{-| Distribute items evenly, with an equal size space between each element and
-the start and end.
-
-    justifyContent spaceEvenly
+    flexGrow (num 0.6)
 
 -}
-spaceEvenly : Value { provides | spaceEvenly : Supported }
-spaceEvenly =
-    Value "space-evenly"
+flexGrow :
+    BaseValue
+        { num : Supported
+        , zero : Supported
+        , calc : Supported
+        }
+    -> Style
+flexGrow (Value val) =
+    AppendProperty ("flex-grow:" ++ val)
 
 
-{-| The `first baseline` value used for properties such as [`alignContent`](#alignContent),
-[`alignItems`](#alignItems),
-and [`alignSelf`](#alignSelf).
+{-| Sets [`flex-shrink`](https://css-tricks.com/almanac/properties/f/flex-shrink/).
 
-    alignItems firstBaseline
+    flexShrink (num 2)
 
--}
-firstBaseline : Value { provides | firstBaseline : Supported }
-firstBaseline =
-    Value "first baseline"
-
-
-{-| The `last baseline` value used for properties such as [`alignContent`](#alignContent),
-[`alignItems`](#alignItems),
-and [`alignSelf`](#alignSelf).
-
-    alignItems lastBaseline
+    flexShrink (num 0.6)
 
 -}
-lastBaseline : Value { provides | lastBaseline : Supported }
-lastBaseline =
-    Value "last baseline"
+flexShrink :
+    BaseValue
+        { num : Supported
+        , zero : Supported
+        , calc : Supported
+        }
+    -> Style
+flexShrink (Value val) =
+    AppendProperty ("flex-shrink:" ++ val)
 
 
-{-| The `safe` value used for properties such as [`alignContent2`](#alignContent2).
+{-| Sets [`flex-wrap`](https://css-tricks.com/almanac/properties/f/flex-wrap/).
 
-    alignContent2 safe center
+    flexWrap wrap
 
--}
-safe : Value { provides | safe : Supported }
-safe =
-    Value "safe"
+    flexWrap wrapReverse
 
-
-{-| The `unsafe` value used for properties such as [`alignContent2`](#alignContent2).
-
-    alignContent2 unsafe center
-
--}
-unsafe : Value { provides | unsafe : Supported }
-unsafe =
-    Value "unsafe"
-
-
-{-| The `legacy` value used for properties such as [`justifyItems`](#justifyItems).
-
-    justifyItems legacy
+    flexWrap nowrap
 
 -}
-legacy : Value { provides | legacy : Supported }
-legacy =
-    Value "legacy"
+flexWrap :
+    BaseValue
+        { nowrap : Supported
+        , wrap : Supported
+        , wrapReverse : Supported
+        }
+    -> Style
+flexWrap (Value val) =
+    AppendProperty ("flex-wrap:" ++ val)
 
 
-{-| The `legacy left` value used for properties such as [`justifyItems`](#justifyItems).
+{-| The [`flex-flow`](https://css-tricks.com/almanac/properties/f/flex-flow/) shorthand property.
 
-    justifyItems legacyLeft
+    flexFlow rowReverse
 
--}
-legacyLeft : Value { provides | legacyLeft : Supported }
-legacyLeft =
-    Value "legacy left"
+    flexFlow wrap
 
+    flexFlow inherit
 
-{-| The `legacy right` value used for properties such as [`justifyItems`](#justifyItems).
-
-    justifyItems legacyRight
-
--}
-legacyRight : Value { provides | legacyRight : Supported }
-legacyRight =
-    Value "legacy right"
-
-
-{-| The `legacy center` value used for properties such as [`justifyItems`](#justifyItems).
-
-    justifyItems legacyCenter
+    flexFlow2 column wrapReverse
 
 -}
-legacyCenter : Value { provides | legacyCenter : Supported }
-legacyCenter =
-    Value "legacy center"
+flexFlow :
+    BaseValue
+        { row : Supported
+        , rowReverse : Supported
+        , column : Supported
+        , columnReverse : Supported
+        , nowrap : Supported
+        , wrap : Supported
+        , wrapReverse : Supported
+        }
+    -> Style
+flexFlow (Value directionOrWrapping) =
+    AppendProperty ("flex-flow:" ++ directionOrWrapping)
 
 
+{-| The [`flex-flow`](https://css-tricks.com/almanac/properties/f/flex-flow/) shorthand property.
 
--- FLEXBOX --
+    flexFlow rowReverse
+
+    flexFlow wrap
+
+    flexFlow inherit
+
+    flexFlow2 column wrapReverse
+
+-}
+flexFlow2 :
+    Value
+        { row : Supported
+        , rowReverse : Supported
+        , column : Supported
+        , columnReverse : Supported
+        }
+    ->
+        Value
+            { nowrap : Supported
+            , wrap : Supported
+            , wrapReverse : Supported
+            }
+    -> Style
+flexFlow2 (Value direction_) (Value wrapping) =
+    AppendProperty ("flex-flow:" ++ direction_ ++ " " ++ wrapping)
 
 
 {-| Sets [`align-content`](https://css-tricks.com/almanac/properties/a/align-content/).
@@ -9299,143 +9190,6 @@ placeSelf2 (Value alignSelfValue) (Value justifySelfValue) =
     AppendProperty ("place-self:" ++ alignSelfValue ++ " " ++ justifySelfValue)
 
 
-{-| Sets [`flex-basis`](https://css-tricks.com/almanac/properties/f/flex-basis/).
-
-    flexBasis (em 10)
-
-    flexBasis (px 3)
-
-    flexBasis (pct 100)
-
-    flexBasis auto
-
--}
-flexBasis : BaseValue (WidthSupported { content : Supported }) -> Style
-flexBasis (Value val) =
-    AppendProperty ("flex-basis:" ++ val)
-
-
-{-| Sets [`flex-grow`](https://css-tricks.com/almanac/properties/f/flex-grow/).
-
-    flexGrow (num 3)
-
-    flexGrow (num 0.6)
-
--}
-flexGrow :
-    BaseValue
-        { num : Supported
-        , zero : Supported
-        , calc : Supported
-        }
-    -> Style
-flexGrow (Value val) =
-    AppendProperty ("flex-grow:" ++ val)
-
-
-{-| Sets [`flex-shrink`](https://css-tricks.com/almanac/properties/f/flex-shrink/).
-
-    flexShrink (num 2)
-
-    flexShrink (num 0.6)
-
--}
-flexShrink :
-    BaseValue
-        { num : Supported
-        , zero : Supported
-        , calc : Supported
-        }
-    -> Style
-flexShrink (Value val) =
-    AppendProperty ("flex-shrink:" ++ val)
-
-
-{-| The [`flex`](https://css-tricks.com/almanac/properties/f/flex/) shorthand property.
-
-    flex none
-
-    flex auto
-
-    flex (num 1)
-
--}
-flex :
-    BaseValue
-        (WidthSupported
-            { none : Supported
-            , content : Supported
-            , num : Supported
-            }
-        )
-    -> Style
-flex (Value growOrBasis) =
-    AppendProperty ("flex:" ++ growOrBasis)
-
-
-{-| The [`flex`](https://css-tricks.com/almanac/properties/f/flex/) shorthand property.
-
-    flex2 zero auto
-
--}
-flex2 :
-    Value
-        { num : Supported
-        , zero : Supported
-        , calc : Supported
-        }
-    ->
-        Value
-            (WidthSupported
-                { content : Supported
-                , num : Supported
-                }
-            )
-    -> Style
-flex2 (Value grow) (Value shrinkOrBasis) =
-    AppendProperty ("flex:" ++ grow ++ " " ++ shrinkOrBasis)
-
-
-{-| The [`flex`](https://css-tricks.com/almanac/properties/f/flex/) shorthand property.
-
-    flex3 (num 1) zero (pct 50)
-
--}
-flex3 :
-    Value
-        { num : Supported
-        , zero : Supported
-        , calc : Supported
-        }
-    ->
-        Value
-            { num : Supported
-            , zero : Supported
-            , calc : Supported
-            }
-    -> Value (WidthSupported { content : Supported })
-    -> Style
-flex3 (Value grow) (Value shrink) (Value basis) =
-    AppendProperty ("flex:" ++ grow ++ " " ++ shrink ++ " " ++ basis)
-
-
-{-| Sets [`flex-direction`](https://css-tricks.com/almanac/properties/f/flex-direction/).
-
-    flexDirection column
-
--}
-flexDirection :
-    BaseValue
-        { row : Supported
-        , rowReverse : Supported
-        , column : Supported
-        , columnReverse : Supported
-        }
-    -> Style
-flexDirection (Value val) =
-    AppendProperty ("flex-direction:" ++ val)
-
-
 {-| The `row` [`flex-direction` value](https://developer.mozilla.org/en-US/docs/Web/CSS/flex-direction#Values).
 
     flexDirection row
@@ -9466,24 +9220,169 @@ columnReverse =
     Value "column-reverse"
 
 
-{-| Sets [`flex-wrap`](https://css-tricks.com/almanac/properties/f/flex-wrap/).
+{-| The `flex-start` value used by [`alignItems`](#alignItems),
+[`justifyContent`](#justifyContent),
+and [`alignContent`](#alignContent).
 
-    flexWrap wrap
+    alignItems flexStart
 
-    flexWrap wrapReverse
+    justifyContent flexStart
 
-    flexWrap nowrap
+    alignContent flexStart
 
 -}
-flexWrap :
-    BaseValue
-        { nowrap : Supported
-        , wrap : Supported
-        , wrapReverse : Supported
-        }
-    -> Style
-flexWrap (Value val) =
-    AppendProperty ("flex-wrap:" ++ val)
+flexStart : Value { provides | flexStart : Supported }
+flexStart =
+    Value "flex-start"
+
+
+{-| The `flex-end` value used by [`alignItems`](#alignItems),
+[`justifyContent`](#justifyContent),
+and [`alignContent`](#alignContent).
+
+    alignItems flexEnd
+
+    justifyContent flexEnd
+
+    alignContent flexEnd
+
+-}
+flexEnd : Value { provides | flexEnd : Supported }
+flexEnd =
+    Value "flex-end"
+
+
+{-| -}
+selfStart : Value { provides | selfStart : Supported }
+selfStart =
+    Value "self-start"
+
+
+{-| -}
+selfEnd : Value { provides | selfEnd : Supported }
+selfEnd =
+    Value "self-end"
+
+
+{-| The `space-between` value used by [`justifyContent`](#justifyContent)
+and [`alignContent`](#alignContent).
+
+    justifyContent spaceBetween
+
+    alignContent spaceBetween
+
+-}
+spaceBetween : Value { provides | spaceBetween : Supported }
+spaceBetween =
+    Value "space-between"
+
+
+{-| The `space-around` value used by [`justifyContent`](#justifyContent)
+and [`alignContent`](#alignContent).
+
+    justifyContent spaceAround
+
+    alignContent spaceAround
+
+-}
+spaceAround : Value { provides | spaceAround : Supported }
+spaceAround =
+    Value "space-around"
+
+
+{-| Distribute items evenly, with an equal size space between each element and
+the start and end.
+
+    justifyContent spaceEvenly
+
+-}
+spaceEvenly : Value { provides | spaceEvenly : Supported }
+spaceEvenly =
+    Value "space-evenly"
+
+
+{-| The `first baseline` value used for properties such as [`alignContent`](#alignContent),
+[`alignItems`](#alignItems),
+and [`alignSelf`](#alignSelf).
+
+    alignItems firstBaseline
+
+-}
+firstBaseline : Value { provides | firstBaseline : Supported }
+firstBaseline =
+    Value "first baseline"
+
+
+{-| The `last baseline` value used for properties such as [`alignContent`](#alignContent),
+[`alignItems`](#alignItems),
+and [`alignSelf`](#alignSelf).
+
+    alignItems lastBaseline
+
+-}
+lastBaseline : Value { provides | lastBaseline : Supported }
+lastBaseline =
+    Value "last baseline"
+
+
+{-| The `safe` value used for properties such as [`alignContent2`](#alignContent2).
+
+    alignContent2 safe center
+
+-}
+safe : Value { provides | safe : Supported }
+safe =
+    Value "safe"
+
+
+{-| The `unsafe` value used for properties such as [`alignContent2`](#alignContent2).
+
+    alignContent2 unsafe center
+
+-}
+unsafe : Value { provides | unsafe : Supported }
+unsafe =
+    Value "unsafe"
+
+
+{-| The `legacy` value used for properties such as [`justifyItems`](#justifyItems).
+
+    justifyItems legacy
+
+-}
+legacy : Value { provides | legacy : Supported }
+legacy =
+    Value "legacy"
+
+
+{-| The `legacy left` value used for properties such as [`justifyItems`](#justifyItems).
+
+    justifyItems legacyLeft
+
+-}
+legacyLeft : Value { provides | legacyLeft : Supported }
+legacyLeft =
+    Value "legacy left"
+
+
+{-| The `legacy right` value used for properties such as [`justifyItems`](#justifyItems).
+
+    justifyItems legacyRight
+
+-}
+legacyRight : Value { provides | legacyRight : Supported }
+legacyRight =
+    Value "legacy right"
+
+
+{-| The `legacy center` value used for properties such as [`justifyItems`](#justifyItems).
+
+    justifyItems legacyCenter
+
+-}
+legacyCenter : Value { provides | legacyCenter : Supported }
+legacyCenter =
+    Value "legacy center"
 
 
 {-| The `wrap` [`flex-wrap` value](https://developer.mozilla.org/en-US/docs/Web/CSS/flex-wrap#Values).
@@ -9506,65 +9405,20 @@ wrapReverse =
     Value "wrap-reverse"
 
 
-{-| The [`flex-flow`](https://css-tricks.com/almanac/properties/f/flex-flow/) shorthand property.
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+--------------------------------- GRID ---------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
 
-    flexFlow rowReverse
-
-    flexFlow wrap
-
-    flexFlow inherit
-
-    flexFlow2 column wrapReverse
-
--}
-flexFlow :
-    BaseValue
-        { row : Supported
-        , rowReverse : Supported
-        , column : Supported
-        , columnReverse : Supported
-        , nowrap : Supported
-        , wrap : Supported
-        , wrapReverse : Supported
-        }
-    -> Style
-flexFlow (Value directionOrWrapping) =
-    AppendProperty ("flex-flow:" ++ directionOrWrapping)
-
-
-{-| The [`flex-flow`](https://css-tricks.com/almanac/properties/f/flex-flow/) shorthand property.
-
-    flexFlow rowReverse
-
-    flexFlow wrap
-
-    flexFlow inherit
-
-    flexFlow2 column wrapReverse
-
--}
-flexFlow2 :
-    Value
-        { row : Supported
-        , rowReverse : Supported
-        , column : Supported
-        , columnReverse : Supported
-        }
-    ->
-        Value
-            { nowrap : Supported
-            , wrap : Supported
-            , wrapReverse : Supported
-            }
-    -> Style
-flexFlow2 (Value direction_) (Value wrapping) =
-    AppendProperty ("flex-flow:" ++ direction_ ++ " " ++ wrapping)
-
-
-
-
-
--- GRID --
 
 {-| The 1-argument version of the [`grid-auto-columns`](https://css-tricks.com/almanac/properties/g/grid-auto-columns/)
 property.
@@ -10024,7 +9878,133 @@ gridTemplateAreasList listStr =
         |> String.join " "
         )
 
--- FONT SIZE --
+
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+---------------------------------- GAP ---------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+
+
+{-| Sets the [`gap`](https://css-tricks.com/almanac/properties/g/gap/) property.
+
+The `gap` property is a shorthand for setting `row-gap` and `column-gap`
+in a single declaration.
+
+`gap` specifies the size of spacing between items within grid, flex
+and multi-column layouts.
+
+    gap initial
+
+    gap (px 20) -- 20px gap between all items.
+
+    gap2 (px 20) (px 40) -- 20px row gap, 40px column gap.
+
+-}
+gap :
+    BaseValue
+        (LengthSupported
+            { pct : Supported
+            }
+        )
+    -> Style
+gap (Value val) =
+    AppendProperty ("gap:" ++ val)
+
+
+{-| Sets the [`gap`](https://css-tricks.com/almanac/properties/g/gap/) property.
+
+The `gap` property is a shorthand for setting `row-gap` and `column-gap`
+in a single declaration.
+
+`gap` specifies the size of spacing between items within grid, flex
+and multi-column layouts.
+
+    gap2 (px 20) (px 40) -- 20px row gap, 40px column gap.
+
+-}
+gap2 :
+    Value
+        (LengthSupported
+            { pct : Supported
+            }
+        )
+    ->
+        Value
+            (LengthSupported
+                { pct : Supported
+                }
+            )
+    -> Style
+gap2 (Value rowVal) (Value columnVal) =
+    AppendProperty ("gap:" ++ rowVal ++ " " ++ columnVal)
+
+
+{-| Sets the [`row-gap`](https://developer.mozilla.org/en-US/docs/Web/CSS/row-gap) property.
+
+`row-gap` specifies the size of spacing between rows of items within grid, flex
+and multi-column layouts.
+
+    rowGap normal
+
+    rowGap (px 20)
+
+-}
+rowGap :
+    BaseValue
+        (LengthSupported
+            { normal : Supported
+            , pct : Supported
+            }
+        )
+    -> Style
+rowGap (Value widthVal) =
+    AppendProperty ("row-gap:" ++ widthVal)
+
+
+{-| Sets the [`column-gap`](https://developer.mozilla.org/en-US/docs/Web/CSS/column-gap) property.
+
+`column-gap` specifies the size of spacing between column of items within grid, flex
+and multi-column layouts.
+
+    columnGap normal
+
+    columnGap (px 20)
+
+-}
+columnGap :
+    BaseValue
+        (LengthSupported
+            { normal : Supported
+            , pct : Supported
+            }
+        )
+    -> Style
+columnGap (Value widthVal) =
+    AppendProperty ("column-gap:" ++ widthVal)
+
+
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------- FONT SIZE ------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
 
 
 {-| Sets [`font-size`](https://css-tricks.com/almanac/properties/f/font-size/)
@@ -11251,340 +11231,19 @@ fontVariantPosition (Value val) =
     AppendProperty ("font-variant-position:" ++ val)
 
 
-
--- CURSOR --
-
-
-{-| A type alias used for the various [`cursor`](#cursor) properties
--}
-type alias CursorKeyword =
-    { pointer : Supported
-    , auto : Supported
-    , default : Supported
-    , none : Supported
-    , contextMenu : Supported
-    , help : Supported
-    , progress : Supported
-    , wait : Supported
-    , cell : Supported
-    , crosshair : Supported
-    , text : Supported
-    , verticalText : Supported
-    , alias : Supported
-    , copy : Supported
-    , move : Supported
-    , noDrop : Supported
-    , notAllowed : Supported
-    , allScroll : Supported
-    , colResize : Supported
-    , rowResize : Supported
-    , nResize : Supported
-    , eResize : Supported
-    , sResize : Supported
-    , wResize : Supported
-    , neResize : Supported
-    , nwResize : Supported
-    , seResize : Supported
-    , swResize : Supported
-    , ewResize : Supported
-    , nsResize : Supported
-    , neswResize : Supported
-    , nwseResize : Supported
-    , zoomIn : Supported
-    , zoomOut : Supported
-    , grab : Supported
-    , grabbing : Supported
-    }
-
-
-{-| The [`cursor`](https://css-tricks.com/almanac/properties/c/cursor/)
-property.
-
-    cursor notAllowed
-
--}
-cursor : BaseValue CursorKeyword -> Style
-cursor (Value val) =
-    AppendProperty ("cursor:" ++ val)
-
-
-{-| The [`cursor`](https://css-tricks.com/almanac/properties/c/cursor/)
-property.
-
-    cursor2 (url "https://example.com") move
-
--}
-cursor2 : Value { url : Supported } -> Value CursorKeyword -> Style
-cursor2 (Value urlVal) (Value fallbackVal) =
-    AppendProperty ("cursor:" ++ urlVal ++ "," ++ fallbackVal)
-
-
-{-| The [`cursor`](https://css-tricks.com/almanac/properties/c/cursor/)
-property.
-
-    cursor4 (url "https://example.com") (num 34) zero move
-
--}
-cursor4 :
-    Value { url : Supported }
-    ->
-        Value
-            { num : Supported
-            , zero : Supported
-            }
-    ->
-        Value
-            { num : Supported
-            , zero : Supported
-            }
-    -> Value CursorKeyword
-    -> Style
-cursor4 (Value urlVal) (Value xVal) (Value yVal) (Value fallbackVal) =
-    AppendProperty
-        ("cursor:"
-            ++ urlVal
-            ++ " "
-            ++ xVal
-            ++ " "
-            ++ yVal
-            ++ ","
-            ++ fallbackVal
-        )
-
-
-{-| The `pointer` value for the [`cursor`](#cursor) property.
--}
-pointer : Value { provides | pointer : Supported }
-pointer =
-    Value "pointer"
-
-
-{-| The `default` value for the [`cursor`](#cursor) property.
--}
-default : Value { provides | default : Supported }
-default =
-    Value "default"
-
-
-{-| The `context-menu` value for the [`cursor`](#cursor) property.
--}
-contextMenu : Value { provides | contextMenu : Supported }
-contextMenu =
-    Value "context-menu"
-
-
-{-| The `help` value for the [`cursor`](#cursor) property.
--}
-help : Value { provides | help : Supported }
-help =
-    Value "help"
-
-
-{-| The `progress` value for the [`cursor`](#cursor) property.
--}
-progress : Value { provides | progress : Supported }
-progress =
-    Value "progress"
-
-
-{-| The `wait` value for the [`cursor`](#cursor) property.
--}
-wait : Value { provides | wait : Supported }
-wait =
-    Value "wait"
-
-
-{-| The `cell` value for the [`cursor`](#cursor) property.
--}
-cell : Value { provides | cell : Supported }
-cell =
-    Value "cell"
-
-
-{-| The `crosshair` value for the [`cursor`](#cursor) property.
--}
-crosshair : Value { provides | crosshair : Supported }
-crosshair =
-    Value "crosshair"
-
-
-{-| The `vertical-text` value for the [`cursor`](#cursor) property.
--}
-verticalText : Value { provides | verticalText : Supported }
-verticalText =
-    Value "vertical-text"
-
-
-{-| The `alias` value for the [`cursor`](#cursor) property.
--}
-alias : Value { provides | alias : Supported }
-alias =
-    Value "alias"
-
-
-{-| The `copy` value for the [`cursor`](#cursor) property.
--}
-copy : Value { provides | copy : Supported }
-copy =
-    Value "copy"
-
-
-{-| The `move` value for the [`cursor`](#cursor) property.
--}
-move : Value { provides | move : Supported }
-move =
-    Value "move"
-
-
-{-| The `no-drop` value for the [`cursor`](#cursor) property.
--}
-noDrop : Value { provides | noDrop : Supported }
-noDrop =
-    Value "no-drop"
-
-
-{-| The `notAllowed` value for the [`cursor`](#cursor) property.
--}
-notAllowed : Value { provides | notAllowed : Supported }
-notAllowed =
-    Value "not-allowed"
-
-
-{-| The `all-scroll` value for the [`cursor`](#cursor) property.
--}
-allScroll : Value { provides | allScroll : Supported }
-allScroll =
-    Value "all-scroll"
-
-
-{-| The `col-resize` value for the [`cursor`](#cursor) property.
--}
-colResize : Value { provides | colResize : Supported }
-colResize =
-    Value "col-resize"
-
-
-{-| The `row-resize` value for the [`cursor`](#cursor) property.
--}
-rowResize : Value { provides | rowResize : Supported }
-rowResize =
-    Value "row-resize"
-
-
-{-| The `n-resize` value for the [`cursor`](#cursor) property.
--}
-nResize : Value { provides | nResize : Supported }
-nResize =
-    Value "n-resize"
-
-
-{-| The `e-resize` value for the [`cursor`](#cursor) property.
--}
-eResize : Value { provides | eResize : Supported }
-eResize =
-    Value "e-resize"
-
-
-{-| The `s-resize` value for the [`cursor`](#cursor) property.
--}
-sResize : Value { provides | sResize : Supported }
-sResize =
-    Value "s-resize"
-
-
-{-| The `w-resize` value for the [`cursor`](#cursor) property.
--}
-wResize : Value { provides | wResize : Supported }
-wResize =
-    Value "w-resize"
-
-
-{-| The `ne-resize` value for the [`cursor`](#cursor) property.
--}
-neResize : Value { provides | neResize : Supported }
-neResize =
-    Value "ne-resize"
-
-
-{-| The `nw-resize` value for the [`cursor`](#cursor) property.
--}
-nwResize : Value { provides | nwResize : Supported }
-nwResize =
-    Value "nw-resize"
-
-
-{-| The `se-resize` value for the [`cursor`](#cursor) property.
--}
-seResize : Value { provides | seResize : Supported }
-seResize =
-    Value "se-resize"
-
-
-{-| The `sw-resize` value for the [`cursor`](#cursor) property.
--}
-swResize : Value { provides | swResize : Supported }
-swResize =
-    Value "sw-resize"
-
-
-{-| The `ew-resize` value for the [`cursor`](#cursor) property.
--}
-ewResize : Value { provides | ewResize : Supported }
-ewResize =
-    Value "ew-resize"
-
-
-{-| The `ns-resize` value for the [`cursor`](#cursor) property.
--}
-nsResize : Value { provides | nsResize : Supported }
-nsResize =
-    Value "ns-resize"
-
-
-{-| The `nesw-resize` value for the [`cursor`](#cursor) property.
--}
-neswResize : Value { provides | neswResize : Supported }
-neswResize =
-    Value "nesw-resize"
-
-
-{-| The `nwse-resize` value for the [`cursor`](#cursor) property.
--}
-nwseResize : Value { provides | nwseResize : Supported }
-nwseResize =
-    Value "nwse-resize"
-
-
-{-| The `zoom-in` value for the [`cursor`](#cursor) property.
--}
-zoomIn : Value { provides | zoomIn : Supported }
-zoomIn =
-    Value "zoom-in"
-
-
-{-| The `zoom-out` value for the [`cursor`](#cursor) property.
--}
-zoomOut : Value { provides | zoomOut : Supported }
-zoomOut =
-    Value "zoom-out"
-
-
-{-| The `grab` value for the [`cursor`](#cursor) property.
--}
-grab : Value { provides | grab : Supported }
-grab =
-    Value "grab"
-
-
-{-| The `grabbing` value for the [`cursor`](#cursor) property.
--}
-grabbing : Value { provides | grabbing : Supported }
-grabbing =
-    Value "grabbing"
-
-
-
-
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+--------------------------------- COLOR --------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
 
 
 {-| Sets [`color`](https://css-tricks.com/almanac/properties/c/color/).
@@ -11599,6 +11258,21 @@ grabbing =
 color : BaseValue Color -> Style
 color (Value val) =
     AppendProperty ("color:" ++ val)
+
+
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+--------------------------- BACKGROUND ---------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
 
 
 {-| Sets [`background-color`](https://css-tricks.com/almanac/properties/b/background-color/).
@@ -11911,9 +11585,6 @@ luminosity : Value { provides | luminosity : Supported }
 luminosity =
     Value "luminosity"
 
-
-
--- BACKGROUND CLIP --
 
 
 {-| Sets [`background-clip`](https://css-tricks.com/almanac/properties/b/background-clip/).
@@ -12340,10 +12011,6 @@ round =
     Value "round"
 
 
-
--- BACKGROUND SIZE --
-
-
 {-| Sets [`background-size`](https://css-tricks.com/almanac/properties/b/background-size/).
 
     backgroundSize cover
@@ -12398,8 +12065,643 @@ backgroundSize2 (Value widthVal) (Value heightVal) =
     AppendProperty ("background-size:" ++ widthVal ++ " " ++ heightVal)
 
 
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------ BOX-SHADOW ------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
 
-{- GRADIENTS -}
+
+{-| Configuration for [`boxShadow`](#boxShadow).
+-}
+type alias BoxShadowConfig =
+    { offsetX :
+        Value
+            (LengthSupported
+                { pct : Supported
+                }
+            )
+    , offsetY :
+        Value
+            (LengthSupported
+                { pct : Supported
+                }
+            )
+    , blurRadius :
+        Maybe
+            (Value
+                (LengthSupported
+                    { pct : Supported
+                    }
+                )
+            )
+    , spreadRadius :
+        Maybe
+            (Value
+                (LengthSupported
+                    { pct : Supported
+                    }
+                )
+            )
+    , color :
+        Maybe (Value Color)
+    , inset : Bool
+    }
+
+
+{-| Default [`boxShadow`](#boxShadow) configuration.
+
+It is equivalent to the following CSS:
+
+    box-shadow: 0 0;
+
+-}
+defaultBoxShadow : BoxShadowConfig
+defaultBoxShadow =
+    { offsetX = zero
+    , offsetY = zero
+    , blurRadius = Nothing
+    , spreadRadius = Nothing
+    , color = Nothing
+    , inset = False
+    }
+
+
+{-| The [`box-shadow`](https://css-tricks.com/almanac/properties/b/box-shadow/) property.
+
+    boxShadow initial
+
+    boxShadow none
+
+For defining shadows look at [`boxShadows`](#boxShadows).
+
+-}
+boxShadow : BaseValue { none : Supported } -> Style
+boxShadow (Value val) =
+    AppendProperty ("box-shadow:" ++ val)
+
+
+{-| Sets [`box-shadow`](https://css-tricks.com/almanac/properties/b/box-shadow/).
+
+    boxShadows [] -- "box-shadow: none"
+
+    -- "box-shadow: 3px 5px #aabbcc"
+    button
+        [ css
+            [ boxShadows
+                [ { defaultBoxShadow
+                    | offsetX = px 3
+                    , offsetY = px 5
+                    , color = Just (hex "#aabbcc")
+                  }
+                ]
+            ]
+        ]
+        [ text "Zap!" ]
+
+-}
+boxShadows : List BoxShadowConfig -> Style
+boxShadows configs =
+    let
+        value =
+            case configs of
+                [] ->
+                    "none"
+
+                _ ->
+                    configs
+                        |> List.map boxShadowConfigToString
+                        |> String.join ", "
+    in
+    AppendProperty ("box-shadow:" ++ value)
+
+
+boxShadowConfigToString : BoxShadowConfig -> String
+boxShadowConfigToString config =
+    let
+        (Value offsetX) =
+            config.offsetX
+
+        (Value offsetY) =
+            config.offsetY
+
+        blurRadius =
+            case config.blurRadius of
+                Just (Value value) ->
+                    " " ++ value
+
+                Nothing ->
+                    case config.spreadRadius of
+                        Just _ ->
+                            " 0"
+
+                        Nothing ->
+                            ""
+
+        spreadRadius =
+            case config.spreadRadius of
+                Just (Value value) ->
+                    " " ++ value
+
+                Nothing ->
+                    ""
+
+        insetStr =
+            if config.inset then
+                "inset "
+
+            else
+                ""
+
+        colorVal =
+            config.color
+                |> Maybe.map (unpackValue >> (++) " ")
+                |> Maybe.withDefault ""
+    in
+    insetStr ++ offsetX ++ " " ++ offsetY ++ blurRadius ++ spreadRadius ++ colorVal
+
+
+
+
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+-------------------------------- CURSORS -------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+
+
+{-| A type alias used for the various [`cursor`](#cursor) properties
+-}
+type alias CursorKeyword =
+    { pointer : Supported
+    , auto : Supported
+    , default : Supported
+    , none : Supported
+    , contextMenu : Supported
+    , help : Supported
+    , progress : Supported
+    , wait : Supported
+    , cell : Supported
+    , crosshair : Supported
+    , text : Supported
+    , verticalText : Supported
+    , alias : Supported
+    , copy : Supported
+    , move : Supported
+    , noDrop : Supported
+    , notAllowed : Supported
+    , allScroll : Supported
+    , colResize : Supported
+    , rowResize : Supported
+    , nResize : Supported
+    , eResize : Supported
+    , sResize : Supported
+    , wResize : Supported
+    , neResize : Supported
+    , nwResize : Supported
+    , seResize : Supported
+    , swResize : Supported
+    , ewResize : Supported
+    , nsResize : Supported
+    , neswResize : Supported
+    , nwseResize : Supported
+    , zoomIn : Supported
+    , zoomOut : Supported
+    , grab : Supported
+    , grabbing : Supported
+    }
+
+
+{-| The [`cursor`](https://css-tricks.com/almanac/properties/c/cursor/)
+property.
+
+    cursor notAllowed
+
+-}
+cursor : BaseValue CursorKeyword -> Style
+cursor (Value val) =
+    AppendProperty ("cursor:" ++ val)
+
+
+{-| The [`cursor`](https://css-tricks.com/almanac/properties/c/cursor/)
+property.
+
+    cursor2 (url "https://example.com") move
+
+-}
+cursor2 : Value { url : Supported } -> Value CursorKeyword -> Style
+cursor2 (Value urlVal) (Value fallbackVal) =
+    AppendProperty ("cursor:" ++ urlVal ++ "," ++ fallbackVal)
+
+
+{-| The [`cursor`](https://css-tricks.com/almanac/properties/c/cursor/)
+property.
+
+    cursor4 (url "https://example.com") (num 34) zero move
+
+-}
+cursor4 :
+    Value { url : Supported }
+    ->
+        Value
+            { num : Supported
+            , zero : Supported
+            }
+    ->
+        Value
+            { num : Supported
+            , zero : Supported
+            }
+    -> Value CursorKeyword
+    -> Style
+cursor4 (Value urlVal) (Value xVal) (Value yVal) (Value fallbackVal) =
+    AppendProperty
+        ("cursor:"
+            ++ urlVal
+            ++ " "
+            ++ xVal
+            ++ " "
+            ++ yVal
+            ++ ","
+            ++ fallbackVal
+        )
+
+
+{-| The `pointer` value for the [`cursor`](#cursor) property.
+-}
+pointer : Value { provides | pointer : Supported }
+pointer =
+    Value "pointer"
+
+
+{-| The `default` value for the [`cursor`](#cursor) property.
+-}
+default : Value { provides | default : Supported }
+default =
+    Value "default"
+
+
+{-| The `context-menu` value for the [`cursor`](#cursor) property.
+-}
+contextMenu : Value { provides | contextMenu : Supported }
+contextMenu =
+    Value "context-menu"
+
+
+{-| The `help` value for the [`cursor`](#cursor) property.
+-}
+help : Value { provides | help : Supported }
+help =
+    Value "help"
+
+
+{-| The `progress` value for the [`cursor`](#cursor) property.
+-}
+progress : Value { provides | progress : Supported }
+progress =
+    Value "progress"
+
+
+{-| The `wait` value for the [`cursor`](#cursor) property.
+-}
+wait : Value { provides | wait : Supported }
+wait =
+    Value "wait"
+
+
+{-| The `cell` value for the [`cursor`](#cursor) property.
+-}
+cell : Value { provides | cell : Supported }
+cell =
+    Value "cell"
+
+
+{-| The `crosshair` value for the [`cursor`](#cursor) property.
+-}
+crosshair : Value { provides | crosshair : Supported }
+crosshair =
+    Value "crosshair"
+
+
+{-| The `vertical-text` value for the [`cursor`](#cursor) property.
+-}
+verticalText : Value { provides | verticalText : Supported }
+verticalText =
+    Value "vertical-text"
+
+
+{-| The `alias` value for the [`cursor`](#cursor) property.
+-}
+alias : Value { provides | alias : Supported }
+alias =
+    Value "alias"
+
+
+{-| The `copy` value for the [`cursor`](#cursor) property.
+-}
+copy : Value { provides | copy : Supported }
+copy =
+    Value "copy"
+
+
+{-| The `move` value for the [`cursor`](#cursor) property.
+-}
+move : Value { provides | move : Supported }
+move =
+    Value "move"
+
+
+{-| The `no-drop` value for the [`cursor`](#cursor) property.
+-}
+noDrop : Value { provides | noDrop : Supported }
+noDrop =
+    Value "no-drop"
+
+
+{-| The `notAllowed` value for the [`cursor`](#cursor) property.
+-}
+notAllowed : Value { provides | notAllowed : Supported }
+notAllowed =
+    Value "not-allowed"
+
+
+{-| The `all-scroll` value for the [`cursor`](#cursor) property.
+-}
+allScroll : Value { provides | allScroll : Supported }
+allScroll =
+    Value "all-scroll"
+
+
+{-| The `col-resize` value for the [`cursor`](#cursor) property.
+-}
+colResize : Value { provides | colResize : Supported }
+colResize =
+    Value "col-resize"
+
+
+{-| The `row-resize` value for the [`cursor`](#cursor) property.
+-}
+rowResize : Value { provides | rowResize : Supported }
+rowResize =
+    Value "row-resize"
+
+
+{-| The `n-resize` value for the [`cursor`](#cursor) property.
+-}
+nResize : Value { provides | nResize : Supported }
+nResize =
+    Value "n-resize"
+
+
+{-| The `e-resize` value for the [`cursor`](#cursor) property.
+-}
+eResize : Value { provides | eResize : Supported }
+eResize =
+    Value "e-resize"
+
+
+{-| The `s-resize` value for the [`cursor`](#cursor) property.
+-}
+sResize : Value { provides | sResize : Supported }
+sResize =
+    Value "s-resize"
+
+
+{-| The `w-resize` value for the [`cursor`](#cursor) property.
+-}
+wResize : Value { provides | wResize : Supported }
+wResize =
+    Value "w-resize"
+
+
+{-| The `ne-resize` value for the [`cursor`](#cursor) property.
+-}
+neResize : Value { provides | neResize : Supported }
+neResize =
+    Value "ne-resize"
+
+
+{-| The `nw-resize` value for the [`cursor`](#cursor) property.
+-}
+nwResize : Value { provides | nwResize : Supported }
+nwResize =
+    Value "nw-resize"
+
+
+{-| The `se-resize` value for the [`cursor`](#cursor) property.
+-}
+seResize : Value { provides | seResize : Supported }
+seResize =
+    Value "se-resize"
+
+
+{-| The `sw-resize` value for the [`cursor`](#cursor) property.
+-}
+swResize : Value { provides | swResize : Supported }
+swResize =
+    Value "sw-resize"
+
+
+{-| The `ew-resize` value for the [`cursor`](#cursor) property.
+-}
+ewResize : Value { provides | ewResize : Supported }
+ewResize =
+    Value "ew-resize"
+
+
+{-| The `ns-resize` value for the [`cursor`](#cursor) property.
+-}
+nsResize : Value { provides | nsResize : Supported }
+nsResize =
+    Value "ns-resize"
+
+
+{-| The `nesw-resize` value for the [`cursor`](#cursor) property.
+-}
+neswResize : Value { provides | neswResize : Supported }
+neswResize =
+    Value "nesw-resize"
+
+
+{-| The `nwse-resize` value for the [`cursor`](#cursor) property.
+-}
+nwseResize : Value { provides | nwseResize : Supported }
+nwseResize =
+    Value "nwse-resize"
+
+
+{-| The `zoom-in` value for the [`cursor`](#cursor) property.
+-}
+zoomIn : Value { provides | zoomIn : Supported }
+zoomIn =
+    Value "zoom-in"
+
+
+{-| The `zoom-out` value for the [`cursor`](#cursor) property.
+-}
+zoomOut : Value { provides | zoomOut : Supported }
+zoomOut =
+    Value "zoom-out"
+
+
+{-| The `grab` value for the [`cursor`](#cursor) property.
+-}
+grab : Value { provides | grab : Supported }
+grab =
+    Value "grab"
+
+
+{-| The `grabbing` value for the [`cursor`](#cursor) property.
+-}
+grabbing : Value { provides | grabbing : Supported }
+grabbing =
+    Value "grabbing"
+
+
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+----------------------------- TEXT SHADOW ------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+
+
+{-| Configuration for [`textShadow`](#textShadow).
+-}
+type alias TextShadowConfig =
+    { offsetX :
+        Value
+            (LengthSupported
+                { pct : Supported
+                }
+            )
+    , offsetY :
+        Value
+            (LengthSupported
+                { pct : Supported
+                }
+            )
+    , blurRadius :
+        Maybe
+            (Value
+                (LengthSupported
+                    { pct : Supported
+                    }
+                )
+            )
+    , color : Maybe (Value Color)
+    }
+
+
+{-| Default [`textShadow`](#textShadow) configuration.
+
+It is equivalent to the following CSS:
+
+    text-shadow: 0 0;
+
+-}
+defaultTextShadow : TextShadowConfig
+defaultTextShadow =
+    { offsetX = zero
+    , offsetY = zero
+    , blurRadius = Nothing
+    , color = Nothing
+    }
+
+
+{-| Sets [`text-shadow`](https://css-tricks.com/almanac/properties/t/text-shadow/).
+
+    textShadow [] -- "text-shadow: none"
+
+    -- "text-shadow: 3px 5px #aabbcc"
+    span
+        [ css
+            [ textShadow
+                [ { defaultTextShadow
+                    | offsetX = px 3
+                    , offsetY = px 5
+                    , color = Just (hex "#aabbcc")
+                  }
+                ]
+            ]
+        ]
+        [ text "Zap!" ]
+
+-}
+textShadow : List TextShadowConfig -> Style
+textShadow configs =
+    let
+        values =
+            case configs of
+                [] ->
+                    "none"
+
+                _ ->
+                    configs
+                        |> List.map textShadowConfigToString
+                        |> String.join ","
+    in
+    AppendProperty ("text-shadow:" ++ values)
+
+
+textShadowConfigToString : TextShadowConfig -> String
+textShadowConfigToString config =
+    let
+        offsetX =
+            unpackValue config.offsetX
+
+        offsetY =
+            unpackValue config.offsetY
+
+        blurRadius =
+            config.blurRadius
+                |> Maybe.map (unpackValue >> (++) " ")
+                |> Maybe.withDefault ""
+
+        colorSetting =
+            config.color
+                |> Maybe.map (unpackValue >> (++) " ")
+                |> Maybe.withDefault ""
+    in
+    offsetX ++ " " ++ offsetY ++ blurRadius ++ colorSetting
+
+
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------ GRADIENTS -------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
 
 
 {-| Produces [`linear-gradient()`](https://developer.mozilla.org/en-US/docs/Web/CSS/linear-gradient())
@@ -12633,8 +12935,19 @@ toTopRight =
     Value "to top right"
 
 
-
--- LIST STYLE --
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------ LIST STYLE ------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
 
 
 {-| A type alias used to accept a [list-style-type](https://developer.mozilla.org/en-US/docs/Web/CSS/list-style-type)
@@ -13495,7 +13808,20 @@ useGlyphOrientation =
     Value "use-glyph-orientation"
 
 
--- TEXT RENDERING --
+
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+--------------------------- TEXT RENDERING -----------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
 
 
 {-| Sets [`text-rendering`](https://css-tricks.com/almanac/properties/t/text-rendering/).
@@ -13547,8 +13873,19 @@ optimizeSpeed =
     Value "optimizeSpeed"
 
 
-
--- TEXT TRANSFORM --
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+---------------------------- TEXT-TRANSFORM ----------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
 
 
 {-| Sets [`text-transform`](https://css-tricks.com/almanac/properties/t/text-transform/).
@@ -14743,105 +15080,6 @@ columnRuleColor (Value colorVal) =
     AppendProperty ("column-rule-color:" ++ colorVal)
 
 
-{-| Sets the [`gap`](https://css-tricks.com/almanac/properties/g/gap/) property.
-
-The `gap` property is a shorthand for setting `row-gap` and `column-gap`
-in a single declaration.
-
-`gap` specifies the size of spacing between items within grid, flex
-and multi-column layouts.
-
-    gap initial
-
-    gap (px 20) -- 20px gap between all items.
-
-    gap2 (px 20) (px 40) -- 20px row gap, 40px column gap.
-
--}
-gap :
-    BaseValue
-        (LengthSupported
-            { pct : Supported
-            }
-        )
-    -> Style
-gap (Value val) =
-    AppendProperty ("gap:" ++ val)
-
-
-{-| Sets the [`gap`](https://css-tricks.com/almanac/properties/g/gap/) property.
-
-The `gap` property is a shorthand for setting `row-gap` and `column-gap`
-in a single declaration.
-
-`gap` specifies the size of spacing between items within grid, flex
-and multi-column layouts.
-
-    gap2 (px 20) (px 40) -- 20px row gap, 40px column gap.
-
--}
-gap2 :
-    Value
-        (LengthSupported
-            { pct : Supported
-            }
-        )
-    ->
-        Value
-            (LengthSupported
-                { pct : Supported
-                }
-            )
-    -> Style
-gap2 (Value rowVal) (Value columnVal) =
-    AppendProperty ("gap:" ++ rowVal ++ " " ++ columnVal)
-
-
-{-| Sets the [`row-gap`](https://developer.mozilla.org/en-US/docs/Web/CSS/row-gap) property.
-
-`row-gap` specifies the size of spacing between rows of items within grid, flex
-and multi-column layouts.
-
-    rowGap normal
-
-    rowGap (px 20)
-
--}
-rowGap :
-    BaseValue
-        (LengthSupported
-            { normal : Supported
-            , pct : Supported
-            }
-        )
-    -> Style
-rowGap (Value widthVal) =
-    AppendProperty ("row-gap:" ++ widthVal)
-
-
-{-| Sets the [`column-gap`](https://developer.mozilla.org/en-US/docs/Web/CSS/column-gap) property.
-
-`column-gap` specifies the size of spacing between column of items within grid, flex
-and multi-column layouts.
-
-    columnGap normal
-
-    columnGap (px 20)
-
--}
-columnGap :
-    BaseValue
-        (LengthSupported
-            { normal : Supported
-            , pct : Supported
-            }
-        )
-    -> Style
-columnGap (Value widthVal) =
-    AppendProperty ("column-gap:" ++ widthVal)
-
-
-
 -- STROKE --
 
 
@@ -15651,8 +15889,19 @@ columnRule3 (Value widthVal) (Value styleVal) (Value colorVal) =
     AppendProperty ("column-rule:" ++ widthVal ++ " " ++ styleVal ++ " " ++ colorVal)
 
 
-
--- TRANSFORM
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+----------------------------- TRANSFORM --------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
 
 
 {-| A type alias used to accept a [transform-function](https://developer.mozilla.org/en-US/docs/Web/CSS/transform-function)
@@ -16385,7 +16634,19 @@ perspective_ (Value length) =
 
 
 
--- ANIMATION --
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------- ANIMATION ------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
 
 
 {-| The [`animation-name`](https://developer.mozilla.org/en-US/docs/Web/CSS/animation-name) property.
@@ -16922,6 +17183,16 @@ forwards =
 backwards : Value { provides | backwards : Supported }
 backwards =
     Value "backwards"
+
+
+
+
+
+
+
+
+
+
 
 
 {-| Named after the hash mark in the CSS specification [CSS-VALUES-3].

--- a/src/Css.elm
+++ b/src/Css.elm
@@ -183,6 +183,9 @@ module Css exposing
     , xxSmall, xSmall, small, medium, large, xLarge, xxLarge, smaller, larger, lineHeight, letterSpacing
     , fontSizeAdjust
 
+    -- @font-face
+    , fontDisplay, fallback, swap, optional
+
     -- font family
     , fontFamily, fontFamilies, serif, sansSerif, monospace, cursive, fantasy, systemUi
 
@@ -234,6 +237,17 @@ module Css exposing
     , mixed, sideways, sidewaysRight, upright, useGlyphOrientation
     , wordBreak
     , breakAll, keepAll
+    , wordSpacing
+    , tabSize
+    , hyphens
+    , manual
+    , quotes, quotes2, quotes4
+    , textOverflow, textOverflow2
+    , ellipsis
+    , lineBreak
+    , loose
+    , hangingPunctuation, hangingPunctuation2, hangingPunctuation3
+    , first, last, forceEnd, allowEnd
 
     -- script handling
     , direction, ltr, rtl
@@ -321,15 +335,6 @@ module Css exposing
     , maskType
     , noClip, add, subtract, intersect, exclude, alpha, luminance, matchSource
 
-    -- ??
-    , wordSpacing
-    , tabSize
-    , fontDisplay, fallback, swap, optional
-    , hyphens, quotes, quotes2, quotes4, textOverflow, textOverflow2, lineBreak, manual, ellipsis, loose
-    , hangingPunctuation, hangingPunctuation2, hangingPunctuation3, first, last, forceEnd, allowEnd
-    , lineClamp
-    , LineWidth, LineWidthSupported, LineStyle, LineStyleSupported
-    
     -- tables
     , borderCollapse
     , collapse, separate
@@ -340,6 +345,10 @@ module Css exposing
     , tableLayout
 
 
+    
+    -- ??
+    , lineClamp
+    , LineWidth, LineWidthSupported, LineStyle, LineStyleSupported
     , verticalAlign
     , textTop, textBottom, middle
     , whiteSpace
@@ -375,23 +384,36 @@ module Css exposing
 
     -- ??
     , opacity
+
     , zoom
     
-    -- ??
     , speak, spellOut
+
     , userSelect
+
     , bleed
+
     , orphans, widows
+
     , mixBlendMode
+
     , imageRendering, crispEdges, pixelated
+
     , backfaceVisibility
+
     , objectFit, scaleDown
     , objectPosition, objectPosition2, objectPosition4
+
     , boxDecorationBreak
+
     , clipPath, clipPath2
+
     , caretColor
+
     , resize, horizontal, vertical
-    , contain, contain2, contain3, contain4, size, layout, paint
+
+    , contain, contain2, contain3, contain4
+    , size, layout, paint
     )
 
 {-| If you need something that `elm-css` does not support right now, the
@@ -11139,6 +11161,79 @@ fontSizeAdjust (Value val) =
 ------------------------------------------------------------------------
 ------------------------------------------------------------------------
 ------------------------------------------------------------------------
+------------------------------- FONT-FACE ------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+
+
+{-| Sets [`font-display`](https://css-tricks.com/almanac/properties/f/font-display/)
+
+    fontDisplay auto
+
+    fontDisplay block
+
+    fontDisplay swap
+
+    fontDisplay fallback
+
+    fontDisplay optional
+
+-}
+fontDisplay :
+    BaseValue
+        { auto : Supported
+        , block : Supported
+        , swap : Supported
+        , fallback : Supported
+        , optional : Supported
+        }
+    -> Style
+fontDisplay (Value val) =
+    AppendProperty ("font-display:" ++ val)
+
+
+{-| Sets `fallback` value for usage with [`fontDisplay`](#fontDisplay) or [`strokeLinejoin`](#strokeLinejoin2).
+
+      fontDisplay fallback
+
+      strokeLinejoin2 miter fallback
+
+-}
+fallback : Value { provides | fallback : Supported }
+fallback =
+    Value "fallback"
+
+
+{-| Sets `swap` value for usage with [`fontDisplay`](#fontDisplay).
+
+    fontDisplay swap
+
+-}
+swap : Value { provides | swap : Supported }
+swap =
+    Value "swap"
+
+
+{-| Sets `optional` value for usage with [`fontDisplay`](#fontDisplay).
+
+      fontDisplay optional
+
+-}
+optional : Value { provides | optional : Supported }
+optional =
+    Value "optional"
+
+
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
 ------------------------------ FONT FAMILY -----------------------------
 ------------------------------------------------------------------------
 ------------------------------------------------------------------------
@@ -14211,6 +14306,377 @@ breakAll =
 keepAll : Value { provides | keepAll : Supported }
 keepAll =
     Value "keep-all"
+
+
+{-| Sets [`word-spacing`](https://css-tricks.com/almanac/properties/w/word-spacing/).
+
+    wordSpacing normal
+
+    wordSpacing zero
+
+    wordSpacing (px 5)
+
+-}
+wordSpacing :
+    BaseValue
+        (LengthSupported
+            { normal : Supported
+            , pct : Supported
+            }
+        )
+    -> Style
+wordSpacing (Value str) =
+    AppendProperty ("word-spacing:" ++ str)
+
+
+
+{-| Sets [`tab-size`](https://css-tricks.com/almanac/properties/t/tab-size/)
+**Note:** only positive integer values are allowed.
+
+    tabSize (int 4)
+
+-}
+tabSize :
+    BaseValue
+        (LengthSupported
+            { auto : Supported
+            , int : Supported
+            }
+        )
+    -> Style
+tabSize (Value val) =
+    AppendProperty ("tab-size:" ++ val)
+
+
+{-| Sets [`hyphens`](https://css-tricks.com/almanac/properties/h/hyphens/)
+
+    hyphens none
+
+    hyphens manual
+
+    hyphens auto
+
+-}
+hyphens :
+    BaseValue
+        { none : Supported
+        , manual : Supported
+        , auto : Supported
+        }
+    -> Style
+hyphens (Value val) =
+    AppendProperty ("hyphens:" ++ val)
+
+
+{-| Sets `manual` value for usage with [`hyphens`](#hyphens).
+
+    hyphens manual
+
+-}
+manual : Value { provides | manual : Supported }
+manual =
+    Value "manual"
+
+
+{-| Sets the [`quotes`](https://css-tricks.com/almanac/properties/q/quotes/) property.
+
+This one-argument version can only use keyword or global values.
+
+    quotes none
+
+    quotes inherit
+
+    quotes2 (string "\"") (string "\"")
+
+    quotes4 (string "\"") (string "\"") (string "'") (string "'")
+
+-}
+quotes :
+    BaseValue
+        { none : Supported
+        , auto : Supported
+        }
+    -> Style
+quotes (Value val) =
+    AppendProperty ("quotes:" ++ val)
+
+
+{-| Sets the [`quotes`](https://css-tricks.com/almanac/properties/q/quotes/) property.
+
+This 2-argument version sets the starting and closing quotation marks for
+a top-level quote (a quote that is not nested within another quote). It only accepts
+string values.
+
+    quotes auto
+
+    quotes2 (string "\"") (string "\"") -- "Hey, this is a first-level quote."
+
+    quotes2 (string "'") (string "'") -- 'Hey, this is a first-level quote.'
+
+    quotes2 (string "«") (string "»") -- «Hey, this is a first-level quote.»
+
+-}
+quotes2 :
+    Value
+        { string : Supported
+        }
+    ->
+        Value
+            { string : Supported
+            }
+    -> Style
+quotes2 (Value lv1StartQuote) (Value lv1EndQuote) =
+    AppendProperty ("quotes:" ++ lv1StartQuote ++ " " ++ lv1EndQuote)
+
+
+{-| Sets the [`quotes`](https://css-tricks.com/almanac/properties/q/quotes/) property.
+
+This 4-argument version sets the starting and closing quotation marks for both
+a top-level quote and a nested quote. It only accepts
+string values.
+
+    quotes auto
+
+    quotes2 (string "\"") (string "\"")
+
+    -- "Hey, this is a first-level quote."
+
+
+    quotes4 (string "\"") (string "\"") (string "\'") (string "\'")
+
+    {- "Hey, this is a first-level quote.
+    'And this is someone else I made up for
+    a second-level quote!' Yeah, I did that!"
+    -}
+
+    quotes4 (string "«") (string "»") (string "👏") (string "🤔")
+
+    {- «Hey, this is a first-level quote.
+    👏And this is someone else I made up for
+    a second-level quote!🤔 Yeah, I did that!»
+    -}
+
+-}
+quotes4 :
+    Value
+        { string : Supported
+        }
+    ->
+        Value
+            { string : Supported
+            }
+    ->
+        Value
+            { string : Supported
+            }
+    ->
+        Value
+            { string : Supported
+            }
+    -> Style
+quotes4 (Value lv1StartQuote) (Value lv1EndQuote) (Value lv2StartQuote) (Value lv2EndQuote) =
+    AppendProperty ("quotes:" ++ lv1StartQuote ++ " " ++ lv1EndQuote ++ " " ++ lv2StartQuote ++ " " ++ lv2EndQuote)
+
+
+{-| Sets the [`text-overflow`](https://css-tricks.com/almanac/properties/t/text-overflow/) property.
+
+`text-overflow` describes how text that gets cut off is signalled to users.
+
+When the one-argument version is used, it sets the end of text (right end for LTR users) that is cut off.
+
+    textOverflow ellipsis
+
+When the two-argument version is used, it specifies how the
+text cut-off is displayed at the start (left in LTR) and
+the end (right in LTR) of the text.
+
+    textOverflow2 ellipsis ellipsis
+
+-}
+textOverflow :
+    BaseValue
+        { clip : Supported
+        , ellipsis : Supported
+        }
+    -> Style
+textOverflow (Value value) =
+    AppendProperty ("text-overflow:" ++ value)
+
+
+{-| Sets the [`text-overflow`](https://css-tricks.com/almanac/properties/t/text-overflow/) property.
+
+`text-overflow` describes how text that gets cut off is signalled to users.
+
+This version specifies how the text cut-off is displayed at the start
+(left in LTR) and at the end (right in LTR) of the text.
+
+    textOverflow2 ellipsis ellipsis
+
+-}
+textOverflow2 :
+    Value
+        { clip : Supported
+        , ellipsis : Supported
+        }
+    ->
+        Value
+            { clip : Supported
+            , ellipsis : Supported
+            }
+    -> Style
+textOverflow2 (Value startValue) (Value endValue) =
+    AppendProperty ("text-overflow:" ++ startValue ++ " " ++ endValue)
+
+
+{-| Sets `ellipsis` value for usage with [`textOverflow`](#textOverflow).
+
+    textOverflow ellipsis
+
+-}
+ellipsis : Value { provides | ellipsis : Supported }
+ellipsis =
+    Value "ellipsis"
+
+
+{-| Sets the [`lineBreak`](https://css-tricks.com/almanac/properties/l/line-break/) property.
+
+    lineBreak auto
+
+    lineBreak strict
+
+-}
+lineBreak :
+    BaseValue
+        { auto : Supported
+        , loose : Supported
+        , normal : Supported
+        , strict : Supported
+        , anywhere : Supported
+        }
+    -> Style
+lineBreak (Value value) =
+    AppendProperty ("line-break:" ++ value)
+
+
+{-| Sets `loose` value for usage with [`lineBreak`](#lineBreak).
+
+    lineBreak loose
+
+-}
+loose : Value { provides | loose : Supported }
+loose =
+    Value "loose"
+
+
+{-| Sets [`hanging-punctuation`](https://css-tricks.com/almanac/properties/h/hanging-punctuation/)
+
+    hangingPunctuation none
+
+    hangingPunctuation first
+
+    hangingPunctuation2 first forceEnd
+
+    hangingPunctuation3 first allowEnd last
+
+-}
+hangingPunctuation :
+    BaseValue
+        { none : Supported
+        , first : Supported
+        , forceEnd : Supported
+        , allowEnd : Supported
+        , last : Supported
+        }
+    -> Style
+hangingPunctuation (Value val) =
+    AppendProperty ("hanging-punctuation:" ++ val)
+
+
+{-| Sets [`hanging-punctuation`](https://css-tricks.com/almanac/properties/h/hanging-punctuation/)
+
+    hangingPunctuation2 first forceEnd
+
+-}
+hangingPunctuation2 :
+    Value
+        { first : Supported
+        , last : Supported
+        }
+    ->
+        Value
+            { first : Supported
+            , forceEnd : Supported
+            , allowEnd : Supported
+            , last : Supported
+            }
+    -> Style
+hangingPunctuation2 (Value val1) (Value val2) =
+    AppendProperty ("hanging-punctuation:" ++ val1 ++ " " ++ val2)
+
+
+{-| Sets [`hanging-punctuation`](https://css-tricks.com/almanac/properties/h/hanging-punctuation/)
+
+    hangingPunctuation3 first allowEnd last
+
+-}
+hangingPunctuation3 :
+    Value
+        { first : Supported
+        , last : Supported
+        }
+    ->
+        Value
+            { forceEnd : Supported
+            , allowEnd : Supported
+            }
+    ->
+        Value
+            { first : Supported
+            , last : Supported
+            }
+    -> Style
+hangingPunctuation3 (Value val1) (Value val2) (Value val3) =
+    AppendProperty ("hanging-punctuation:" ++ val1 ++ " " ++ val2 ++ " " ++ val3)
+
+
+{-| Sets `first` value for usage with [`hangingPunctuation`](#hangingPunctuation).
+
+      hangingPunctuation first
+
+-}
+first : Value { provides | first : Supported }
+first =
+    Value "first"
+
+
+{-| Sets `last` value for usage with [`hangingPunctuation`](#hangingPunctuation).
+
+      hangingPunctuation last
+
+-}
+last : Value { provides | last : Supported }
+last =
+    Value "last"
+
+
+{-| Sets `force-end` value for usage with [`hangingPunctuation`](#hangingPunctuation).
+
+      hangingPunctuation forceEnd
+
+-}
+forceEnd : Value { provides | forceEnd : Supported }
+forceEnd =
+    Value "force-end"
+
+
+{-| Sets `allow-end` value for usage with [`hangingPunctuation`](#hangingPunctuation).
+
+      hangingPunctuation allowEnd
+
+-}
+allowEnd : Value { provides | allowEnd : Supported }
+allowEnd =
+    Value "allow-end"
 
 
 ------------------------------------------------------------------------
@@ -20312,393 +20778,8 @@ boxDecorationBreak (Value val) =
     AppendProperty ("box-decoration-break:" ++ val)
 
 
-{-| Sets `swap` value for usage with [`fontDisplay`](#fontDisplay).
 
-    fontDisplay swap
 
--}
-swap : Value { provides | swap : Supported }
-swap =
-    Value "swap"
-
-
-{-| Sets `fallback` value for usage with [`fontDisplay`](#fontDisplay) or [`strokeLinejoin`](#strokeLinejoin2).
-
-      fontDisplay fallback
-
-      strokeLinejoin2 miter fallback
-
--}
-fallback : Value { provides | fallback : Supported }
-fallback =
-    Value "fallback"
-
-
-{-| Sets `optional` value for usage with [`fontDisplay`](#fontDisplay).
-
-      fontDisplay optional
-
--}
-optional : Value { provides | optional : Supported }
-optional =
-    Value "optional"
-
-
-{-| Sets [`font-display`](https://css-tricks.com/almanac/properties/f/font-display/)
-
-    fontDisplay auto
-
-    fontDisplay block
-
-    fontDisplay swap
-
-    fontDisplay fallback
-
-    fontDisplay optional
-
--}
-fontDisplay :
-    BaseValue
-        { auto : Supported
-        , block : Supported
-        , swap : Supported
-        , fallback : Supported
-        , optional : Supported
-        }
-    -> Style
-fontDisplay (Value val) =
-    AppendProperty ("font-display:" ++ val)
-
-
-{-| Sets `first` value for usage with [`hangingPunctuation`](#hangingPunctuation).
-
-      hangingPunctuation first
-
--}
-first : Value { provides | first : Supported }
-first =
-    Value "first"
-
-
-{-| Sets `last` value for usage with [`hangingPunctuation`](#hangingPunctuation).
-
-      hangingPunctuation last
-
--}
-last : Value { provides | last : Supported }
-last =
-    Value "last"
-
-
-{-| Sets `force-end` value for usage with [`hangingPunctuation`](#hangingPunctuation).
-
-      hangingPunctuation forceEnd
-
--}
-forceEnd : Value { provides | forceEnd : Supported }
-forceEnd =
-    Value "force-end"
-
-
-{-| Sets `allow-end` value for usage with [`hangingPunctuation`](#hangingPunctuation).
-
-      hangingPunctuation allowEnd
-
--}
-allowEnd : Value { provides | allowEnd : Supported }
-allowEnd =
-    Value "allow-end"
-
-
-{-| Sets [`hanging-punctuation`](https://css-tricks.com/almanac/properties/h/hanging-punctuation/)
-
-    hangingPunctuation none
-
-    hangingPunctuation first
-
-    hangingPunctuation2 first forceEnd
-
-    hangingPunctuation3 first allowEnd last
-
--}
-hangingPunctuation :
-    BaseValue
-        { none : Supported
-        , first : Supported
-        , forceEnd : Supported
-        , allowEnd : Supported
-        , last : Supported
-        }
-    -> Style
-hangingPunctuation (Value val) =
-    AppendProperty ("hanging-punctuation:" ++ val)
-
-
-{-| Sets [`hanging-punctuation`](https://css-tricks.com/almanac/properties/h/hanging-punctuation/)
-
-    hangingPunctuation2 first forceEnd
-
--}
-hangingPunctuation2 :
-    Value
-        { first : Supported
-        , last : Supported
-        }
-    ->
-        Value
-            { first : Supported
-            , forceEnd : Supported
-            , allowEnd : Supported
-            , last : Supported
-            }
-    -> Style
-hangingPunctuation2 (Value val1) (Value val2) =
-    AppendProperty ("hanging-punctuation:" ++ val1 ++ " " ++ val2)
-
-
-{-| Sets [`hanging-punctuation`](https://css-tricks.com/almanac/properties/h/hanging-punctuation/)
-
-    hangingPunctuation3 first allowEnd last
-
--}
-hangingPunctuation3 :
-    Value
-        { first : Supported
-        , last : Supported
-        }
-    ->
-        Value
-            { forceEnd : Supported
-            , allowEnd : Supported
-            }
-    ->
-        Value
-            { first : Supported
-            , last : Supported
-            }
-    -> Style
-hangingPunctuation3 (Value val1) (Value val2) (Value val3) =
-    AppendProperty ("hanging-punctuation:" ++ val1 ++ " " ++ val2 ++ " " ++ val3)
-
-
-{-| Sets [`hyphens`](https://css-tricks.com/almanac/properties/h/hyphens/)
-
-    hyphens none
-
-    hyphens manual
-
-    hyphens auto
-
--}
-hyphens :
-    BaseValue
-        { none : Supported
-        , manual : Supported
-        , auto : Supported
-        }
-    -> Style
-hyphens (Value val) =
-    AppendProperty ("hyphens:" ++ val)
-
-
-{-| Sets the [`quotes`](https://css-tricks.com/almanac/properties/q/quotes/) property.
-
-This one-argument version can only use keyword or global values.
-
-    quotes none
-
-    quotes inherit
-
-    quotes2 (string "\"") (string "\"")
-
-    quotes4 (string "\"") (string "\"") (string "'") (string "'")
-
--}
-quotes :
-    BaseValue
-        { none : Supported
-        , auto : Supported
-        }
-    -> Style
-quotes (Value val) =
-    AppendProperty ("quotes:" ++ val)
-
-
-{-| Sets the [`quotes`](https://css-tricks.com/almanac/properties/q/quotes/) property.
-
-This 2-argument version sets the starting and closing quotation marks for
-a top-level quote (a quote that is not nested within another quote). It only accepts
-string values.
-
-    quotes auto
-
-    quotes2 (string "\"") (string "\"") -- "Hey, this is a first-level quote."
-
-    quotes2 (string "'") (string "'") -- 'Hey, this is a first-level quote.'
-
-    quotes2 (string "«") (string "»") -- «Hey, this is a first-level quote.»
-
--}
-quotes2 :
-    Value
-        { string : Supported
-        }
-    ->
-        Value
-            { string : Supported
-            }
-    -> Style
-quotes2 (Value lv1StartQuote) (Value lv1EndQuote) =
-    AppendProperty ("quotes:" ++ lv1StartQuote ++ " " ++ lv1EndQuote)
-
-
-{-| Sets the [`quotes`](https://css-tricks.com/almanac/properties/q/quotes/) property.
-
-This 4-argument version sets the starting and closing quotation marks for both
-a top-level quote and a nested quote. It only accepts
-string values.
-
-    quotes auto
-
-    quotes2 (string "\"") (string "\"")
-
-    -- "Hey, this is a first-level quote."
-
-
-    quotes4 (string "\"") (string "\"") (string "\'") (string "\'")
-
-    {- "Hey, this is a first-level quote.
-    'And this is someone else I made up for
-    a second-level quote!' Yeah, I did that!"
-    -}
-
-    quotes4 (string "«") (string "»") (string "👏") (string "🤔")
-
-    {- «Hey, this is a first-level quote.
-    👏And this is someone else I made up for
-    a second-level quote!🤔 Yeah, I did that!»
-    -}
-
--}
-quotes4 :
-    Value
-        { string : Supported
-        }
-    ->
-        Value
-            { string : Supported
-            }
-    ->
-        Value
-            { string : Supported
-            }
-    ->
-        Value
-            { string : Supported
-            }
-    -> Style
-quotes4 (Value lv1StartQuote) (Value lv1EndQuote) (Value lv2StartQuote) (Value lv2EndQuote) =
-    AppendProperty ("quotes:" ++ lv1StartQuote ++ " " ++ lv1EndQuote ++ " " ++ lv2StartQuote ++ " " ++ lv2EndQuote)
-
-
-{-| Sets the [`text-overflow`](https://css-tricks.com/almanac/properties/t/text-overflow/) property.
-
-`text-overflow` describes how text that gets cut off is signalled to users.
-
-When the one-argument version is used, it sets the end of text (right end for LTR users) that is cut off.
-
-    textOverflow ellipsis
-
-When the two-argument version is used, it specifies how the
-text cut-off is displayed at the start (left in LTR) and
-the end (right in LTR) of the text.
-
-    textOverflow2 ellipsis ellipsis
-
--}
-textOverflow :
-    BaseValue
-        { clip : Supported
-        , ellipsis : Supported
-        }
-    -> Style
-textOverflow (Value value) =
-    AppendProperty ("text-overflow:" ++ value)
-
-
-{-| Sets the [`text-overflow`](https://css-tricks.com/almanac/properties/t/text-overflow/) property.
-
-`text-overflow` describes how text that gets cut off is signalled to users.
-
-This version specifies how the text cut-off is displayed at the start
-(left in LTR) and at the end (right in LTR) of the text.
-
-    textOverflow2 ellipsis ellipsis
-
--}
-textOverflow2 :
-    Value
-        { clip : Supported
-        , ellipsis : Supported
-        }
-    ->
-        Value
-            { clip : Supported
-            , ellipsis : Supported
-            }
-    -> Style
-textOverflow2 (Value startValue) (Value endValue) =
-    AppendProperty ("text-overflow:" ++ startValue ++ " " ++ endValue)
-
-
-{-| Sets the [`lineBreak`](https://css-tricks.com/almanac/properties/l/line-break/) property.
-
-    lineBreak auto
-
-    lineBreak strict
-
--}
-lineBreak :
-    BaseValue
-        { auto : Supported
-        , loose : Supported
-        , normal : Supported
-        , strict : Supported
-        , anywhere : Supported
-        }
-    -> Style
-lineBreak (Value value) =
-    AppendProperty ("line-break:" ++ value)
-
-
-{-| Sets `manual` value for usage with [`hyphens`](#hyphens).
-
-    hyphens manual
-
--}
-manual : Value { provides | manual : Supported }
-manual =
-    Value "manual"
-
-
-{-| Sets `ellipsis` value for usage with [`textOverflow`](#textOverflow).
-
-    textOverflow ellipsis
-
--}
-ellipsis : Value { provides | ellipsis : Supported }
-ellipsis =
-    Value "ellipsis"
-
-
-{-| Sets `loose` value for usage with [`lineBreak`](#lineBreak).
-
-    lineBreak loose
-
--}
-loose : Value { provides | loose : Supported }
-loose =
-    Value "loose"
 
 
 {-| Sets [`object-position`](https://css-tricks.com/almanac/properties/o/object-position/).
@@ -20956,24 +21037,6 @@ speak (Value val) =
     AppendProperty ("speak:" ++ val)
 
 
-{-| Sets [`tab-size`](https://css-tricks.com/almanac/properties/t/tab-size/)
-**Note:** only positive integer values are allowed.
-
-    tabSize (int 4)
-
--}
-tabSize :
-    BaseValue
-        (LengthSupported
-            { auto : Supported
-            , int : Supported
-            }
-        )
-    -> Style
-tabSize (Value val) =
-    AppendProperty ("tab-size:" ++ val)
-
-
 {-| Sets [`transform-origin`](https://css-tricks.com/almanac/properties/t/transform-origin/).
 
     transformOrigin top_
@@ -21094,29 +21157,6 @@ widows :
     -> Style
 widows (Value val) =
     AppendProperty ("widows:" ++ val)
-
-
-{-| Sets [`word-spacing`](https://css-tricks.com/almanac/properties/w/word-spacing/).
-
-    wordSpacing normal
-
-    wordSpacing zero
-
-    wordSpacing (px 5)
-
--}
-wordSpacing :
-    BaseValue
-        (LengthSupported
-            { normal : Supported
-            , pct : Supported
-            }
-        )
-    -> Style
-wordSpacing (Value str) =
-    AppendProperty ("word-spacing:" ++ str)
-
-
 
 
 {-| The [`resize`](https://css-tricks.com/almanac/properties/r/resize/) property.

--- a/src/Css.elm
+++ b/src/Css.elm
@@ -4,6 +4,16 @@ module Css exposing
     , property
     , important
 
+    -- pseudo-classes
+    , pseudoClass
+    , active, checked, disabled, empty, enabled
+    , firstChild, firstOfType, focus, fullscreen, hover, inRange
+    , indeterminate, invalid, lastChild, lastOfType, link, onlyChild
+    , onlyOfType, outOfRange, readOnly, readWrite, required
+    , root, scope, target, valid, visited
+    , pseudoElement
+    , before, after, backdrop, cue, marker, placeholder, selection
+
     -- common value groups
     , BaseValue
     , ImageSupported, Image
@@ -19,9 +29,9 @@ module Css exposing
     -- common value types
     , zero, px, em, ex, ch, rem, vh, vw, vmin, vmax, mm, cm, q, inches, pt, pc, pct
     , fr, minmax, fitContentTo
-    , num, int 
     , deg, grad, rad, turn
     , s, ms
+    , num, int 
     , rgb, rgba, hsl, hsla, hex, currentcolor
     , string, customIdent, url
     , circle, circleAt, circleAt2, ellipse, ellipseAt, ellipseAt2, closestSide, farthestSide, polygon, path
@@ -43,32 +53,25 @@ module Css exposing
     , content, fill_, stroke, text, style
     , clip, cover, contain_
 
-    -- pseudo-classes
-    , pseudoClass
-    , active, checked, disabled, empty, enabled
-    , firstChild, firstOfType, focus, fullscreen, hover, inRange
-    , indeterminate, invalid, lastChild, lastOfType, link, onlyChild
-    , onlyOfType, outOfRange, readOnly, readWrite, required
-    , root, scope, target, valid, visited
-    , pseudoElement
-    , before, after, backdrop, cue, marker, placeholder, selection
-
     -- all
     , all
 
     -- sizing
     , width, minWidth, maxWidth, height, minHeight, maxHeight
-    , blockSize, minBlockSize, maxBlockSize, inlineSize, minInlineSize, maxInlineSize
-
-    -- paddings
-    , padding, padding2, padding3, padding4, paddingTop, paddingRight, paddingBottom, paddingLeft
-    , paddingBlock, paddingBlock2, paddingBlockStart, paddingBlockEnd
-    , paddingInline, paddingInline2, paddingInlineStart, paddingInlineEnd
+    , blockSize, minBlockSize, maxBlockSize
+    , inlineSize, minInlineSize, maxInlineSize
 
     -- margins
-    , margin, margin2, margin3, margin4, marginTop, marginRight, marginBottom, marginLeft
+    , margin, margin2, margin3, margin4
+    , marginTop, marginRight, marginBottom, marginLeft
     , marginBlock, marginBlock2, marginBlockStart, marginBlockEnd
     , marginInline, marginInline2, marginInlineStart, marginInlineEnd
+
+    -- paddings
+    , padding, padding2, padding3, padding4
+    , paddingTop, paddingRight, paddingBottom, paddingLeft
+    , paddingBlock, paddingBlock2, paddingBlockStart, paddingBlockEnd
+    , paddingInline, paddingInline2, paddingInlineStart, paddingInlineEnd
 
     -- borders
     , border, border2, border3
@@ -82,20 +85,39 @@ module Css exposing
     , borderInline, borderInline2, borderInline3
     , borderInlineStart, borderInlineStart2, borderInlineStart3
     , borderInlineEnd, borderInlineEnd2, borderInlineEnd3
-    , borderWidth, borderWidth2, borderWidth3, borderWidth4, borderTopWidth, borderRightWidth, borderBottomWidth, borderLeftWidth
+    , borderWidth, borderWidth2, borderWidth3, borderWidth4
+    , borderTopWidth, borderRightWidth, borderBottomWidth, borderLeftWidth
     , borderBlockWidth, borderBlockStartWidth, borderBlockEndWidth, borderInlineWidth, borderInlineStartWidth, borderInlineEndWidth
-    , borderStyle, borderStyle2, borderStyle3, borderStyle4, borderTopStyle, borderRightStyle, borderBottomStyle, borderLeftStyle
+    , borderStyle, borderStyle2, borderStyle3, borderStyle4
+    , borderTopStyle, borderRightStyle, borderBottomStyle, borderLeftStyle
     , borderBlockStyle, borderBlockStartStyle, borderBlockEndStyle, borderInlineStyle, borderInlineStartStyle, borderInlineEndStyle
     , dotted, dashed, solid, double, groove, ridge, inset_, outset
-    , borderColor, borderColor2, borderColor3, borderColor4, borderTopColor, borderRightColor, borderBottomColor, borderLeftColor
+    , borderColor, borderColor2, borderColor3, borderColor4
+    , borderTopColor, borderRightColor, borderBottomColor, borderLeftColor
     , borderBlockColor, borderBlockStartColor, borderBlockEndColor, borderInlineColor, borderInlineStartColor, borderInlineEndColor
-    , borderRadius, borderRadius2, borderRadius3, borderRadius4, borderTopLeftRadius, borderTopLeftRadius2, borderTopRightRadius, borderTopRightRadius2, borderBottomRightRadius, borderBottomRightRadius2, borderBottomLeftRadius, borderBottomLeftRadius2
+    , borderRadius, borderRadius2, borderRadius3, borderRadius4
+    , borderTopLeftRadius, borderTopLeftRadius2, borderTopRightRadius, borderTopRightRadius2, borderBottomRightRadius, borderBottomRightRadius2, borderBottomLeftRadius, borderBottomLeftRadius2
     , borderStartStartRadius, borderStartStartRadius2, borderStartEndRadius, borderStartEndRadius2, borderEndStartRadius, borderEndStartRadius2, borderEndEndRadius, borderEndEndRadius2
     , borderImageOutset, borderImageOutset2, borderImageOutset3, borderImageOutset4
     , borderImageWidth, borderImageWidth2, borderImageWidth3, borderImageWidth4
 
     -- outlines
-    , outline, outline3, outlineWidth, outlineColor, invert, outlineStyle, outlineOffset
+    , outline, outline3, outlineWidth, outlineColor
+    , invert, outlineStyle, outlineOffset
+
+    -- ??
+    , display, display2, displayListItem2, displayListItem3
+    , flex_, flow, flowRoot, grid, contents, listItem, inlineBlock, inlineFlex, inlineTable, inlineGrid, rubyBase, rubyBaseContainer, rubyText, rubyTextContainer, runIn, table, tableCaption, tableCell, tableColumn, tableColumnGroup, tableFooterGroup, tableHeaderGroup, tableRow, tableRowGroup
+    , position
+    , absolute, fixed, relative, static, sticky
+    , zIndex
+
+    -- insets
+    , inset, inset2, inset3, inset4, top, right, bottom, left
+    , insetBlock, insetBlock2, insetInline, insetInline2, insetBlockStart, insetBlockEnd, insetInlineStart, insetInlineEnd
+
+    -- gaps
+    , gap, gap2, rowGap, columnGap
 
     -- color
     , color, backgroundColor
@@ -111,19 +133,7 @@ module Css exposing
     , TextShadowConfig, textShadow, defaultTextShadow
     , LineWidth, LineWidthSupported, LineStyle, LineStyleSupported
 
-    -- ??
-    , display, display2, displayListItem2, displayListItem3
-    , flex_, flow, flowRoot, grid, contents, listItem, inlineBlock, inlineFlex, inlineTable, inlineGrid, rubyBase, rubyBaseContainer, rubyText, rubyTextContainer, runIn, table, tableCaption, tableCell, tableColumn, tableColumnGroup, tableFooterGroup, tableHeaderGroup, tableRow, tableRowGroup
-    , position, zIndex
-    , absolute, fixed, relative, static, sticky
-
-    -- insets
-    , inset, inset2, inset3, inset4, top, right, bottom, left
-    , insetBlock, insetBlock2, insetInline, insetInline2, insetBlockStart, insetBlockEnd, insetInlineStart, insetInlineEnd
-
-    -- gaps
-    , gap, gap2, rowGap, columnGap
-
+    
     -- ??
     , boxSizing
     , alignContent, alignContent2, alignItems, alignItems2, alignSelf, alignSelf2, justifyContent, justifyContent2, justifyItems, justifyItems2, justifySelf, justifySelf2
@@ -251,13 +261,16 @@ module Css exposing
     , scrollbarColor, scrollbarWidth
     , scrollBehavior, smooth, scrollSnapAlign, scrollSnapStop
     , scrollSnapType, scrollSnapType2, mandatory, proximity
-    , scrollMargin, scrollMargin2, scrollMargin3, scrollMargin4, scrollMarginTop, scrollMarginLeft, scrollMarginRight, scrollMarginBottom
+    , scrollMargin, scrollMargin2, scrollMargin3, scrollMargin4
+    , scrollMarginTop, scrollMarginLeft, scrollMarginRight, scrollMarginBottom
     , scrollMarginBlock, scrollMarginBlock2, scrollMarginInline, scrollMarginInline2
     , scrollMarginBlockStart, scrollMarginBlockEnd, scrollMarginInlineStart, scrollMarginInlineEnd
-    , scrollPadding, scrollPadding2, scrollPadding3, scrollPadding4, scrollPaddingTop, scrollPaddingLeft, scrollPaddingRight, scrollPaddingBottom
+    , scrollPadding, scrollPadding2, scrollPadding3, scrollPadding4
+    , scrollPaddingTop, scrollPaddingLeft, scrollPaddingRight, scrollPaddingBottom
     , scrollPaddingBlock, scrollPaddingBlock2, scrollPaddingInline, scrollPaddingInline2
     , scrollPaddingBlockStart, scrollPaddingBlockEnd, scrollPaddingInlineStart, scrollPaddingInlineEnd
-    , overscrollBehavior, overscrollBehavior2, overscrollBehaviorX, overscrollBehaviorY, overscrollBehaviorBlock, overscrollBehaviorInline
+    , overscrollBehavior, overscrollBehavior2
+    , overscrollBehaviorX, overscrollBehaviorY, overscrollBehaviorBlock, overscrollBehaviorInline
     
     -- ??
     , speak, spellOut
@@ -1196,6 +1209,310 @@ makeImportant str =
         str ++ " !important"
 
 
+
+
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+---------------------------- PSEUDO-CLASSES ----------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+
+
+{-| Define a custom pseudo-class.
+
+This can be useful for deprecated [pseudo-classes](https://css-tricks.com/pseudo-class-selectors/) such as `-moz-any-link`, which
+[has been deprecated and removed](https://www.fxsitecompat.com/en-CA/docs/2016/any-link-css-pseudo-class-has-been-unprefixed/)
+in modern browsers.
+
+    button
+        [ css [ pseudoClass "-moz-any-link" [ color (hex "f00") ] ] ]
+        [ text "Whee!" ]
+
+...outputs
+
+    <button class="f9fcb2">Whee!</button>
+
+    <style>
+        .f9fcb2:-moz-any-link {
+            color: #f00;
+        }
+    </style>
+
+-}
+pseudoClass : String -> List Style -> Style
+pseudoClass pseudoClassName =
+    Preprocess.ExtendSelector (Structure.PseudoClassSelector pseudoClassName)
+
+
+{-| An [`:active`](https://css-tricks.com/almanac/selectors/a/active/)
+[pseudo-class](https://css-tricks.com/pseudo-class-selectors/).
+
+    button [ active [ color (rgb 12 160 190) ] ]
+
+-}
+active : List Style -> Style
+active =
+    pseudoClass "active"
+
+
+{-| A [`:checked`](https://developer.mozilla.org/en-US/docs/Web/CSS/:checked)
+[pseudo-class](https://css-tricks.com/pseudo-class-selectors/).
+
+This pseudo-class is for any checkbox, option or radio input that is checked or toggled on.
+
+    checked
+        [ backgroundColor (rgb 0 0 255)
+        ]
+
+-}
+checked : List Style -> Style
+checked =
+    pseudoClass "checked"
+
+
+{-| A [`:disabled`](https://developer.mozilla.org/en-US/docs/Web/CSS/:disabled)
+[pseudo-class](https://css-tricks.com/pseudo-class-selectors/).
+
+    button [ disabled [ color (rgb 194 194 194) ] ]
+
+-}
+disabled : List Style -> Style
+disabled =
+    pseudoClass "disabled"
+
+
+{-| An [`:empty`](https://developer.mozilla.org/en-US/docs/Web/CSS/:empty)
+[pseudo-class](https://css-tricks.com/pseudo-class-selectors/).
+
+    empty
+        [ backgroundColor (rgb 20 20 20)
+        ]
+
+-}
+empty : List Style -> Style
+empty =
+    pseudoClass "empty"
+
+
+{-| An [`:enabled`](https://developer.mozilla.org/en-US/docs/Web/CSS/:enabled)
+[pseudo-class](https://css-tricks.com/pseudo-class-selectors/).
+
+    enabled
+        [ borderColor (rgba 150 150 0 0.5)
+        ]
+
+-}
+enabled : List Style -> Style
+enabled =
+    pseudoClass "enabled"
+
+
+{-| A [`:first-of-type`](https://developer.mozilla.org/en-US/docs/Web/CSS/:first-child)
+[pseudo-class](https://css-tricks.com/pseudo-class-selectors/).
+
+    firstChild
+        [ fontWeight bold
+        ]
+
+-}
+firstChild : List Style -> Style
+firstChild =
+    pseudoClass "first-child"
+
+
+{-| A [`:first-of-type`](https://developer.mozilla.org/en-US/docs/Web/CSS/:first-of-type)
+[pseudo-class](https://css-tricks.com/pseudo-class-selectors/).
+
+    firstOfType
+        [ color (rgb 255 0 0)
+        ]
+
+-}
+firstOfType : List Style -> Style
+firstOfType =
+    pseudoClass "first-of-type"
+
+
+{-| A [`:focus`](https://developer.mozilla.org/en-US/docs/Web/CSS/:focus)
+[pseudo-class](https://css-tricks.com/pseudo-class-selectors/).
+
+    focus
+        [ border3 (px 2) solid (rgb 0 0 0)
+        ]
+
+-}
+focus : List Style -> Style
+focus =
+    pseudoClass "focus"
+
+
+{-| A [`:fullscreen`](https://developer.mozilla.org/en-US/docs/Web/CSS/:fullscreen)
+[pseudo-class](https://css-tricks.com/pseudo-class-selectors/).
+
+    fullscreen
+        [ backgroundColor (rgb 0 0 0)
+        ]
+
+-}
+fullscreen : List Style -> Style
+fullscreen =
+    pseudoClass "fullscreen"
+
+
+{-| A [`:hover`](https://developer.mozilla.org/en-US/docs/Web/CSS/:hover)
+[pseudo-class](https://css-tricks.com/pseudo-class-selectors/).
+
+    hover
+        [ fontWeight bold
+        , color (rgb 255 50 0)
+        ]
+
+-}
+hover : List Style -> Style
+hover =
+    pseudoClass "hover"
+
+
+{-| An [`:in-range`](https://developer.mozilla.org/en-US/docs/Web/CSS/:in-range)
+[pseudo-class](https://css-tricks.com/pseudo-class-selectors/).
+
+    inRange
+        [ backgroundColor (rgb 0 255 0)
+        ]
+
+-}
+inRange : List Style -> Style
+inRange =
+    pseudoClass "in-range"
+
+
+{-| An [`:indeterminate`](https://developer.mozilla.org/en-US/docs/Web/CSS/:indeterminate)
+[pseudo-class](https://css-tricks.com/pseudo-class-selectors/).
+
+    indeterminate
+        [ backgroundColor (rgb 100 100 100)
+        ]
+
+-}
+indeterminate : List Style -> Style
+indeterminate =
+    pseudoClass "indeterminate"
+
+
+{-| An [`:invalid`](https://developer.mozilla.org/en-US/docs/Web/CSS/:invalid)
+[pseudo-class](https://css-tricks.com/pseudo-class-selectors/).
+
+    invalid
+        [ color (rgb 255 0 0)
+        , fontWeight bold
+        ]
+
+-}
+invalid : List Style -> Style
+invalid =
+    pseudoClass "invalid"
+
+
+{-| A [`:last-child`](https://developer.mozilla.org/en-US/docs/Web/CSS/:last-child)
+[pseudo-class](https://css-tricks.com/pseudo-class-selectors/).
+
+    lastChild
+        [ backgroundColor (rgb 0 0 255)
+        ]
+
+-}
+lastChild : List Style -> Style
+lastChild =
+    pseudoClass "last-child"
+
+
+{-| A [`:last-of-type`](https://developer.mozilla.org/en-US/docs/Web/CSS/:last-of-type)
+[pseudo-class](https://css-tricks.com/pseudo-class-selectors/).
+
+    lastOfType
+        [ color (rgb 100 100 100)
+        ]
+
+-}
+lastOfType : List Style -> Style
+lastOfType =
+    pseudoClass "last-of-type"
+
+
+{-| A [`:link`](https://developer.mozilla.org/en-US/docs/Web/CSS/:link)
+[pseudo-class](https://css-tricks.com/pseudo-class-selectors/).
+
+    link
+        [ color (rgb 0 0 255)
+        ]
+
+-}
+link : List Style -> Style
+link =
+    pseudoClass "link"
+
+
+{-| An [`:only-child`](https://developer.mozilla.org/en-US/docs/Web/CSS/:only-child)
+[pseudo-class](https://css-tricks.com/pseudo-class-selectors/).
+
+    onlyChild
+        [ backgroundColor (rgb 255 255 255)
+        ]
+
+-}
+onlyChild : List Style -> Style
+onlyChild =
+    pseudoClass "only-child"
+
+
+{-| An [`:only-of-type`](https://developer.mozilla.org/en-US/docs/Web/CSS/:only-of-type)
+[pseudo-class](https://css-tricks.com/pseudo-class-selectors/).
+
+    onlyOfType
+        [ color (rgb 255 0 0)
+        , fontStyle italic
+        ]
+
+-}
+onlyOfType : List Style -> Style
+onlyOfType =
+    pseudoClass "only-of-type"
+
+
+{-| An [`:out-of-range`](https://developer.mozilla.org/en-US/docs/Web/CSS/:out-of-range)
+[pseudo-class](https://css-tricks.com/pseudo-class-selectors/).
+
+    outOfRange
+        [ color (rgb 255 0 0)
+        ]
+
+-}
+outOfRange : List Style -> Style
+outOfRange =
+    pseudoClass "out-of-range"
+
+
+{-| A [`:read-only`](https://developer.mozilla.org/en-US/docs/Web/CSS/:read-only)
+[pseudo-class](https://css-tricks.com/pseudo-class-selectors/).
+
+    readOnly
+        [ color (rgb 50 50 50)
+        ]
+
+-}
+readOnly : List Style -> Style
+readOnly =
+    pseudoClass "read-only"
+
+
 ------------------------------------------------------------------------
 ------------------------------------------------------------------------
 ------------------------------------------------------------------------
@@ -1710,46 +2027,6 @@ fitContentTo (Value val) =
 ------------------------------------------------------------------------
 ------------------------------------------------------------------------
 ------------------------------------------------------------------------
-------------------------------- NUMBERS --------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-
-
-{-| A unitless number. Useful with properties like
-[`flexGrow`](#flexGrow),
-and [`order`](#order)
-which accept unitless numbers.
-
-    flexGrow (num 2)
-
-    order (num -2)
-
--}
-num : Float -> Value { provides | num : Supported }
-num value =
-    Value (String.fromFloat value)
-
-
-{-| A unitless integer. Useful with properties like [`zIndex`](#zIndex) which accept unitless integers.
-
-    zIndex (int 3)
-
--}
-int : Int -> Value { provides | int : Supported }
-int value =
-    Value (String.fromInt value)
-
-
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
 ------------------------------ ANGLES ----------------------------------
 ------------------------------------------------------------------------
 ------------------------------------------------------------------------
@@ -1840,6 +2117,46 @@ s value =
 ms : Float -> Value { provides | ms : Supported }
 ms value =
     Value (String.fromFloat value ++ "ms")
+
+
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------- NUMBERS --------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+
+
+{-| A unitless number. Useful with properties like
+[`flexGrow`](#flexGrow),
+and [`order`](#order)
+which accept unitless numbers.
+
+    flexGrow (num 2)
+
+    order (num -2)
+
+-}
+num : Float -> Value { provides | num : Supported }
+num value =
+    Value (String.fromFloat value)
+
+
+{-| A unitless integer. Useful with properties like [`zIndex`](#zIndex) which accept unitless integers.
+
+    zIndex (int 3)
+
+-}
+int : Int -> Value { provides | int : Supported }
+int value =
+    Value (String.fromInt value)
 
 
 ------------------------------------------------------------------------
@@ -2395,6 +2712,7 @@ dppx val =
 ------------------------------------------------------------------------
 ------------------------------------------------------------------------
 ------------------------------------------------------------------------
+
 
 {-| The [`inherit`](https://developer.mozilla.org/en-US/docs/Web/CSS/inherit) value.
 Any CSS property can be set to this value.
@@ -3468,6 +3786,3055 @@ contain_ =
     Value "contain"
 
 
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+--------------------------------- ALL ----------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+
+
+{-| Sets an [`all`](https://css-tricks.com/almanac/properties/a/all/) property.
+
+    all inherit
+
+-}
+all : BaseValue a -> Style
+all (Value val) =
+    AppendProperty ("all:" ++ val)
+
+
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------- SIZING --------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+
+
+{-| The [`width`](https://css-tricks.com/almanac/properties/w/width/) property.
+
+    width (px 150)
+
+    width (em 1.5)
+
+    width auto
+
+    width minContent
+
+-}
+width :
+    BaseValue
+        (LengthSupported
+            { pct : Supported
+            , auto : Supported
+            , maxContent : Supported
+            , minContent : Supported
+            , fitContent : Supported
+            }
+        )
+    -> Style
+width (Value sizeVal) =
+    AppendProperty ("width:" ++ sizeVal)
+
+
+{-| The [`min-width`](https://css-tricks.com/almanac/properties/m/min-width/) property.
+
+    minWidth (px 150)
+
+    minWidth (em 1.5)
+
+    minWidth auto
+
+-}
+minWidth :
+    BaseValue
+        (LengthSupported
+            { auto : Supported
+            , maxContent : Supported
+            , minContent : Supported
+            , fitContent : Supported
+            , pct : Supported
+            }
+        )
+    -> Style
+minWidth (Value sizeVal) =
+    AppendProperty ("min-width:" ++ sizeVal)
+
+
+{-| The [`max-width`](https://css-tricks.com/almanac/properties/m/max-width/) property.
+
+    maxWidth (px 150)
+
+    maxWidth (em 1.5)
+
+    maxWidth auto
+
+-}
+maxWidth :
+    BaseValue
+        (LengthSupported
+            { maxContent : Supported
+            , minContent : Supported
+            , fitContent : Supported
+            , none : Supported
+            , pct : Supported
+            }
+        )
+    -> Style
+maxWidth (Value sizeVal) =
+    AppendProperty ("max-width:" ++ sizeVal)
+
+
+{-| The [`height`](https://css-tricks.com/almanac/properties/h/height/) property.
+
+    height (px 34)
+
+-}
+height :
+    BaseValue
+        (LengthSupported
+            { pct : Supported
+            , auto : Supported
+            , maxContent : Supported
+            , minContent : Supported
+            , fitContent : Supported
+            }
+        )
+    -> Style
+height (Value val) =
+    AppendProperty ("height:" ++ val)
+
+
+{-| The [`min-height`](https://css-tricks.com/almanac/properties/m/min-height/) property.
+
+    minHeight (px 20)
+
+-}
+minHeight :
+    BaseValue
+        (LengthSupported
+            { pct : Supported
+            , auto : Supported
+            , maxContent : Supported
+            , minContent : Supported
+            , fitContent : Supported
+            }
+        )
+    -> Style
+minHeight (Value val) =
+    AppendProperty ("min-height:" ++ val)
+
+
+{-| The [`max-height`](https://css-tricks.com/almanac/properties/m/min-height/) property.
+
+    maxHeight (px 20)
+
+-}
+maxHeight :
+    BaseValue
+        (LengthSupported
+            { pct : Supported
+            , none : Supported
+            , maxContent : Supported
+            , minContent : Supported
+            , fitContent : Supported
+            }
+        )
+    -> Style
+maxHeight (Value val) =
+    AppendProperty ("max-height:" ++ val)
+
+
+{-| The [`block-size`](https://css-tricks.com/almanac/properties/b/block-size/) property.
+
+    blockSize (px 20)
+
+-}
+blockSize :
+    BaseValue
+        (LengthSupported
+            { pct : Supported
+            , none : Supported
+            , maxContent : Supported
+            , minContent : Supported
+            , fitContent : Supported
+            }
+        )
+    -> Style
+blockSize (Value val) =
+    AppendProperty ("block-size:" ++ val)
+
+
+{-| The [`min-block-size`](https://developer.mozilla.org/en-US/docs/Web/CSS/min-block-size) property.
+
+    minBlockSize (px 20)
+
+-}
+minBlockSize :
+    BaseValue
+        (LengthSupported
+            { pct : Supported
+            , none : Supported
+            , maxContent : Supported
+            , minContent : Supported
+            , fitContent : Supported
+            }
+        )
+    -> Style
+minBlockSize (Value val) =
+    AppendProperty ("min-block-size:" ++ val)
+
+
+{-| The [`max-block-size`](https://developer.mozilla.org/en-US/docs/Web/CSS/max-block-size) property.
+
+    maxBlockSize (px 20)
+
+-}
+maxBlockSize :
+    BaseValue
+        (LengthSupported
+            { pct : Supported
+            , none : Supported
+            , maxContent : Supported
+            , minContent : Supported
+            , fitContent : Supported
+            }
+        )
+    -> Style
+maxBlockSize (Value val) =
+    AppendProperty ("max-block-size:" ++ val)
+
+
+{-| The [`inline-size`](https://css-tricks.com/almanac/properties/i/inline-size/) property.
+
+    inlineSize (px 20)
+
+-}
+inlineSize :
+    BaseValue
+        (LengthSupported
+            { pct : Supported
+            , none : Supported
+            , maxContent : Supported
+            , minContent : Supported
+            , fitContent : Supported
+            }
+        )
+    -> Style
+inlineSize (Value val) =
+    AppendProperty ("inline-size:" ++ val)
+
+
+{-| The [`min-inline-size`](https://developer.mozilla.org/en-US/docs/Web/CSS/min-inline-size) property.
+
+    minInlineSize (px 20)
+
+-}
+minInlineSize :
+    BaseValue
+        (LengthSupported
+            { pct : Supported
+            , none : Supported
+            , maxContent : Supported
+            , minContent : Supported
+            , fitContent : Supported
+            }
+        )
+    -> Style
+minInlineSize (Value val) =
+    AppendProperty ("min-inline-size:" ++ val)
+
+
+{-| The [`max-inline-size`](https://developer.mozilla.org/en-US/docs/Web/CSS/max-inline-size) property.
+
+    maxInlineSize (px 20)
+
+-}
+maxInlineSize :
+    BaseValue
+        (LengthSupported
+            { pct : Supported
+            , none : Supported
+            , maxContent : Supported
+            , minContent : Supported
+            , fitContent : Supported
+            }
+        )
+    -> Style
+maxInlineSize (Value val) =
+    AppendProperty ("max-inline-size:" ++ val)
+
+
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------- MARGINS --------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+
+
+
+{-| Sets [`margin`](https://css-tricks.com/almanac/properties/m/margin/) property.
+The `margin` property is a shorthand property for setting `margin-top`,
+`margin-right`, `margin-bottom`, and `margin-left` in a single declaration.
+
+If there is only one argument value, it applies to all sides. If there are two
+values, the top and bottom margins are set to the first value and the right and
+left margins are set to the second. If there are three values, the top is set
+to the first value, the left and right are set to the second, and the bottom is
+set to the third. If there are four values they apply to the top, right,
+bottom, and left, respectively.
+
+    margin (em 4) -- set all margins to 4em
+
+    margin2 (em 4) (px 2) -- top & bottom = 4em, right & left = 2px
+
+    margin3 (em 4) (px 2) (pct 5) -- top = 4em, right = 2px, bottom = 5%, left = 2px
+
+    margin4 (em 4) (px 2) (pct 5) (px 3) -- top = 4em, right = 2px, bottom = 5%, left = 3px
+
+You may want to check out [this article on collapsing margins](https://css-tricks.com/good-ol-margin-collapsing/)!
+
+-}
+margin :
+    BaseValue
+        (LengthSupported
+            { pct : Supported
+            , auto : Supported
+            }
+        )
+    -> Style
+margin (Value value) =
+    AppendProperty ("margin:" ++ value)
+
+
+{-| Sets [`margin`](https://css-tricks.com/almanac/properties/m/margin/) property.
+The `margin2` property is a shorthand property for setting `margin-top`,
+`margin-right`, `margin-bottom`, and `margin-left` in a single declaration.
+
+The top and bottom margins are set to the first value and the right and left
+margins are set to the second.
+
+    margin2 (em 4) (px 2) -- top & bottom = 4em, right & left = 2px
+
+You may want to check out [this article on collapsing margins](https://css-tricks.com/good-ol-margin-collapsing/)!
+
+-}
+margin2 :
+    Value
+        (LengthSupported
+            { pct : Supported
+            , auto : Supported
+            }
+        )
+    ->
+        Value
+            (LengthSupported
+                { pct : Supported
+                , auto : Supported
+                }
+            )
+    -> Style
+margin2 (Value valueTopBottom) (Value valueRightLeft) =
+    AppendProperty ("margin:" ++ valueTopBottom ++ " " ++ valueRightLeft)
+
+
+{-| Sets [`margin`](https://css-tricks.com/almanac/properties/m/margin/) property.
+The `margin3` property is a shorthand property for setting `margin-top`,
+`margin-right`, `margin-bottom`, and `margin-left` in a single declaration.
+
+The top margin is set to the first value, the left and right are set to the
+second, and the bottom is set to the third.
+
+    margin3 (em 4) (px 2) (pct 5) -- top = 4em, right = 2px, bottom = 5%, left = 2px
+
+You may want to check out [this article on collapsing margins](https://css-tricks.com/good-ol-margin-collapsing/)!
+
+-}
+margin3 :
+    Value
+        (LengthSupported
+            { pct : Supported
+            , auto : Supported
+            }
+        )
+    ->
+        Value
+            (LengthSupported
+                { pct : Supported
+                , auto : Supported
+                }
+            )
+    ->
+        Value
+            (LengthSupported
+                { pct : Supported
+                , auto : Supported
+                }
+            )
+    -> Style
+margin3 (Value valueTop) (Value valueRightLeft) (Value valueBottom) =
+    AppendProperty ("margin:" ++ valueTop ++ " " ++ valueRightLeft ++ " " ++ valueBottom)
+
+
+{-| Sets [`margin`](https://css-tricks.com/almanac/properties/m/margin/) property.
+The `margin4` property is a shorthand property for setting `margin-top`,
+`margin-right`, `margin-bottom`, and `margin-left` in a single declaration.
+
+The four values apply to the top, right, bottom, and left margins.
+
+    margin4 (em 4) (px 2) (pct 5) (px 3) -- top = 4em, right = 2px, bottom = 5%, left = 3px
+
+You may want to check out [this article on collapsing margins](https://css-tricks.com/good-ol-margin-collapsing/)!
+
+-}
+margin4 :
+    Value
+        (LengthSupported
+            { pct : Supported
+            , auto : Supported
+            }
+        )
+    ->
+        Value
+            (LengthSupported
+                { pct : Supported
+                , auto : Supported
+                }
+            )
+    ->
+        Value
+            (LengthSupported
+                { pct : Supported
+                , auto : Supported
+                }
+            )
+    ->
+        Value
+            (LengthSupported
+                { pct : Supported
+                , auto : Supported
+                }
+            )
+    -> Style
+margin4 (Value valueTop) (Value valueRight) (Value valueBottom) (Value valueLeft) =
+    AppendProperty ("margin:" ++ valueTop ++ " " ++ valueRight ++ " " ++ valueBottom ++ " " ++ valueLeft)
+
+
+{-| Sets [`margin-top`](https://developer.mozilla.org/en-US/docs/Web/CSS/margin-top) property.
+
+    marginTop (px 4)
+
+This article on [`margin-top` versus `margin-bottom`](https://css-tricks.com/margin-bottom-margin-top/) may be useful.
+
+-}
+marginTop :
+    BaseValue
+        (LengthSupported
+            { pct : Supported
+            , auto : Supported
+            }
+        )
+    -> Style
+marginTop (Value value) =
+    AppendProperty ("margin-top:" ++ value)
+
+
+{-| Sets [`margin-right`](https://developer.mozilla.org/en-US/docs/Web/CSS/margin-right) property.
+
+    marginRight (px 4)
+
+-}
+marginRight :
+    BaseValue
+        (LengthSupported
+            { pct : Supported
+            , auto : Supported
+            }
+        )
+    -> Style
+marginRight (Value value) =
+    AppendProperty ("margin-right:" ++ value)
+
+
+{-| Sets [`margin-bottom`](https://developer.mozilla.org/en-US/docs/Web/CSS/margin-bottom) property.
+
+    marginBottom (px 4)
+
+This article on [`margin-top` versus `margin-bottom`](https://css-tricks.com/margin-bottom-margin-top/) may be useful.
+
+-}
+marginBottom :
+    BaseValue
+        (LengthSupported
+            { pct : Supported
+            , auto : Supported
+            }
+        )
+    -> Style
+marginBottom (Value value) =
+    AppendProperty ("margin-bottom:" ++ value)
+
+
+{-| Sets [`margin-left`](https://developer.mozilla.org/en-US/docs/Web/CSS/margin-left) property.
+
+    marginLeft (px 4)
+
+-}
+marginLeft :
+    BaseValue
+        (LengthSupported
+            { pct : Supported
+            , auto : Supported
+            }
+        )
+    -> Style
+marginLeft (Value value) =
+    AppendProperty ("margin-left:" ++ value)
+
+
+
+{-| Sets [`margin-block`](https://css-tricks.com/almanac/properties/m/margin-block/) property.
+The `margin-block` property is a shorthand property for setting `margin-block-start` and
+`margin-block-end` in a single declaration.
+
+If there is only one argument value, it applies to both sides. If there are two
+values, the block start margin is set to the first value and the block end margin
+is set to the second.
+
+    marginBlock (em 4) -- set both block margins to 4em
+
+    marginBlock2 (em 4) (px 2) -- block start = 4em, block end = 2px
+
+You may want to check out [this article on collapsing margins](https://css-tricks.com/good-ol-margin-collapsing/)!
+
+-}
+marginBlock :
+    BaseValue
+        (LengthSupported
+            { pct : Supported
+            , auto : Supported
+            }
+        )
+    -> Style
+marginBlock (Value value) =
+    AppendProperty ("margin-block:" ++ value)
+
+
+{-| Sets [`margin-block`](https://css-tricks.com/almanac/properties/m/margin-block/) property.
+The `margin-block` property is a shorthand property for setting `margin-block-start` and
+`margin-block-end` in a single declaration.
+
+The block start margin is set to the first value and the block end margin
+is set to the second.
+
+    marginBlock2 (em 4) (px 2) -- block start = 4em, block end = 2px
+
+You may want to check out [this article on collapsing margins](https://css-tricks.com/good-ol-margin-collapsing/)!
+
+-}
+marginBlock2 :
+    Value
+        (LengthSupported
+            { pct : Supported
+            , auto : Supported
+            }
+        )
+    ->
+        Value
+            (LengthSupported
+                { pct : Supported
+                , auto : Supported
+                }
+            )
+    -> Style
+marginBlock2 (Value valueStart) (Value valueEnd) =
+    AppendProperty ("margin-block:" ++ valueStart ++ " " ++ valueEnd)
+
+
+{-| Sets [`margin-block-start`](https://developer.mozilla.org/en-US/docs/Web/CSS/margin-block-start) property.
+
+    marginBlockStart (px 4)
+
+-}
+marginBlockStart :
+    BaseValue
+        (LengthSupported
+            { pct : Supported
+            , auto : Supported
+            }
+        )
+    -> Style
+marginBlockStart (Value value) =
+    AppendProperty ("margin-block-start:" ++ value)
+
+
+{-| Sets [`margin-block-end`](https://developer.mozilla.org/en-US/docs/Web/CSS/margin-block-end) property.
+
+    marginBlockEnd (px 4)
+
+-}
+marginBlockEnd :
+    BaseValue
+        (LengthSupported
+            { pct : Supported
+            , auto : Supported
+            }
+        )
+    -> Style
+marginBlockEnd (Value value) =
+    AppendProperty ("margin-block-end:" ++ value)
+
+
+{-| Sets [`margin-inline`](https://css-tricks.com/almanac/properties/m/margin-inline/) property.
+The `margin-inline` property is a shorthand property for setting `margin-inline-start` and
+`margin-inline-end` in a single declaration.
+
+If there is only one argument value, it applies to both sides. If there are two
+values, the inline start margin is set to the first value and the inline end margin
+is set to the second.
+
+    marginInline (em 4) -- set both inline margins to 4em
+
+    marginInline2 (em 4) (px 2) -- inline start = 4em, inline end = 2px
+
+You may want to check out [this article on collapsing margins](https://css-tricks.com/good-ol-margin-collapsing/)!
+
+-}
+marginInline :
+    BaseValue
+        (LengthSupported
+            { pct : Supported
+            , auto : Supported
+            }
+        )
+    -> Style
+marginInline (Value value) =
+    AppendProperty ("margin-inline:" ++ value)
+
+
+{-| Sets [`margin-inline`](https://css-tricks.com/almanac/properties/m/margin-inline/) property.
+The `margin-inline` property is a shorthand property for setting `margin-inline-start` and
+`margin-inline-end` in a single declaration.
+
+The inline start margin is set to the first value and the inline end margin
+is set to the second.
+
+    marginInline2 (em 4) (px 2) -- inline start = 4em, inline end = 2px
+
+You may want to check out [this article on collapsing margins](https://css-tricks.com/good-ol-margin-collapsing/)!
+
+-}
+marginInline2 :
+    Value
+        (LengthSupported
+            { pct : Supported
+            , auto : Supported
+            }
+        )
+    ->
+        Value
+            (LengthSupported
+                { pct : Supported
+                , auto : Supported
+                }
+            )
+    -> Style
+marginInline2 (Value valueStart) (Value valueEnd) =
+    AppendProperty ("margin-inline:" ++ valueStart ++ " " ++ valueEnd)
+
+
+{-| Sets [`margin-inline-start`](https://developer.mozilla.org/en-US/docs/Web/CSS/margin-inline-start) property.
+
+    marginInlineStart (px 4)
+
+-}
+marginInlineStart :
+    BaseValue
+        (LengthSupported
+            { pct : Supported
+            , auto : Supported
+            }
+        )
+    -> Style
+marginInlineStart (Value value) =
+    AppendProperty ("margin-inline-start:" ++ value)
+
+
+{-| Sets [`margin-inline-end`](https://developer.mozilla.org/en-US/docs/Web/CSS/margin-inline-end) property.
+
+    marginInlineEnd (px 4)
+
+-}
+marginInlineEnd :
+    BaseValue
+        (LengthSupported
+            { pct : Supported
+            , auto : Supported
+            }
+        )
+    -> Style
+marginInlineEnd (Value value) =
+    AppendProperty ("margin-inline-end:" ++ value)
+
+
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------- PADDING --------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+
+
+{-| Sets [`padding`](https://css-tricks.com/almanac/properties/p/padding/) property.
+The `padding` property is a shorthand property for setting `padding-top`,
+`padding-right`, `padding-bottom`, and `padding-left` in a single declaration.
+
+If there is only one argument value, it applies to all sides. If there are two
+values, the top and bottom paddings are set to the first value and the right and
+left paddings are set to the second. If there are three values, the top is set
+to the first value, the left and right are set to the second, and the bottom is
+set to the third. If there are four values they apply to the top, right,
+bottom, and left, respectively.
+
+    padding (em 4) -- set all margins to 4em
+
+    padding2 (em 4) (px 2) -- top & bottom = 4em, right & left = 2px
+
+    padding3 (em 4) (px 2) (pct 5) -- top = 4em, right = 2px, bottom = 5%, left = 2px
+
+    padding4 (em 4) (px 2) (pct 5) (px 3) -- top = 4em, right = 2px, bottom = 5%, left = 3px
+
+-}
+padding :
+    BaseValue
+        (LengthSupported
+            { pct : Supported
+            }
+        )
+    -> Style
+padding (Value value) =
+    AppendProperty ("padding:" ++ value)
+
+
+{-| Sets [`padding`](https://css-tricks.com/almanac/properties/p/padding/) property.
+The `padding2` property is a shorthand property for setting `padding-top`,
+`padding-right`, `padding-bottom`, and `padding-left` in a single declaration.
+
+The top and bottom margins are set to the first value and the right and left
+margins are set to the second.
+
+    padding2 (em 4) (px 2) -- top & bottom = 4em, right & left = 2px
+
+-}
+padding2 :
+    Value
+        (LengthSupported
+            { pct : Supported
+            }
+        )
+    ->
+        Value
+            (LengthSupported
+                { pct : Supported
+                }
+            )
+    -> Style
+padding2 (Value valueTopBottom) (Value valueRightLeft) =
+    AppendProperty ("padding:" ++ valueTopBottom ++ " " ++ valueRightLeft)
+
+
+{-| Sets [`padding`](https://css-tricks.com/almanac/properties/p/padding/) property.
+The `padding3` property is a shorthand property for setting `padding-top`,
+`padding-right`, `padding-bottom`, and `padding-left` in a single declaration.
+
+The top padding is set to the first value, the left and right are set to the
+second, and the bottom is set to the third.
+
+    padding3 (em 4) (px 2) (pct 5) -- top = 4em, right = 2px, bottom = 5%, left = 2px
+
+-}
+padding3 :
+    Value
+        (LengthSupported
+            { pct : Supported
+            }
+        )
+    ->
+        Value
+            (LengthSupported
+                { pct : Supported
+                }
+            )
+    ->
+        Value
+            (LengthSupported
+                { pct : Supported
+                }
+            )
+    -> Style
+padding3 (Value valueTop) (Value valueRightLeft) (Value valueBottom) =
+    AppendProperty ("padding:" ++ valueTop ++ " " ++ valueRightLeft ++ " " ++ valueBottom)
+
+
+{-| Sets [`padding`](https://css-tricks.com/almanac/properties/p/padding/) property.
+The `padding4` property is a shorthand property for setting `padding-top`,
+`padding-right`, `padding-bottom`, and `padding-left` in a single declaration.
+
+The four values apply to the top, right, bottom, and left paddings.
+
+    padding4 (em 4) (px 2) (pct 5) (px 3) -- top = 4em, right = 2px, bottom = 5%, left = 3px
+
+-}
+padding4 :
+    Value
+        (LengthSupported
+            { pct : Supported
+            }
+        )
+    ->
+        Value
+            (LengthSupported
+                { pct : Supported
+                }
+            )
+    ->
+        Value
+            (LengthSupported
+                { pct : Supported
+                }
+            )
+    ->
+        Value
+            (LengthSupported
+                { pct : Supported
+                }
+            )
+    -> Style
+padding4 (Value valueTop) (Value valueRight) (Value valueBottom) (Value valueLeft) =
+    AppendProperty ("padding:" ++ valueTop ++ " " ++ valueRight ++ " " ++ valueBottom ++ " " ++ valueLeft)
+
+
+{-| Sets [`padding-top`](https://developer.mozilla.org/en-US/docs/Web/CSS/padding-top) property.
+
+    paddingTop (px 4)
+
+-}
+paddingTop :
+    BaseValue
+        (LengthSupported
+            { pct : Supported
+            }
+        )
+    -> Style
+paddingTop (Value value) =
+    AppendProperty ("padding-top:" ++ value)
+
+
+{-| Sets [`padding-right`](https://developer.mozilla.org/en-US/docs/Web/CSS/padding-right) property.
+
+    paddingRight (px 4)
+
+-}
+paddingRight :
+    BaseValue
+        (LengthSupported
+            { pct : Supported
+            }
+        )
+    -> Style
+paddingRight (Value value) =
+    AppendProperty ("padding-right:" ++ value)
+
+
+{-| Sets [`padding-bottom`](https://developer.mozilla.org/en-US/docs/Web/CSS/padding-bottom) property.
+
+    paddingBottom (px 4)
+
+-}
+paddingBottom :
+    BaseValue
+        (LengthSupported
+            { pct : Supported
+            }
+        )
+    -> Style
+paddingBottom (Value value) =
+    AppendProperty ("padding-bottom:" ++ value)
+
+
+{-| Sets [`padding-left`](https://developer.mozilla.org/en-US/docs/Web/CSS/padding-left) property.
+
+    paddingLeft (px 4)
+
+-}
+paddingLeft :
+    BaseValue
+        (LengthSupported
+            { pct : Supported
+            }
+        )
+    -> Style
+paddingLeft (Value value) =
+    AppendProperty ("padding-left:" ++ value)
+
+
+{-| Sets [`padding-block`](https://css-tricks.com/almanac/properties/p/padding-block/) property.
+The `padding-block` property is a shorthand property for setting `padding-block-start` and
+`padding-block-end` in a single declaration.
+
+If there is only one argument value, it applies to both sides. If there are two
+values, the block start is set to the first value and the block end is set to the second.
+
+    paddingBlock (em 4) -- set both block start and block end to 4em
+
+    paddingBlock2 (em 4) (px 2) -- block start = 4em, block end = 2px
+
+-}
+paddingBlock :
+    BaseValue
+        (LengthSupported
+            { pct : Supported
+            }
+        )
+    -> Style
+paddingBlock (Value value) =
+    AppendProperty ("padding-block:" ++ value)
+
+
+{-| Sets [`padding-block`](https://css-tricks.com/almanac/properties/p/padding-block/) property.
+
+The `padding-block` property is a shorthand property for setting `padding-block-start` and
+`padding-block-end` in a single declaration.
+
+The block start value is set to the first value and the block end value is set to the second.
+
+    paddingBlock2 (em 4) (px 2) -- block start = 4em, block end = 2px
+
+-}
+paddingBlock2 :
+    Value
+        (LengthSupported
+            { pct : Supported
+            }
+        )
+    ->
+        Value
+            (LengthSupported
+                { pct : Supported
+                }
+            )
+    -> Style
+paddingBlock2 (Value valueStart) (Value valueEnd) =
+    AppendProperty ("padding-block:" ++ valueStart ++ " " ++ valueEnd)
+
+
+{-| Sets [`padding-block-start`](https://developer.mozilla.org/en-US/docs/Web/CSS/padding-block-start) property.
+
+    paddingBlockStart (px 4)
+
+-}
+paddingBlockStart :
+    BaseValue
+        (LengthSupported
+            { pct : Supported
+            }
+        )
+    -> Style
+paddingBlockStart (Value value) =
+    AppendProperty ("padding-block-start:" ++ value)
+
+
+{-| Sets [`padding-block-end`](https://developer.mozilla.org/en-US/docs/Web/CSS/padding-block-end) property.
+
+    paddingBlockEnd (px 4)
+
+-}
+paddingBlockEnd :
+    BaseValue
+        (LengthSupported
+            { pct : Supported
+            }
+        )
+    -> Style
+paddingBlockEnd (Value value) =
+    AppendProperty ("padding-block-end:" ++ value)
+
+
+{-| Sets [`padding-inline`](https://css-tricks.com/almanac/properties/p/padding-inline/) property.
+
+The `padding-inline` property is a shorthand property for setting `padding-inline-start` and
+`padding-inline-end` and in a single declaration.
+
+If there is only one argument value, it applies to both sides. If there are two
+values, the inline start is set to the first value and the inline end is set to the second.
+
+    paddingInline (em 4) -- set both inline start and inline end to 4em
+
+    paddingInline2 (em 4) (px 2) -- inline start = 4em, inline end = 2px
+
+-}
+paddingInline :
+    BaseValue
+        (LengthSupported
+            { pct : Supported
+            }
+        )
+    -> Style
+paddingInline (Value value) =
+    AppendProperty ("padding-inline:" ++ value)
+
+
+{-| Sets [`padding-inline`](https://css-tricks.com/almanac/properties/p/padding-inline/) property.
+
+The `padding-inline` property is a shorthand property for setting `padding-inline-start` and
+`padding-inline-end` in a single declaration.
+
+The inline start value is set to the first value and the inline end value is set to the second.
+
+    paddingInline2 (em 4) (px 2) -- inline start = 4em, inline end = 2px
+
+-}
+paddingInline2 :
+    Value
+        (LengthSupported
+            { pct : Supported
+            }
+        )
+    ->
+        Value
+            (LengthSupported
+                { pct : Supported
+                }
+            )
+    -> Style
+paddingInline2 (Value valueStart) (Value valueEnd) =
+    AppendProperty ("padding-inline:" ++ valueStart ++ " " ++ valueEnd)
+
+
+{-| Sets [`padding-inline-start`](https://developer.mozilla.org/en-US/docs/Web/CSS/padding-inline-start) property.
+
+    paddingInlineStart (px 4)
+
+-}
+paddingInlineStart :
+    BaseValue
+        (LengthSupported
+            { pct : Supported
+            }
+        )
+    -> Style
+paddingInlineStart (Value value) =
+    AppendProperty ("padding-inline-start:" ++ value)
+
+
+{-| Sets [`padding-inline-end`](https://developer.mozilla.org/en-US/docs/Web/CSS/padding-inline-end) property.
+
+    paddingInlineEnd (px 4)
+
+-}
+paddingInlineEnd :
+    BaseValue
+        (LengthSupported
+            { pct : Supported
+            }
+        )
+    -> Style
+paddingInlineEnd (Value value) =
+    AppendProperty ("padding-inline-end:" ++ value)
+
+
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+-------------------------------- BORDER --------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+
+
+{-| Sets [`border`](https://css-tricks.com/almanac/properties/b/border/) property.
+
+    border (px 1)
+
+    border2 (px 1) solid
+
+    border3 (px 1) solid (hex "#f00")
+
+-}
+border : BaseValue LineWidth -> Style
+border (Value widthVal) =
+    AppendProperty ("border:" ++ widthVal)
+
+
+{-| Sets [`border`](https://css-tricks.com/almanac/properties/b/border/) property.
+
+    border (px 1)
+
+    border2 (px 1) solid
+
+    border3 (px 1) solid (hex "#f00")
+
+-}
+border2 : Value LineWidth -> Value LineStyle -> Style
+border2 (Value widthVal) (Value styleVal) =
+    AppendProperty ("border:" ++ widthVal ++ " " ++ styleVal)
+
+
+{-| Sets [`border`](https://css-tricks.com/almanac/properties/b/border/) property.
+
+    border (px 1)
+
+    border2 (px 1) solid
+
+    border3 (px 1) solid (hex "#f00")
+
+-}
+border3 : Value LineWidth -> Value LineStyle -> Value Color -> Style
+border3 (Value widthVal) (Value styleVal) (Value colorVal) =
+    AppendProperty ("border:" ++ widthVal ++ " " ++ styleVal ++ " " ++ colorVal)
+
+
+{-| Sets [`border-top`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-top) property.
+
+    borderTop (px 1)
+
+    borderTop2 (px 1) solid
+
+    borderTop3 (px 1) solid (hex "#f00")
+
+-}
+borderTop : BaseValue LineWidth -> Style
+borderTop (Value widthVal) =
+    AppendProperty ("border-top:" ++ widthVal)
+
+
+{-| Sets [`border-top`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-top) property.
+
+    borderTop (px 1)
+
+    borderTop2 (px 1) solid
+
+    borderTop3 (px 1) solid (hex "#f00")
+
+-}
+borderTop2 : Value LineWidth -> Value LineStyle -> Style
+borderTop2 (Value widthVal) (Value styleVal) =
+    AppendProperty ("border-top:" ++ widthVal ++ " " ++ styleVal)
+
+
+{-| Sets [`border-top`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-top) property.
+
+    borderTop (px 1)
+
+    borderTop2 (px 1) solid
+
+    borderTop3 (px 1) solid (hex "#f00")
+
+-}
+borderTop3 : Value LineWidth -> Value LineStyle -> Value Color -> Style
+borderTop3 (Value widthVal) (Value styleVal) (Value colorVal) =
+    AppendProperty ("border-top:" ++ widthVal ++ " " ++ styleVal ++ " " ++ colorVal)
+
+
+{-| Sets [`border-right`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-right) property.
+
+    borderRight (px 1)
+
+    borderRight2 (px 1) solid
+
+    borderRight3 (px 1) solid (hex "#f00")
+
+-}
+borderRight : BaseValue LineWidth -> Style
+borderRight (Value widthVal) =
+    AppendProperty ("border-right:" ++ widthVal)
+
+
+{-| Sets [`border-right`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-right) property.
+
+    borderRight (px 1)
+
+    borderRight2 (px 1) solid
+
+    borderRight3 (px 1) solid (hex "#f00")
+
+-}
+borderRight2 : Value LineWidth -> Value LineStyle -> Style
+borderRight2 (Value widthVal) (Value styleVal) =
+    AppendProperty ("border-right:" ++ widthVal ++ " " ++ styleVal)
+
+
+{-| Sets [`border-right`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-right) property.
+
+    borderRight (px 1)
+
+    borderRight2 (px 1) solid
+
+    borderRight3 (px 1) solid (hex "#f00")
+
+-}
+borderRight3 : Value LineWidth -> Value LineStyle -> Value Color -> Style
+borderRight3 (Value widthVal) (Value styleVal) (Value colorVal) =
+    AppendProperty ("border-right:" ++ widthVal ++ " " ++ styleVal ++ " " ++ colorVal)
+
+
+{-| Sets [`border-bottom`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-bottom) property.
+
+    borderBottom (px 1)
+
+    borderBottom2 (px 1) solid
+
+    borderBottom3 (px 1) solid (hex "#f00")
+
+-}
+borderBottom : BaseValue LineWidth -> Style
+borderBottom (Value widthVal) =
+    AppendProperty ("border-bottom:" ++ widthVal)
+
+
+{-| Sets [`border-bottom`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-bottom) property.
+
+    borderBottom (px 1)
+
+    borderBottom2 (px 1) solid
+
+    borderBottom3 (px 1) solid (hex "#f00")
+
+-}
+borderBottom2 : Value LineWidth -> Value LineStyle -> Style
+borderBottom2 (Value widthVal) (Value styleVal) =
+    AppendProperty ("border-bottom:" ++ widthVal ++ " " ++ styleVal)
+
+
+{-| Sets [`border-bottom`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-bottom) property.
+
+    borderBottom (px 1)
+
+    borderBottom2 (px 1) solid
+
+    borderBottom3 (px 1) solid (hex "#f00")
+
+-}
+borderBottom3 : Value LineWidth -> Value LineStyle -> Value Color -> Style
+borderBottom3 (Value widthVal) (Value styleVal) (Value colorVal) =
+    AppendProperty ("border-bottom:" ++ widthVal ++ " " ++ styleVal ++ " " ++ colorVal)
+
+
+{-| Sets [`border-left`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-left) property.
+
+    borderLeft (px 1)
+
+    borderLeft2 (px 1) solid
+
+    borderLeft3 (px 1) solid (hex "#f00")
+
+-}
+borderLeft : BaseValue LineWidth -> Style
+borderLeft (Value widthVal) =
+    AppendProperty ("border-left:" ++ widthVal)
+
+
+{-| Sets [`border-left`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-left) property.
+
+    borderLeft (px 1)
+
+    borderLeft2 (px 1) solid
+
+    borderLeft3 (px 1) solid (hex "#f00")
+
+-}
+borderLeft2 : Value LineWidth -> Value LineStyle -> Style
+borderLeft2 (Value widthVal) (Value styleVal) =
+    AppendProperty ("border-left:" ++ widthVal ++ " " ++ styleVal)
+
+
+{-| Sets [`border-left`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-left) property.
+
+    borderLeft (px 1)
+
+    borderLeft2 (px 1) solid
+
+    borderLeft3 (px 1) solid (hex "#f00")
+
+-}
+borderLeft3 : Value LineWidth -> Value LineStyle -> Value Color -> Style
+borderLeft3 (Value widthVal) (Value styleVal) (Value colorVal) =
+    AppendProperty ("border-left:" ++ widthVal ++ " " ++ styleVal ++ " " ++ colorVal)
+
+
+{-| Sets [`border-block`](https://css-tricks.com/almanac/properties/b/border-block/) property.
+
+    borderBlock (px 1)
+
+    borderBlock2 (px 1) solid
+
+    borderBlock3 (px 1) solid (hex "#f00")
+
+-}
+borderBlock : BaseValue LineWidth -> Style
+borderBlock (Value widthVal) =
+    AppendProperty ("border-block:" ++ widthVal)
+
+
+{-| Sets [`border-block`](https://css-tricks.com/almanac/properties/b/border-block/) property.
+
+    borderBlock (px 1)
+
+    borderBlock2 (px 1) solid
+
+    borderBlock3 (px 1) solid (hex "#f00")
+
+-}
+borderBlock2 : Value LineWidth -> Value LineStyle -> Style
+borderBlock2 (Value widthVal) (Value styleVal) =
+    AppendProperty ("border-block:" ++ widthVal ++ " " ++ styleVal)
+
+
+{-| Sets [`border-block`](https://css-tricks.com/almanac/properties/b/border-block/) property.
+
+    borderBlock (px 1)
+
+    borderBlock2 (px 1) solid
+
+    borderBlock3 (px 1) solid (hex "#f00")
+
+-}
+borderBlock3 : Value LineWidth -> Value LineStyle -> Value Color -> Style
+borderBlock3 (Value widthVal) (Value styleVal) (Value colorVal) =
+    AppendProperty ("border-block:" ++ widthVal ++ " " ++ styleVal ++ " " ++ colorVal)
+
+
+{-| Sets [`border-block-start`](https://css-tricks.com/almanac/properties/b/border-block-start/) property.
+
+    borderBlockStart (px 1)
+
+    borderBlockStart2 (px 1) solid
+
+    borderBlockStart3 (px 1) solid (hex "#f00")
+
+-}
+borderBlockStart : BaseValue LineWidth -> Style
+borderBlockStart (Value widthVal) =
+    AppendProperty ("border-block-start:" ++ widthVal)
+
+
+{-| Sets [`border-block-start`](https://css-tricks.com/almanac/properties/b/border-block-start/) property.
+
+    borderBlockStart (px 1)
+
+    borderBlockStart2 (px 1) solid
+
+    borderBlockStart3 (px 1) solid (hex "#f00")
+
+-}
+borderBlockStart2 : Value LineWidth -> Value LineStyle -> Style
+borderBlockStart2 (Value widthVal) (Value styleVal) =
+    AppendProperty ("border-block-start:" ++ widthVal ++ " " ++ styleVal)
+
+
+{-| Sets [`border-block-start`](https://css-tricks.com/almanac/properties/b/border-block-start/) property.
+
+    borderBlockStart (px 1)
+
+    borderBlockStart2 (px 1) solid
+
+    borderBlockStart3 (px 1) solid (hex "#f00")
+
+-}
+borderBlockStart3 : Value LineWidth -> Value LineStyle -> Value Color -> Style
+borderBlockStart3 (Value widthVal) (Value styleVal) (Value colorVal) =
+    AppendProperty ("border-block-start:" ++ widthVal ++ " " ++ styleVal ++ " " ++ colorVal)
+
+
+{-| Sets [`border-block-end`](https://css-tricks.com/almanac/properties/b/border-block-end/) property.
+
+    borderBlockEnd (px 1)
+
+    borderBlockEnd2 (px 1) solid
+
+    borderBlockEnd3 (px 1) solid (hex "#f00")
+
+-}
+borderBlockEnd : BaseValue LineWidth -> Style
+borderBlockEnd (Value widthVal) =
+    AppendProperty ("border-block-end:" ++ widthVal)
+
+
+{-| Sets [`border-block-end`](https://css-tricks.com/almanac/properties/b/border-block-end/) property.
+
+    borderBlockEnd (px 1)
+
+    borderBlockEnd2 (px 1) solid
+
+    borderBlockEnd3 (px 1) solid (hex "#f00")
+
+-}
+borderBlockEnd2 : Value LineWidth -> Value LineStyle -> Style
+borderBlockEnd2 (Value widthVal) (Value styleVal) =
+    AppendProperty ("border-block-end:" ++ widthVal ++ " " ++ styleVal)
+
+
+{-| Sets [`border-block-end`](https://css-tricks.com/almanac/properties/b/border-block-end/) property.
+
+    borderBlockEnd (px 1)
+
+    borderBlockEnd2 (px 1) solid
+
+    borderBlockEnd3 (px 1) solid (hex "#f00")
+
+-}
+borderBlockEnd3 : Value LineWidth -> Value LineStyle -> Value Color -> Style
+borderBlockEnd3 (Value widthVal) (Value styleVal) (Value colorVal) =
+    AppendProperty ("border-block-end:" ++ widthVal ++ " " ++ styleVal ++ " " ++ colorVal)
+
+
+{-| Sets [`border-inline`](https://css-tricks.com/almanac/properties/b/border-inline/) property.
+
+    borderInline (px 1)
+
+    borderInline2 (px 1) solid
+
+    borderInline3 (px 1) solid (hex "#f00")
+
+-}
+borderInline : BaseValue LineWidth -> Style
+borderInline (Value widthVal) =
+    AppendProperty ("border-inline:" ++ widthVal)
+
+
+{-| Sets [`border-inline`](https://css-tricks.com/almanac/properties/b/border-inline/) property.
+
+    borderInline (px 1)
+
+    borderInline2 (px 1) solid
+
+    borderInline3 (px 1) solid (hex "#f00")
+
+-}
+borderInline2 : Value LineWidth -> Value LineStyle -> Style
+borderInline2 (Value widthVal) (Value styleVal) =
+    AppendProperty ("border-inline:" ++ widthVal ++ " " ++ styleVal)
+
+
+{-| Sets [`border-inline`](https://css-tricks.com/almanac/properties/b/border-inline/) property.
+
+    borderInline (px 1)
+
+    borderInline2 (px 1) solid
+
+    borderInline3 (px 1) solid (hex "#f00")
+
+-}
+borderInline3 : Value LineWidth -> Value LineStyle -> Value Color -> Style
+borderInline3 (Value widthVal) (Value styleVal) (Value colorVal) =
+    AppendProperty ("border-inline:" ++ widthVal ++ " " ++ styleVal ++ " " ++ colorVal)
+
+
+{-| Sets [`border-inline-start`](https://css-tricks.com/almanac/properties/b/border-inline-start/) property.
+
+    borderInlineStart (px 1)
+
+    borderInlineStart2 (px 1) solid
+
+    borderInlineStart3 (px 1) solid (hex "#f00")
+
+-}
+borderInlineStart : BaseValue LineWidth -> Style
+borderInlineStart (Value widthVal) =
+    AppendProperty ("border-inline-start:" ++ widthVal)
+
+
+{-| Sets [`border-inline-start`](https://css-tricks.com/almanac/properties/b/border-inline-start/) property.
+
+    borderInlineStart (px 1)
+
+    borderInlineStart2 (px 1) solid
+
+    borderInlineStart3 (px 1) solid (hex "#f00")
+
+-}
+borderInlineStart2 : Value LineWidth -> Value LineStyle -> Style
+borderInlineStart2 (Value widthVal) (Value styleVal) =
+    AppendProperty ("border-inline-start:" ++ widthVal ++ " " ++ styleVal)
+
+
+{-| Sets [`border-inline-start`](https://css-tricks.com/almanac/properties/b/border-inline-start/) property.
+
+    borderInlineStart (px 1)
+
+    borderInlineStart2 (px 1) solid
+
+    borderInlineStart3 (px 1) solid (hex "#f00")
+
+-}
+borderInlineStart3 : Value LineWidth -> Value LineStyle -> Value Color -> Style
+borderInlineStart3 (Value widthVal) (Value styleVal) (Value colorVal) =
+    AppendProperty ("border-inline-start:" ++ widthVal ++ " " ++ styleVal ++ " " ++ colorVal)
+
+
+{-| Sets [`border-inline-end`](https://css-tricks.com/almanac/properties/b/border-inline-end/) property.
+
+    borderInlineEnd (px 1)
+
+    borderInlineEnd2 (px 1) solid
+
+    borderInlineEnd3 (px 1) solid (hex "#f00")
+
+-}
+borderInlineEnd : BaseValue LineWidth -> Style
+borderInlineEnd (Value widthVal) =
+    AppendProperty ("border-inline-end:" ++ widthVal)
+
+
+{-| Sets [`border-inline-end`](https://css-tricks.com/almanac/properties/b/border-inline-end/) property.
+
+    borderInlineEnd (px 1)
+
+    borderInlineEnd2 (px 1) solid
+
+    borderInlineEnd3 (px 1) solid (hex "#f00")
+
+-}
+borderInlineEnd2 : Value LineWidth -> Value LineStyle -> Style
+borderInlineEnd2 (Value widthVal) (Value styleVal) =
+    AppendProperty ("border-inline-end:" ++ widthVal ++ " " ++ styleVal)
+
+
+{-| Sets [`border-inline-end`](https://css-tricks.com/almanac/properties/b/border-inline-end/) property.
+
+    borderInlineEnd (px 1)
+
+    borderInlineEnd2 (px 1) solid
+
+    borderInlineEnd3 (px 1) solid (hex "#f00")
+
+-}
+borderInlineEnd3 : Value LineWidth -> Value LineStyle -> Value Color -> Style
+borderInlineEnd3 (Value widthVal) (Value styleVal) (Value colorVal) =
+    AppendProperty ("border-inline-end:" ++ widthVal ++ " " ++ styleVal ++ " " ++ colorVal)
+
+
+{-| Sets [`border-width`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-width) property.
+
+    borderWidth (px 1)
+
+    borderWidth2 (px 1) thin
+
+    borderWidth3 (px 1) thin zero
+
+    borderWidth4 (px 1) thin zero (em 1)
+
+-}
+borderWidth : BaseValue LineWidth -> Style
+borderWidth (Value widthVal) =
+    AppendProperty ("border-width:" ++ widthVal)
+
+
+{-| Sets [`border-width`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-width) property.
+
+    borderWidth (px 1)
+
+    borderWidth2 (px 1) thin
+
+    borderWidth3 (px 1) thin zero
+
+    borderWidth4 (px 1) thin zero (em 1)
+
+-}
+borderWidth2 : Value LineWidth -> Value LineWidth -> Style
+borderWidth2 (Value widthTopBottom) (Value widthRightLeft) =
+    AppendProperty ("border-width:" ++ widthTopBottom ++ " " ++ widthRightLeft)
+
+
+{-| Sets [`border-width`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-width) property.
+
+    borderWidth (px 1)
+
+    borderWidth2 (px 1) thin
+
+    borderWidth3 (px 1) thin zero
+
+    borderWidth4 (px 1) thin zero (em 1)
+
+-}
+borderWidth3 : Value LineWidth -> Value LineWidth -> Value LineWidth -> Style
+borderWidth3 (Value widthTop) (Value widthRightLeft) (Value widthBottom) =
+    AppendProperty ("border-width:" ++ widthTop ++ " " ++ widthRightLeft ++ " " ++ widthBottom)
+
+
+{-| Sets [`border-width`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-width) property.
+
+    borderWidth (px 1)
+
+    borderWidth2 (px 1) thin
+
+    borderWidth3 (px 1) thin zero
+
+    borderWidth4 (px 1) thin zero (em 1)
+
+-}
+borderWidth4 : Value LineWidth -> Value LineWidth -> Value LineWidth -> Value LineWidth -> Style
+borderWidth4 (Value widthTop) (Value widthRight) (Value widthBottom) (Value widthLeft) =
+    AppendProperty ("border-width:" ++ widthTop ++ " " ++ widthRight ++ " " ++ widthBottom ++ " " ++ widthLeft)
+
+
+{-| Sets [`border-top-width`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-top-width) property.
+
+    borderTopWidth (px 1)
+
+-}
+borderTopWidth : BaseValue LineWidth -> Style
+borderTopWidth (Value widthVal) =
+    AppendProperty ("border-top-width:" ++ widthVal)
+
+
+{-| Sets [`border-right-width`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-right-width) property.
+
+    borderRightWidth (px 1)
+
+-}
+borderRightWidth : BaseValue LineWidth -> Style
+borderRightWidth (Value widthVal) =
+    AppendProperty ("border-right-width:" ++ widthVal)
+
+
+{-| Sets [`border-bottom-width`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-bottom-width) property.
+
+    borderBottomWidth (px 1)
+
+-}
+borderBottomWidth : BaseValue LineWidth -> Style
+borderBottomWidth (Value widthVal) =
+    AppendProperty ("border-bottom-width:" ++ widthVal)
+
+
+{-| Sets [`border-left-width`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-left-width) property.
+
+    borderLeftWidth (px 1)
+
+-}
+borderLeftWidth : BaseValue LineWidth -> Style
+borderLeftWidth (Value widthVal) =
+    AppendProperty ("border-left-width:" ++ widthVal)
+
+
+{-| Sets [`border-block-width`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-block-width) property.
+
+    borderBlockWidth (px 1)
+
+-}
+borderBlockWidth : BaseValue LineWidth -> Style
+borderBlockWidth (Value widthVal) =
+    AppendProperty ("border-block-width:" ++ widthVal)
+
+
+{-| Sets [`border-block-start-width`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-block-start-width) property.
+
+    borderBlockStartWidth (px 1)
+
+-}
+borderBlockStartWidth : BaseValue LineWidth -> Style
+borderBlockStartWidth (Value widthVal) =
+    AppendProperty ("border-block-start-width:" ++ widthVal)
+
+
+{-| Sets [`border-block-end-width`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-block-end-width) property.
+
+    borderBlockEndWidth (px 1)
+
+-}
+borderBlockEndWidth : BaseValue LineWidth -> Style
+borderBlockEndWidth (Value widthVal) =
+    AppendProperty ("border-block-end-width:" ++ widthVal)
+
+
+{-| Sets [`border-inline-width`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-inline-width) property.
+
+    borderTopWidth (px 1)
+
+-}
+borderInlineWidth : BaseValue LineWidth -> Style
+borderInlineWidth (Value widthVal) =
+    AppendProperty ("border-inline-width:" ++ widthVal)
+
+
+{-| Sets [`border-inline-start-width`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-inline-start-width) property.
+
+    borderInlineStartWidth (px 1)
+
+-}
+borderInlineStartWidth : BaseValue LineWidth -> Style
+borderInlineStartWidth (Value widthVal) =
+    AppendProperty ("border-inline-start-width:" ++ widthVal)
+
+
+{-| Sets [`border-inline-end-width`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-inline-end-width) property.
+
+    borderInlineEndWidth (px 1)
+
+-}
+borderInlineEndWidth : BaseValue LineWidth -> Style
+borderInlineEndWidth (Value widthVal) =
+    AppendProperty ("border-inline-end-width:" ++ widthVal)
+
+
+{-| Sets [`border-style`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-style) property.
+
+    borderStyle solid
+
+    borderStyle2 solid none
+
+    borderStyle3 solid none dotted
+
+    borderStyle4 solid none dotted groove
+
+-}
+borderStyle : BaseValue LineStyle -> Style
+borderStyle (Value styleVal) =
+    AppendProperty ("border-style:" ++ styleVal)
+
+
+{-| Sets [`border-style`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-style) property.
+
+    borderStyle solid
+
+-}
+borderStyle2 : Value LineStyle -> Value LineStyle -> Style
+borderStyle2 (Value styleTopBottom) (Value styleRigthLeft) =
+    AppendProperty ("border-style:" ++ styleTopBottom ++ " " ++ styleRigthLeft)
+
+
+{-| Sets [`border-style`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-style) property.
+
+    borderStyle2 solid none
+
+-}
+borderStyle3 : Value LineStyle -> Value LineStyle -> Value LineStyle -> Style
+borderStyle3 (Value styleTop) (Value styleRigthLeft) (Value styleBottom) =
+    AppendProperty ("border-style:" ++ styleTop ++ " " ++ styleRigthLeft ++ " " ++ styleBottom)
+
+
+{-| Sets [`border-style`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-style) property.
+
+    borderStyle4 solid none dotted groove
+
+-}
+borderStyle4 : Value LineStyle -> Value LineStyle -> Value LineStyle -> Value LineStyle -> Style
+borderStyle4 (Value styleTop) (Value styleRigt) (Value styleBottom) (Value styleLeft) =
+    AppendProperty ("border-style:" ++ styleTop ++ " " ++ styleRigt ++ " " ++ styleBottom ++ " " ++ styleLeft)
+
+
+{-| Sets [`border-top-style`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-top-style) property.
+
+    borderTopStyle solid
+
+-}
+borderTopStyle : BaseValue LineStyle -> Style
+borderTopStyle (Value styleVal) =
+    AppendProperty ("border-top-style:" ++ styleVal)
+
+
+{-| Sets [`border-right-style`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-right-style) property.
+
+    borderRightStyle solid
+
+-}
+borderRightStyle : BaseValue LineStyle -> Style
+borderRightStyle (Value styleVal) =
+    AppendProperty ("border-right-style:" ++ styleVal)
+
+
+{-| Sets [`border-bottom-style`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-bottom-style) property.
+
+    borderBottomStyle solid
+
+-}
+borderBottomStyle : BaseValue LineStyle -> Style
+borderBottomStyle (Value styleVal) =
+    AppendProperty ("border-bottom-style:" ++ styleVal)
+
+
+{-| Sets [`border-left-style`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-left-style) property.
+
+    borderLeftStyle solid
+
+-}
+borderLeftStyle : BaseValue LineStyle -> Style
+borderLeftStyle (Value styleVal) =
+    AppendProperty ("border-left-style:" ++ styleVal)
+
+
+{-| Sets [`border-block-style`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-block-style) property.
+
+    borderBlockStyle solid
+
+-}
+borderBlockStyle : BaseValue LineStyle -> Style
+borderBlockStyle (Value styleVal) =
+    AppendProperty ("border-block-style:" ++ styleVal)
+
+
+{-| Sets [`border-block-start-style`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-block-start-style) property.
+
+    borderBlockStartStyle solid
+
+-}
+borderBlockStartStyle : BaseValue LineStyle -> Style
+borderBlockStartStyle (Value styleVal) =
+    AppendProperty ("border-block-start-style:" ++ styleVal)
+
+
+{-| Sets [`border-block-end-style`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-block-end-style) property.
+
+    borderBlockEndStyle solid
+
+-}
+borderBlockEndStyle : BaseValue LineStyle -> Style
+borderBlockEndStyle (Value styleVal) =
+    AppendProperty ("border-block-end-style:" ++ styleVal)
+
+
+{-| Sets [`border-inline-style`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-inline-style) property.
+
+    borderInlineStyle solid
+
+-}
+borderInlineStyle : BaseValue LineStyle -> Style
+borderInlineStyle (Value styleVal) =
+    AppendProperty ("border-inline-style:" ++ styleVal)
+
+
+{-| Sets [`border-inline-start-style`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-inline-start-style) property.
+
+    borderInlineStartStyle solid
+
+-}
+borderInlineStartStyle : BaseValue LineStyle -> Style
+borderInlineStartStyle (Value styleVal) =
+    AppendProperty ("border-inline-start-style:" ++ styleVal)
+
+
+{-| Sets [`border-inline-end-style`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-inline-end-style) property.
+
+    borderInlineEndStyle solid
+
+-}
+borderInlineEndStyle : BaseValue LineStyle -> Style
+borderInlineEndStyle (Value styleVal) =
+    AppendProperty ("border-inline-end-style:" ++ styleVal)
+
+
+{-| Sets [`border-color`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-color) property.
+
+    borderColor (rgb 0 0 0)
+
+    borderColor2 (rgb 0 0 0) (hsl 10 10 10)
+
+    borderColor3 (rgb 0 0 0) (hsl 10 10 10) (hex "#fff")
+
+    borderColor4 (rgb 0 0 0) (hsl 10 10 10) (hex "#fff") transparent
+
+-}
+borderColor : BaseValue Color -> Style
+borderColor (Value colorVal) =
+    AppendProperty ("border-color:" ++ colorVal)
+
+
+{-| Sets [`border-color`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-color) property.
+
+    borderColor (rgb 0 0 0)
+
+    borderColor2 (rgb 0 0 0) (hsl 10 10 10)
+
+    borderColor3 (rgb 0 0 0) (hsl 10 10 10) (hex "#fff")
+
+    borderColor4 (rgb 0 0 0) (hsl 10 10 10) (hex "#fff") transparent
+
+-}
+borderColor2 : Value Color -> Value Color -> Style
+borderColor2 (Value colorTopBottom) (Value colorRightLeft) =
+    AppendProperty ("border-color:" ++ colorTopBottom ++ " " ++ colorRightLeft)
+
+
+{-| Sets [`border-color`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-color) property.
+
+    borderColor (rgb 0 0 0)
+
+    borderColor2 (rgb 0 0 0) (hsl 10 10 10)
+
+    borderColor3 (rgb 0 0 0) (hsl 10 10 10) (hex "#fff")
+
+    borderColor4 (rgb 0 0 0) (hsl 10 10 10) (hex "#fff") transparent
+
+-}
+borderColor3 : Value Color -> Value Color -> Value Color -> Style
+borderColor3 (Value colorTop) (Value colorRightLeft) (Value colorBottom) =
+    AppendProperty ("border-color:" ++ colorTop ++ " " ++ colorRightLeft ++ " " ++ colorBottom)
+
+
+{-| Sets [`border-color`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-color) property.
+
+    borderColor (rgb 0 0 0)
+
+    borderColor2 (rgb 0 0 0) (hsl 10 10 10)
+
+    borderColor3 (rgb 0 0 0) (hsl 10 10 10) (hex "#fff")
+
+    borderColor4 (rgb 0 0 0) (hsl 10 10 10) (hex "#fff") transparent
+
+-}
+borderColor4 : Value Color -> Value Color -> Value Color -> Value Color -> Style
+borderColor4 (Value colorTop) (Value colorRight) (Value colorBottom) (Value colorLeft) =
+    AppendProperty ("border-color:" ++ colorTop ++ " " ++ colorRight ++ " " ++ colorBottom ++ " " ++ colorLeft)
+
+
+{-| Sets [`border-top-color`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-top-color) property.
+
+    borderTopColor (rgb 0 0 0)
+
+-}
+borderTopColor : BaseValue Color -> Style
+borderTopColor (Value colorVal) =
+    AppendProperty ("border-top-color:" ++ colorVal)
+
+
+{-| Sets [`border-right-color`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-right-color) property.
+
+    borderRightColor (rgb 0 0 0)
+
+-}
+borderRightColor : BaseValue Color -> Style
+borderRightColor (Value colorVal) =
+    AppendProperty ("border-right-color:" ++ colorVal)
+
+
+{-| Sets [`border-bottom-color`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-bottom-color) property.
+
+    borderBottomColor (rgb 0 0 0)
+
+-}
+borderBottomColor : BaseValue Color -> Style
+borderBottomColor (Value colorVal) =
+    AppendProperty ("border-bottom-color:" ++ colorVal)
+
+
+{-| Sets [`border-left-color`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-left-color) property.
+
+    borderLeftColor (rgb 0 0 0)
+
+-}
+borderLeftColor : BaseValue Color -> Style
+borderLeftColor (Value colorVal) =
+    AppendProperty ("border-left-color:" ++ colorVal)
+
+
+{-| Sets [`border-block-color`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-block-color) property.
+
+    borderBlockColor (rgb 0 0 0)
+
+-}
+borderBlockColor : BaseValue Color -> Style
+borderBlockColor (Value colorVal) =
+    AppendProperty ("border-block-color:" ++ colorVal)
+
+
+{-| Sets [`border-block-start-color`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-block-start-color) property.
+
+    borderBlockStartColor (rgb 0 0 0)
+
+-}
+borderBlockStartColor : BaseValue Color -> Style
+borderBlockStartColor (Value colorVal) =
+    AppendProperty ("border-block-start-color:" ++ colorVal)
+
+
+{-| Sets [`border-block-end-color`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-block-end-color) property.
+
+    borderBlockEndColor (rgb 0 0 0)
+
+-}
+borderBlockEndColor : BaseValue Color -> Style
+borderBlockEndColor (Value colorVal) =
+    AppendProperty ("border-block-end-color:" ++ colorVal)
+
+
+{-| Sets [`border-inline-color`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-inline-color) property.
+
+    borderInlineColor (rgb 0 0 0)
+
+-}
+borderInlineColor : BaseValue Color -> Style
+borderInlineColor (Value colorVal) =
+    AppendProperty ("border-inline-color:" ++ colorVal)
+
+
+{-| Sets [`border-inline-start-color`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-inline-start-color) property.
+
+    borderInlineStartColor (rgb 0 0 0)
+
+-}
+borderInlineStartColor : BaseValue Color -> Style
+borderInlineStartColor (Value colorVal) =
+    AppendProperty ("border-inline-start-color:" ++ colorVal)
+
+
+{-| Sets [`border-inline-end-color`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-inline-end-color) property.
+
+    borderInlineEndColor (rgb 0 0 0)
+
+-}
+borderInlineEndColor : BaseValue Color -> Style
+borderInlineEndColor (Value colorVal) =
+    AppendProperty ("border-inline-end-color:" ++ colorVal)
+
+
+
+
+-- BORDER STYLE --
+
+
+{-| The `dotted` value used by properties such as [`borderStyle`](#borderStyle),
+[`columnRuleStyle`](#columnRuleStyle), and [`textDecorationStyle`](#textDecorationStyle).
+
+It represents a line that consists of dots.
+
+    borderStyle dotted
+
+    columnRuleStyle dotted
+
+    textDecorationStyle dotted
+
+-}
+dotted : Value { provides | dotted : Supported }
+dotted =
+    Value "dotted"
+
+
+{-| The `dashed` value used by properties such as [`borderStyle`](#borderStyle),
+[`columnRuleStyle`](#columnRuleStyle), and [`textDecorationStyle`](#textDecorationStyle).
+
+    borderStyle dashed
+
+    columnRuleStyle dashed
+
+    textDecorationStyle dashed
+
+It represents a line that consists of dashes.
+
+-}
+dashed : Value { provides | dashed : Supported }
+dashed =
+    Value "dashed"
+
+
+{-| The `solid` value used by properties such as [`borderStyle`](#borderStyle),
+[`columnRuleStyle`](#columnRuleStyle), and [`textDecorationStyle`](#textDecorationStyle).
+
+    borderStyle solid
+
+    columnRuleStyle solid
+
+    textDecorationStyle solid
+
+It represents a solid, continuous line.
+
+-}
+solid : Value { provides | solid : Supported }
+solid =
+    Value "solid"
+
+
+{-| The `double` value used by properties such as [`borderStyle`](#borderStyle),
+[`columnRuleStyle`](#columnRuleStyle), and [`textDecorationStyle`](#textDecorationStyle).
+
+    borderStyle double
+
+    columnRuleStyle double
+
+    textDecorationStyle double
+
+It represents a double line: two lines side by side.
+
+-}
+double : Value { provides | double : Supported }
+double =
+    Value "double"
+
+
+{-| The `groove` value used by properties such as [`borderStyle`](#borderStyle),
+[`columnRuleStyle`](#columnRuleStyle), and [`textDecorationStyle`](#textDecorationStyle).
+
+    borderStyle groove
+
+    columnRuleStyle groove
+
+    textDecorationStyle groove
+
+Adds a bevel based on the color value, which makes things appear pressed into the document.
+
+-}
+groove : Value { provides | groove : Supported }
+groove =
+    Value "groove"
+
+
+{-| The `ridge` value used by properties such as [`borderStyle`](#borderStyle),
+[`columnRuleStyle`](#columnRuleStyle), and [`textDecorationStyle`](#textDecorationStyle).
+
+    borderStyle ridge
+
+    columnRuleStyle ridge
+
+    textDecorationStyle ridge
+
+Similar to [`groove`](#groove), but reverses the color values in a way that makes things appear raised.
+
+-}
+ridge : Value { provides | ridge : Supported }
+ridge =
+    Value "ridge"
+
+
+{-| The `inset` value used by properties such as [`borderStyle`](#borderStyle),
+[`columnRuleStyle`](#columnRuleStyle), and [`textDecorationStyle`](#textDecorationStyle).
+
+This is called `inset_` rather than `inset` because [`inset` is already a property function](#inset).
+
+    borderStyle inset_
+
+    columnRuleStyle inset_
+
+    textDecorationStyle inset_
+
+Adds a split tone to the line that makes it appear slightly depressed.
+
+Contrast with [`outset`](#outset)
+
+-}
+inset_ : Value { provides | inset_ : Supported }
+inset_ =
+    Value "inset"
+
+
+{-| The `outset` value used by properties such as [`borderStyle`](#borderStyle),
+[`columnRuleStyle`](#columnRuleStyle),
+and [`textDecorationStyle`](#textDecorationStyle),
+and [`strokeAlign`](#strokeAlign).
+
+    borderStyle outset
+
+    columnRuleStyle outset
+
+    strokeAlign outset
+
+    textDecorationStyle outset
+
+Similar to [`inset_`](#inset_), but reverses the colors in a way that makes it appear slightly raised.
+
+-}
+outset : Value { provides | outset : Supported }
+outset =
+    Value "outset"
+
+
+
+{- BORDER RADIUS -}
+
+
+{-| Sets [`border-radius`](https://css-tricks.com/almanac/properties/b/border-radius/) property.
+
+    borderRadius (em 4)
+
+    borderRadius2 (em 4) (px 2)
+
+    borderRadius3 (em 4) (px 2) (pct 5)
+
+    borderRadius4 (em 4) (px 2) (pct 5) (px 3)
+
+-}
+borderRadius :
+    BaseValue
+        (LengthSupported
+            { pct : Supported
+            }
+        )
+    -> Style
+borderRadius (Value radius) =
+    AppendProperty ("border-radius:" ++ radius)
+
+
+{-| Sets [`border-radius`](https://css-tricks.com/almanac/properties/b/border-radius/) property.
+
+    borderRadius (em 4)
+
+    borderRadius2 (em 4) (px 2)
+
+    borderRadius3 (em 4) (px 2) (pct 5)
+
+    borderRadius4 (em 4) (px 2) (pct 5) (px 3)
+
+-}
+borderRadius2 :
+    Value
+        (LengthSupported
+            { pct : Supported
+            }
+        )
+    ->
+        Value
+            (LengthSupported
+                { pct : Supported
+                }
+            )
+    -> Style
+borderRadius2 (Value radiusTopLeftAndBottomRight) (Value radiusTopRightAndBottomLeft) =
+    AppendProperty ("border-radius:" ++ radiusTopLeftAndBottomRight ++ " " ++ radiusTopRightAndBottomLeft)
+
+
+{-| Sets [`border-radius`](https://css-tricks.com/almanac/properties/b/border-radius/) property.
+
+    borderRadius (em 4)
+
+    borderRadius2 (em 4) (px 2)
+
+    borderRadius3 (em 4) (px 2) (pct 5)
+
+    borderRadius4 (em 4) (px 2) (pct 5) (px 3)
+
+-}
+borderRadius3 :
+    Value
+        (LengthSupported
+            { pct : Supported
+            }
+        )
+    ->
+        Value
+            (LengthSupported
+                { pct : Supported
+                }
+            )
+    ->
+        Value
+            (LengthSupported
+                { pct : Supported
+                }
+            )
+    -> Style
+borderRadius3 (Value radiusTopLeft) (Value radiusTopRightAndBottomLeft) (Value radiusBottomRight) =
+    AppendProperty ("border-radius:" ++ radiusTopLeft ++ " " ++ radiusTopRightAndBottomLeft ++ " " ++ radiusBottomRight)
+
+
+{-| Sets [`border-radius`](https://css-tricks.com/almanac/properties/b/border-radius/) property.
+
+    borderRadius (em 4)
+
+    borderRadius2 (em 4) (px 2)
+
+    borderRadius3 (em 4) (px 2) (pct 5)
+
+    borderRadius4 (em 4) (px 2) (pct 5) (px 3)
+
+-}
+borderRadius4 :
+    Value
+        (LengthSupported
+            { pct : Supported
+            }
+        )
+    ->
+        Value
+            (LengthSupported
+                { pct : Supported
+                }
+            )
+    ->
+        Value
+            (LengthSupported
+                { pct : Supported
+                }
+            )
+    ->
+        Value
+            (LengthSupported
+                { pct : Supported
+                }
+            )
+    -> Style
+borderRadius4 (Value radiusTopLeft) (Value radiusTopRight) (Value radiusBottomRight) (Value radiusBottomLeft) =
+    AppendProperty ("border-radius:" ++ radiusTopLeft ++ " " ++ radiusTopRight ++ " " ++ radiusBottomRight ++ " " ++ radiusBottomLeft)
+
+
+{-| Sets [`border-top-left-radius`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-top-left-radius) property.
+
+    borderTopLeftRadius (em 4)
+
+    borderTopLeftRadius2 (em 4) (px 2)
+
+-}
+borderTopLeftRadius :
+    BaseValue
+        (LengthSupported
+            { pct : Supported
+            }
+        )
+    -> Style
+borderTopLeftRadius (Value radius) =
+    AppendProperty ("border-top-left-radius:" ++ radius)
+
+
+{-| Sets [`border-top-left-radius`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-top-left-radius) property.
+
+    borderTopLeftRadius (em 4)
+
+    borderTopLeftRadius2 (em 4) (px 2)
+
+-}
+borderTopLeftRadius2 :
+    Value
+        (LengthSupported
+            { pct : Supported
+            }
+        )
+    ->
+        Value
+            (LengthSupported
+                { pct : Supported
+                }
+            )
+    -> Style
+borderTopLeftRadius2 (Value valHorizontal) (Value valVertical) =
+    AppendProperty ("border-top-left-radius:" ++ valHorizontal ++ " " ++ valVertical)
+
+
+{-| Sets [`border-top-right-radius`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-top-right-radius) property.
+
+    borderTopRightRadius (em 4)
+
+    borderTopRightRadius2 (em 4) (px 2)
+
+-}
+borderTopRightRadius :
+    BaseValue
+        (LengthSupported
+            { pct : Supported
+            }
+        )
+    -> Style
+borderTopRightRadius (Value radius) =
+    AppendProperty ("border-top-right-radius:" ++ radius)
+
+
+{-| Sets [`border-top-right-radius`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-top-right-radius) property.
+
+    borderTopRightRadius (em 4)
+
+    borderTopRightRadius2 (em 4) (px 2)
+
+-}
+borderTopRightRadius2 :
+    Value
+        (LengthSupported
+            { pct : Supported
+            }
+        )
+    ->
+        Value
+            (LengthSupported
+                { pct : Supported
+                }
+            )
+    -> Style
+borderTopRightRadius2 (Value valHorizontal) (Value valVertical) =
+    AppendProperty ("border-top-right-radius:" ++ valHorizontal ++ " " ++ valVertical)
+
+
+{-| Sets [`border-bottom-right-radius`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-bottom-right-radius) property.
+
+    borderBottomRightRadius (em 4)
+
+    borderBottomRightRadius2 (em 4) (px 2)
+
+-}
+borderBottomRightRadius :
+    BaseValue
+        (LengthSupported
+            { pct : Supported
+            }
+        )
+    -> Style
+borderBottomRightRadius (Value radius) =
+    AppendProperty ("border-bottom-right-radius:" ++ radius)
+
+
+{-| Sets [`border-bottom-right-radius`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-bottom-right-radius) property.
+
+    borderBottomRightRadius (em 4)
+
+    borderBottomRightRadius2 (em 4) (px 2)
+
+-}
+borderBottomRightRadius2 :
+    Value
+        (LengthSupported
+            { pct : Supported
+            }
+        )
+    ->
+        Value
+            (LengthSupported
+                { pct : Supported
+                }
+            )
+    -> Style
+borderBottomRightRadius2 (Value valHorizontal) (Value valVertical) =
+    AppendProperty ("border-bottom-right-radius:" ++ valHorizontal ++ " " ++ valVertical)
+
+
+{-| Sets [`border-bottom-left-radius`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-bottom-left-radius) property.
+
+    borderBottomLeftRadius (em 4)
+
+    borderBottomLeftRadius2 (em 4) (px 2)
+
+-}
+borderBottomLeftRadius :
+    BaseValue
+        (LengthSupported
+            { pct : Supported
+            }
+        )
+    -> Style
+borderBottomLeftRadius (Value radius) =
+    AppendProperty ("border-bottom-left-radius:" ++ radius)
+
+
+{-| Sets [`border-bottom-left-radius`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-bottom-left-radius) property.
+
+    borderBottomLeftRadius (em 4)
+
+    borderBottomLeftRadius2 (em 4) (px 2)
+
+-}
+borderBottomLeftRadius2 :
+    Value
+        (LengthSupported
+            { pct : Supported
+            }
+        )
+    ->
+        Value
+            (LengthSupported
+                { pct : Supported
+                }
+            )
+    -> Style
+borderBottomLeftRadius2 (Value valHorizontal) (Value valVertical) =
+    AppendProperty ("border-bottom-left-radius:" ++ valHorizontal ++ " " ++ valVertical)
+
+
+{-| Sets [`border-start-start-radius`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-start-start-radius) property.
+
+    borderStartStartRadius (em 4)
+
+    borderStartStartRadius2 (em 4) (px 2)
+
+-}
+borderStartStartRadius :
+    BaseValue
+        (LengthSupported
+            { pct : Supported
+            }
+        )
+    -> Style
+borderStartStartRadius (Value radius) =
+    AppendProperty ("border-start-start-radius:" ++ radius)
+
+
+{-| Sets [`border-start-start-radius`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-start-start-radius) property.
+
+    borderStartStartRadius (em 4)
+
+    borderStartStartRadius2 (em 4) (px 2)
+
+-}
+borderStartStartRadius2 :
+    Value
+        (LengthSupported
+            { pct : Supported
+            }
+        )
+    ->
+        Value
+            (LengthSupported
+                { pct : Supported
+                }
+            )
+    -> Style
+borderStartStartRadius2 (Value horizontalValue) (Value verticalValue) =
+    AppendProperty ("border-start-start-radius:" ++ horizontalValue ++ " " ++ verticalValue)
+
+
+{-| Sets [`border-start-end-radius`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-start-end-radius) property.
+
+    borderStartEndRadius (em 4)
+
+    borderStartEndRadius2 (em 4) (px 2)
+
+-}
+borderStartEndRadius :
+    BaseValue
+        (LengthSupported
+            { pct : Supported
+            }
+        )
+    -> Style
+borderStartEndRadius (Value radius) =
+    AppendProperty ("border-start-end-radius:" ++ radius)
+
+
+{-| Sets [`border-start-end-radius`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-start-end-radius) property.
+
+    borderStartEndRadius (em 4)
+
+    borderStartEndRadius2 (em 4) (px 2)
+
+-}
+borderStartEndRadius2 :
+    Value
+        (LengthSupported
+            { pct : Supported
+            }
+        )
+    ->
+        Value
+            (LengthSupported
+                { pct : Supported
+                }
+            )
+    -> Style
+borderStartEndRadius2 (Value horizontalValue) (Value verticalValue) =
+    AppendProperty ("border-start-end-radius:" ++ horizontalValue ++ " " ++ verticalValue)
+
+
+{-| Sets [`border-end-start-radius`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-end-start-radius) property.
+
+    borderEndStartRadius (em 4)
+
+    borderEndStartRadius2 (em 4) (px 2)
+
+-}
+borderEndStartRadius :
+    BaseValue
+        (LengthSupported
+            { pct : Supported
+            }
+        )
+    -> Style
+borderEndStartRadius (Value radius) =
+    AppendProperty ("border-end-start-radius:" ++ radius)
+
+
+{-| Sets [`border-end-start-radius`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-end-start-radius) property.
+
+    borderEndStartRadius (em 4)
+
+    borderEndStartRadius2 (em 4) (px 2)
+
+-}
+borderEndStartRadius2 :
+    Value
+        (LengthSupported
+            { pct : Supported
+            }
+        )
+    ->
+        Value
+            (LengthSupported
+                { pct : Supported
+                }
+            )
+    -> Style
+borderEndStartRadius2 (Value horizontalValue) (Value verticalValue) =
+    AppendProperty ("border-end-start-radius:" ++ horizontalValue ++ " " ++ verticalValue)
+
+
+{-| Sets [`border-end-end-radius`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-end-end-radius) property.
+
+    borderEndEndRadius (em 4)
+
+    borderEndEndRadius2 (em 4) (px 2)
+
+-}
+borderEndEndRadius :
+    BaseValue
+        (LengthSupported
+            { pct : Supported
+            }
+        )
+    -> Style
+borderEndEndRadius (Value radius) =
+    AppendProperty ("border-end-end-radius:" ++ radius)
+
+
+{-| Sets [`border-end-end-radius`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-end-end-radius) property.
+
+    borderEndEndRadius (em 4)
+
+    borderEndEndRadius2 (em 4) (px 2)
+
+-}
+borderEndEndRadius2 :
+    Value
+        (LengthSupported
+            { pct : Supported
+            }
+        )
+    ->
+        Value
+            (LengthSupported
+                { pct : Supported
+                }
+            )
+    -> Style
+borderEndEndRadius2 (Value horizontalValue) (Value verticalValue) =
+    AppendProperty ("border-end-end-radius:" ++ horizontalValue ++ " " ++ verticalValue)
+
+
+{-| Sets [`border-image-outset`](https://css-tricks.com/almanac/properties/b/border-image/) property.
+
+    borderImageOutset (rem 1)
+
+    borderImageOutset2 (num 1) (num 1.2)
+
+    borderImageOutset3 (px 30) (num 2) (px 45)
+
+    borderImageOutset4 (px 7) (px 12) (px 14) (px 5)
+
+Specifies the distance by which an element's border image is set out from its border box. Supports values specified as length units or unitless numbers. Negative values are invalid.
+
+-}
+borderImageOutset :
+    BaseValue
+        (LengthSupported
+            { num : Supported
+            }
+        )
+    -> Style
+borderImageOutset (Value widthVal) =
+    AppendProperty ("border-image-outset:" ++ widthVal)
+
+
+{-| Sets [`border-image-outset`](https://css-tricks.com/almanac/properties/b/border-image/) property.
+
+    borderImageOutset (rem 1)
+
+    borderImageOutset2 (num 1) (num 1.2)
+
+    borderImageOutset3 (px 30) (num 2) (px 45)
+
+    borderImageOutset4 (px 7) (px 12) (px 14) (px 5)
+
+Specifies the distance by which an element's border image is set out from its border box. Supports values specified as length units or unitless numbers. Negative values are invalid.
+
+-}
+borderImageOutset2 :
+    Value
+        (LengthSupported
+            { num : Supported
+            }
+        )
+    ->
+        Value
+            (LengthSupported
+                { num : Supported
+                }
+            )
+    -> Style
+borderImageOutset2 (Value valueTopBottom) (Value valueRightLeft) =
+    AppendProperty ("border-image-outset:" ++ valueTopBottom ++ " " ++ valueRightLeft)
+
+
+{-| Sets [`border-image-outset`](https://css-tricks.com/almanac/properties/b/border-image/) property.
+
+    borderImageOutset (rem 1)
+
+    borderImageOutset2 (num 1) (num 1.2)
+
+    borderImageOutset3 (px 30) (num 2) (px 45)
+
+    borderImageOutset4 (px 7) (px 12) (px 14) (px 5)
+
+Specifies the distance by which an element's border image is set out from its border box. Supports values specified as length units or unitless numbers. Negative values are invalid.
+
+-}
+borderImageOutset3 :
+    Value
+        (LengthSupported
+            { num : Supported
+            }
+        )
+    ->
+        Value
+            (LengthSupported
+                { num : Supported
+                }
+            )
+    ->
+        Value
+            (LengthSupported
+                { num : Supported
+                }
+            )
+    -> Style
+borderImageOutset3 (Value valueTop) (Value valueRightLeft) (Value valueBottom) =
+    AppendProperty ("border-image-outset:" ++ valueTop ++ " " ++ valueRightLeft ++ " " ++ valueBottom)
+
+
+{-| Sets [`border-image-outset`](https://css-tricks.com/almanac/properties/b/border-image/) property.
+
+    borderImageOutset (rem 1)
+
+    borderImageOutset2 (num 1) (num 1.2)
+
+    borderImageOutset3 (px 30) (num 2) (px 45)
+
+    borderImageOutset4 (px 7) (px 12) (px 14) (px 5)
+
+Specifies the distance by which an element's border image is set out from its border box. Supports values specified as length units or unitless numbers. Negative values are invalid.
+
+-}
+borderImageOutset4 :
+    Value
+        (LengthSupported
+            { num : Supported
+            }
+        )
+    ->
+        Value
+            (LengthSupported
+                { num : Supported
+                }
+            )
+    ->
+        Value
+            (LengthSupported
+                { num : Supported
+                }
+            )
+    ->
+        Value
+            (LengthSupported
+                { num : Supported
+                }
+            )
+    -> Style
+borderImageOutset4 (Value valueTop) (Value valueRight) (Value valueBottom) (Value valueLeft) =
+    AppendProperty ("border-image-outset:" ++ valueTop ++ " " ++ valueRight ++ " " ++ valueBottom ++ " " ++ valueLeft)
+
+
+{-| Sets [`border-image-width`](https://css-tricks.com/almanac/properties/b/border-image/) property.
+
+    borderImageWidth (rem 1)
+
+    borderImageWidth2 (num 1) (num 1.2)
+
+    borderImageWidth3 (pct 5) (pct 15) (pct 10)
+
+    borderImageWidth4 (px 7) (px 12) (px 14) (px 5)
+
+Specifies the width of an element's border image. Supports values specified as length units, percentages, unitless numbers or auto. Negative values are invalid.
+
+-}
+borderImageWidth :
+    BaseValue
+        (LengthSupported
+            { pct : Supported
+            , num : Supported
+            , auto : Supported
+            }
+        )
+    -> Style
+borderImageWidth (Value widthVal) =
+    AppendProperty ("border-image-width:" ++ widthVal)
+
+
+{-| Sets [`border-image-width`](https://css-tricks.com/almanac/properties/b/border-image/) property.
+
+    borderImageWidth (rem 1)
+
+    borderImageWidth2 (num 1) (num 1.2)
+
+    borderImageWidth3 (pct 5) (pct 15) (pct 10)
+
+    borderImageWidth4 (px 7) (px 12) (px 14) (px 5)
+
+Specifies the width of an element's border image. Supports values specified as length units, percentages, unitless numbers or auto. Negative values are invalid.
+
+-}
+borderImageWidth2 :
+    Value
+        (LengthSupported
+            { pct : Supported
+            , num : Supported
+            , auto : Supported
+            }
+        )
+    ->
+        Value
+            (LengthSupported
+                { pct : Supported
+                , num : Supported
+                , auto : Supported
+                }
+            )
+    -> Style
+borderImageWidth2 (Value valueTopBottom) (Value valueRightLeft) =
+    AppendProperty ("border-image-width:" ++ valueTopBottom ++ " " ++ valueRightLeft)
+
+
+{-| Sets [`border-image-width`](https://css-tricks.com/almanac/properties/b/border-image/) property.
+
+    borderImageWidth (rem 1)
+
+    borderImageWidth2 (num 1) (num 1.2)
+
+    borderImageWidth3 (pct 5) (pct 15) (pct 10)
+
+    borderImageWidth4 (px 7) (px 12) (px 14) (px 5)
+
+Specifies the width of an element's border image. Supports values specified as length units, percentages, unitless numbers or auto. Negative values are invalid.
+
+-}
+borderImageWidth3 :
+    Value
+        (LengthSupported
+            { pct : Supported
+            , num : Supported
+            }
+        )
+    ->
+        Value
+            (LengthSupported
+                { pct : Supported
+                , num : Supported
+                , auto : Supported
+                }
+            )
+    ->
+        Value
+            (LengthSupported
+                { pct : Supported
+                , num : Supported
+                , auto : Supported
+                }
+            )
+    -> Style
+borderImageWidth3 (Value valueTop) (Value valueRightLeft) (Value valueBottom) =
+    AppendProperty ("border-image-width:" ++ valueTop ++ " " ++ valueRightLeft ++ " " ++ valueBottom)
+
+
+{-| Sets [`border-image-width`](https://css-tricks.com/almanac/properties/b/border-image/) property.
+
+    borderImageWidth (rem 1)
+
+    borderImageWidth2 (num 1) (num 1.2)
+
+    borderImageWidth3 (pct 5) (pct 15) (pct 10)
+
+    borderImageWidth4 (px 7) (px 12) (px 14) (px 5)
+
+Specifies the width of an element's border image. Supports values specified as length units, percentages, unitless numbers or auto. Negative values are invalid.
+
+-}
+borderImageWidth4 :
+    Value
+        (LengthSupported
+            { pct : Supported
+            , num : Supported
+            , auto : Supported
+            }
+        )
+    ->
+        Value
+            (LengthSupported
+                { pct : Supported
+                , num : Supported
+                , auto : Supported
+                }
+            )
+    ->
+        Value
+            (LengthSupported
+                { pct : Supported
+                , num : Supported
+                , auto : Supported
+                }
+            )
+    ->
+        Value
+            (LengthSupported
+                { pct : Supported
+                , num : Supported
+                , auto : Supported
+                }
+            )
+    -> Style
+borderImageWidth4 (Value valueTop) (Value valueRight) (Value valueBottom) (Value valueLeft) =
+    AppendProperty ("border-image-width:" ++ valueTop ++ " " ++ valueRight ++ " " ++ valueBottom ++ " " ++ valueLeft)
+
+
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+-------------------------------- OUTLINE -------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+
+
+{-| Sets [`outline`](https://css-tricks.com/almanac/properties/o/outline/).
+
+    outline zero
+
+    outline none
+
+-}
+outline :
+    BaseValue
+        (LineWidthSupported
+            (LineStyleSupported
+                (ColorSupported
+                    { auto : Supported
+                    , invert : Supported
+                    }
+                )
+            )
+        )
+    -> Style
+outline (Value val) =
+    AppendProperty ("outline:" ++ val)
+
+
+{-| Sets [`outline`](https://css-tricks.com/almanac/properties/o/outline/).
+
+    outline3 (em 0.25) auto (rgb 120 250 32)
+
+-}
+outline3 :
+    Value LineWidth
+    -> Value (LineStyleSupported { auto : Supported })
+    -> Value (ColorSupported { invert : Supported })
+    -> Style
+outline3 (Value widthVal) (Value styleVal) (Value colorVal) =
+    AppendProperty
+        ("outline:"
+            ++ widthVal
+            ++ " "
+            ++ styleVal
+            ++ " "
+            ++ colorVal
+        )
+
+
+{-| Sets [`outline-width`](https://developer.mozilla.org/en-US/docs/Web/CSS/outline-width).
+
+    outlineWidth (px 2)
+
+    outlineWidth thin
+
+-}
+outlineWidth : BaseValue LineWidth -> Style
+outlineWidth (Value val) =
+    AppendProperty ("outline-width:" ++ val)
+
+
+{-| Sets [`outline-color`](https://developer.mozilla.org/en-US/docs/Web/CSS/outline-color).
+
+    outlineColor (hex "eee")
+
+    outlineColor invert
+
+-}
+outlineColor : BaseValue (ColorSupported { invert : Supported }) -> Style
+outlineColor (Value val) =
+    AppendProperty ("outline-color:" ++ val)
+
+
+{-| The `invert` value used by properties such as [`outlineColor`](#outlineColor)
+
+    outlineColor invert
+
+-}
+invert : Value { provides | invert : Supported }
+invert =
+    Value "invert"
+
+
+{-| Sets [`outline-style`](https://developer.mozilla.org/en-US/docs/Web/CSS/outline-style).
+
+    outlineStyle auto
+
+    outlineStyle dashed
+
+-}
+outlineStyle : BaseValue (LineStyleSupported { auto : Supported }) -> Style
+outlineStyle (Value val) =
+    AppendProperty ("outline-style:" ++ val)
+
+
+{-| Sets [`outline-offset`](https://css-tricks.com/almanac/properties/o/outline-offset/).
+
+    outlineOffset (px 2)
+
+-}
+outlineOffset : BaseValue Length -> Style
+outlineOffset (Value val) =
+    AppendProperty ("outline-offset:" ++ val)
+
+
 
 ------------------------------------------------------------------------
 ------------------------------------------------------------------------
@@ -3647,9 +7014,391 @@ anywhere =
     Value "anywhere"
 
 
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------- DISPLAY --------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
 
 
--- POSITIONS --
+{-| Sets [`display`](https://css-tricks.com/almanac/properties/d/display/).
+
+    display block
+
+**Note:** This function accepts `flex_` rather than `flex` because [`flex` is already a property function](#flex).
+
+-}
+display :
+    BaseValue
+        { block : Supported
+        , flex_ : Supported
+        , flow : Supported
+        , flowRoot : Supported
+        , grid : Supported
+        , listItem : Supported
+        , inline : Supported
+        , inlineBlock : Supported
+        , inlineFlex : Supported
+        , inlineGrid : Supported
+        , inlineTable : Supported
+        , none : Supported
+        , contents : Supported
+        , ruby : Supported
+        , rubyBase : Supported
+        , rubyBaseContainer : Supported
+        , rubyText : Supported
+        , rubyTextContainer : Supported
+        , runIn : Supported
+        , table : Supported
+        , tableCaption : Supported
+        , tableCell : Supported
+        , tableColumn : Supported
+        , tableColumnGroup : Supported
+        , tableFooterGroup : Supported
+        , tableHeaderGroup : Supported
+        , tableRow : Supported
+        , tableRowGroup : Supported
+        }
+    -> Style
+display (Value val) =
+    AppendProperty ("display:" ++ val)
+
+
+{-| Sets [`display`](https://css-tricks.com/almanac/properties/d/display/).
+
+    display2 block flex_
+
+**Note:** This function accepts `flex_` rather than `flex` because [`flex` is already a property function](#flex).
+For `display: inline list-item` and similar property values that include `list-item`
+look at [`displayListItem2`](#displayListItem2) and [`displayListItem3`](#displayListItem3).
+
+-}
+display2 :
+    Value
+        { block : Supported
+        , inline : Supported
+        , runIn : Supported
+        }
+    ->
+        Value
+            { flow : Supported
+            , flowRoot : Supported
+            , table : Supported
+            , flex_ : Supported
+            , grid : Supported
+            , ruby : Supported
+            }
+    -> Style
+display2 (Value displayOutside) (Value displayInside) =
+    AppendProperty ("display:" ++ displayOutside ++ " " ++ displayInside)
+
+
+{-| The [`display`](https://css-tricks.com/almanac/properties/d/display/) property.
+This function is used to generate complex `display: list-item` properties
+such as `display: block list-item`.
+
+    displayListItem2 block
+
+-}
+displayListItem2 :
+    Value
+        { block : Supported
+        , inline : Supported
+        , runIn : Supported
+        , flow : Supported
+        , flowRoot : Supported
+        }
+    -> Style
+displayListItem2 (Value val) =
+    AppendProperty ("display:list-item " ++ val)
+
+
+{-| The [`display`](https://css-tricks.com/almanac/properties/d/display/) property.
+This function is used to generate complex `display: list-item` properties
+such as `display: block flow-root list-item`.
+
+    displayListItem3 block flowRoot
+
+-}
+displayListItem3 :
+    Value
+        { block : Supported
+        , inline : Supported
+        , runIn : Supported
+        }
+    ->
+        Value
+            { flow : Supported
+            , flowRoot : Supported
+            }
+    -> Style
+displayListItem3 (Value displayOutside) (Value displayFlow) =
+    AppendProperty ("display:list-item " ++ displayOutside ++ " " ++ displayFlow)
+
+
+{-| The `flex` value used by [`display`](#display).
+
+    display flex_
+
+The value is called `flex_` instead of `flex` because [`flex` is already a property function](#flex).
+
+-}
+flex_ : Value { provides | flex_ : Supported }
+flex_ =
+    Value "flex"
+
+
+{-| The `flow` value used by [`display`](#display).
+
+    display flow
+
+-}
+flow : Value { provides | flow : Supported }
+flow =
+    Value "flow"
+
+
+{-| The `flow-root` value used by [`display`](#display).
+
+    display flowRoot
+
+-}
+flowRoot : Value { provides | flowRoot : Supported }
+flowRoot =
+    Value "flow-root"
+
+
+{-| The `grid` value used by [`display`](#display).
+
+    display grid
+
+-}
+grid : Value { provides | grid : Supported }
+grid =
+    Value "grid"
+
+
+{-| The `contents` value used by [`display`](#display).
+
+    display contents
+
+-}
+contents : Value { provides | contents : Supported }
+contents =
+    Value "contents"
+
+
+{-| The `inline-block` value used by [`display`](#display).
+
+    display inlineBlock
+
+-}
+inlineBlock : Value { provides | inlineBlock : Supported }
+inlineBlock =
+    Value "inline-block"
+
+
+{-| The `inline-flex` value used by [`display`](#display).
+
+    display inlineFlex
+
+-}
+inlineFlex : Value { provides | inlineFlex : Supported }
+inlineFlex =
+    Value "inline-flex"
+
+
+{-| The `list-item` value used by [`display`](#display).
+
+    display listItem
+
+-}
+listItem : Value { provides | listItem : Supported }
+listItem =
+    Value "list-item"
+
+
+{-| The `inline-table` value used by [`display`](#display).
+
+    display inlineTable
+
+-}
+inlineTable : Value { provides | inlineTable : Supported }
+inlineTable =
+    Value "inline-table"
+
+
+{-| The `inline-grid` value used by [`display`](#display).
+
+    display inlineGrid
+
+-}
+inlineGrid : Value { provides | inlineGrid : Supported }
+inlineGrid =
+    Value "inline-grid"
+
+
+{-| The `ruby-base` value used by [`display`](#display).
+
+    display rubyBase
+
+-}
+rubyBase : Value { provides | rubyBase : Supported }
+rubyBase =
+    Value "ruby-base"
+
+
+{-| The `ruby-base-container` value used by [`display`](#display).
+
+    display rubyBaseContainer
+
+-}
+rubyBaseContainer : Value { provides | rubyBaseContainer : Supported }
+rubyBaseContainer =
+    Value "ruby-base-container"
+
+
+{-| The `ruby-text` value used by [`display`](#display).
+
+    display rubyText
+
+-}
+rubyText : Value { provides | rubyText : Supported }
+rubyText =
+    Value "ruby-text"
+
+
+{-| The `ruby-text-container` value used by [`display`](#display).
+
+    display rubyTextContainer
+
+-}
+rubyTextContainer : Value { provides | rubyTextContainer : Supported }
+rubyTextContainer =
+    Value "ruby-text-container"
+
+
+{-| The `run-in` value used by [`display`](#display).
+
+    display runIn
+
+-}
+runIn : Value { provides | runIn : Supported }
+runIn =
+    Value "run-in"
+
+
+{-| The `table` value used by [`display`](#display).
+
+    display table
+
+-}
+table : Value { provides | table : Supported }
+table =
+    Value "table"
+
+
+{-| The `table-caption` value used by [`display`](#display).
+
+    display tableCaption
+
+-}
+tableCaption : Value { provides | tableCaption : Supported }
+tableCaption =
+    Value "table-caption"
+
+
+{-| The `table-cell` value used by [`display`](#display).
+
+    display tableCell
+
+-}
+tableCell : Value { provides | tableCell : Supported }
+tableCell =
+    Value "table-cell"
+
+
+{-| The `table-column` value used by [`display`](#display).
+
+    display tableColumn
+
+-}
+tableColumn : Value { provides | tableColumn : Supported }
+tableColumn =
+    Value "table-column"
+
+
+{-| The `table-column-group` value used by [`display`](#display).
+
+    display tableColumnGroup
+
+-}
+tableColumnGroup : Value { provides | tableColumnGroup : Supported }
+tableColumnGroup =
+    Value "table-column-group"
+
+
+{-| The `table-footer-group` value used by [`display`](#display).
+
+    display tableFooterGroup
+
+-}
+tableFooterGroup : Value { provides | tableFooterGroup : Supported }
+tableFooterGroup =
+    Value "table-footer-group"
+
+
+{-| The `table-header-group` value used by [`display`](#display).
+
+    display tableHeaderGroup
+
+-}
+tableHeaderGroup : Value { provides | tableHeaderGroup : Supported }
+tableHeaderGroup =
+    Value "table-header-group"
+
+
+{-| The `table-row` value used by [`display`](#display).
+
+    display tableRow
+
+-}
+tableRow : Value { provides | tableRow : Supported }
+tableRow =
+    Value "table-row"
+
+
+{-| The `table-row-group` value used by [`display`](#display).
+
+    display tableRowGroup
+
+-}
+tableRowGroup : Value { provides | tableRowGroup : Supported }
+tableRowGroup =
+    Value "table-row-group"
+
+
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------- POSITION -------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
 
 
 {-| Sets the [`position`](https://css-tricks.com/almanac/properties/p/position/) of an element.
@@ -3670,6 +7419,87 @@ position :
     -> Style
 position (Value val) =
     AppendProperty ("position:" ++ val)
+
+
+{-| An [`absolute` `position`](https://developer.mozilla.org/en-US/docs/Web/CSS/position#relative).
+
+    position absolute
+
+The default `position` value is [`static`](#static). See also [`position: sticky`](#sticky), and [the differences between absolute, relative, and fixed positioning](<https://css-tricks.com/absolute-relative-fixed-positioining-how-do-they-differ/>
+
+-}
+absolute : Value { provides | absolute : Supported }
+absolute =
+    Value "absolute"
+
+
+{-| A [`fixed` `position`](https://developer.mozilla.org/en-US/docs/Web/CSS/position#Values)
+or [`fixed` `background-attachment`](https://developer.mozilla.org/en-US/docs/Web/CSS/background-attachment#Values)
+or [`fixed` `table-layout`](https://css-tricks.com/almanac/properties/t/table-layout/).
+
+    position fixed
+
+    backgroundAttachment fixed
+
+    tableLayout fixed
+
+The default `position` value is [`static`](#static). See also [`position: sticky`](#sticky), and [the differences between absolute, relative, and fixed positioning](https://css-tricks.com/absolute-relative-fixed-positioining-how-do-they-differ/)
+
+-}
+fixed : Value { provides | fixed : Supported }
+fixed =
+    Value "fixed"
+
+
+{-| A [`relative` `position`](https://developer.mozilla.org/en-US/docs/Web/CSS/position#Values).
+
+    position relative
+
+The default `position` value is [`static`](#static). See also [`position: sticky`](#sticky), and [the differences between absolute, relative, and fixed positioning](https://css-tricks.com/absolute-relative-fixed-positioining-how-do-they-differ/).
+
+-}
+relative : Value { provides | relative : Supported }
+relative =
+    Value "relative"
+
+
+{-| A [`static` `position`](https://developer.mozilla.org/en-US/docs/Web/CSS/position#Values).
+
+    position static
+
+This is the default `position` value. See also [`position: sticky`](#sticky), and [the differences between absolute, relative, and fixed positioning](https://css-tricks.com/absolute-relative-fixed-positioining-how-do-they-differ/).
+
+-}
+static : Value { provides | static : Supported }
+static =
+    Value "static"
+
+
+{-| A [`sticky` `position`](https://css-tricks.com/position-sticky-2/)
+
+    position sticky
+
+The default `position` value is [`static`](#static). See also [the differences between absolute, relative, and fixed positioning](https://css-tricks.com/absolute-relative-fixed-positioining-how-do-they-differ/).
+
+-}
+sticky : Value { provides | sticky : Supported }
+sticky =
+    Value "sticky"
+
+
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------- INSETS --------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
 
 
 {-| Sets the [`inset`](https://developer.mozilla.org/en-US/docs/Web/CSS/inset) property.
@@ -4108,72 +7938,6 @@ insetInlineEnd (Value val) =
     AppendProperty ("inset-inline-end:" ++ val)
 
 
-{-| An [`absolute` `position`](https://developer.mozilla.org/en-US/docs/Web/CSS/position#relative).
-
-    position absolute
-
-The default `position` value is [`static`](#static). See also [`position: sticky`](#sticky), and [the differences between absolute, relative, and fixed positioning](<https://css-tricks.com/absolute-relative-fixed-positioining-how-do-they-differ/>
-
--}
-absolute : Value { provides | absolute : Supported }
-absolute =
-    Value "absolute"
-
-
-{-| A [`fixed` `position`](https://developer.mozilla.org/en-US/docs/Web/CSS/position#Values)
-or [`fixed` `background-attachment`](https://developer.mozilla.org/en-US/docs/Web/CSS/background-attachment#Values)
-or [`fixed` `table-layout`](https://css-tricks.com/almanac/properties/t/table-layout/).
-
-    position fixed
-
-    backgroundAttachment fixed
-
-    tableLayout fixed
-
-The default `position` value is [`static`](#static). See also [`position: sticky`](#sticky), and [the differences between absolute, relative, and fixed positioning](https://css-tricks.com/absolute-relative-fixed-positioining-how-do-they-differ/)
-
--}
-fixed : Value { provides | fixed : Supported }
-fixed =
-    Value "fixed"
-
-
-{-| A [`relative` `position`](https://developer.mozilla.org/en-US/docs/Web/CSS/position#Values).
-
-    position relative
-
-The default `position` value is [`static`](#static). See also [`position: sticky`](#sticky), and [the differences between absolute, relative, and fixed positioning](https://css-tricks.com/absolute-relative-fixed-positioining-how-do-they-differ/).
-
--}
-relative : Value { provides | relative : Supported }
-relative =
-    Value "relative"
-
-
-{-| A [`static` `position`](https://developer.mozilla.org/en-US/docs/Web/CSS/position#Values).
-
-    position static
-
-This is the default `position` value. See also [`position: sticky`](#sticky), and [the differences between absolute, relative, and fixed positioning](https://css-tricks.com/absolute-relative-fixed-positioining-how-do-they-differ/).
-
--}
-static : Value { provides | static : Supported }
-static =
-    Value "static"
-
-
-{-| A [`sticky` `position`](https://css-tricks.com/position-sticky-2/)
-
-    position sticky
-
-The default `position` value is [`static`](#static). See also [the differences between absolute, relative, and fixed positioning](https://css-tricks.com/absolute-relative-fixed-positioining-how-do-they-differ/).
-
--}
-sticky : Value { provides | sticky : Supported }
-sticky =
-    Value "sticky"
-
-
 {-| Sets [`z-index`](https://css-tricks.com/almanac/properties/z/z-index/)
 
     zIndex (int 10)
@@ -4191,591 +7955,6 @@ zIndex :
     -> Style
 zIndex (Value val) =
     AppendProperty ("z-index:" ++ val)
-
-
-
--- PADDINGS --
-
-
-{-| Sets [`padding`](https://css-tricks.com/almanac/properties/p/padding/) property.
-The `padding` property is a shorthand property for setting `padding-top`,
-`padding-right`, `padding-bottom`, and `padding-left` in a single declaration.
-
-If there is only one argument value, it applies to all sides. If there are two
-values, the top and bottom paddings are set to the first value and the right and
-left paddings are set to the second. If there are three values, the top is set
-to the first value, the left and right are set to the second, and the bottom is
-set to the third. If there are four values they apply to the top, right,
-bottom, and left, respectively.
-
-    padding (em 4) -- set all margins to 4em
-
-    padding2 (em 4) (px 2) -- top & bottom = 4em, right & left = 2px
-
-    padding3 (em 4) (px 2) (pct 5) -- top = 4em, right = 2px, bottom = 5%, left = 2px
-
-    padding4 (em 4) (px 2) (pct 5) (px 3) -- top = 4em, right = 2px, bottom = 5%, left = 3px
-
--}
-padding :
-    BaseValue
-        (LengthSupported
-            { pct : Supported
-            }
-        )
-    -> Style
-padding (Value value) =
-    AppendProperty ("padding:" ++ value)
-
-
-{-| Sets [`padding`](https://css-tricks.com/almanac/properties/p/padding/) property.
-The `padding2` property is a shorthand property for setting `padding-top`,
-`padding-right`, `padding-bottom`, and `padding-left` in a single declaration.
-
-The top and bottom margins are set to the first value and the right and left
-margins are set to the second.
-
-    padding2 (em 4) (px 2) -- top & bottom = 4em, right & left = 2px
-
--}
-padding2 :
-    Value
-        (LengthSupported
-            { pct : Supported
-            }
-        )
-    ->
-        Value
-            (LengthSupported
-                { pct : Supported
-                }
-            )
-    -> Style
-padding2 (Value valueTopBottom) (Value valueRightLeft) =
-    AppendProperty ("padding:" ++ valueTopBottom ++ " " ++ valueRightLeft)
-
-
-{-| Sets [`padding`](https://css-tricks.com/almanac/properties/p/padding/) property.
-The `padding3` property is a shorthand property for setting `padding-top`,
-`padding-right`, `padding-bottom`, and `padding-left` in a single declaration.
-
-The top padding is set to the first value, the left and right are set to the
-second, and the bottom is set to the third.
-
-    padding3 (em 4) (px 2) (pct 5) -- top = 4em, right = 2px, bottom = 5%, left = 2px
-
--}
-padding3 :
-    Value
-        (LengthSupported
-            { pct : Supported
-            }
-        )
-    ->
-        Value
-            (LengthSupported
-                { pct : Supported
-                }
-            )
-    ->
-        Value
-            (LengthSupported
-                { pct : Supported
-                }
-            )
-    -> Style
-padding3 (Value valueTop) (Value valueRightLeft) (Value valueBottom) =
-    AppendProperty ("padding:" ++ valueTop ++ " " ++ valueRightLeft ++ " " ++ valueBottom)
-
-
-{-| Sets [`padding`](https://css-tricks.com/almanac/properties/p/padding/) property.
-The `padding4` property is a shorthand property for setting `padding-top`,
-`padding-right`, `padding-bottom`, and `padding-left` in a single declaration.
-
-The four values apply to the top, right, bottom, and left paddings.
-
-    padding4 (em 4) (px 2) (pct 5) (px 3) -- top = 4em, right = 2px, bottom = 5%, left = 3px
-
--}
-padding4 :
-    Value
-        (LengthSupported
-            { pct : Supported
-            }
-        )
-    ->
-        Value
-            (LengthSupported
-                { pct : Supported
-                }
-            )
-    ->
-        Value
-            (LengthSupported
-                { pct : Supported
-                }
-            )
-    ->
-        Value
-            (LengthSupported
-                { pct : Supported
-                }
-            )
-    -> Style
-padding4 (Value valueTop) (Value valueRight) (Value valueBottom) (Value valueLeft) =
-    AppendProperty ("padding:" ++ valueTop ++ " " ++ valueRight ++ " " ++ valueBottom ++ " " ++ valueLeft)
-
-
-{-| Sets [`padding-top`](https://developer.mozilla.org/en-US/docs/Web/CSS/padding-top) property.
-
-    paddingTop (px 4)
-
--}
-paddingTop :
-    BaseValue
-        (LengthSupported
-            { pct : Supported
-            }
-        )
-    -> Style
-paddingTop (Value value) =
-    AppendProperty ("padding-top:" ++ value)
-
-
-{-| Sets [`padding-right`](https://developer.mozilla.org/en-US/docs/Web/CSS/padding-right) property.
-
-    paddingRight (px 4)
-
--}
-paddingRight :
-    BaseValue
-        (LengthSupported
-            { pct : Supported
-            }
-        )
-    -> Style
-paddingRight (Value value) =
-    AppendProperty ("padding-right:" ++ value)
-
-
-{-| Sets [`padding-bottom`](https://developer.mozilla.org/en-US/docs/Web/CSS/padding-bottom) property.
-
-    paddingBottom (px 4)
-
--}
-paddingBottom :
-    BaseValue
-        (LengthSupported
-            { pct : Supported
-            }
-        )
-    -> Style
-paddingBottom (Value value) =
-    AppendProperty ("padding-bottom:" ++ value)
-
-
-{-| Sets [`padding-left`](https://developer.mozilla.org/en-US/docs/Web/CSS/padding-left) property.
-
-    paddingLeft (px 4)
-
--}
-paddingLeft :
-    BaseValue
-        (LengthSupported
-            { pct : Supported
-            }
-        )
-    -> Style
-paddingLeft (Value value) =
-    AppendProperty ("padding-left:" ++ value)
-
-
-{-| Sets [`padding-block`](https://css-tricks.com/almanac/properties/p/padding-block/) property.
-The `padding-block` property is a shorthand property for setting `padding-block-start` and
-`padding-block-end` in a single declaration.
-
-If there is only one argument value, it applies to both sides. If there are two
-values, the block start is set to the first value and the block end is set to the second.
-
-    paddingBlock (em 4) -- set both block start and block end to 4em
-
-    paddingBlock2 (em 4) (px 2) -- block start = 4em, block end = 2px
-
--}
-paddingBlock :
-    BaseValue
-        (LengthSupported
-            { pct : Supported
-            }
-        )
-    -> Style
-paddingBlock (Value value) =
-    AppendProperty ("padding-block:" ++ value)
-
-
-{-| Sets [`padding-block`](https://css-tricks.com/almanac/properties/p/padding-block/) property.
-
-The `padding-block` property is a shorthand property for setting `padding-block-start` and
-`padding-block-end` in a single declaration.
-
-The block start value is set to the first value and the block end value is set to the second.
-
-    paddingBlock2 (em 4) (px 2) -- block start = 4em, block end = 2px
-
--}
-paddingBlock2 :
-    Value
-        (LengthSupported
-            { pct : Supported
-            }
-        )
-    ->
-        Value
-            (LengthSupported
-                { pct : Supported
-                }
-            )
-    -> Style
-paddingBlock2 (Value valueStart) (Value valueEnd) =
-    AppendProperty ("padding-block:" ++ valueStart ++ " " ++ valueEnd)
-
-
-{-| Sets [`padding-block-start`](https://developer.mozilla.org/en-US/docs/Web/CSS/padding-block-start) property.
-
-    paddingBlockStart (px 4)
-
--}
-paddingBlockStart :
-    BaseValue
-        (LengthSupported
-            { pct : Supported
-            }
-        )
-    -> Style
-paddingBlockStart (Value value) =
-    AppendProperty ("padding-block-start:" ++ value)
-
-
-{-| Sets [`padding-block-end`](https://developer.mozilla.org/en-US/docs/Web/CSS/padding-block-end) property.
-
-    paddingBlockEnd (px 4)
-
--}
-paddingBlockEnd :
-    BaseValue
-        (LengthSupported
-            { pct : Supported
-            }
-        )
-    -> Style
-paddingBlockEnd (Value value) =
-    AppendProperty ("padding-block-end:" ++ value)
-
-
-{-| Sets [`padding-inline`](https://css-tricks.com/almanac/properties/p/padding-inline/) property.
-
-The `padding-inline` property is a shorthand property for setting `padding-inline-start` and
-`padding-inline-end` and in a single declaration.
-
-If there is only one argument value, it applies to both sides. If there are two
-values, the inline start is set to the first value and the inline end is set to the second.
-
-    paddingInline (em 4) -- set both inline start and inline end to 4em
-
-    paddingInline2 (em 4) (px 2) -- inline start = 4em, inline end = 2px
-
--}
-paddingInline :
-    BaseValue
-        (LengthSupported
-            { pct : Supported
-            }
-        )
-    -> Style
-paddingInline (Value value) =
-    AppendProperty ("padding-inline:" ++ value)
-
-
-{-| Sets [`padding-inline`](https://css-tricks.com/almanac/properties/p/padding-inline/) property.
-
-The `padding-inline` property is a shorthand property for setting `padding-inline-start` and
-`padding-inline-end` in a single declaration.
-
-The inline start value is set to the first value and the inline end value is set to the second.
-
-    paddingInline2 (em 4) (px 2) -- inline start = 4em, inline end = 2px
-
--}
-paddingInline2 :
-    Value
-        (LengthSupported
-            { pct : Supported
-            }
-        )
-    ->
-        Value
-            (LengthSupported
-                { pct : Supported
-                }
-            )
-    -> Style
-paddingInline2 (Value valueStart) (Value valueEnd) =
-    AppendProperty ("padding-inline:" ++ valueStart ++ " " ++ valueEnd)
-
-
-{-| Sets [`padding-inline-start`](https://developer.mozilla.org/en-US/docs/Web/CSS/padding-inline-start) property.
-
-    paddingInlineStart (px 4)
-
--}
-paddingInlineStart :
-    BaseValue
-        (LengthSupported
-            { pct : Supported
-            }
-        )
-    -> Style
-paddingInlineStart (Value value) =
-    AppendProperty ("padding-inline-start:" ++ value)
-
-
-{-| Sets [`padding-inline-end`](https://developer.mozilla.org/en-US/docs/Web/CSS/padding-inline-end) property.
-
-    paddingInlineEnd (px 4)
-
--}
-paddingInlineEnd :
-    BaseValue
-        (LengthSupported
-            { pct : Supported
-            }
-        )
-    -> Style
-paddingInlineEnd (Value value) =
-    AppendProperty ("padding-inline-end:" ++ value)
-
-
-
--- MARGINS --
-
-
-{-| Sets [`margin`](https://css-tricks.com/almanac/properties/m/margin/) property.
-The `margin` property is a shorthand property for setting `margin-top`,
-`margin-right`, `margin-bottom`, and `margin-left` in a single declaration.
-
-If there is only one argument value, it applies to all sides. If there are two
-values, the top and bottom margins are set to the first value and the right and
-left margins are set to the second. If there are three values, the top is set
-to the first value, the left and right are set to the second, and the bottom is
-set to the third. If there are four values they apply to the top, right,
-bottom, and left, respectively.
-
-    margin (em 4) -- set all margins to 4em
-
-    margin2 (em 4) (px 2) -- top & bottom = 4em, right & left = 2px
-
-    margin3 (em 4) (px 2) (pct 5) -- top = 4em, right = 2px, bottom = 5%, left = 2px
-
-    margin4 (em 4) (px 2) (pct 5) (px 3) -- top = 4em, right = 2px, bottom = 5%, left = 3px
-
-You may want to check out [this article on collapsing margins](https://css-tricks.com/good-ol-margin-collapsing/)!
-
--}
-margin :
-    BaseValue
-        (LengthSupported
-            { pct : Supported
-            , auto : Supported
-            }
-        )
-    -> Style
-margin (Value value) =
-    AppendProperty ("margin:" ++ value)
-
-
-{-| Sets [`margin`](https://css-tricks.com/almanac/properties/m/margin/) property.
-The `margin2` property is a shorthand property for setting `margin-top`,
-`margin-right`, `margin-bottom`, and `margin-left` in a single declaration.
-
-The top and bottom margins are set to the first value and the right and left
-margins are set to the second.
-
-    margin2 (em 4) (px 2) -- top & bottom = 4em, right & left = 2px
-
-You may want to check out [this article on collapsing margins](https://css-tricks.com/good-ol-margin-collapsing/)!
-
--}
-margin2 :
-    Value
-        (LengthSupported
-            { pct : Supported
-            , auto : Supported
-            }
-        )
-    ->
-        Value
-            (LengthSupported
-                { pct : Supported
-                , auto : Supported
-                }
-            )
-    -> Style
-margin2 (Value valueTopBottom) (Value valueRightLeft) =
-    AppendProperty ("margin:" ++ valueTopBottom ++ " " ++ valueRightLeft)
-
-
-{-| Sets [`margin`](https://css-tricks.com/almanac/properties/m/margin/) property.
-The `margin3` property is a shorthand property for setting `margin-top`,
-`margin-right`, `margin-bottom`, and `margin-left` in a single declaration.
-
-The top margin is set to the first value, the left and right are set to the
-second, and the bottom is set to the third.
-
-    margin3 (em 4) (px 2) (pct 5) -- top = 4em, right = 2px, bottom = 5%, left = 2px
-
-You may want to check out [this article on collapsing margins](https://css-tricks.com/good-ol-margin-collapsing/)!
-
--}
-margin3 :
-    Value
-        (LengthSupported
-            { pct : Supported
-            , auto : Supported
-            }
-        )
-    ->
-        Value
-            (LengthSupported
-                { pct : Supported
-                , auto : Supported
-                }
-            )
-    ->
-        Value
-            (LengthSupported
-                { pct : Supported
-                , auto : Supported
-                }
-            )
-    -> Style
-margin3 (Value valueTop) (Value valueRightLeft) (Value valueBottom) =
-    AppendProperty ("margin:" ++ valueTop ++ " " ++ valueRightLeft ++ " " ++ valueBottom)
-
-
-{-| Sets [`margin`](https://css-tricks.com/almanac/properties/m/margin/) property.
-The `margin4` property is a shorthand property for setting `margin-top`,
-`margin-right`, `margin-bottom`, and `margin-left` in a single declaration.
-
-The four values apply to the top, right, bottom, and left margins.
-
-    margin4 (em 4) (px 2) (pct 5) (px 3) -- top = 4em, right = 2px, bottom = 5%, left = 3px
-
-You may want to check out [this article on collapsing margins](https://css-tricks.com/good-ol-margin-collapsing/)!
-
--}
-margin4 :
-    Value
-        (LengthSupported
-            { pct : Supported
-            , auto : Supported
-            }
-        )
-    ->
-        Value
-            (LengthSupported
-                { pct : Supported
-                , auto : Supported
-                }
-            )
-    ->
-        Value
-            (LengthSupported
-                { pct : Supported
-                , auto : Supported
-                }
-            )
-    ->
-        Value
-            (LengthSupported
-                { pct : Supported
-                , auto : Supported
-                }
-            )
-    -> Style
-margin4 (Value valueTop) (Value valueRight) (Value valueBottom) (Value valueLeft) =
-    AppendProperty ("margin:" ++ valueTop ++ " " ++ valueRight ++ " " ++ valueBottom ++ " " ++ valueLeft)
-
-
-{-| Sets [`margin-top`](https://developer.mozilla.org/en-US/docs/Web/CSS/margin-top) property.
-
-    marginTop (px 4)
-
-This article on [`margin-top` versus `margin-bottom`](https://css-tricks.com/margin-bottom-margin-top/) may be useful.
-
--}
-marginTop :
-    BaseValue
-        (LengthSupported
-            { pct : Supported
-            , auto : Supported
-            }
-        )
-    -> Style
-marginTop (Value value) =
-    AppendProperty ("margin-top:" ++ value)
-
-
-{-| Sets [`margin-right`](https://developer.mozilla.org/en-US/docs/Web/CSS/margin-right) property.
-
-    marginRight (px 4)
-
--}
-marginRight :
-    BaseValue
-        (LengthSupported
-            { pct : Supported
-            , auto : Supported
-            }
-        )
-    -> Style
-marginRight (Value value) =
-    AppendProperty ("margin-right:" ++ value)
-
-
-{-| Sets [`margin-bottom`](https://developer.mozilla.org/en-US/docs/Web/CSS/margin-bottom) property.
-
-    marginBottom (px 4)
-
-This article on [`margin-top` versus `margin-bottom`](https://css-tricks.com/margin-bottom-margin-top/) may be useful.
-
--}
-marginBottom :
-    BaseValue
-        (LengthSupported
-            { pct : Supported
-            , auto : Supported
-            }
-        )
-    -> Style
-marginBottom (Value value) =
-    AppendProperty ("margin-bottom:" ++ value)
-
-
-{-| Sets [`margin-left`](https://developer.mozilla.org/en-US/docs/Web/CSS/margin-left) property.
-
-    marginLeft (px 4)
-
--}
-marginLeft :
-    BaseValue
-        (LengthSupported
-            { pct : Supported
-            , auto : Supported
-            }
-        )
-    -> Style
-marginLeft (Value value) =
-    AppendProperty ("margin-left:" ++ value)
 
 
 
@@ -4798,480 +7977,6 @@ boxSizing :
 boxSizing (Value value) =
     AppendProperty ("box-sizing:" ++ value)
 
-
-
--- PSEUDO-CLASSES --
-
-
-{-| Define a custom pseudo-class.
-
-This can be useful for deprecated [pseudo-classes](https://css-tricks.com/pseudo-class-selectors/) such as `-moz-any-link`, which
-[has been deprecated and removed](https://www.fxsitecompat.com/en-CA/docs/2016/any-link-css-pseudo-class-has-been-unprefixed/)
-in modern browsers.
-
-    button
-        [ css [ pseudoClass "-moz-any-link" [ color (hex "f00") ] ] ]
-        [ text "Whee!" ]
-
-...outputs
-
-    <button class="f9fcb2">Whee!</button>
-
-    <style>
-        .f9fcb2:-moz-any-link {
-            color: #f00;
-        }
-    </style>
-
--}
-pseudoClass : String -> List Style -> Style
-pseudoClass pseudoClassName =
-    Preprocess.ExtendSelector (Structure.PseudoClassSelector pseudoClassName)
-
-
-{-| An [`:active`](https://css-tricks.com/almanac/selectors/a/active/)
-[pseudo-class](https://css-tricks.com/pseudo-class-selectors/).
-
-    button [ active [ color (rgb 12 160 190) ] ]
-
--}
-active : List Style -> Style
-active =
-    pseudoClass "active"
-
-
-{-| A [`:checked`](https://developer.mozilla.org/en-US/docs/Web/CSS/:checked)
-[pseudo-class](https://css-tricks.com/pseudo-class-selectors/).
-
-This pseudo-class is for any checkbox, option or radio input that is checked or toggled on.
-
-    checked
-        [ backgroundColor (rgb 0 0 255)
-        ]
-
--}
-checked : List Style -> Style
-checked =
-    pseudoClass "checked"
-
-
-{-| A [`:disabled`](https://developer.mozilla.org/en-US/docs/Web/CSS/:disabled)
-[pseudo-class](https://css-tricks.com/pseudo-class-selectors/).
-
-    button [ disabled [ color (rgb 194 194 194) ] ]
-
--}
-disabled : List Style -> Style
-disabled =
-    pseudoClass "disabled"
-
-
-{-| An [`:empty`](https://developer.mozilla.org/en-US/docs/Web/CSS/:empty)
-[pseudo-class](https://css-tricks.com/pseudo-class-selectors/).
-
-    empty
-        [ backgroundColor (rgb 20 20 20)
-        ]
-
--}
-empty : List Style -> Style
-empty =
-    pseudoClass "empty"
-
-
-{-| An [`:enabled`](https://developer.mozilla.org/en-US/docs/Web/CSS/:enabled)
-[pseudo-class](https://css-tricks.com/pseudo-class-selectors/).
-
-    enabled
-        [ borderColor (rgba 150 150 0 0.5)
-        ]
-
--}
-enabled : List Style -> Style
-enabled =
-    pseudoClass "enabled"
-
-
-{-| A [`:first-of-type`](https://developer.mozilla.org/en-US/docs/Web/CSS/:first-child)
-[pseudo-class](https://css-tricks.com/pseudo-class-selectors/).
-
-    firstChild
-        [ fontWeight bold
-        ]
-
--}
-firstChild : List Style -> Style
-firstChild =
-    pseudoClass "first-child"
-
-
-{-| A [`:first-of-type`](https://developer.mozilla.org/en-US/docs/Web/CSS/:first-of-type)
-[pseudo-class](https://css-tricks.com/pseudo-class-selectors/).
-
-    firstOfType
-        [ color (rgb 255 0 0)
-        ]
-
--}
-firstOfType : List Style -> Style
-firstOfType =
-    pseudoClass "first-of-type"
-
-
-{-| A [`:focus`](https://developer.mozilla.org/en-US/docs/Web/CSS/:focus)
-[pseudo-class](https://css-tricks.com/pseudo-class-selectors/).
-
-    focus
-        [ border3 (px 2) solid (rgb 0 0 0)
-        ]
-
--}
-focus : List Style -> Style
-focus =
-    pseudoClass "focus"
-
-
-{-| A [`:fullscreen`](https://developer.mozilla.org/en-US/docs/Web/CSS/:fullscreen)
-[pseudo-class](https://css-tricks.com/pseudo-class-selectors/).
-
-    fullscreen
-        [ backgroundColor (rgb 0 0 0)
-        ]
-
--}
-fullscreen : List Style -> Style
-fullscreen =
-    pseudoClass "fullscreen"
-
-
-{-| A [`:hover`](https://developer.mozilla.org/en-US/docs/Web/CSS/:hover)
-[pseudo-class](https://css-tricks.com/pseudo-class-selectors/).
-
-    hover
-        [ fontWeight bold
-        , color (rgb 255 50 0)
-        ]
-
--}
-hover : List Style -> Style
-hover =
-    pseudoClass "hover"
-
-
-{-| An [`:in-range`](https://developer.mozilla.org/en-US/docs/Web/CSS/:in-range)
-[pseudo-class](https://css-tricks.com/pseudo-class-selectors/).
-
-    inRange
-        [ backgroundColor (rgb 0 255 0)
-        ]
-
--}
-inRange : List Style -> Style
-inRange =
-    pseudoClass "in-range"
-
-
-{-| An [`:indeterminate`](https://developer.mozilla.org/en-US/docs/Web/CSS/:indeterminate)
-[pseudo-class](https://css-tricks.com/pseudo-class-selectors/).
-
-    indeterminate
-        [ backgroundColor (rgb 100 100 100)
-        ]
-
--}
-indeterminate : List Style -> Style
-indeterminate =
-    pseudoClass "indeterminate"
-
-
-{-| An [`:invalid`](https://developer.mozilla.org/en-US/docs/Web/CSS/:invalid)
-[pseudo-class](https://css-tricks.com/pseudo-class-selectors/).
-
-    invalid
-        [ color (rgb 255 0 0)
-        , fontWeight bold
-        ]
-
--}
-invalid : List Style -> Style
-invalid =
-    pseudoClass "invalid"
-
-
-{-| A [`:last-child`](https://developer.mozilla.org/en-US/docs/Web/CSS/:last-child)
-[pseudo-class](https://css-tricks.com/pseudo-class-selectors/).
-
-    lastChild
-        [ backgroundColor (rgb 0 0 255)
-        ]
-
--}
-lastChild : List Style -> Style
-lastChild =
-    pseudoClass "last-child"
-
-
-{-| A [`:last-of-type`](https://developer.mozilla.org/en-US/docs/Web/CSS/:last-of-type)
-[pseudo-class](https://css-tricks.com/pseudo-class-selectors/).
-
-    lastOfType
-        [ color (rgb 100 100 100)
-        ]
-
--}
-lastOfType : List Style -> Style
-lastOfType =
-    pseudoClass "last-of-type"
-
-
-{-| A [`:link`](https://developer.mozilla.org/en-US/docs/Web/CSS/:link)
-[pseudo-class](https://css-tricks.com/pseudo-class-selectors/).
-
-    link
-        [ color (rgb 0 0 255)
-        ]
-
--}
-link : List Style -> Style
-link =
-    pseudoClass "link"
-
-
-{-| An [`:only-child`](https://developer.mozilla.org/en-US/docs/Web/CSS/:only-child)
-[pseudo-class](https://css-tricks.com/pseudo-class-selectors/).
-
-    onlyChild
-        [ backgroundColor (rgb 255 255 255)
-        ]
-
--}
-onlyChild : List Style -> Style
-onlyChild =
-    pseudoClass "only-child"
-
-
-{-| An [`:only-of-type`](https://developer.mozilla.org/en-US/docs/Web/CSS/:only-of-type)
-[pseudo-class](https://css-tricks.com/pseudo-class-selectors/).
-
-    onlyOfType
-        [ color (rgb 255 0 0)
-        , fontStyle italic
-        ]
-
--}
-onlyOfType : List Style -> Style
-onlyOfType =
-    pseudoClass "only-of-type"
-
-
-{-| An [`:out-of-range`](https://developer.mozilla.org/en-US/docs/Web/CSS/:out-of-range)
-[pseudo-class](https://css-tricks.com/pseudo-class-selectors/).
-
-    outOfRange
-        [ color (rgb 255 0 0)
-        ]
-
--}
-outOfRange : List Style -> Style
-outOfRange =
-    pseudoClass "out-of-range"
-
-
-{-| A [`:read-only`](https://developer.mozilla.org/en-US/docs/Web/CSS/:read-only)
-[pseudo-class](https://css-tricks.com/pseudo-class-selectors/).
-
-    readOnly
-        [ color (rgb 50 50 50)
-        ]
-
--}
-readOnly : List Style -> Style
-readOnly =
-    pseudoClass "read-only"
-
-
-{-| Sets [`margin-block`](https://css-tricks.com/almanac/properties/m/margin-block/) property.
-The `margin-block` property is a shorthand property for setting `margin-block-start` and
-`margin-block-end` in a single declaration.
-
-If there is only one argument value, it applies to both sides. If there are two
-values, the block start margin is set to the first value and the block end margin
-is set to the second.
-
-    marginBlock (em 4) -- set both block margins to 4em
-
-    marginBlock2 (em 4) (px 2) -- block start = 4em, block end = 2px
-
-You may want to check out [this article on collapsing margins](https://css-tricks.com/good-ol-margin-collapsing/)!
-
--}
-marginBlock :
-    BaseValue
-        (LengthSupported
-            { pct : Supported
-            , auto : Supported
-            }
-        )
-    -> Style
-marginBlock (Value value) =
-    AppendProperty ("margin-block:" ++ value)
-
-
-{-| Sets [`margin-block`](https://css-tricks.com/almanac/properties/m/margin-block/) property.
-The `margin-block` property is a shorthand property for setting `margin-block-start` and
-`margin-block-end` in a single declaration.
-
-The block start margin is set to the first value and the block end margin
-is set to the second.
-
-    marginBlock2 (em 4) (px 2) -- block start = 4em, block end = 2px
-
-You may want to check out [this article on collapsing margins](https://css-tricks.com/good-ol-margin-collapsing/)!
-
--}
-marginBlock2 :
-    Value
-        (LengthSupported
-            { pct : Supported
-            , auto : Supported
-            }
-        )
-    ->
-        Value
-            (LengthSupported
-                { pct : Supported
-                , auto : Supported
-                }
-            )
-    -> Style
-marginBlock2 (Value valueStart) (Value valueEnd) =
-    AppendProperty ("margin-block:" ++ valueStart ++ " " ++ valueEnd)
-
-
-{-| Sets [`margin-block-start`](https://developer.mozilla.org/en-US/docs/Web/CSS/margin-block-start) property.
-
-    marginBlockStart (px 4)
-
--}
-marginBlockStart :
-    BaseValue
-        (LengthSupported
-            { pct : Supported
-            , auto : Supported
-            }
-        )
-    -> Style
-marginBlockStart (Value value) =
-    AppendProperty ("margin-block-start:" ++ value)
-
-
-{-| Sets [`margin-block-end`](https://developer.mozilla.org/en-US/docs/Web/CSS/margin-block-end) property.
-
-    marginBlockEnd (px 4)
-
--}
-marginBlockEnd :
-    BaseValue
-        (LengthSupported
-            { pct : Supported
-            , auto : Supported
-            }
-        )
-    -> Style
-marginBlockEnd (Value value) =
-    AppendProperty ("margin-block-end:" ++ value)
-
-
-{-| Sets [`margin-inline`](https://css-tricks.com/almanac/properties/m/margin-inline/) property.
-The `margin-inline` property is a shorthand property for setting `margin-inline-start` and
-`margin-inline-end` in a single declaration.
-
-If there is only one argument value, it applies to both sides. If there are two
-values, the inline start margin is set to the first value and the inline end margin
-is set to the second.
-
-    marginInline (em 4) -- set both inline margins to 4em
-
-    marginInline2 (em 4) (px 2) -- inline start = 4em, inline end = 2px
-
-You may want to check out [this article on collapsing margins](https://css-tricks.com/good-ol-margin-collapsing/)!
-
--}
-marginInline :
-    BaseValue
-        (LengthSupported
-            { pct : Supported
-            , auto : Supported
-            }
-        )
-    -> Style
-marginInline (Value value) =
-    AppendProperty ("margin-inline:" ++ value)
-
-
-{-| Sets [`margin-inline`](https://css-tricks.com/almanac/properties/m/margin-inline/) property.
-The `margin-inline` property is a shorthand property for setting `margin-inline-start` and
-`margin-inline-end` in a single declaration.
-
-The inline start margin is set to the first value and the inline end margin
-is set to the second.
-
-    marginInline2 (em 4) (px 2) -- inline start = 4em, inline end = 2px
-
-You may want to check out [this article on collapsing margins](https://css-tricks.com/good-ol-margin-collapsing/)!
-
--}
-marginInline2 :
-    Value
-        (LengthSupported
-            { pct : Supported
-            , auto : Supported
-            }
-        )
-    ->
-        Value
-            (LengthSupported
-                { pct : Supported
-                , auto : Supported
-                }
-            )
-    -> Style
-marginInline2 (Value valueStart) (Value valueEnd) =
-    AppendProperty ("margin-inline:" ++ valueStart ++ " " ++ valueEnd)
-
-
-{-| Sets [`margin-inline-start`](https://developer.mozilla.org/en-US/docs/Web/CSS/margin-inline-start) property.
-
-    marginInlineStart (px 4)
-
--}
-marginInlineStart :
-    BaseValue
-        (LengthSupported
-            { pct : Supported
-            , auto : Supported
-            }
-        )
-    -> Style
-marginInlineStart (Value value) =
-    AppendProperty ("margin-inline-start:" ++ value)
-
-
-{-| Sets [`margin-inline-end`](https://developer.mozilla.org/en-US/docs/Web/CSS/margin-inline-end) property.
-
-    marginInlineEnd (px 4)
-
--}
-marginInlineEnd :
-    BaseValue
-        (LengthSupported
-            { pct : Supported
-            , auto : Supported
-            }
-        )
-    -> Style
-marginInlineEnd (Value value) =
-    AppendProperty ("margin-inline-end:" ++ value)
 
 
 {-| A [`:read-write`](https://developer.mozilla.org/en-US/docs/Web/CSS/:read-write)
@@ -5889,364 +8594,6 @@ dividedBy (Value second) =
 
 
 -- DISPLAY --
-
-
-{-| Sets [`display`](https://css-tricks.com/almanac/properties/d/display/).
-
-    display block
-
-**Note:** This function accepts `flex_` rather than `flex` because [`flex` is already a property function](#flex).
-
--}
-display :
-    BaseValue
-        { block : Supported
-        , flex_ : Supported
-        , flow : Supported
-        , flowRoot : Supported
-        , grid : Supported
-        , listItem : Supported
-        , inline : Supported
-        , inlineBlock : Supported
-        , inlineFlex : Supported
-        , inlineGrid : Supported
-        , inlineTable : Supported
-        , none : Supported
-        , contents : Supported
-        , ruby : Supported
-        , rubyBase : Supported
-        , rubyBaseContainer : Supported
-        , rubyText : Supported
-        , rubyTextContainer : Supported
-        , runIn : Supported
-        , table : Supported
-        , tableCaption : Supported
-        , tableCell : Supported
-        , tableColumn : Supported
-        , tableColumnGroup : Supported
-        , tableFooterGroup : Supported
-        , tableHeaderGroup : Supported
-        , tableRow : Supported
-        , tableRowGroup : Supported
-        }
-    -> Style
-display (Value val) =
-    AppendProperty ("display:" ++ val)
-
-
-{-| Sets [`display`](https://css-tricks.com/almanac/properties/d/display/).
-
-    display2 block flex_
-
-**Note:** This function accepts `flex_` rather than `flex` because [`flex` is already a property function](#flex).
-For `display: inline list-item` and similar property values that include `list-item`
-look at [`displayListItem2`](#displayListItem2) and [`displayListItem3`](#displayListItem3).
-
--}
-display2 :
-    Value
-        { block : Supported
-        , inline : Supported
-        , runIn : Supported
-        }
-    ->
-        Value
-            { flow : Supported
-            , flowRoot : Supported
-            , table : Supported
-            , flex_ : Supported
-            , grid : Supported
-            , ruby : Supported
-            }
-    -> Style
-display2 (Value displayOutside) (Value displayInside) =
-    AppendProperty ("display:" ++ displayOutside ++ " " ++ displayInside)
-
-
-{-| The [`display`](https://css-tricks.com/almanac/properties/d/display/) property.
-This function is used to generate complex `display: list-item` properties
-such as `display: block list-item`.
-
-    displayListItem2 block
-
--}
-displayListItem2 :
-    Value
-        { block : Supported
-        , inline : Supported
-        , runIn : Supported
-        , flow : Supported
-        , flowRoot : Supported
-        }
-    -> Style
-displayListItem2 (Value val) =
-    AppendProperty ("display:list-item " ++ val)
-
-
-{-| The [`display`](https://css-tricks.com/almanac/properties/d/display/) property.
-This function is used to generate complex `display: list-item` properties
-such as `display: block flow-root list-item`.
-
-    displayListItem3 block flowRoot
-
--}
-displayListItem3 :
-    Value
-        { block : Supported
-        , inline : Supported
-        , runIn : Supported
-        }
-    ->
-        Value
-            { flow : Supported
-            , flowRoot : Supported
-            }
-    -> Style
-displayListItem3 (Value displayOutside) (Value displayFlow) =
-    AppendProperty ("display:list-item " ++ displayOutside ++ " " ++ displayFlow)
-
-
-{-| The `flex` value used by [`display`](#display).
-
-    display flex_
-
-The value is called `flex_` instead of `flex` because [`flex` is already a property function](#flex).
-
--}
-flex_ : Value { provides | flex_ : Supported }
-flex_ =
-    Value "flex"
-
-
-{-| The `flow` value used by [`display`](#display).
-
-    display flow
-
--}
-flow : Value { provides | flow : Supported }
-flow =
-    Value "flow"
-
-
-{-| The `flow-root` value used by [`display`](#display).
-
-    display flowRoot
-
--}
-flowRoot : Value { provides | flowRoot : Supported }
-flowRoot =
-    Value "flow-root"
-
-
-{-| The `grid` value used by [`display`](#display).
-
-    display grid
-
--}
-grid : Value { provides | grid : Supported }
-grid =
-    Value "grid"
-
-
-{-| The `contents` value used by [`display`](#display).
-
-    display contents
-
--}
-contents : Value { provides | contents : Supported }
-contents =
-    Value "contents"
-
-
-{-| The `inline-block` value used by [`display`](#display).
-
-    display inlineBlock
-
--}
-inlineBlock : Value { provides | inlineBlock : Supported }
-inlineBlock =
-    Value "inline-block"
-
-
-{-| The `inline-flex` value used by [`display`](#display).
-
-    display inlineFlex
-
--}
-inlineFlex : Value { provides | inlineFlex : Supported }
-inlineFlex =
-    Value "inline-flex"
-
-
-{-| The `list-item` value used by [`display`](#display).
-
-    display listItem
-
--}
-listItem : Value { provides | listItem : Supported }
-listItem =
-    Value "list-item"
-
-
-{-| The `inline-table` value used by [`display`](#display).
-
-    display inlineTable
-
--}
-inlineTable : Value { provides | inlineTable : Supported }
-inlineTable =
-    Value "inline-table"
-
-
-{-| The `inline-grid` value used by [`display`](#display).
-
-    display inlineGrid
-
--}
-inlineGrid : Value { provides | inlineGrid : Supported }
-inlineGrid =
-    Value "inline-grid"
-
-
-{-| The `ruby-base` value used by [`display`](#display).
-
-    display rubyBase
-
--}
-rubyBase : Value { provides | rubyBase : Supported }
-rubyBase =
-    Value "ruby-base"
-
-
-{-| The `ruby-base-container` value used by [`display`](#display).
-
-    display rubyBaseContainer
-
--}
-rubyBaseContainer : Value { provides | rubyBaseContainer : Supported }
-rubyBaseContainer =
-    Value "ruby-base-container"
-
-
-{-| The `ruby-text` value used by [`display`](#display).
-
-    display rubyText
-
--}
-rubyText : Value { provides | rubyText : Supported }
-rubyText =
-    Value "ruby-text"
-
-
-{-| The `ruby-text-container` value used by [`display`](#display).
-
-    display rubyTextContainer
-
--}
-rubyTextContainer : Value { provides | rubyTextContainer : Supported }
-rubyTextContainer =
-    Value "ruby-text-container"
-
-
-{-| The `run-in` value used by [`display`](#display).
-
-    display runIn
-
--}
-runIn : Value { provides | runIn : Supported }
-runIn =
-    Value "run-in"
-
-
-{-| The `table` value used by [`display`](#display).
-
-    display table
-
--}
-table : Value { provides | table : Supported }
-table =
-    Value "table"
-
-
-{-| The `table-caption` value used by [`display`](#display).
-
-    display tableCaption
-
--}
-tableCaption : Value { provides | tableCaption : Supported }
-tableCaption =
-    Value "table-caption"
-
-
-{-| The `table-cell` value used by [`display`](#display).
-
-    display tableCell
-
--}
-tableCell : Value { provides | tableCell : Supported }
-tableCell =
-    Value "table-cell"
-
-
-{-| The `table-column` value used by [`display`](#display).
-
-    display tableColumn
-
--}
-tableColumn : Value { provides | tableColumn : Supported }
-tableColumn =
-    Value "table-column"
-
-
-{-| The `table-column-group` value used by [`display`](#display).
-
-    display tableColumnGroup
-
--}
-tableColumnGroup : Value { provides | tableColumnGroup : Supported }
-tableColumnGroup =
-    Value "table-column-group"
-
-
-{-| The `table-footer-group` value used by [`display`](#display).
-
-    display tableFooterGroup
-
--}
-tableFooterGroup : Value { provides | tableFooterGroup : Supported }
-tableFooterGroup =
-    Value "table-footer-group"
-
-
-{-| The `table-header-group` value used by [`display`](#display).
-
-    display tableHeaderGroup
-
--}
-tableHeaderGroup : Value { provides | tableHeaderGroup : Supported }
-tableHeaderGroup =
-    Value "table-header-group"
-
-
-{-| The `table-row` value used by [`display`](#display).
-
-    display tableRow
-
--}
-tableRow : Value { provides | tableRow : Supported }
-tableRow =
-    Value "table-row"
-
-
-{-| The `table-row-group` value used by [`display`](#display).
-
-    display tableRowGroup
-
--}
-tableRowGroup : Value { provides | tableRowGroup : Supported }
-tableRowGroup =
-    Value "table-row-group"
-
 
 
 -- ALIGN-ITEMS VALUES --
@@ -11070,1946 +13417,6 @@ upperRoman =
 
 
 
--- BORDERS --
-
-
-{-| Sets [`border`](https://css-tricks.com/almanac/properties/b/border/) property.
-
-    border (px 1)
-
-    border2 (px 1) solid
-
-    border3 (px 1) solid (hex "#f00")
-
--}
-border : BaseValue LineWidth -> Style
-border (Value widthVal) =
-    AppendProperty ("border:" ++ widthVal)
-
-
-{-| Sets [`border`](https://css-tricks.com/almanac/properties/b/border/) property.
-
-    border (px 1)
-
-    border2 (px 1) solid
-
-    border3 (px 1) solid (hex "#f00")
-
--}
-border2 : Value LineWidth -> Value LineStyle -> Style
-border2 (Value widthVal) (Value styleVal) =
-    AppendProperty ("border:" ++ widthVal ++ " " ++ styleVal)
-
-
-{-| Sets [`border`](https://css-tricks.com/almanac/properties/b/border/) property.
-
-    border (px 1)
-
-    border2 (px 1) solid
-
-    border3 (px 1) solid (hex "#f00")
-
--}
-border3 : Value LineWidth -> Value LineStyle -> Value Color -> Style
-border3 (Value widthVal) (Value styleVal) (Value colorVal) =
-    AppendProperty ("border:" ++ widthVal ++ " " ++ styleVal ++ " " ++ colorVal)
-
-
-{-| Sets [`border-top`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-top) property.
-
-    borderTop (px 1)
-
-    borderTop2 (px 1) solid
-
-    borderTop3 (px 1) solid (hex "#f00")
-
--}
-borderTop : BaseValue LineWidth -> Style
-borderTop (Value widthVal) =
-    AppendProperty ("border-top:" ++ widthVal)
-
-
-{-| Sets [`border-top`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-top) property.
-
-    borderTop (px 1)
-
-    borderTop2 (px 1) solid
-
-    borderTop3 (px 1) solid (hex "#f00")
-
--}
-borderTop2 : Value LineWidth -> Value LineStyle -> Style
-borderTop2 (Value widthVal) (Value styleVal) =
-    AppendProperty ("border-top:" ++ widthVal ++ " " ++ styleVal)
-
-
-{-| Sets [`border-top`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-top) property.
-
-    borderTop (px 1)
-
-    borderTop2 (px 1) solid
-
-    borderTop3 (px 1) solid (hex "#f00")
-
--}
-borderTop3 : Value LineWidth -> Value LineStyle -> Value Color -> Style
-borderTop3 (Value widthVal) (Value styleVal) (Value colorVal) =
-    AppendProperty ("border-top:" ++ widthVal ++ " " ++ styleVal ++ " " ++ colorVal)
-
-
-{-| Sets [`border-right`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-right) property.
-
-    borderRight (px 1)
-
-    borderRight2 (px 1) solid
-
-    borderRight3 (px 1) solid (hex "#f00")
-
--}
-borderRight : BaseValue LineWidth -> Style
-borderRight (Value widthVal) =
-    AppendProperty ("border-right:" ++ widthVal)
-
-
-{-| Sets [`border-right`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-right) property.
-
-    borderRight (px 1)
-
-    borderRight2 (px 1) solid
-
-    borderRight3 (px 1) solid (hex "#f00")
-
--}
-borderRight2 : Value LineWidth -> Value LineStyle -> Style
-borderRight2 (Value widthVal) (Value styleVal) =
-    AppendProperty ("border-right:" ++ widthVal ++ " " ++ styleVal)
-
-
-{-| Sets [`border-right`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-right) property.
-
-    borderRight (px 1)
-
-    borderRight2 (px 1) solid
-
-    borderRight3 (px 1) solid (hex "#f00")
-
--}
-borderRight3 : Value LineWidth -> Value LineStyle -> Value Color -> Style
-borderRight3 (Value widthVal) (Value styleVal) (Value colorVal) =
-    AppendProperty ("border-right:" ++ widthVal ++ " " ++ styleVal ++ " " ++ colorVal)
-
-
-{-| Sets [`border-bottom`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-bottom) property.
-
-    borderBottom (px 1)
-
-    borderBottom2 (px 1) solid
-
-    borderBottom3 (px 1) solid (hex "#f00")
-
--}
-borderBottom : BaseValue LineWidth -> Style
-borderBottom (Value widthVal) =
-    AppendProperty ("border-bottom:" ++ widthVal)
-
-
-{-| Sets [`border-bottom`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-bottom) property.
-
-    borderBottom (px 1)
-
-    borderBottom2 (px 1) solid
-
-    borderBottom3 (px 1) solid (hex "#f00")
-
--}
-borderBottom2 : Value LineWidth -> Value LineStyle -> Style
-borderBottom2 (Value widthVal) (Value styleVal) =
-    AppendProperty ("border-bottom:" ++ widthVal ++ " " ++ styleVal)
-
-
-{-| Sets [`border-bottom`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-bottom) property.
-
-    borderBottom (px 1)
-
-    borderBottom2 (px 1) solid
-
-    borderBottom3 (px 1) solid (hex "#f00")
-
--}
-borderBottom3 : Value LineWidth -> Value LineStyle -> Value Color -> Style
-borderBottom3 (Value widthVal) (Value styleVal) (Value colorVal) =
-    AppendProperty ("border-bottom:" ++ widthVal ++ " " ++ styleVal ++ " " ++ colorVal)
-
-
-{-| Sets [`border-left`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-left) property.
-
-    borderLeft (px 1)
-
-    borderLeft2 (px 1) solid
-
-    borderLeft3 (px 1) solid (hex "#f00")
-
--}
-borderLeft : BaseValue LineWidth -> Style
-borderLeft (Value widthVal) =
-    AppendProperty ("border-left:" ++ widthVal)
-
-
-{-| Sets [`border-left`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-left) property.
-
-    borderLeft (px 1)
-
-    borderLeft2 (px 1) solid
-
-    borderLeft3 (px 1) solid (hex "#f00")
-
--}
-borderLeft2 : Value LineWidth -> Value LineStyle -> Style
-borderLeft2 (Value widthVal) (Value styleVal) =
-    AppendProperty ("border-left:" ++ widthVal ++ " " ++ styleVal)
-
-
-{-| Sets [`border-left`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-left) property.
-
-    borderLeft (px 1)
-
-    borderLeft2 (px 1) solid
-
-    borderLeft3 (px 1) solid (hex "#f00")
-
--}
-borderLeft3 : Value LineWidth -> Value LineStyle -> Value Color -> Style
-borderLeft3 (Value widthVal) (Value styleVal) (Value colorVal) =
-    AppendProperty ("border-left:" ++ widthVal ++ " " ++ styleVal ++ " " ++ colorVal)
-
-
-{-| Sets [`border-block`](https://css-tricks.com/almanac/properties/b/border-block/) property.
-
-    borderBlock (px 1)
-
-    borderBlock2 (px 1) solid
-
-    borderBlock3 (px 1) solid (hex "#f00")
-
--}
-borderBlock : BaseValue LineWidth -> Style
-borderBlock (Value widthVal) =
-    AppendProperty ("border-block:" ++ widthVal)
-
-
-{-| Sets [`border-block`](https://css-tricks.com/almanac/properties/b/border-block/) property.
-
-    borderBlock (px 1)
-
-    borderBlock2 (px 1) solid
-
-    borderBlock3 (px 1) solid (hex "#f00")
-
--}
-borderBlock2 : Value LineWidth -> Value LineStyle -> Style
-borderBlock2 (Value widthVal) (Value styleVal) =
-    AppendProperty ("border-block:" ++ widthVal ++ " " ++ styleVal)
-
-
-{-| Sets [`border-block`](https://css-tricks.com/almanac/properties/b/border-block/) property.
-
-    borderBlock (px 1)
-
-    borderBlock2 (px 1) solid
-
-    borderBlock3 (px 1) solid (hex "#f00")
-
--}
-borderBlock3 : Value LineWidth -> Value LineStyle -> Value Color -> Style
-borderBlock3 (Value widthVal) (Value styleVal) (Value colorVal) =
-    AppendProperty ("border-block:" ++ widthVal ++ " " ++ styleVal ++ " " ++ colorVal)
-
-
-{-| Sets [`border-block-start`](https://css-tricks.com/almanac/properties/b/border-block-start/) property.
-
-    borderBlockStart (px 1)
-
-    borderBlockStart2 (px 1) solid
-
-    borderBlockStart3 (px 1) solid (hex "#f00")
-
--}
-borderBlockStart : BaseValue LineWidth -> Style
-borderBlockStart (Value widthVal) =
-    AppendProperty ("border-block-start:" ++ widthVal)
-
-
-{-| Sets [`border-block-start`](https://css-tricks.com/almanac/properties/b/border-block-start/) property.
-
-    borderBlockStart (px 1)
-
-    borderBlockStart2 (px 1) solid
-
-    borderBlockStart3 (px 1) solid (hex "#f00")
-
--}
-borderBlockStart2 : Value LineWidth -> Value LineStyle -> Style
-borderBlockStart2 (Value widthVal) (Value styleVal) =
-    AppendProperty ("border-block-start:" ++ widthVal ++ " " ++ styleVal)
-
-
-{-| Sets [`border-block-start`](https://css-tricks.com/almanac/properties/b/border-block-start/) property.
-
-    borderBlockStart (px 1)
-
-    borderBlockStart2 (px 1) solid
-
-    borderBlockStart3 (px 1) solid (hex "#f00")
-
--}
-borderBlockStart3 : Value LineWidth -> Value LineStyle -> Value Color -> Style
-borderBlockStart3 (Value widthVal) (Value styleVal) (Value colorVal) =
-    AppendProperty ("border-block-start:" ++ widthVal ++ " " ++ styleVal ++ " " ++ colorVal)
-
-
-{-| Sets [`border-block-end`](https://css-tricks.com/almanac/properties/b/border-block-end/) property.
-
-    borderBlockEnd (px 1)
-
-    borderBlockEnd2 (px 1) solid
-
-    borderBlockEnd3 (px 1) solid (hex "#f00")
-
--}
-borderBlockEnd : BaseValue LineWidth -> Style
-borderBlockEnd (Value widthVal) =
-    AppendProperty ("border-block-end:" ++ widthVal)
-
-
-{-| Sets [`border-block-end`](https://css-tricks.com/almanac/properties/b/border-block-end/) property.
-
-    borderBlockEnd (px 1)
-
-    borderBlockEnd2 (px 1) solid
-
-    borderBlockEnd3 (px 1) solid (hex "#f00")
-
--}
-borderBlockEnd2 : Value LineWidth -> Value LineStyle -> Style
-borderBlockEnd2 (Value widthVal) (Value styleVal) =
-    AppendProperty ("border-block-end:" ++ widthVal ++ " " ++ styleVal)
-
-
-{-| Sets [`border-block-end`](https://css-tricks.com/almanac/properties/b/border-block-end/) property.
-
-    borderBlockEnd (px 1)
-
-    borderBlockEnd2 (px 1) solid
-
-    borderBlockEnd3 (px 1) solid (hex "#f00")
-
--}
-borderBlockEnd3 : Value LineWidth -> Value LineStyle -> Value Color -> Style
-borderBlockEnd3 (Value widthVal) (Value styleVal) (Value colorVal) =
-    AppendProperty ("border-block-end:" ++ widthVal ++ " " ++ styleVal ++ " " ++ colorVal)
-
-
-{-| Sets [`border-inline`](https://css-tricks.com/almanac/properties/b/border-inline/) property.
-
-    borderInline (px 1)
-
-    borderInline2 (px 1) solid
-
-    borderInline3 (px 1) solid (hex "#f00")
-
--}
-borderInline : BaseValue LineWidth -> Style
-borderInline (Value widthVal) =
-    AppendProperty ("border-inline:" ++ widthVal)
-
-
-{-| Sets [`border-inline`](https://css-tricks.com/almanac/properties/b/border-inline/) property.
-
-    borderInline (px 1)
-
-    borderInline2 (px 1) solid
-
-    borderInline3 (px 1) solid (hex "#f00")
-
--}
-borderInline2 : Value LineWidth -> Value LineStyle -> Style
-borderInline2 (Value widthVal) (Value styleVal) =
-    AppendProperty ("border-inline:" ++ widthVal ++ " " ++ styleVal)
-
-
-{-| Sets [`border-inline`](https://css-tricks.com/almanac/properties/b/border-inline/) property.
-
-    borderInline (px 1)
-
-    borderInline2 (px 1) solid
-
-    borderInline3 (px 1) solid (hex "#f00")
-
--}
-borderInline3 : Value LineWidth -> Value LineStyle -> Value Color -> Style
-borderInline3 (Value widthVal) (Value styleVal) (Value colorVal) =
-    AppendProperty ("border-inline:" ++ widthVal ++ " " ++ styleVal ++ " " ++ colorVal)
-
-
-{-| Sets [`border-inline-start`](https://css-tricks.com/almanac/properties/b/border-inline-start/) property.
-
-    borderInlineStart (px 1)
-
-    borderInlineStart2 (px 1) solid
-
-    borderInlineStart3 (px 1) solid (hex "#f00")
-
--}
-borderInlineStart : BaseValue LineWidth -> Style
-borderInlineStart (Value widthVal) =
-    AppendProperty ("border-inline-start:" ++ widthVal)
-
-
-{-| Sets [`border-inline-start`](https://css-tricks.com/almanac/properties/b/border-inline-start/) property.
-
-    borderInlineStart (px 1)
-
-    borderInlineStart2 (px 1) solid
-
-    borderInlineStart3 (px 1) solid (hex "#f00")
-
--}
-borderInlineStart2 : Value LineWidth -> Value LineStyle -> Style
-borderInlineStart2 (Value widthVal) (Value styleVal) =
-    AppendProperty ("border-inline-start:" ++ widthVal ++ " " ++ styleVal)
-
-
-{-| Sets [`border-inline-start`](https://css-tricks.com/almanac/properties/b/border-inline-start/) property.
-
-    borderInlineStart (px 1)
-
-    borderInlineStart2 (px 1) solid
-
-    borderInlineStart3 (px 1) solid (hex "#f00")
-
--}
-borderInlineStart3 : Value LineWidth -> Value LineStyle -> Value Color -> Style
-borderInlineStart3 (Value widthVal) (Value styleVal) (Value colorVal) =
-    AppendProperty ("border-inline-start:" ++ widthVal ++ " " ++ styleVal ++ " " ++ colorVal)
-
-
-{-| Sets [`border-inline-end`](https://css-tricks.com/almanac/properties/b/border-inline-end/) property.
-
-    borderInlineEnd (px 1)
-
-    borderInlineEnd2 (px 1) solid
-
-    borderInlineEnd3 (px 1) solid (hex "#f00")
-
--}
-borderInlineEnd : BaseValue LineWidth -> Style
-borderInlineEnd (Value widthVal) =
-    AppendProperty ("border-inline-end:" ++ widthVal)
-
-
-{-| Sets [`border-inline-end`](https://css-tricks.com/almanac/properties/b/border-inline-end/) property.
-
-    borderInlineEnd (px 1)
-
-    borderInlineEnd2 (px 1) solid
-
-    borderInlineEnd3 (px 1) solid (hex "#f00")
-
--}
-borderInlineEnd2 : Value LineWidth -> Value LineStyle -> Style
-borderInlineEnd2 (Value widthVal) (Value styleVal) =
-    AppendProperty ("border-inline-end:" ++ widthVal ++ " " ++ styleVal)
-
-
-{-| Sets [`border-inline-end`](https://css-tricks.com/almanac/properties/b/border-inline-end/) property.
-
-    borderInlineEnd (px 1)
-
-    borderInlineEnd2 (px 1) solid
-
-    borderInlineEnd3 (px 1) solid (hex "#f00")
-
--}
-borderInlineEnd3 : Value LineWidth -> Value LineStyle -> Value Color -> Style
-borderInlineEnd3 (Value widthVal) (Value styleVal) (Value colorVal) =
-    AppendProperty ("border-inline-end:" ++ widthVal ++ " " ++ styleVal ++ " " ++ colorVal)
-
-
-{-| Sets [`border-width`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-width) property.
-
-    borderWidth (px 1)
-
-    borderWidth2 (px 1) thin
-
-    borderWidth3 (px 1) thin zero
-
-    borderWidth4 (px 1) thin zero (em 1)
-
--}
-borderWidth : BaseValue LineWidth -> Style
-borderWidth (Value widthVal) =
-    AppendProperty ("border-width:" ++ widthVal)
-
-
-{-| Sets [`border-width`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-width) property.
-
-    borderWidth (px 1)
-
-    borderWidth2 (px 1) thin
-
-    borderWidth3 (px 1) thin zero
-
-    borderWidth4 (px 1) thin zero (em 1)
-
--}
-borderWidth2 : Value LineWidth -> Value LineWidth -> Style
-borderWidth2 (Value widthTopBottom) (Value widthRightLeft) =
-    AppendProperty ("border-width:" ++ widthTopBottom ++ " " ++ widthRightLeft)
-
-
-{-| Sets [`border-width`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-width) property.
-
-    borderWidth (px 1)
-
-    borderWidth2 (px 1) thin
-
-    borderWidth3 (px 1) thin zero
-
-    borderWidth4 (px 1) thin zero (em 1)
-
--}
-borderWidth3 : Value LineWidth -> Value LineWidth -> Value LineWidth -> Style
-borderWidth3 (Value widthTop) (Value widthRightLeft) (Value widthBottom) =
-    AppendProperty ("border-width:" ++ widthTop ++ " " ++ widthRightLeft ++ " " ++ widthBottom)
-
-
-{-| Sets [`border-width`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-width) property.
-
-    borderWidth (px 1)
-
-    borderWidth2 (px 1) thin
-
-    borderWidth3 (px 1) thin zero
-
-    borderWidth4 (px 1) thin zero (em 1)
-
--}
-borderWidth4 : Value LineWidth -> Value LineWidth -> Value LineWidth -> Value LineWidth -> Style
-borderWidth4 (Value widthTop) (Value widthRight) (Value widthBottom) (Value widthLeft) =
-    AppendProperty ("border-width:" ++ widthTop ++ " " ++ widthRight ++ " " ++ widthBottom ++ " " ++ widthLeft)
-
-
-{-| Sets [`border-top-width`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-top-width) property.
-
-    borderTopWidth (px 1)
-
--}
-borderTopWidth : BaseValue LineWidth -> Style
-borderTopWidth (Value widthVal) =
-    AppendProperty ("border-top-width:" ++ widthVal)
-
-
-{-| Sets [`border-right-width`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-right-width) property.
-
-    borderRightWidth (px 1)
-
--}
-borderRightWidth : BaseValue LineWidth -> Style
-borderRightWidth (Value widthVal) =
-    AppendProperty ("border-right-width:" ++ widthVal)
-
-
-{-| Sets [`border-bottom-width`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-bottom-width) property.
-
-    borderBottomWidth (px 1)
-
--}
-borderBottomWidth : BaseValue LineWidth -> Style
-borderBottomWidth (Value widthVal) =
-    AppendProperty ("border-bottom-width:" ++ widthVal)
-
-
-{-| Sets [`border-left-width`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-left-width) property.
-
-    borderLeftWidth (px 1)
-
--}
-borderLeftWidth : BaseValue LineWidth -> Style
-borderLeftWidth (Value widthVal) =
-    AppendProperty ("border-left-width:" ++ widthVal)
-
-
-{-| Sets [`border-block-width`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-block-width) property.
-
-    borderBlockWidth (px 1)
-
--}
-borderBlockWidth : BaseValue LineWidth -> Style
-borderBlockWidth (Value widthVal) =
-    AppendProperty ("border-block-width:" ++ widthVal)
-
-
-{-| Sets [`border-block-start-width`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-block-start-width) property.
-
-    borderBlockStartWidth (px 1)
-
--}
-borderBlockStartWidth : BaseValue LineWidth -> Style
-borderBlockStartWidth (Value widthVal) =
-    AppendProperty ("border-block-start-width:" ++ widthVal)
-
-
-{-| Sets [`border-block-end-width`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-block-end-width) property.
-
-    borderBlockEndWidth (px 1)
-
--}
-borderBlockEndWidth : BaseValue LineWidth -> Style
-borderBlockEndWidth (Value widthVal) =
-    AppendProperty ("border-block-end-width:" ++ widthVal)
-
-
-{-| Sets [`border-inline-width`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-inline-width) property.
-
-    borderTopWidth (px 1)
-
--}
-borderInlineWidth : BaseValue LineWidth -> Style
-borderInlineWidth (Value widthVal) =
-    AppendProperty ("border-inline-width:" ++ widthVal)
-
-
-{-| Sets [`border-inline-start-width`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-inline-start-width) property.
-
-    borderInlineStartWidth (px 1)
-
--}
-borderInlineStartWidth : BaseValue LineWidth -> Style
-borderInlineStartWidth (Value widthVal) =
-    AppendProperty ("border-inline-start-width:" ++ widthVal)
-
-
-{-| Sets [`border-inline-end-width`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-inline-end-width) property.
-
-    borderInlineEndWidth (px 1)
-
--}
-borderInlineEndWidth : BaseValue LineWidth -> Style
-borderInlineEndWidth (Value widthVal) =
-    AppendProperty ("border-inline-end-width:" ++ widthVal)
-
-
-{-| Sets [`border-style`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-style) property.
-
-    borderStyle solid
-
-    borderStyle2 solid none
-
-    borderStyle3 solid none dotted
-
-    borderStyle4 solid none dotted groove
-
--}
-borderStyle : BaseValue LineStyle -> Style
-borderStyle (Value styleVal) =
-    AppendProperty ("border-style:" ++ styleVal)
-
-
-{-| Sets [`border-style`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-style) property.
-
-    borderStyle solid
-
--}
-borderStyle2 : Value LineStyle -> Value LineStyle -> Style
-borderStyle2 (Value styleTopBottom) (Value styleRigthLeft) =
-    AppendProperty ("border-style:" ++ styleTopBottom ++ " " ++ styleRigthLeft)
-
-
-{-| Sets [`border-style`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-style) property.
-
-    borderStyle2 solid none
-
--}
-borderStyle3 : Value LineStyle -> Value LineStyle -> Value LineStyle -> Style
-borderStyle3 (Value styleTop) (Value styleRigthLeft) (Value styleBottom) =
-    AppendProperty ("border-style:" ++ styleTop ++ " " ++ styleRigthLeft ++ " " ++ styleBottom)
-
-
-{-| Sets [`border-style`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-style) property.
-
-    borderStyle4 solid none dotted groove
-
--}
-borderStyle4 : Value LineStyle -> Value LineStyle -> Value LineStyle -> Value LineStyle -> Style
-borderStyle4 (Value styleTop) (Value styleRigt) (Value styleBottom) (Value styleLeft) =
-    AppendProperty ("border-style:" ++ styleTop ++ " " ++ styleRigt ++ " " ++ styleBottom ++ " " ++ styleLeft)
-
-
-{-| Sets [`border-top-style`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-top-style) property.
-
-    borderTopStyle solid
-
--}
-borderTopStyle : BaseValue LineStyle -> Style
-borderTopStyle (Value styleVal) =
-    AppendProperty ("border-top-style:" ++ styleVal)
-
-
-{-| Sets [`border-right-style`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-right-style) property.
-
-    borderRightStyle solid
-
--}
-borderRightStyle : BaseValue LineStyle -> Style
-borderRightStyle (Value styleVal) =
-    AppendProperty ("border-right-style:" ++ styleVal)
-
-
-{-| Sets [`border-bottom-style`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-bottom-style) property.
-
-    borderBottomStyle solid
-
--}
-borderBottomStyle : BaseValue LineStyle -> Style
-borderBottomStyle (Value styleVal) =
-    AppendProperty ("border-bottom-style:" ++ styleVal)
-
-
-{-| Sets [`border-left-style`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-left-style) property.
-
-    borderLeftStyle solid
-
--}
-borderLeftStyle : BaseValue LineStyle -> Style
-borderLeftStyle (Value styleVal) =
-    AppendProperty ("border-left-style:" ++ styleVal)
-
-
-{-| Sets [`border-block-style`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-block-style) property.
-
-    borderBlockStyle solid
-
--}
-borderBlockStyle : BaseValue LineStyle -> Style
-borderBlockStyle (Value styleVal) =
-    AppendProperty ("border-block-style:" ++ styleVal)
-
-
-{-| Sets [`border-block-start-style`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-block-start-style) property.
-
-    borderBlockStartStyle solid
-
--}
-borderBlockStartStyle : BaseValue LineStyle -> Style
-borderBlockStartStyle (Value styleVal) =
-    AppendProperty ("border-block-start-style:" ++ styleVal)
-
-
-{-| Sets [`border-block-end-style`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-block-end-style) property.
-
-    borderBlockEndStyle solid
-
--}
-borderBlockEndStyle : BaseValue LineStyle -> Style
-borderBlockEndStyle (Value styleVal) =
-    AppendProperty ("border-block-end-style:" ++ styleVal)
-
-
-{-| Sets [`border-inline-style`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-inline-style) property.
-
-    borderInlineStyle solid
-
--}
-borderInlineStyle : BaseValue LineStyle -> Style
-borderInlineStyle (Value styleVal) =
-    AppendProperty ("border-inline-style:" ++ styleVal)
-
-
-{-| Sets [`border-inline-start-style`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-inline-start-style) property.
-
-    borderInlineStartStyle solid
-
--}
-borderInlineStartStyle : BaseValue LineStyle -> Style
-borderInlineStartStyle (Value styleVal) =
-    AppendProperty ("border-inline-start-style:" ++ styleVal)
-
-
-{-| Sets [`border-inline-end-style`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-inline-end-style) property.
-
-    borderInlineEndStyle solid
-
--}
-borderInlineEndStyle : BaseValue LineStyle -> Style
-borderInlineEndStyle (Value styleVal) =
-    AppendProperty ("border-inline-end-style:" ++ styleVal)
-
-
-{-| Sets [`border-color`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-color) property.
-
-    borderColor (rgb 0 0 0)
-
-    borderColor2 (rgb 0 0 0) (hsl 10 10 10)
-
-    borderColor3 (rgb 0 0 0) (hsl 10 10 10) (hex "#fff")
-
-    borderColor4 (rgb 0 0 0) (hsl 10 10 10) (hex "#fff") transparent
-
--}
-borderColor : BaseValue Color -> Style
-borderColor (Value colorVal) =
-    AppendProperty ("border-color:" ++ colorVal)
-
-
-{-| Sets [`border-color`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-color) property.
-
-    borderColor (rgb 0 0 0)
-
-    borderColor2 (rgb 0 0 0) (hsl 10 10 10)
-
-    borderColor3 (rgb 0 0 0) (hsl 10 10 10) (hex "#fff")
-
-    borderColor4 (rgb 0 0 0) (hsl 10 10 10) (hex "#fff") transparent
-
--}
-borderColor2 : Value Color -> Value Color -> Style
-borderColor2 (Value colorTopBottom) (Value colorRightLeft) =
-    AppendProperty ("border-color:" ++ colorTopBottom ++ " " ++ colorRightLeft)
-
-
-{-| Sets [`border-color`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-color) property.
-
-    borderColor (rgb 0 0 0)
-
-    borderColor2 (rgb 0 0 0) (hsl 10 10 10)
-
-    borderColor3 (rgb 0 0 0) (hsl 10 10 10) (hex "#fff")
-
-    borderColor4 (rgb 0 0 0) (hsl 10 10 10) (hex "#fff") transparent
-
--}
-borderColor3 : Value Color -> Value Color -> Value Color -> Style
-borderColor3 (Value colorTop) (Value colorRightLeft) (Value colorBottom) =
-    AppendProperty ("border-color:" ++ colorTop ++ " " ++ colorRightLeft ++ " " ++ colorBottom)
-
-
-{-| Sets [`border-color`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-color) property.
-
-    borderColor (rgb 0 0 0)
-
-    borderColor2 (rgb 0 0 0) (hsl 10 10 10)
-
-    borderColor3 (rgb 0 0 0) (hsl 10 10 10) (hex "#fff")
-
-    borderColor4 (rgb 0 0 0) (hsl 10 10 10) (hex "#fff") transparent
-
--}
-borderColor4 : Value Color -> Value Color -> Value Color -> Value Color -> Style
-borderColor4 (Value colorTop) (Value colorRight) (Value colorBottom) (Value colorLeft) =
-    AppendProperty ("border-color:" ++ colorTop ++ " " ++ colorRight ++ " " ++ colorBottom ++ " " ++ colorLeft)
-
-
-{-| Sets [`border-top-color`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-top-color) property.
-
-    borderTopColor (rgb 0 0 0)
-
--}
-borderTopColor : BaseValue Color -> Style
-borderTopColor (Value colorVal) =
-    AppendProperty ("border-top-color:" ++ colorVal)
-
-
-{-| Sets [`border-right-color`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-right-color) property.
-
-    borderRightColor (rgb 0 0 0)
-
--}
-borderRightColor : BaseValue Color -> Style
-borderRightColor (Value colorVal) =
-    AppendProperty ("border-right-color:" ++ colorVal)
-
-
-{-| Sets [`border-bottom-color`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-bottom-color) property.
-
-    borderBottomColor (rgb 0 0 0)
-
--}
-borderBottomColor : BaseValue Color -> Style
-borderBottomColor (Value colorVal) =
-    AppendProperty ("border-bottom-color:" ++ colorVal)
-
-
-{-| Sets [`border-left-color`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-left-color) property.
-
-    borderLeftColor (rgb 0 0 0)
-
--}
-borderLeftColor : BaseValue Color -> Style
-borderLeftColor (Value colorVal) =
-    AppendProperty ("border-left-color:" ++ colorVal)
-
-
-{-| Sets [`border-block-color`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-block-color) property.
-
-    borderBlockColor (rgb 0 0 0)
-
--}
-borderBlockColor : BaseValue Color -> Style
-borderBlockColor (Value colorVal) =
-    AppendProperty ("border-block-color:" ++ colorVal)
-
-
-{-| Sets [`border-block-start-color`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-block-start-color) property.
-
-    borderBlockStartColor (rgb 0 0 0)
-
--}
-borderBlockStartColor : BaseValue Color -> Style
-borderBlockStartColor (Value colorVal) =
-    AppendProperty ("border-block-start-color:" ++ colorVal)
-
-
-{-| Sets [`border-block-end-color`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-block-end-color) property.
-
-    borderBlockEndColor (rgb 0 0 0)
-
--}
-borderBlockEndColor : BaseValue Color -> Style
-borderBlockEndColor (Value colorVal) =
-    AppendProperty ("border-block-end-color:" ++ colorVal)
-
-
-{-| Sets [`border-inline-color`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-inline-color) property.
-
-    borderInlineColor (rgb 0 0 0)
-
--}
-borderInlineColor : BaseValue Color -> Style
-borderInlineColor (Value colorVal) =
-    AppendProperty ("border-inline-color:" ++ colorVal)
-
-
-{-| Sets [`border-inline-start-color`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-inline-start-color) property.
-
-    borderInlineStartColor (rgb 0 0 0)
-
--}
-borderInlineStartColor : BaseValue Color -> Style
-borderInlineStartColor (Value colorVal) =
-    AppendProperty ("border-inline-start-color:" ++ colorVal)
-
-
-{-| Sets [`border-inline-end-color`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-inline-end-color) property.
-
-    borderInlineEndColor (rgb 0 0 0)
-
--}
-borderInlineEndColor : BaseValue Color -> Style
-borderInlineEndColor (Value colorVal) =
-    AppendProperty ("border-inline-end-color:" ++ colorVal)
-
-
-
-
--- BORDER STYLE --
-
-
-{-| The `dotted` value used by properties such as [`borderStyle`](#borderStyle),
-[`columnRuleStyle`](#columnRuleStyle), and [`textDecorationStyle`](#textDecorationStyle).
-
-It represents a line that consists of dots.
-
-    borderStyle dotted
-
-    columnRuleStyle dotted
-
-    textDecorationStyle dotted
-
--}
-dotted : Value { provides | dotted : Supported }
-dotted =
-    Value "dotted"
-
-
-{-| The `dashed` value used by properties such as [`borderStyle`](#borderStyle),
-[`columnRuleStyle`](#columnRuleStyle), and [`textDecorationStyle`](#textDecorationStyle).
-
-    borderStyle dashed
-
-    columnRuleStyle dashed
-
-    textDecorationStyle dashed
-
-It represents a line that consists of dashes.
-
--}
-dashed : Value { provides | dashed : Supported }
-dashed =
-    Value "dashed"
-
-
-{-| The `solid` value used by properties such as [`borderStyle`](#borderStyle),
-[`columnRuleStyle`](#columnRuleStyle), and [`textDecorationStyle`](#textDecorationStyle).
-
-    borderStyle solid
-
-    columnRuleStyle solid
-
-    textDecorationStyle solid
-
-It represents a solid, continuous line.
-
--}
-solid : Value { provides | solid : Supported }
-solid =
-    Value "solid"
-
-
-{-| The `double` value used by properties such as [`borderStyle`](#borderStyle),
-[`columnRuleStyle`](#columnRuleStyle), and [`textDecorationStyle`](#textDecorationStyle).
-
-    borderStyle double
-
-    columnRuleStyle double
-
-    textDecorationStyle double
-
-It represents a double line: two lines side by side.
-
--}
-double : Value { provides | double : Supported }
-double =
-    Value "double"
-
-
-{-| The `groove` value used by properties such as [`borderStyle`](#borderStyle),
-[`columnRuleStyle`](#columnRuleStyle), and [`textDecorationStyle`](#textDecorationStyle).
-
-    borderStyle groove
-
-    columnRuleStyle groove
-
-    textDecorationStyle groove
-
-Adds a bevel based on the color value, which makes things appear pressed into the document.
-
--}
-groove : Value { provides | groove : Supported }
-groove =
-    Value "groove"
-
-
-{-| The `ridge` value used by properties such as [`borderStyle`](#borderStyle),
-[`columnRuleStyle`](#columnRuleStyle), and [`textDecorationStyle`](#textDecorationStyle).
-
-    borderStyle ridge
-
-    columnRuleStyle ridge
-
-    textDecorationStyle ridge
-
-Similar to [`groove`](#groove), but reverses the color values in a way that makes things appear raised.
-
--}
-ridge : Value { provides | ridge : Supported }
-ridge =
-    Value "ridge"
-
-
-{-| The `inset` value used by properties such as [`borderStyle`](#borderStyle),
-[`columnRuleStyle`](#columnRuleStyle), and [`textDecorationStyle`](#textDecorationStyle).
-
-This is called `inset_` rather than `inset` because [`inset` is already a property function](#inset).
-
-    borderStyle inset_
-
-    columnRuleStyle inset_
-
-    textDecorationStyle inset_
-
-Adds a split tone to the line that makes it appear slightly depressed.
-
-Contrast with [`outset`](#outset)
-
--}
-inset_ : Value { provides | inset_ : Supported }
-inset_ =
-    Value "inset"
-
-
-{-| The `outset` value used by properties such as [`borderStyle`](#borderStyle),
-[`columnRuleStyle`](#columnRuleStyle),
-and [`textDecorationStyle`](#textDecorationStyle),
-and [`strokeAlign`](#strokeAlign).
-
-    borderStyle outset
-
-    columnRuleStyle outset
-
-    strokeAlign outset
-
-    textDecorationStyle outset
-
-Similar to [`inset_`](#inset_), but reverses the colors in a way that makes it appear slightly raised.
-
--}
-outset : Value { provides | outset : Supported }
-outset =
-    Value "outset"
-
-
-
-{- BORDER RADIUS -}
-
-
-{-| Sets [`border-radius`](https://css-tricks.com/almanac/properties/b/border-radius/) property.
-
-    borderRadius (em 4)
-
-    borderRadius2 (em 4) (px 2)
-
-    borderRadius3 (em 4) (px 2) (pct 5)
-
-    borderRadius4 (em 4) (px 2) (pct 5) (px 3)
-
--}
-borderRadius :
-    BaseValue
-        (LengthSupported
-            { pct : Supported
-            }
-        )
-    -> Style
-borderRadius (Value radius) =
-    AppendProperty ("border-radius:" ++ radius)
-
-
-{-| Sets [`border-radius`](https://css-tricks.com/almanac/properties/b/border-radius/) property.
-
-    borderRadius (em 4)
-
-    borderRadius2 (em 4) (px 2)
-
-    borderRadius3 (em 4) (px 2) (pct 5)
-
-    borderRadius4 (em 4) (px 2) (pct 5) (px 3)
-
--}
-borderRadius2 :
-    Value
-        (LengthSupported
-            { pct : Supported
-            }
-        )
-    ->
-        Value
-            (LengthSupported
-                { pct : Supported
-                }
-            )
-    -> Style
-borderRadius2 (Value radiusTopLeftAndBottomRight) (Value radiusTopRightAndBottomLeft) =
-    AppendProperty ("border-radius:" ++ radiusTopLeftAndBottomRight ++ " " ++ radiusTopRightAndBottomLeft)
-
-
-{-| Sets [`border-radius`](https://css-tricks.com/almanac/properties/b/border-radius/) property.
-
-    borderRadius (em 4)
-
-    borderRadius2 (em 4) (px 2)
-
-    borderRadius3 (em 4) (px 2) (pct 5)
-
-    borderRadius4 (em 4) (px 2) (pct 5) (px 3)
-
--}
-borderRadius3 :
-    Value
-        (LengthSupported
-            { pct : Supported
-            }
-        )
-    ->
-        Value
-            (LengthSupported
-                { pct : Supported
-                }
-            )
-    ->
-        Value
-            (LengthSupported
-                { pct : Supported
-                }
-            )
-    -> Style
-borderRadius3 (Value radiusTopLeft) (Value radiusTopRightAndBottomLeft) (Value radiusBottomRight) =
-    AppendProperty ("border-radius:" ++ radiusTopLeft ++ " " ++ radiusTopRightAndBottomLeft ++ " " ++ radiusBottomRight)
-
-
-{-| Sets [`border-radius`](https://css-tricks.com/almanac/properties/b/border-radius/) property.
-
-    borderRadius (em 4)
-
-    borderRadius2 (em 4) (px 2)
-
-    borderRadius3 (em 4) (px 2) (pct 5)
-
-    borderRadius4 (em 4) (px 2) (pct 5) (px 3)
-
--}
-borderRadius4 :
-    Value
-        (LengthSupported
-            { pct : Supported
-            }
-        )
-    ->
-        Value
-            (LengthSupported
-                { pct : Supported
-                }
-            )
-    ->
-        Value
-            (LengthSupported
-                { pct : Supported
-                }
-            )
-    ->
-        Value
-            (LengthSupported
-                { pct : Supported
-                }
-            )
-    -> Style
-borderRadius4 (Value radiusTopLeft) (Value radiusTopRight) (Value radiusBottomRight) (Value radiusBottomLeft) =
-    AppendProperty ("border-radius:" ++ radiusTopLeft ++ " " ++ radiusTopRight ++ " " ++ radiusBottomRight ++ " " ++ radiusBottomLeft)
-
-
-{-| Sets [`border-top-left-radius`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-top-left-radius) property.
-
-    borderTopLeftRadius (em 4)
-
-    borderTopLeftRadius2 (em 4) (px 2)
-
--}
-borderTopLeftRadius :
-    BaseValue
-        (LengthSupported
-            { pct : Supported
-            }
-        )
-    -> Style
-borderTopLeftRadius (Value radius) =
-    AppendProperty ("border-top-left-radius:" ++ radius)
-
-
-{-| Sets [`border-top-left-radius`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-top-left-radius) property.
-
-    borderTopLeftRadius (em 4)
-
-    borderTopLeftRadius2 (em 4) (px 2)
-
--}
-borderTopLeftRadius2 :
-    Value
-        (LengthSupported
-            { pct : Supported
-            }
-        )
-    ->
-        Value
-            (LengthSupported
-                { pct : Supported
-                }
-            )
-    -> Style
-borderTopLeftRadius2 (Value valHorizontal) (Value valVertical) =
-    AppendProperty ("border-top-left-radius:" ++ valHorizontal ++ " " ++ valVertical)
-
-
-{-| Sets [`border-top-right-radius`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-top-right-radius) property.
-
-    borderTopRightRadius (em 4)
-
-    borderTopRightRadius2 (em 4) (px 2)
-
--}
-borderTopRightRadius :
-    BaseValue
-        (LengthSupported
-            { pct : Supported
-            }
-        )
-    -> Style
-borderTopRightRadius (Value radius) =
-    AppendProperty ("border-top-right-radius:" ++ radius)
-
-
-{-| Sets [`border-top-right-radius`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-top-right-radius) property.
-
-    borderTopRightRadius (em 4)
-
-    borderTopRightRadius2 (em 4) (px 2)
-
--}
-borderTopRightRadius2 :
-    Value
-        (LengthSupported
-            { pct : Supported
-            }
-        )
-    ->
-        Value
-            (LengthSupported
-                { pct : Supported
-                }
-            )
-    -> Style
-borderTopRightRadius2 (Value valHorizontal) (Value valVertical) =
-    AppendProperty ("border-top-right-radius:" ++ valHorizontal ++ " " ++ valVertical)
-
-
-{-| Sets [`border-bottom-right-radius`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-bottom-right-radius) property.
-
-    borderBottomRightRadius (em 4)
-
-    borderBottomRightRadius2 (em 4) (px 2)
-
--}
-borderBottomRightRadius :
-    BaseValue
-        (LengthSupported
-            { pct : Supported
-            }
-        )
-    -> Style
-borderBottomRightRadius (Value radius) =
-    AppendProperty ("border-bottom-right-radius:" ++ radius)
-
-
-{-| Sets [`border-bottom-right-radius`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-bottom-right-radius) property.
-
-    borderBottomRightRadius (em 4)
-
-    borderBottomRightRadius2 (em 4) (px 2)
-
--}
-borderBottomRightRadius2 :
-    Value
-        (LengthSupported
-            { pct : Supported
-            }
-        )
-    ->
-        Value
-            (LengthSupported
-                { pct : Supported
-                }
-            )
-    -> Style
-borderBottomRightRadius2 (Value valHorizontal) (Value valVertical) =
-    AppendProperty ("border-bottom-right-radius:" ++ valHorizontal ++ " " ++ valVertical)
-
-
-{-| Sets [`border-bottom-left-radius`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-bottom-left-radius) property.
-
-    borderBottomLeftRadius (em 4)
-
-    borderBottomLeftRadius2 (em 4) (px 2)
-
--}
-borderBottomLeftRadius :
-    BaseValue
-        (LengthSupported
-            { pct : Supported
-            }
-        )
-    -> Style
-borderBottomLeftRadius (Value radius) =
-    AppendProperty ("border-bottom-left-radius:" ++ radius)
-
-
-{-| Sets [`border-bottom-left-radius`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-bottom-left-radius) property.
-
-    borderBottomLeftRadius (em 4)
-
-    borderBottomLeftRadius2 (em 4) (px 2)
-
--}
-borderBottomLeftRadius2 :
-    Value
-        (LengthSupported
-            { pct : Supported
-            }
-        )
-    ->
-        Value
-            (LengthSupported
-                { pct : Supported
-                }
-            )
-    -> Style
-borderBottomLeftRadius2 (Value valHorizontal) (Value valVertical) =
-    AppendProperty ("border-bottom-left-radius:" ++ valHorizontal ++ " " ++ valVertical)
-
-
-{-| Sets [`border-start-start-radius`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-start-start-radius) property.
-
-    borderStartStartRadius (em 4)
-
-    borderStartStartRadius2 (em 4) (px 2)
-
--}
-borderStartStartRadius :
-    BaseValue
-        (LengthSupported
-            { pct : Supported
-            }
-        )
-    -> Style
-borderStartStartRadius (Value radius) =
-    AppendProperty ("border-start-start-radius:" ++ radius)
-
-
-{-| Sets [`border-start-start-radius`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-start-start-radius) property.
-
-    borderStartStartRadius (em 4)
-
-    borderStartStartRadius2 (em 4) (px 2)
-
--}
-borderStartStartRadius2 :
-    Value
-        (LengthSupported
-            { pct : Supported
-            }
-        )
-    ->
-        Value
-            (LengthSupported
-                { pct : Supported
-                }
-            )
-    -> Style
-borderStartStartRadius2 (Value horizontalValue) (Value verticalValue) =
-    AppendProperty ("border-start-start-radius:" ++ horizontalValue ++ " " ++ verticalValue)
-
-
-{-| Sets [`border-start-end-radius`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-start-end-radius) property.
-
-    borderStartEndRadius (em 4)
-
-    borderStartEndRadius2 (em 4) (px 2)
-
--}
-borderStartEndRadius :
-    BaseValue
-        (LengthSupported
-            { pct : Supported
-            }
-        )
-    -> Style
-borderStartEndRadius (Value radius) =
-    AppendProperty ("border-start-end-radius:" ++ radius)
-
-
-{-| Sets [`border-start-end-radius`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-start-end-radius) property.
-
-    borderStartEndRadius (em 4)
-
-    borderStartEndRadius2 (em 4) (px 2)
-
--}
-borderStartEndRadius2 :
-    Value
-        (LengthSupported
-            { pct : Supported
-            }
-        )
-    ->
-        Value
-            (LengthSupported
-                { pct : Supported
-                }
-            )
-    -> Style
-borderStartEndRadius2 (Value horizontalValue) (Value verticalValue) =
-    AppendProperty ("border-start-end-radius:" ++ horizontalValue ++ " " ++ verticalValue)
-
-
-{-| Sets [`border-end-start-radius`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-end-start-radius) property.
-
-    borderEndStartRadius (em 4)
-
-    borderEndStartRadius2 (em 4) (px 2)
-
--}
-borderEndStartRadius :
-    BaseValue
-        (LengthSupported
-            { pct : Supported
-            }
-        )
-    -> Style
-borderEndStartRadius (Value radius) =
-    AppendProperty ("border-end-start-radius:" ++ radius)
-
-
-{-| Sets [`border-end-start-radius`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-end-start-radius) property.
-
-    borderEndStartRadius (em 4)
-
-    borderEndStartRadius2 (em 4) (px 2)
-
--}
-borderEndStartRadius2 :
-    Value
-        (LengthSupported
-            { pct : Supported
-            }
-        )
-    ->
-        Value
-            (LengthSupported
-                { pct : Supported
-                }
-            )
-    -> Style
-borderEndStartRadius2 (Value horizontalValue) (Value verticalValue) =
-    AppendProperty ("border-end-start-radius:" ++ horizontalValue ++ " " ++ verticalValue)
-
-
-{-| Sets [`border-end-end-radius`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-end-end-radius) property.
-
-    borderEndEndRadius (em 4)
-
-    borderEndEndRadius2 (em 4) (px 2)
-
--}
-borderEndEndRadius :
-    BaseValue
-        (LengthSupported
-            { pct : Supported
-            }
-        )
-    -> Style
-borderEndEndRadius (Value radius) =
-    AppendProperty ("border-end-end-radius:" ++ radius)
-
-
-{-| Sets [`border-end-end-radius`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-end-end-radius) property.
-
-    borderEndEndRadius (em 4)
-
-    borderEndEndRadius2 (em 4) (px 2)
-
--}
-borderEndEndRadius2 :
-    Value
-        (LengthSupported
-            { pct : Supported
-            }
-        )
-    ->
-        Value
-            (LengthSupported
-                { pct : Supported
-                }
-            )
-    -> Style
-borderEndEndRadius2 (Value horizontalValue) (Value verticalValue) =
-    AppendProperty ("border-end-end-radius:" ++ horizontalValue ++ " " ++ verticalValue)
-
-
-{-| Sets [`border-image-outset`](https://css-tricks.com/almanac/properties/b/border-image/) property.
-
-    borderImageOutset (rem 1)
-
-    borderImageOutset2 (num 1) (num 1.2)
-
-    borderImageOutset3 (px 30) (num 2) (px 45)
-
-    borderImageOutset4 (px 7) (px 12) (px 14) (px 5)
-
-Specifies the distance by which an element's border image is set out from its border box. Supports values specified as length units or unitless numbers. Negative values are invalid.
-
--}
-borderImageOutset :
-    BaseValue
-        (LengthSupported
-            { num : Supported
-            }
-        )
-    -> Style
-borderImageOutset (Value widthVal) =
-    AppendProperty ("border-image-outset:" ++ widthVal)
-
-
-{-| Sets [`border-image-outset`](https://css-tricks.com/almanac/properties/b/border-image/) property.
-
-    borderImageOutset (rem 1)
-
-    borderImageOutset2 (num 1) (num 1.2)
-
-    borderImageOutset3 (px 30) (num 2) (px 45)
-
-    borderImageOutset4 (px 7) (px 12) (px 14) (px 5)
-
-Specifies the distance by which an element's border image is set out from its border box. Supports values specified as length units or unitless numbers. Negative values are invalid.
-
--}
-borderImageOutset2 :
-    Value
-        (LengthSupported
-            { num : Supported
-            }
-        )
-    ->
-        Value
-            (LengthSupported
-                { num : Supported
-                }
-            )
-    -> Style
-borderImageOutset2 (Value valueTopBottom) (Value valueRightLeft) =
-    AppendProperty ("border-image-outset:" ++ valueTopBottom ++ " " ++ valueRightLeft)
-
-
-{-| Sets [`border-image-outset`](https://css-tricks.com/almanac/properties/b/border-image/) property.
-
-    borderImageOutset (rem 1)
-
-    borderImageOutset2 (num 1) (num 1.2)
-
-    borderImageOutset3 (px 30) (num 2) (px 45)
-
-    borderImageOutset4 (px 7) (px 12) (px 14) (px 5)
-
-Specifies the distance by which an element's border image is set out from its border box. Supports values specified as length units or unitless numbers. Negative values are invalid.
-
--}
-borderImageOutset3 :
-    Value
-        (LengthSupported
-            { num : Supported
-            }
-        )
-    ->
-        Value
-            (LengthSupported
-                { num : Supported
-                }
-            )
-    ->
-        Value
-            (LengthSupported
-                { num : Supported
-                }
-            )
-    -> Style
-borderImageOutset3 (Value valueTop) (Value valueRightLeft) (Value valueBottom) =
-    AppendProperty ("border-image-outset:" ++ valueTop ++ " " ++ valueRightLeft ++ " " ++ valueBottom)
-
-
-{-| Sets [`border-image-outset`](https://css-tricks.com/almanac/properties/b/border-image/) property.
-
-    borderImageOutset (rem 1)
-
-    borderImageOutset2 (num 1) (num 1.2)
-
-    borderImageOutset3 (px 30) (num 2) (px 45)
-
-    borderImageOutset4 (px 7) (px 12) (px 14) (px 5)
-
-Specifies the distance by which an element's border image is set out from its border box. Supports values specified as length units or unitless numbers. Negative values are invalid.
-
--}
-borderImageOutset4 :
-    Value
-        (LengthSupported
-            { num : Supported
-            }
-        )
-    ->
-        Value
-            (LengthSupported
-                { num : Supported
-                }
-            )
-    ->
-        Value
-            (LengthSupported
-                { num : Supported
-                }
-            )
-    ->
-        Value
-            (LengthSupported
-                { num : Supported
-                }
-            )
-    -> Style
-borderImageOutset4 (Value valueTop) (Value valueRight) (Value valueBottom) (Value valueLeft) =
-    AppendProperty ("border-image-outset:" ++ valueTop ++ " " ++ valueRight ++ " " ++ valueBottom ++ " " ++ valueLeft)
-
-
-{-| Sets [`border-image-width`](https://css-tricks.com/almanac/properties/b/border-image/) property.
-
-    borderImageWidth (rem 1)
-
-    borderImageWidth2 (num 1) (num 1.2)
-
-    borderImageWidth3 (pct 5) (pct 15) (pct 10)
-
-    borderImageWidth4 (px 7) (px 12) (px 14) (px 5)
-
-Specifies the width of an element's border image. Supports values specified as length units, percentages, unitless numbers or auto. Negative values are invalid.
-
--}
-borderImageWidth :
-    BaseValue
-        (LengthSupported
-            { pct : Supported
-            , num : Supported
-            , auto : Supported
-            }
-        )
-    -> Style
-borderImageWidth (Value widthVal) =
-    AppendProperty ("border-image-width:" ++ widthVal)
-
-
-{-| Sets [`border-image-width`](https://css-tricks.com/almanac/properties/b/border-image/) property.
-
-    borderImageWidth (rem 1)
-
-    borderImageWidth2 (num 1) (num 1.2)
-
-    borderImageWidth3 (pct 5) (pct 15) (pct 10)
-
-    borderImageWidth4 (px 7) (px 12) (px 14) (px 5)
-
-Specifies the width of an element's border image. Supports values specified as length units, percentages, unitless numbers or auto. Negative values are invalid.
-
--}
-borderImageWidth2 :
-    Value
-        (LengthSupported
-            { pct : Supported
-            , num : Supported
-            , auto : Supported
-            }
-        )
-    ->
-        Value
-            (LengthSupported
-                { pct : Supported
-                , num : Supported
-                , auto : Supported
-                }
-            )
-    -> Style
-borderImageWidth2 (Value valueTopBottom) (Value valueRightLeft) =
-    AppendProperty ("border-image-width:" ++ valueTopBottom ++ " " ++ valueRightLeft)
-
-
-{-| Sets [`border-image-width`](https://css-tricks.com/almanac/properties/b/border-image/) property.
-
-    borderImageWidth (rem 1)
-
-    borderImageWidth2 (num 1) (num 1.2)
-
-    borderImageWidth3 (pct 5) (pct 15) (pct 10)
-
-    borderImageWidth4 (px 7) (px 12) (px 14) (px 5)
-
-Specifies the width of an element's border image. Supports values specified as length units, percentages, unitless numbers or auto. Negative values are invalid.
-
--}
-borderImageWidth3 :
-    Value
-        (LengthSupported
-            { pct : Supported
-            , num : Supported
-            }
-        )
-    ->
-        Value
-            (LengthSupported
-                { pct : Supported
-                , num : Supported
-                , auto : Supported
-                }
-            )
-    ->
-        Value
-            (LengthSupported
-                { pct : Supported
-                , num : Supported
-                , auto : Supported
-                }
-            )
-    -> Style
-borderImageWidth3 (Value valueTop) (Value valueRightLeft) (Value valueBottom) =
-    AppendProperty ("border-image-width:" ++ valueTop ++ " " ++ valueRightLeft ++ " " ++ valueBottom)
-
-
-{-| Sets [`border-image-width`](https://css-tricks.com/almanac/properties/b/border-image/) property.
-
-    borderImageWidth (rem 1)
-
-    borderImageWidth2 (num 1) (num 1.2)
-
-    borderImageWidth3 (pct 5) (pct 15) (pct 10)
-
-    borderImageWidth4 (px 7) (px 12) (px 14) (px 5)
-
-Specifies the width of an element's border image. Supports values specified as length units, percentages, unitless numbers or auto. Negative values are invalid.
-
--}
-borderImageWidth4 :
-    Value
-        (LengthSupported
-            { pct : Supported
-            , num : Supported
-            , auto : Supported
-            }
-        )
-    ->
-        Value
-            (LengthSupported
-                { pct : Supported
-                , num : Supported
-                , auto : Supported
-                }
-            )
-    ->
-        Value
-            (LengthSupported
-                { pct : Supported
-                , num : Supported
-                , auto : Supported
-                }
-            )
-    ->
-        Value
-            (LengthSupported
-                { pct : Supported
-                , num : Supported
-                , auto : Supported
-                }
-            )
-    -> Style
-borderImageWidth4 (Value valueTop) (Value valueRight) (Value valueBottom) (Value valueLeft) =
-    AppendProperty ("border-image-width:" ++ valueTop ++ " " ++ valueRight ++ " " ++ valueBottom ++ " " ++ valueLeft)
-
-
-
--- OUTLINE --
-
-
-{-| Sets [`outline`](https://css-tricks.com/almanac/properties/o/outline/).
-
-    outline zero
-
-    outline none
-
--}
-outline :
-    BaseValue
-        (LineWidthSupported
-            (LineStyleSupported
-                (ColorSupported
-                    { auto : Supported
-                    , invert : Supported
-                    }
-                )
-            )
-        )
-    -> Style
-outline (Value val) =
-    AppendProperty ("outline:" ++ val)
-
-
-{-| Sets [`outline`](https://css-tricks.com/almanac/properties/o/outline/).
-
-    outline3 (em 0.25) auto (rgb 120 250 32)
-
--}
-outline3 :
-    Value LineWidth
-    -> Value (LineStyleSupported { auto : Supported })
-    -> Value (ColorSupported { invert : Supported })
-    -> Style
-outline3 (Value widthVal) (Value styleVal) (Value colorVal) =
-    AppendProperty
-        ("outline:"
-            ++ widthVal
-            ++ " "
-            ++ styleVal
-            ++ " "
-            ++ colorVal
-        )
-
-
-{-| Sets [`outline-width`](https://developer.mozilla.org/en-US/docs/Web/CSS/outline-width).
-
-    outlineWidth (px 2)
-
-    outlineWidth thin
-
--}
-outlineWidth : BaseValue LineWidth -> Style
-outlineWidth (Value val) =
-    AppendProperty ("outline-width:" ++ val)
-
-
-{-| Sets [`outline-color`](https://developer.mozilla.org/en-US/docs/Web/CSS/outline-color).
-
-    outlineColor (hex "eee")
-
-    outlineColor invert
-
--}
-outlineColor : BaseValue (ColorSupported { invert : Supported }) -> Style
-outlineColor (Value val) =
-    AppendProperty ("outline-color:" ++ val)
-
-
-{-| The `invert` value used by properties such as [`outlineColor`](#outlineColor)
-
-    outlineColor invert
-
--}
-invert : Value { provides | invert : Supported }
-invert =
-    Value "invert"
-
-
-{-| Sets [`outline-style`](https://developer.mozilla.org/en-US/docs/Web/CSS/outline-style).
-
-    outlineStyle auto
-
-    outlineStyle dashed
-
--}
-outlineStyle : BaseValue (LineStyleSupported { auto : Supported }) -> Style
-outlineStyle (Value val) =
-    AppendProperty ("outline-style:" ++ val)
-
-
-{-| Sets [`outline-offset`](https://css-tricks.com/almanac/properties/o/outline-offset/).
-
-    outlineOffset (px 2)
-
--}
-outlineOffset : BaseValue Length -> Style
-outlineOffset (Value val) =
-    AppendProperty ("outline-offset:" ++ val)
-
-
-
 -- TEXT ORIENTATION --
 
 
@@ -16644,299 +17051,6 @@ letterSpacing :
 letterSpacing (Value val) =
     AppendProperty ("letter-spacing:" ++ val)
 
-
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------- LENGTHS --------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-
-
-{-| Sets an [`all`](https://css-tricks.com/almanac/properties/a/all/) property.
-
-    all inherit
-
--}
-all : BaseValue a -> Style
-all (Value val) =
-    AppendProperty ("all:" ++ val)
-
-
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------- SIZING --------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-
-
-{-| The [`width`](https://css-tricks.com/almanac/properties/w/width/) property.
-
-    width (px 150)
-
-    width (em 1.5)
-
-    width auto
-
-    width minContent
-
--}
-width :
-    BaseValue
-        (LengthSupported
-            { pct : Supported
-            , auto : Supported
-            , maxContent : Supported
-            , minContent : Supported
-            , fitContent : Supported
-            }
-        )
-    -> Style
-width (Value sizeVal) =
-    AppendProperty ("width:" ++ sizeVal)
-
-
-{-| The [`min-width`](https://css-tricks.com/almanac/properties/m/min-width/) property.
-
-    minWidth (px 150)
-
-    minWidth (em 1.5)
-
-    minWidth auto
-
--}
-minWidth :
-    BaseValue
-        (LengthSupported
-            { auto : Supported
-            , maxContent : Supported
-            , minContent : Supported
-            , fitContent : Supported
-            , pct : Supported
-            }
-        )
-    -> Style
-minWidth (Value sizeVal) =
-    AppendProperty ("min-width:" ++ sizeVal)
-
-
-{-| The [`max-width`](https://css-tricks.com/almanac/properties/m/max-width/) property.
-
-    maxWidth (px 150)
-
-    maxWidth (em 1.5)
-
-    maxWidth auto
-
--}
-maxWidth :
-    BaseValue
-        (LengthSupported
-            { maxContent : Supported
-            , minContent : Supported
-            , fitContent : Supported
-            , none : Supported
-            , pct : Supported
-            }
-        )
-    -> Style
-maxWidth (Value sizeVal) =
-    AppendProperty ("max-width:" ++ sizeVal)
-
-
-{-| The [`height`](https://css-tricks.com/almanac/properties/h/height/) property.
-
-    height (px 34)
-
--}
-height :
-    BaseValue
-        (LengthSupported
-            { pct : Supported
-            , auto : Supported
-            , maxContent : Supported
-            , minContent : Supported
-            , fitContent : Supported
-            }
-        )
-    -> Style
-height (Value val) =
-    AppendProperty ("height:" ++ val)
-
-
-{-| The [`min-height`](https://css-tricks.com/almanac/properties/m/min-height/) property.
-
-    minHeight (px 20)
-
--}
-minHeight :
-    BaseValue
-        (LengthSupported
-            { pct : Supported
-            , auto : Supported
-            , maxContent : Supported
-            , minContent : Supported
-            , fitContent : Supported
-            }
-        )
-    -> Style
-minHeight (Value val) =
-    AppendProperty ("min-height:" ++ val)
-
-
-{-| The [`max-height`](https://css-tricks.com/almanac/properties/m/min-height/) property.
-
-    maxHeight (px 20)
-
--}
-maxHeight :
-    BaseValue
-        (LengthSupported
-            { pct : Supported
-            , none : Supported
-            , maxContent : Supported
-            , minContent : Supported
-            , fitContent : Supported
-            }
-        )
-    -> Style
-maxHeight (Value val) =
-    AppendProperty ("max-height:" ++ val)
-
-
-{-| The [`block-size`](https://css-tricks.com/almanac/properties/b/block-size/) property.
-
-    blockSize (px 20)
-
--}
-blockSize :
-    BaseValue
-        (LengthSupported
-            { pct : Supported
-            , none : Supported
-            , maxContent : Supported
-            , minContent : Supported
-            , fitContent : Supported
-            }
-        )
-    -> Style
-blockSize (Value val) =
-    AppendProperty ("block-size:" ++ val)
-
-
-{-| The [`min-block-size`](https://developer.mozilla.org/en-US/docs/Web/CSS/min-block-size) property.
-
-    minBlockSize (px 20)
-
--}
-minBlockSize :
-    BaseValue
-        (LengthSupported
-            { pct : Supported
-            , none : Supported
-            , maxContent : Supported
-            , minContent : Supported
-            , fitContent : Supported
-            }
-        )
-    -> Style
-minBlockSize (Value val) =
-    AppendProperty ("min-block-size:" ++ val)
-
-
-{-| The [`max-block-size`](https://developer.mozilla.org/en-US/docs/Web/CSS/max-block-size) property.
-
-    maxBlockSize (px 20)
-
--}
-maxBlockSize :
-    BaseValue
-        (LengthSupported
-            { pct : Supported
-            , none : Supported
-            , maxContent : Supported
-            , minContent : Supported
-            , fitContent : Supported
-            }
-        )
-    -> Style
-maxBlockSize (Value val) =
-    AppendProperty ("max-block-size:" ++ val)
-
-
-{-| The [`inline-size`](https://css-tricks.com/almanac/properties/i/inline-size/) property.
-
-    inlineSize (px 20)
-
--}
-inlineSize :
-    BaseValue
-        (LengthSupported
-            { pct : Supported
-            , none : Supported
-            , maxContent : Supported
-            , minContent : Supported
-            , fitContent : Supported
-            }
-        )
-    -> Style
-inlineSize (Value val) =
-    AppendProperty ("inline-size:" ++ val)
-
-
-{-| The [`min-inline-size`](https://developer.mozilla.org/en-US/docs/Web/CSS/min-inline-size) property.
-
-    minInlineSize (px 20)
-
--}
-minInlineSize :
-    BaseValue
-        (LengthSupported
-            { pct : Supported
-            , none : Supported
-            , maxContent : Supported
-            , minContent : Supported
-            , fitContent : Supported
-            }
-        )
-    -> Style
-minInlineSize (Value val) =
-    AppendProperty ("min-inline-size:" ++ val)
-
-
-{-| The [`max-inline-size`](https://developer.mozilla.org/en-US/docs/Web/CSS/max-inline-size) property.
-
-    maxInlineSize (px 20)
-
--}
-maxInlineSize :
-    BaseValue
-        (LengthSupported
-            { pct : Supported
-            , none : Supported
-            , maxContent : Supported
-            , minContent : Supported
-            , fitContent : Supported
-            }
-        )
-    -> Style
-maxInlineSize (Value val) =
-    AppendProperty ("max-inline-size:" ++ val)
 
 
 {-| Sets [`backface-visibility`](https://css-tricks.com/almanac/properties/b/backface-visibility/)

--- a/src/Css.elm
+++ b/src/Css.elm
@@ -36,6 +36,7 @@ module Css exposing
     , dotted, dashed, solid, double, groove, ridge, inset, outset
     , borderColor, borderColor2, borderColor3, borderColor4, borderTopColor, borderRightColor, borderBottomColor, borderLeftColor
     , borderRadius, borderRadius2, borderRadius3, borderRadius4, borderTopLeftRadius, borderTopLeftRadius2, borderTopRightRadius, borderTopRightRadius2, borderBottomRightRadius, borderBottomRightRadius2, borderBottomLeftRadius, borderBottomLeftRadius2
+    , borderStartStartRadius, borderStartStartRadius2, borderStartEndRadius, borderStartEndRadius2, borderEndStartRadius, borderEndStartRadius2, borderEndEndRadius, borderEndEndRadius2
     , borderImageOutset, borderImageOutset2, borderImageOutset3, borderImageOutset4
     , borderImageWidth, borderImageWidth2, borderImageWidth3, borderImageWidth4
     , outline, outline3, outlineWidth, outlineColor, invert, outlineStyle, outlineOffset
@@ -309,6 +310,8 @@ All CSS properties can have the values `unset`, `initial`, and `inherit`
 ## Border Radius
 
 @docs borderRadius, borderRadius2, borderRadius3, borderRadius4, borderTopLeftRadius, borderTopLeftRadius2, borderTopRightRadius, borderTopRightRadius2, borderBottomRightRadius, borderBottomRightRadius2, borderBottomLeftRadius, borderBottomLeftRadius2
+
+@docs borderStartStartRadius, borderStartStartRadius2, borderStartEndRadius, borderStartEndRadius2, borderEndStartRadius, borderEndStartRadius2, borderEndEndRadius, borderEndEndRadius2
 
 
 ## Border Image
@@ -8168,6 +8171,174 @@ borderBottomLeftRadius2 :
     -> Style
 borderBottomLeftRadius2 (Value horizontal) (Value vertical) =
     AppendProperty ("border-bottom-left-radius:" ++ horizontal ++ " " ++ vertical)
+
+
+{-| Sets [`border-start-start-radius`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-start-start-radius) property.
+
+    borderStartStartRadius (em 4)
+
+    borderStartStartRadius2 (em 4) (px 2)
+
+-}
+borderStartStartRadius :
+    BaseValue
+        (LengthSupported
+            { pct : Supported
+            }
+        )
+    -> Style
+borderStartStartRadius (Value radius) =
+    AppendProperty ("border-start-start-radius:" ++ radius)
+
+
+{-| Sets [`border-start-start-radius`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-start-start-radius) property.
+
+    borderStartStartRadius (em 4)
+
+    borderStartStartRadius2 (em 4) (px 2)
+
+-}
+borderStartStartRadius2 :
+    Value
+        (LengthSupported
+            { pct : Supported
+            }
+        )
+    ->
+        Value
+            (LengthSupported
+                { pct : Supported
+                }
+            )
+    -> Style
+borderStartStartRadius2 (Value horizontal) (Value vertical) =
+    AppendProperty ("border-start-start-radius:" ++ horizontal ++ " " ++ vertical)
+
+
+{-| Sets [`border-start-end-radius`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-start-end-radius) property.
+
+    borderStartEndRadius (em 4)
+
+    borderStartEndRadius2 (em 4) (px 2)
+
+-}
+borderStartEndRadius :
+    BaseValue
+        (LengthSupported
+            { pct : Supported
+            }
+        )
+    -> Style
+borderStartEndRadius (Value radius) =
+    AppendProperty ("border-start-end-radius:" ++ radius)
+
+
+{-| Sets [`border-start-end-radius`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-start-end-radius) property.
+
+    borderStartEndRadius (em 4)
+
+    borderStartEndRadius2 (em 4) (px 2)
+
+-}
+borderStartEndRadius2 :
+    Value
+        (LengthSupported
+            { pct : Supported
+            }
+        )
+    ->
+        Value
+            (LengthSupported
+                { pct : Supported
+                }
+            )
+    -> Style
+borderStartEndRadius2 (Value horizontal) (Value vertical) =
+    AppendProperty ("border-start-end-radius:" ++ horizontal ++ " " ++ vertical)
+
+
+{-| Sets [`border-end-start-radius`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-end-start-radius) property.
+
+    borderEndStartRadius (em 4)
+
+    borderEndStartRadius2 (em 4) (px 2)
+
+-}
+borderEndStartRadius :
+    BaseValue
+        (LengthSupported
+            { pct : Supported
+            }
+        )
+    -> Style
+borderEndStartRadius (Value radius) =
+    AppendProperty ("border-end-start-radius:" ++ radius)
+
+
+{-| Sets [`border-end-start-radius`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-end-start-radius) property.
+
+    borderEndStartRadius (em 4)
+
+    borderEndStartRadius2 (em 4) (px 2)
+
+-}
+borderEndStartRadius2 :
+    Value
+        (LengthSupported
+            { pct : Supported
+            }
+        )
+    ->
+        Value
+            (LengthSupported
+                { pct : Supported
+                }
+            )
+    -> Style
+borderEndStartRadius2 (Value horizontal) (Value vertical) =
+    AppendProperty ("border-end-start-radius:" ++ horizontal ++ " " ++ vertical)
+
+
+{-| Sets [`border-end-end-radius`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-end-end-radius) property.
+
+    borderEndEndRadius (em 4)
+
+    borderEndEndRadius2 (em 4) (px 2)
+
+-}
+borderEndEndRadius :
+    BaseValue
+        (LengthSupported
+            { pct : Supported
+            }
+        )
+    -> Style
+borderEndEndRadius (Value radius) =
+    AppendProperty ("border-end-end-radius:" ++ radius)
+
+
+{-| Sets [`border-end-end-radius`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-end-end-radius) property.
+
+    borderEndEndRadius (em 4)
+
+    borderEndEndRadius2 (em 4) (px 2)
+
+-}
+borderEndEndRadius2 :
+    Value
+        (LengthSupported
+            { pct : Supported
+            }
+        )
+    ->
+        Value
+            (LengthSupported
+                { pct : Supported
+                }
+            )
+    -> Style
+borderEndEndRadius2 (Value horizontal) (Value vertical) =
+    AppendProperty ("border-end-end-radius:" ++ horizontal ++ " " ++ vertical)
 
 
 {-| Sets [`border-image-outset`](https://css-tricks.com/almanac/properties/b/border-image/) property.

--- a/src/Css.elm
+++ b/src/Css.elm
@@ -142,6 +142,7 @@ module Css exposing
     , scrollBehavior, smooth, scrollSnapAlign, always, scrollSnapStop
     , scrollSnapType, scrollSnapType2, x, y, mandatory, proximity
     , scrollMargin, scrollMargin2, scrollMargin3, scrollMargin4, scrollMarginTop, scrollMarginLeft, scrollMarginRight, scrollMarginBottom
+    , scrollMarginBlock, scrollMarginBlock2, scrollMarginInline, scrollMarginInline2
     , scrollPadding, scrollPadding2, scrollPadding3, scrollPadding4, scrollPaddingTop, scrollPaddingLeft, scrollPaddingRight, scrollPaddingBottom
     , speak, spellOut
     , userSelect
@@ -688,6 +689,7 @@ Multiple CSS properties use these values.
 @docs scrollBehavior, smooth, scrollSnapAlign, always, scrollSnapStop
 @docs scrollSnapType, scrollSnapType2, x, y, mandatory, proximity
 @docs scrollMargin, scrollMargin2, scrollMargin3, scrollMargin4, scrollMarginTop, scrollMarginLeft, scrollMarginRight, scrollMarginBottom
+@docs scrollMarginBlock, scrollMarginBlock2, scrollMarginInline, scrollMarginInline2
 @docs scrollPadding, scrollPadding2, scrollPadding3, scrollPadding4, scrollPaddingTop, scrollPaddingLeft, scrollPaddingRight, scrollPaddingBottom
 
 
@@ -13165,6 +13167,108 @@ scrollMarginLeft :
     -> Style
 scrollMarginLeft (Value value) =
     AppendProperty ("scroll-margin-left:" ++ value)
+
+
+{-| Sets [`scroll-margin-block`](https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-margin-block) property.
+The `scrollMarginBlock` property is a shorthand property for setting
+`scroll-margin-block-start` and `scroll-margin-block-end` in a single declaration.
+
+If there is only one argument value, it applies to both sides. If there are two
+values, the block start margin is set to the first value and the block end margin is
+set to the second.
+
+    scrollMarginBlock (em 4) -- set both block margins to 4em
+
+    scrollMarginBlock2 (em 4) (px 2) -- block start = 4em, block end = 2px
+
+-}
+scrollMarginBlock :
+    BaseValue
+        (LengthSupported
+            { auto : Supported
+            }
+        )
+    -> Style
+scrollMarginBlock (Value value) =
+    AppendProperty ("scroll-margin-block:" ++ value)
+
+
+{-| Sets [`scroll-margin-block`](https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-margin-block) property.
+The `scrollMarginBlock2` property is a shorthand property for setting
+`scroll-margin-block-start` and `scroll-margin-block-end` in a single declaration.
+
+The block start margin is set to the first value and the block end margin is
+set to the second.
+
+    scrollMarginBlock2 (em 4) (px 2) -- block start = 4em, block end = 2px
+
+-}
+scrollMarginBlock2 :
+    Value
+        (LengthSupported
+            { auto : Supported
+            }
+        )
+    ->
+        Value
+            (LengthSupported
+                { auto : Supported
+                }
+            )
+    -> Style
+scrollMarginBlock2 (Value valueTopBottom) (Value valueRightLeft) =
+    AppendProperty ("scroll-margin-block:" ++ valueTopBottom ++ " " ++ valueRightLeft)
+
+
+{-| Sets [`scroll-margin-inline`](https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-margin-inline) property.
+The `scrollMarginInline` property is a shorthand property for setting
+`scroll-margin-inline-start` and `scroll-margin-inline-end` in a single declaration.
+
+If there is only one argument value, it applies to both sides. If there are two
+values, the inline start margin is set to the first value and the inline end margin is
+set to the second.
+
+    scrollMarginInline (em 4) -- set both inline margins to 4em
+
+    scrollMarginInline2 (em 4) (px 2) -- inline start = 4em, inline end = 2px
+
+-}
+scrollMarginInline :
+    BaseValue
+        (LengthSupported
+            { auto : Supported
+            }
+        )
+    -> Style
+scrollMarginInline (Value value) =
+    AppendProperty ("scroll-margin-inline:" ++ value)
+
+
+{-| Sets [`scroll-margin-inline`](https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-margin-inline) property.
+The `scrollMarginInline2` property is a shorthand property for setting
+`scroll-margin-inline-start` and `scroll-margin-inline-end` in a single declaration.
+
+The inline start margin is set to the first value and the inline end margin is
+set to the second.
+
+    scrollMarginInline2 (em 4) (px 2) -- inline start = 4em, inline end = 2px
+
+-}
+scrollMarginInline2 :
+    Value
+        (LengthSupported
+            { auto : Supported
+            }
+        )
+    ->
+        Value
+            (LengthSupported
+                { auto : Supported
+                }
+            )
+    -> Style
+scrollMarginInline2 (Value valueTopBottom) (Value valueRightLeft) =
+    AppendProperty ("scroll-margin-inline:" ++ valueTopBottom ++ " " ++ valueRightLeft)
 
 
 {-| Sets [`scroll-padding`](https://css-tricks.com/almanac/properties/s/scroll-padding/) property.

--- a/src/Css.elm
+++ b/src/Css.elm
@@ -21,12 +21,11 @@ module Css exposing
     , minContent, maxContent, fitContent
     , backgroundAttachment, backgroundAttachments, scroll, local
     , backgroundBlendMode, backgroundBlendModes, multiply, screen, overlay, darken, lighten, colorDodge, colorBurn, hardLight, softLight, difference, exclusion, hue, saturation, color_, luminosity
-    , backgroundClip, backgroundClips, backgroundOrigin, backgroundOrigins, paddingBox
+    , backgroundClip, backgroundClips, backgroundOrigin, backgroundOrigins
     , ImageSupported, Image
     , backgroundImage, backgroundImages, backgroundPosition, backgroundPosition2, backgroundPosition3, backgroundPosition4, backgroundRepeat, backgroundRepeat2, backgroundSize, backgroundSize2
     , linearGradient, linearGradient2, stop, stop2, stop3, toBottom, toBottomLeft, toBottomRight, toLeft, toRight, toTop, toTopLeft, toTopRight
     , repeat, noRepeat, repeatX, repeatY, space, round
-    , cover, contain_
     , BoxShadowConfig, boxShadow, boxShadows, defaultBoxShadow
     , TextShadowConfig, textShadow, defaultTextShadow
     , LineWidth, LineWidthSupported, LineStyle, LineStyleSupported
@@ -58,7 +57,7 @@ module Css exposing
     , alignContent, alignContent2, alignItems, alignItems2, alignSelf, alignSelf2, justifyContent, justifyContent2, justifyItems, justifyItems2, justifySelf, justifySelf2
     , flexDirection, row, rowReverse, column, columnReverse
     , order
-    , flexGrow, flexShrink, flexBasis, content
+    , flexGrow, flexShrink, flexBasis
     , flexWrap, nowrap, wrap, wrapReverse
     , flex, flex2, flex3, flexFlow, flexFlow2
     , wordSpacing
@@ -73,29 +72,31 @@ module Css exposing
     , fontFamily, fontFamilies, serif, sansSerif, monospace, cursive, fantasy, systemUi
     , fontStyle, italic, oblique
     , fontWeight, bold, lighter, bolder
-    , fontStretch, ultraCondensed, extraCondensed, condensed, semiCondensed, normal, semiExpanded, expanded, extraExpanded, ultraExpanded
+    , fontStretch, ultraCondensed, extraCondensed, condensed, semiCondensed, semiExpanded, expanded, extraExpanded, ultraExpanded
     , fontFeatureSettings, fontFeatureSettingsList, featureTag, featureTag2
     , fontVariantCaps, smallCaps, allSmallCaps, petiteCaps, allPetiteCaps, unicase, titlingCaps
     , fontVariantEastAsian, fontVariantEastAsian2, fontVariantEastAsian3, jis78, jis83, jis90, jis04, simplified, traditional, proportionalWidth
     , fontVariantLigatures, commonLigatures, noCommonLigatures, discretionaryLigatures, noDiscretionaryLigatures, historicalLigatures, noHistoricalLigatures, contextual, noContextual
     , fontVariantNumeric, fontVariantNumeric4, ordinal, slashedZero, liningNums, oldstyleNums, proportionalNums, tabularNums, diagonalFractions, stackedFractions
     , fontKerning, fontLanguageOverride, fontSynthesis, fontSynthesis2, fontSynthesis3, fontOpticalSizing, fontVariantPosition
-    , stretch, center, flexStart, flexEnd, selfStart, selfEnd, spaceBetween, spaceAround, spaceEvenly, firstBaseline, lastBaseline, safe, unsafe, legacy, legacyLeft, legacyRight, legacyCenter
+    , flexStart, flexEnd, selfStart, selfEnd, spaceBetween, spaceAround, spaceEvenly, firstBaseline, lastBaseline, safe, unsafe, legacy, legacyLeft, legacyRight, legacyCenter
     , url
     , CursorKeyword
     , cursor, cursor2, cursor4, pointer, default, contextMenu, help, progress, wait, cell
-    , crosshair, text, verticalText, alias, copy, move, noDrop
+    , crosshair, verticalText, alias, copy, move, noDrop
     , notAllowed, allScroll, colResize, rowResize, nResize, eResize, sResize
     , wResize, neResize, nwResize, seResize, swResize, ewResize, nsResize
     , neswResize, nwseResize, zoomIn, zoomOut, grab, grabbing
     , ListStyleType, ListStyleTypeSupported
     , listStyle, listStyle2, listStyle3, listStylePosition, inside, outside, listStyleType, string, customIdent, listStyleImage
     , arabicIndic, armenian, bengali, cambodian, circle, cjkDecimal, cjkEarthlyBranch, cjkHeavenlyStem, cjkIdeographic, decimal, decimalLeadingZero, devanagari, disclosureClosed, disclosureOpen, disc, ethiopicNumeric, georgian, gujarati, gurmukhi, hebrew, hiragana, hiraganaIroha, japaneseFormal, japaneseInformal, kannada, katakana, katakanaIroha, khmer, koreanHangulFormal, koreanHanjaFormal, koreanHanjaInformal, lao, lowerAlpha, lowerArmenian, lowerGreek, lowerLatin, lowerRoman, malayalam, monogolian, myanmar, oriya, persian, simpChineseFormal, simpChineseInformal, tamil, telugu, thai, tibetan, tradChineseFormal, tradChineseInformal, upperAlpha, upperArmenian, upperLatin, upperRoman
-    , auto, none
+    , auto, none, normal
     , hidden, visible
-    , contentBox, borderBox
+    , contentBox, borderBox, paddingBox
     , left_, right_, top_, bottom_, block, inline, start, end
     , baseline, clip, ruby
+    , stretch, center, content, text
+    , cover, contain_
     , overflow, overflowX, overflowY, overflowBlock, overflowInline
     , overflowAnchor
     , overflowWrap
@@ -274,7 +275,7 @@ All CSS properties can have the values `unset`, `initial`, and `inherit`
 
 ## Background Clip and Origin
 
-@docs backgroundClip, backgroundClips, backgroundOrigin, backgroundOrigins, paddingBox
+@docs backgroundClip, backgroundClips, backgroundOrigin, backgroundOrigins
 
 
 ## Background Image
@@ -285,8 +286,6 @@ All CSS properties can have the values `unset`, `initial`, and `inherit`
 @docs linearGradient, linearGradient2, stop, stop2, stop3, toBottom, toBottomLeft, toBottomRight, toLeft, toRight, toTop, toTopLeft, toTopRight
 
 @docs repeat, noRepeat, repeatX, repeatY, space, round
-
-@docs cover, contain_
 
 
 ## Box Shadow
@@ -416,7 +415,9 @@ See this [complete guide](https://css-tricks.com/snippets/css/a-guide-to-flexbox
 
 ### Flexbox Sizing
 
-@docs flexGrow, flexShrink, flexBasis, content
+[`content`](#content) is also a supported value.
+
+@docs flexGrow, flexShrink, flexBasis
 
 
 ### Flexbox Wrapping
@@ -471,7 +472,7 @@ See this [complete guide](https://css-tricks.com/snippets/css/a-guide-to-flexbox
 
 [`normal`](#normal) is also a supported font weight.
 
-@docs fontStretch, ultraCondensed, extraCondensed, condensed, semiCondensed, normal, semiExpanded, expanded, extraExpanded, ultraExpanded
+@docs fontStretch, ultraCondensed, extraCondensed, condensed, semiCondensed, semiExpanded, expanded, extraExpanded, ultraExpanded
 
 
 ## Font Feature Settings
@@ -508,7 +509,19 @@ See this [complete guide](https://css-tricks.com/snippets/css/a-guide-to-flexbox
 
 # Align Items
 
-@docs stretch, center, flexStart, flexEnd, selfStart, selfEnd, spaceBetween, spaceAround, spaceEvenly, firstBaseline, lastBaseline, safe, unsafe, legacy, legacyLeft, legacyRight, legacyCenter
+Other values you can use for alignment than the ones listed in this section:
+
+  - [`left_`](#left_)
+  - [`right_`](#right_)
+  - [`top_`](#top_)
+  - [`bottom_`](#bottom_)
+  - [`start`](#start)
+  - [`end`](#end)
+  - [`center`](#center)
+  - [`stretch`](#stretch)
+  - [`baseline`](#baseline)
+
+@docs flexStart, flexEnd, selfStart, selfEnd, spaceBetween, spaceAround, spaceEvenly, firstBaseline, lastBaseline, safe, unsafe, legacy, legacyLeft, legacyRight, legacyCenter
 
 
 # Url
@@ -518,9 +531,11 @@ See this [complete guide](https://css-tricks.com/snippets/css/a-guide-to-flexbox
 
 ## Cursors
 
+[`text`](#text) is also a supported value.
+
 @docs CursorKeyword
 @docs cursor, cursor2, cursor4, pointer, default, contextMenu, help, progress, wait, cell
-@docs crosshair, text, verticalText, alias, copy, move, noDrop
+@docs crosshair, verticalText, alias, copy, move, noDrop
 @docs notAllowed, allScroll, colResize, rowResize, nResize, eResize, sResize
 @docs wResize, neResize, nwResize, seResize, swResize, ewResize, nsResize
 @docs neswResize, nwseResize, zoomIn, zoomOut, grab, grabbing
@@ -539,12 +554,13 @@ See this [complete guide](https://css-tricks.com/snippets/css/a-guide-to-flexbox
 
 Multiple CSS properties use these values.
 
-@docs auto, none
+@docs auto, none, normal
 @docs hidden, visible
-@docs contentBox, borderBox
+@docs contentBox, borderBox, paddingBox
 @docs left_, right_, top_, bottom_, block, inline, start, end
 @docs baseline, clip, ruby
-
+@docs stretch, center, content, text
+@docs cover, contain_
 
 ## Overflow
 
@@ -1047,12 +1063,13 @@ value used by properties such as:
 
   - [`fontLanguageOverride`](#fontLanguageOverride)
 
+```
+listStyleType (string "> ")
 
-    listStyleType (string "> ")
+quotes2 (string "«") (string "»")
 
-    quotes2 (string "«") (string "»")
-
-    fontLanguageOverride (string "ENG")
+fontLanguageOverride (string "ENG")
+```
 
 -}
 string : String -> Value { provides | string : Supported }
@@ -1242,6 +1259,39 @@ none =
     Value "none"
 
 
+{-| The `normal` value, which can be used with such properties as:
+
+  - [`fontVariantCaps`](#fontVariantCaps)
+  - [`fontKerning`](#fontKerning)
+  - [`fontLanguageOverride`](#fontLanguageOverride)
+  - [`whiteSpace`](#whiteSpace)
+  - [`wordBreak`](#wordBreak)
+  - [`columnGap`](#columnGap)
+  - [`zoom`](#zoom)
+  - [`animationDirection`](#animationDirection)
+  - [`alignItems`](#alignItems)
+  - [`lineBreak`](#lineBreak)
+
+```
+alignItems normal
+
+columnGap normal
+
+fontVariantCaps normal
+
+whiteSpace normal
+
+wordBreak normal
+
+zoom normal
+```
+
+-}
+normal : Value { provides | normal : Supported }
+normal =
+    Value "normal"
+
+
 {-| The `hidden` value used for properties such as [`visibility`](https://css-tricks.com/almanac/properties/v/visibility/), [`overflow`](https://css-tricks.com/almanac/properties/o/overflow/) and [`border style`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-style).
 
     visibility hidden
@@ -1282,21 +1332,22 @@ scroll =
     Value "scroll"
 
 
-{-| The `content-box` value, used in the following properties: 
+{-| The `content-box` value, used in the following properties:
 
-- [`boxSizing`](#boxSizing)
-- [`backgroundClip`](#backgroundClip)
-- [`backgroundOrigin`](#backgroundOrigin)
-- [`strokeOrigin`](#strokeOrigin)
+  - [`boxSizing`](#boxSizing)
+  - [`backgroundClip`](#backgroundClip)
+  - [`backgroundOrigin`](#backgroundOrigin)
+  - [`strokeOrigin`](#strokeOrigin)
 
+```
+boxSizing contentBox
 
-    boxSizing contentBox
+backgroundClip contentBox
 
-    backgroundClip contentBox
+backgroundOrigin contentBox
 
-    backgroundOrigin contentBox
-
-    strokeOrigin contentBox
+strokeOrigin contentBox
+```
 
 -}
 contentBox : Value { provides | contentBox : Supported }
@@ -1306,19 +1357,20 @@ contentBox =
 
 {-| The `border-box` value, used in the following properties:
 
-- [`boxSizing`](#boxSizing)
-- [`backgroundClip`](#backgroundClip)
-- [`backgroundOrigin`](backgroundOrigin)
-- [`strokeOrigin`](#strokeOrigin)
+  - [`boxSizing`](#boxSizing)
+  - [`backgroundClip`](#backgroundClip)
+  - [`backgroundOrigin`](backgroundOrigin)
+  - [`strokeOrigin`](#strokeOrigin)
 
+```
+boxSizing borderBox
 
-    boxSizing borderBox
+backgroundClip borderBox
 
-    backgroundClip borderBox
+backgroundOrigin borderBox
 
-    backgroundOrigin borderBox
-
-    strokeOrigin borderBox
+strokeOrigin borderBox
+```
 
 -}
 borderBox : Value { provides | borderBox : Supported }
@@ -1326,35 +1378,50 @@ borderBox =
     Value "border-box"
 
 
+{-| The `padding-box` value, used with [`backgroundClip`](#backgroundClip),
+[`backgroundOrigin`](#backgroundOrigin),
+and [`strokeOrigin`](#strokeOrigin).
+
+    backgroundClip paddingBox
+
+    backgroundOrigin paddingBox
+
+    strokeOrigin paddingBox
+
+-}
+paddingBox : Value { provides | paddingBox : Supported }
+paddingBox =
+    Value "padding-box"
+
+
 {-| The `left` value, used in many properties such as:
 
-- [`backgroundPosition`](#backgroundPosition)
-- [`clear`](#clear)
-- [`float`](#float)
-- [`justifyContent`](#justifyContent)
-- [`justifyItems`](#justifyItems)
-- [`justifySelf`](#justifySelf)
-- [`pageBreakAfter`](#pageBreakAfter)
-- [`textAlign`](#textAlign)
+  - [`backgroundPosition`](#backgroundPosition)
+  - [`clear`](#clear)
+  - [`float`](#float)
+  - [`justifyContent`](#justifyContent)
+  - [`justifyItems`](#justifyItems)
+  - [`justifySelf`](#justifySelf)
+  - [`pageBreakAfter`](#pageBreakAfter)
+  - [`textAlign`](#textAlign)
 
+```
+backgroundPosition left_
 
-    backgroundPosition left_
-    
-    clear left_
+clear left_
 
-    float left_
+float left_
 
-    justifyContent left_
+justifyContent left_
 
-    justifyItems left_
+justifyItems left_
 
-    justifySelf left_
+justifySelf left_
 
-    pageBreakAfter left_
+pageBreakAfter left_
 
-    textAlign left_
-
-
+textAlign left_
+```
 
 The value is called `left_` instead of `left` because [`left` is already a function](#left).
 
@@ -1366,33 +1433,32 @@ left_ =
 
 {-| The `right` value, used in many properties such as:
 
-- [`backgroundPosition`](#backgroundPosition)
-- [`clear`](#clear)
-- [`float`](#float)
-- [`justifyContent`](#justifyContent)
-- [`justifyItems`](#justifyItems)
-- [`justifySelf`](#justifySelf)
-- [`pageBreakAfter`](#pageBreakAfter)
-- [`textAlign`](#textAlign)
+  - [`backgroundPosition`](#backgroundPosition)
+  - [`clear`](#clear)
+  - [`float`](#float)
+  - [`justifyContent`](#justifyContent)
+  - [`justifyItems`](#justifyItems)
+  - [`justifySelf`](#justifySelf)
+  - [`pageBreakAfter`](#pageBreakAfter)
+  - [`textAlign`](#textAlign)
 
+```
+backgroundPosition right_
 
-    backgroundPosition right_
-    
-    clear right_
+clear right_
 
-    float right_
+float right_
 
-    justifyContent right_
+justifyContent right_
 
-    justifyItems right_
+justifyItems right_
 
-    justifySelf right_
+justifySelf right_
 
-    pageBreakAfter right_
+pageBreakAfter right_
 
-    textAlign right_
-
-
+textAlign right_
+```
 
 The value is called `right_` instead of `right` because [`right` is already a function](#right).
 
@@ -1404,26 +1470,27 @@ right_ =
 
 {-| The `top` value, used in the following properties:
 
-- [`backgroundPosition`](#backgroundPosition)
-- [`captionSide`](#captionSide)
-- [`objectPosition2`](#objectPosition2)
-- [`perspectiveOrigin2`](#perspectiveOrigin2)
-- [`strokePosition2`](#strokePosition2)
-- [`transformOrigin`](#transformOrigin)
-- [`verticalAlign`](#verticalAlign)
+  - [`backgroundPosition`](#backgroundPosition)
+  - [`captionSide`](#captionSide)
+  - [`objectPosition2`](#objectPosition2)
+  - [`perspectiveOrigin2`](#perspectiveOrigin2)
+  - [`strokePosition2`](#strokePosition2)
+  - [`transformOrigin`](#transformOrigin)
+  - [`verticalAlign`](#verticalAlign)
 
+```
+backgroundPosition top_
 
-    backgroundPosition top_
+captionSide top_
 
-    captionSide top_
+objectPosition2 right_ top_
 
-    objectPosition2 right_ top_
+perspectiveOrigin2 left_ top_
 
-    perspectiveOrigin2 left_ top_
+transformOrigin top_
 
-    transformOrigin top_
-
-    verticalAlign top_
+verticalAlign top_
+```
 
 The value is called `top_` instead of `top` because [`top` is already a function](#top).
 
@@ -1435,26 +1502,27 @@ top_ =
 
 {-| The `bottom` value, used in the following properties:
 
-- [`backgroundPosition`](#backgroundPosition)
-- [`captionSide`](#captionSide)
-- [`objectPosition2`](#objectPosition2)
-- [`perspectiveOrigin2`](#perspectiveOrigin2)
-- [`strokePosition2`](#strokePosition2)
-- [`transformOrigin`](#transformOrigin)
-- [`verticalAlign`](#verticalAlign)
+  - [`backgroundPosition`](#backgroundPosition)
+  - [`captionSide`](#captionSide)
+  - [`objectPosition2`](#objectPosition2)
+  - [`perspectiveOrigin2`](#perspectiveOrigin2)
+  - [`strokePosition2`](#strokePosition2)
+  - [`transformOrigin`](#transformOrigin)
+  - [`verticalAlign`](#verticalAlign)
 
+```
+backgroundPosition bottom_
 
-    backgroundPosition bottom_
+captionSide bottom_
 
-    captionSide bottom_
+objectPosition2 right_ bottom_
 
-    objectPosition2 right_ bottom_
+perspectiveOrigin2 left_ bottom_
 
-    perspectiveOrigin2 left_ bottom_
+transformOrigin bottom_
 
-    transformOrigin bottom_
-
-    verticalAlign bottom_
+verticalAlign bottom_
+```
 
 The value is called `bottom_` instead of `bottom` because [`bottom` is already a function](#bottom).
 
@@ -1490,18 +1558,19 @@ inline =
 
 {-| The `start` value, used in the following properties:
 
-- [`alignItems`](#alignItems)
-- [`alignContent`](#alignContent)
-- [`alignSelf`](#alignSelf)
-- [`justifyContent`](#justifyContent)
-- [`justifyItems`](#justifyItems)
-- [`justifySelf`](#justifySelf)
-- [`steps2`](#steps2)
+  - [`alignItems`](#alignItems)
+  - [`alignContent`](#alignContent)
+  - [`alignSelf`](#alignSelf)
+  - [`justifyContent`](#justifyContent)
+  - [`justifyItems`](#justifyItems)
+  - [`justifySelf`](#justifySelf)
+  - [`steps2`](#steps2)
 
+```
+alignContent start
 
-    alignContent start
-
-    steps2 3 start
+steps2 3 start
+```
 
 -}
 start : Value { provides | start : Supported }
@@ -1511,38 +1580,40 @@ start =
 
 {-| The `end` value, used in the following properties:
 
-- [`alignItems`](#alignItems)
-- [`alignContent`](#alignContent)
-- [`alignSelf`](#alignSelf)
-- [`justifyContent`](#justifyContent)
-- [`justifyItems`](#justifyItems)
-- [`justifySelf`](#justifySelf)
-- [`steps2`](#steps2)
+  - [`alignItems`](#alignItems)
+  - [`alignContent`](#alignContent)
+  - [`alignSelf`](#alignSelf)
+  - [`justifyContent`](#justifyContent)
+  - [`justifyItems`](#justifyItems)
+  - [`justifySelf`](#justifySelf)
+  - [`steps2`](#steps2)
 
+```
+alignContent end
 
-    alignContent end
-
-    steps2 3 end
+steps2 3 end
+```
 
 -}
 end : Value { provides | end : Supported }
 end =
     Value "end"
+
+
 {-| The `baseline` value, used in the following properties:
 
-- [`alignContent`](#alignContent)
-- [`alignItems`](#alignItems)
-- [`alignSelf`](#alignSelf)
-- [`verticalAlign`](#verticalAlign)
+  - [`alignContent`](#alignContent)
+  - [`alignItems`](#alignItems)
+  - [`alignSelf`](#alignSelf)
+  - [`verticalAlign`](#verticalAlign)
 
+```
+alignItems baseline
 
-    alignItems baseline
-
-    verticalAlign baseline
+verticalAlign baseline
+```
 
 -}
-
-
 baseline : Value { provides | baseline : Supported }
 baseline =
     Value "baseline"
@@ -1564,17 +1635,136 @@ clip =
     Value "clip"
 
 
-
 {-| The `ruby` value used by [`display`](#display) and [`fontVariantEastAsian`](#fontVariantEastAsian).
 
     display ruby
 
-    fontVariantEastAsian2 ruby jis83 
+    fontVariantEastAsian2 ruby jis83
 
 -}
 ruby : Value { provides | ruby : Supported }
 ruby =
     Value "ruby"
+
+
+{-| The `stretch` value used in the following properties:
+
+  - [`alignContent`](#alignContent)
+  - [`alignItems`](#alignItems)
+  - [`alignSelf`](#alignSelf)
+  - [`justifyContent`](#justifyContent)
+  - [`justifyItems`](#justifyItems)
+  - [`justifySelf`](#justifySelf)
+  - [\`strokeDashJustify](#strokeDashJustify)
+
+```
+alignContent stretch
+
+strokeDashJustify stretch
+```
+
+-}
+stretch : Value { provides | stretch : Supported }
+stretch =
+    Value "stretch"
+
+
+{-| The `center` value, used in many properties such as:
+
+  - [`alignContent`](#alignContent)
+  - [`alignItems`](#alignItems)
+  - [`alignSelf`](#alignSelf)
+  - [`backgroundPosition`](#backgroundPosition)
+  - [`justifyContent`](#justifyContent)
+  - [`justifyItems`](#justifyItems)
+  - [`justifySelf`](#justifySelf)
+  - [`scrollSnapAlign`](#scrollSnapAlign)
+
+```
+backgroundPosition enter
+
+justifyContent center
+```
+
+-}
+center : Value { provides | center : Supported }
+center =
+    Value "center"
+
+
+{-| The `content` value used in the following properties:
+
+  - [`flex`](#flex)
+  - [`flex-basis`](#flexBasis)
+  - [`contain`](#contain)
+
+```
+flexBasis content
+
+contain content
+```
+
+-}
+content : Value { provides | content : Supported }
+content =
+    Value "content"
+
+
+{-| The `text` value for the [`cursor`](#cursor),
+[`backgroundClip`](#backgroundClip),
+and [`user-select`](#userSelect) properties.
+
+    backgroundClip text
+
+    cursor text
+
+    userSelect text
+
+-}
+text : Value { provides | text : Supported }
+text =
+    Value "text"
+
+
+{-| Sets `contain` for the following properties:
+
+  - [`backgroundSize`](#backgroundSize) (It always show the whole background
+    image, even if it leaves empty spaces on the sides.)
+  - [`objectFit`](#objectFit) (Replaced content is scaled to maintain proportions within the element's content box.)
+  - [`userSelect`](#userSelect) (Lets selection start within the element but that selection will be contained within that element's bounds.)
+  - [`overscrollBehavior`](#overscrollBehavior) (This means that default scroll overflow behavior
+    is observed inside the element, but scroll chaining will not happen to neighbouring elements.)
+
+```
+backgroundSize contain_
+
+overscrollBehavior contain
+```
+
+The value is called `contain_` instead of `contain` because [`contain`](#contain) is already a function.
+
+-}
+contain_ : Value { provides | contain_ : Supported }
+contain_ =
+    Value "contain"
+
+
+{-| Sets `cover` for the following properties:
+
+- [`backgroundSize`](#backgroundSize)
+- [`objectFit`](#objectFit)
+- [`strokeDashCorner`](#strokeDashCorner)
+- [`strokeSize`](#strokeSize)
+
+
+    backgroundSize cover
+
+    strokeSize cover
+
+-}
+cover : Value { provides | cover : Supported }
+cover =
+    Value "cover"
 
 
 -- OVERFLOW --
@@ -1650,7 +1840,6 @@ overflowY :
     -> Style
 overflowY (Value val) =
     AppendProperty ("overflow-y:" ++ val)
-
 
 
 {-| Sets [`overflow-block`](https://developer.mozilla.org/en-US/docs/Web/CSS/overflow-block).
@@ -3348,7 +3537,7 @@ marker =
 {-| A [`::placeholder`](https://developer.mozilla.org/en-US/docs/Web/CSS/::placeholder)
 [pseudo-element](https://developer.mozilla.org/en-US/docs/Web/CSS/Pseudo-elements).
 
-Be careful when using placeholders as they can compromise accessibility.
+Be careful when using placeholders as they can negatively impact accessibility.
 
     placeholder
         [ opacity (num 1) <| important
@@ -4345,19 +4534,6 @@ tableRowGroup =
 -- ALIGN-ITEMS VALUES --
 
 
-{-| -}
-stretch : Value { provides | stretch : Supported }
-stretch =
-    Value "stretch"
-
-
-{-| -}
-center : Value { provides | center : Supported }
-center =
-    Value "center"
-
-
-
 {-| The `flex-start` value used by [`alignItems`](#alignItems),
 [`justifyContent`](#justifyContent),
 and [`alignContent`](#alignContent).
@@ -4863,23 +5039,6 @@ justifySelf2 (Value overflowPosition) (Value contentPosition) =
 flexBasis : BaseValue (WidthSupported { content : Supported }) -> Style
 flexBasis (Value val) =
     AppendProperty ("flex-basis:" ++ val)
-
-
-{-| The `content` value used in:
-
-  - [`flex-basis`](https://developer.mozilla.org/en-US/docs/Web/CSS/flex-basis#Values) (Indicates automatic sizing based on the item's content)
-  - [`contain`](#contain) (Indicates all containment rules apart from `size` and `style` are applied.)
-
-```
-flexBasis content
-
-contain content
-```
-
--}
-content : Value { provides | content : Supported }
-content =
-    Value "content"
 
 
 {-| Sets [`flex-grow`](https://css-tricks.com/almanac/properties/f/flex-grow/).
@@ -5631,47 +5790,14 @@ fontVariantCaps (Value str) =
     AppendProperty ("font-variant-caps:" ++ str)
 
 
-{-| The `normal` value, which can be used with such properties as:
-
-  - [`fontVariantCaps`](#fontVariantCaps)
-  - [`fontKerning`](#fontKerning)
-  - [`fontLanguageOverride`](#fontLanguageOverride)
-  - [`whiteSpace`](#whiteSpace)
-  - [`wordBreak`](#wordBreak)
-  - [`columnGap`](#columnGap)
-  - [`zoom`](#zoom)
-  - [`animationDirection`](#animationDirection)
-  - [`alignItems`](#alignItems)
-  - [`lineBreak`](#lineBreak)
-
-
-```
-alignItems normal
-
-columnGap normal
-
-fontVariantCaps normal
-
-whiteSpace normal
-
-wordBreak normal
-
-zoom normal
-```
-
--}
-normal : Value { provides | normal : Supported }
-normal =
-    Value "normal"
-
-
 {-| The `small-caps` value used in
-    - [`fontVariantCaps`](#fontVariantCaps)
-    - [`fontSynthesis`](#fontSynthesis)
+- [`fontVariantCaps`](#fontVariantCaps)
+- [`fontSynthesis`](#fontSynthesis)
 
     fontVariantCaps smallCaps
 
     fontSynthesis2 smallCaps style
+
 -}
 smallCaps : Value { provides | smallCaps : Supported }
 smallCaps =
@@ -6198,6 +6324,7 @@ stackedFractions =
 {-| The [`font-kerning`](https://developer.mozilla.org/en-US/docs/Web/CSS/font-kerning) property.
 
     fontKerning none
+
 -}
 fontKerning :
     BaseValue
@@ -6215,6 +6342,7 @@ fontKerning (Value val) =
     fontLanguageOverride normal
 
     fontLanguageOverride (string "ENG")
+
 -}
 fontLanguageOverride :
     BaseValue
@@ -6235,6 +6363,7 @@ fontLanguageOverride (Value val) =
     fontSynthesis2 smallCaps weight
 
     fontSynthesis3 weight style smallCaps
+
 -}
 fontSynthesis :
     BaseValue
@@ -6254,6 +6383,7 @@ This is the two-argument variant, in which you can indicate
 two different font properties to be synthesised by the browser.
 
     fontSynthesis2 smallCaps weight
+
 -}
 fontSynthesis2 :
     Value
@@ -6261,11 +6391,12 @@ fontSynthesis2 :
         , style : Supported
         , smallCaps : Supported
         }
-    -> Value
-        { weight : Supported
-        , style : Supported
-        , smallCaps : Supported
-        }
+    ->
+        Value
+            { weight : Supported
+            , style : Supported
+            , smallCaps : Supported
+            }
     -> Style
 fontSynthesis2 (Value val1) (Value val2) =
     AppendProperty ("font-synthesis:" ++ val1 ++ " " ++ val2)
@@ -6277,6 +6408,7 @@ This is the three-argument variant, in which you can indicate
 all three different font properties to be synthesised by the browser.
 
     fontSynthesis3 weight style smallCaps
+
 -}
 fontSynthesis3 :
     Value
@@ -6284,16 +6416,18 @@ fontSynthesis3 :
         , style : Supported
         , smallCaps : Supported
         }
-    -> Value
-        { weight : Supported
-        , style : Supported
-        , smallCaps : Supported
-        }
-    -> Value
-        { weight : Supported
-        , style : Supported
-        , smallCaps : Supported
-        }
+    ->
+        Value
+            { weight : Supported
+            , style : Supported
+            , smallCaps : Supported
+            }
+    ->
+        Value
+            { weight : Supported
+            , style : Supported
+            , smallCaps : Supported
+            }
     -> Style
 fontSynthesis3 (Value val1) (Value val2) (Value val3) =
     AppendProperty ("font-synthesis:" ++ val1 ++ " " ++ val2 ++ " " ++ val3)
@@ -6302,16 +6436,17 @@ fontSynthesis3 (Value val1) (Value val2) (Value val3) =
 {-| The `weight` value for the [`fontSynthesis`](#fontSynthesis) property.
 
     fontSynthesis weight
+
 -}
 weight : Value { provides | weight : Supported }
 weight =
     Value "weight"
 
 
-
 {-| The [`font-optical-sizing`](https://developer.mozilla.org/en-US/docs/Web/CSS/font-optical-sizing) property.
 
     fontOpticalSizing none
+
 -}
 fontOpticalSizing :
     BaseValue
@@ -6328,6 +6463,7 @@ fontOpticalSizing (Value val) =
     fontVariantPosition sub
 
     fontVariantPosition normal
+
 -}
 fontVariantPosition :
     BaseValue
@@ -6338,6 +6474,7 @@ fontVariantPosition :
     -> Style
 fontVariantPosition (Value val) =
     AppendProperty ("font-variant-position:" ++ val)
+
 
 
 -- CURSOR --
@@ -6494,18 +6631,6 @@ cell =
 crosshair : Value { provides | crosshair : Supported }
 crosshair =
     Value "crosshair"
-
-
-{-| The `text` value for the [`cursor`](#cursor),
-[`backgroundClip`](#backgroundClip),
-and [`user-select`](#userSelect) properties.
-
-    backgroundClip text
-
--}
-text : Value { provides | text : Supported }
-text =
-    Value "text"
 
 
 {-| The `vertical-text` value for the [`cursor`](#cursor) property.
@@ -7036,22 +7161,6 @@ backgroundClips firstValue values =
     AppendProperty ("background-clip:" ++ hashListToString firstValue values)
 
 
-{-| The `padding-box` value, used with [`backgroundClip`](#backgroundClip),
-[`backgroundOrigin`](#backgroundOrigin),
-and [`strokeOrigin`](#strokeOrigin).
-
-    backgroundClip paddingBox
-
-    backgroundOrigin paddingBox
-
-    strokeOrigin paddingBox
-
--}
-paddingBox : Value { provides | paddingBox : Supported }
-paddingBox =
-    Value "padding-box"
-
-
 
 -- BACKGROUND ORIGIN --
 
@@ -7335,7 +7444,7 @@ backgroundRepeat2 (Value horiz) (Value vert) =
     AppendProperty ("background-repeat:" ++ horiz ++ " " ++ vert)
 
 
-{-| Compiles to [`repeat`](https://developer.mozilla.org/en-US/docs/Web/CSS/background-repeat#Values) for [backgrounds](#backgroundRepeat),
+{-| The `repeat` value for [background properties](#backgroundRepeat)
 and [`strokeRepeat`](#strokeRepeat).
 
     backgroundRepeat repeat
@@ -7348,7 +7457,7 @@ repeat =
     Value "repeat"
 
 
-{-| Compiles to [`no-repeat`](https://developer.mozilla.org/en-US/docs/Web/CSS/background-repeat#Values) for [backgrounds](#backgroundRepeat),
+{-| The `no-repeat` value for [background properties](#backgroundRepeat)
 and [`strokeRepeat`](#strokeRepeat).
 
     backgroundRepeat noRepeat
@@ -7361,8 +7470,8 @@ noRepeat =
     Value "no-repeat"
 
 
-{-| Compiles to [`repeat-x`](https://developer.mozilla.org/en-US/docs/Web/CSS/background-repeat#Values) for [repeating backgrounds](#backgroundRepeat),
-and [`strokeRepeat`](#strokeRepeat) horizontally.
+{-| The `repeat-x` value for [repeating backgrounds](#backgroundRepeat)
+and [`strokeRepeat`](#strokeRepeat).
 
     backgroundRepeat repeatX
 
@@ -7374,8 +7483,8 @@ repeatX =
     Value "repeat-x"
 
 
-{-| Compiles to [`repeat-y`](https://developer.mozilla.org/en-US/docs/Web/CSS/background-repeat#Values) for [repeating backgrounds](#backgroundRepeat),
-and [`strokeRepeat`](#strokeRepeat) vertically.
+{-| The `repeat-y` value for [repeating backgrounds](#backgroundRepeat)
+and [`strokeRepeat`](#strokeRepeat).
 
     backgroundRepeat repeatY
 
@@ -7387,8 +7496,8 @@ repeatY =
     Value "repeat-y"
 
 
-{-| Compiles to [`space`](https://developer.mozilla.org/en-US/docs/Web/CSS/background-repeat#Values) for [repeating backgrounds](#backgroundRepeat),
-and [`strokeRepeat`](#strokeRepeat) without cutting off edges by adding space.
+{-| The `space` value for [repeating backgrounds](#backgroundRepeat)
+and [`strokeRepeat`](#strokeRepeat).
 
     backgroundRepeat space
 
@@ -7400,11 +7509,14 @@ space =
     Value "space"
 
 
-{-| The `round` value used for properties such as [repeating background](#backgroundRepeat) without cutting off edges by stretching or shrinking the image,
-and [`strokeLinecap`](#strokeLinecap),
-and [`strokeRepeat`](#strokeRepeat),
-and [`strokeLinejoin`](#strokeLinejoin2).
+{-| The `round` value used for properties such as:
 
+  - [repeating backgrounds](#backgroundRepeat)
+  - [`strokeLinecap`](#strokeLinecap)
+  - [`strokeRepeat`](#strokeRepeat)
+  - [`strokeLinejoin`](#strokeLinejoin2)
+
+```
     backgroundRepeat round
 
     strokeLineCap round
@@ -7412,6 +7524,7 @@ and [`strokeLinejoin`](#strokeLinejoin2).
     strokeLinejoin2 miter round
 
     strokeRepeat round
+```
 
 -}
 round : Value { provides | round : Supported }
@@ -7475,45 +7588,6 @@ backgroundSize2 :
     -> Style
 backgroundSize2 (Value widthVal) (Value heightVal) =
     AppendProperty ("background-size:" ++ widthVal ++ " " ++ heightVal)
-
-
-{-| Sets [`contain`](https://css-tricks.com/almanac/properties/b/background-size/)
-for the following properties:
-
-  - [`backgroundSize`](#backgroundSize) (It always show the whole background
-    image, even if it leaves empty spaces on the sides.)
-  - [`objectFit`](#objectFit) (Replaced content is scaled to maintain proportions within the element's content box.)
-  - [`userSelect`](#userSelect) (Lets selection start within the element but that selection will be contained within that element's bounds.)
-  - [`overscrollBehavior`](#overscrollBehavior) (This means that default scroll overflow behavior
-    is observed inside the element, but scroll chaining will not happen to neighbouring elements.)
-
-```
-backgroundSize contain_
-
-overscrollBehavior contain
-```
-
-The value is called `contain_` instead of `contain` because [`contain`](#contain) is already a function.
-
--}
-contain_ : Value { provides | contain_ : Supported }
-contain_ =
-    Value "contain"
-
-
-{-| Sets [`cover`](https://css-tricks.com/almanac/properties/b/background-size/)
-for [`backgroundSize`](#backgroundSize), and [`strokeSize`](#strokeSize). It fills the whole space available with
-the background image by scaling, even if it cuts off some of the image.
-
-    backgroundSize cover
-
-    strokeSize cover
-
--}
-cover : Value { provides | cover : Supported }
-cover =
-    Value "cover"
-
 
 
 {- GRADIENTS -}
@@ -10259,12 +10333,15 @@ lowercase =
 
 {-| A `full-width` value for:
 
+
 ### [`textTransform`](#textTransform)
+
 Forces the writing of characters in a square so they can be aligned in East Asian scripts.
 
-### [`fontVariantEastAsian`](#fontVariantEastAsian)
-Activates the East Asian characters that are roughly be the same width.
 
+### [`fontVariantEastAsian`](#fontVariantEastAsian)
+
+Activates the East Asian characters that are roughly be the same width.
 
     textTransform fullWidth
 
@@ -10847,14 +10924,14 @@ sub =
     Value "sub"
 
 
-{-|  A `super` value for the following properties:
+{-| A `super` value for the following properties:
 
     - [`fontVariantPosition](#fontVariantPosition)
     - [`verticalAlign`](#verticalAlign)
 
 
     fontVariantPosition super
-    
+
     verticalAlign super
 
 -}
@@ -14116,7 +14193,9 @@ maxInlineSize (Value val) =
 
   - [`flexBasis`](#flexBasis)
 
-    width minContent
+```
+width minContent
+```
 
 -}
 minContent : Value { provides | minContent : Supported }
@@ -14132,7 +14211,9 @@ minContent =
 
   - [`flexBasis`](#flexBasis)
 
-    width maxContent
+```
+width maxContent
+```
 
 -}
 maxContent : Value { provides | maxContent : Supported }
@@ -14148,7 +14229,9 @@ maxContent =
 
   - [`flexBasis`](#flexBasis)
 
-    width fitContent
+```
+width fitContent
+```
 
 -}
 fitContent : Value { provides | fitContent : Supported }
@@ -16841,6 +16924,7 @@ can use for this property.
     contain4 size layout style paint
 
 **Note: The `style` value is considered at-risk from being depreciated.**
+
 -}
 contain4 :
     Value
@@ -16909,6 +16993,7 @@ layout =
     contain style
 
     fontSynthesis style
+
 -}
 style : Value { provides | style : Supported }
 style =

--- a/src/Css.elm
+++ b/src/Css.elm
@@ -188,9 +188,6 @@ module Css exposing
     -- gaps
     , gap, gap2, rowGap, columnGap
 
-    -- color
-    , color
-
     -- backgrounds
     , backgroundColor
     , backgroundAttachment, backgroundAttachments, local
@@ -214,7 +211,8 @@ module Css exposing
     , fontFamily, fontFamilies
     , serif, sansSerif, monospace, cursive, fantasy, systemUi
 
-    -- Font style, weight + stretch
+    -- Font color, style, weight + stretch
+    , color
     , fontStyle, italic, oblique
     , fontWeight, bold, lighter, bolder
     , fontStretch, ultraCondensed, extraCondensed, condensed, semiCondensed, semiExpanded, expanded, extraExpanded, ultraExpanded
@@ -378,11 +376,16 @@ module Css exposing
     , neswResize, nwseResize, zoomIn, zoomOut, grab, grabbing
     , caretColor
 
-    -- shadows and gradients
-    , BoxShadowConfig, boxShadow, boxShadows, defaultBoxShadow
-    , TextShadowConfig, textShadow, defaultTextShadow
-    , linearGradient, linearGradient2, stop, stop2, stop3, toBottom, toBottomLeft, toBottomRight, toLeft, toRight, toTop, toTopLeft, toTopRight
+    -- gradients
+    , linearGradient, linearGradient2
+    , stop, stop2, stop3, toBottom, toBottomLeft, toBottomRight, toLeft, toRight, toTop, toTopLeft, toTopRight
 
+    -- shadows
+    , BoxShadowConfig
+    , boxShadow, boxShadows, defaultBoxShadow
+    , TextShadowConfig
+    , textShadow, defaultTextShadow
+    
     -- transformations and perspective
     , TransformFunction, TransformFunctionSupported
     , transform, transforms
@@ -390,8 +393,8 @@ module Css exposing
     , transformBox
     , matrix, matrix3d
     , scale, scale2, scale3, scale_, scale2_, scaleX, scaleY, scaleZ, scale3d
-    , skew, skew2, skewX, skewY
     , rotate, rotate2, rotate_, rotateX, rotateY, rotateZ, rotate3d, vec3
+    , skew, skew2, skewX, skewY
     , translate, translate2, translateX, translateY, translateZ, translate3d
     , perspective, perspectiveOrigin, perspectiveOrigin2
     , perspective_
@@ -409,7 +412,7 @@ module Css exposing
     , EasingFunction, EasingFunctionSupported
     , linear, ease, easeIn, easeOut, easeInOut, cubicBezier, stepStart, stepEnd, steps, steps2, jumpStart, jumpEnd, jumpNone, jumpBoth, infinite, reverse, alternate, alternateReverse, running, paused, forwards, backwards
 
-    -- visual stuff??
+    -- visual stuff
     , opacity
     , visibility
     , mixBlendMode
@@ -544,10 +547,15 @@ functions let you define custom properties and selectors, respectively.
 
 @docs Color, ColorSupported, hex, rgb, rgba, hsl, hsla, currentcolor
 
-## Shapes
+## Images & Shapes
 
+@docs Image, ImageSupported
 @docs BasicShape, BasicShapeSupported
 @docs circle, circleAt, circleAt2, ellipse, ellipseAt, ellipseAt2, closestSide, farthestSide, polygon, path
+
+## Lines
+@docs LineStyle, LineStyleSupported
+@docs LineWidth, LineWidthSupported
 
 ## Resolution
 
@@ -952,8 +960,9 @@ Other values you can use for flex item alignment:
 @docs fontFamily, fontFamilies
 @docs serif, sansSerif, monospace, cursive, fantasy, systemUi
 
-## Font style, weight & stretch
+## Font color, style, weight & stretch
 
+@docs color
 @docs fontStyle, italic, oblique
 @docs fontWeight, bold, lighter, bolder
 @docs fontStretch, ultraCondensed, extraCondensed, condensed, semiCondensed, semiExpanded, expanded, extraExpanded, ultraExpanded
@@ -1267,102 +1276,91 @@ Other values you can use for flex item alignment:
 ------------------------------------------------------
 
 
+# Gradients
+
+@docs linearGradient, linearGradient2
+@docs stop, stop2, stop3, toBottom, toBottomLeft, toBottomRight, toLeft, toRight, toTop, toTopLeft, toTopRight
 
 
+------------------------------------------------------
 
 
+# Shadows
+
+@docs BoxShadowConfig
+@docs boxShadow, boxShadows, defaultBoxShadow
+@docs TextShadowConfig
+@docs textShadow, defaultTextShadow
 
 
-
-
-
-
-
-
-
-
-
+------------------------------------------------------
 
 
 # Transformation
 
-@docs transform, transforms, transformOrigin, transformOrigin2, transformBox
 @docs TransformFunction, TransformFunctionSupported
-
+@docs transform, transforms
+@docs transformOrigin, transformOrigin2
+@docs transformBox
 
 ## Matrix transformation
 
 @docs matrix, matrix3d
 
+## Scaling (resizing)
+
+@docs scale, scale2, scale3, scale_, scale2_, scaleX, scaleY, scaleZ, scale3d
+
+## Rotation
+
+@docs rotate, rotate2, rotate_, rotateX, rotateY, rotateZ, rotate3d, vec3
+
+## Skewing (distortion)
+
+@docs skew, skew2, skewX, skewY
+
+## Translation (moving)
+
+@docs translate, translate2, translateX, translateY, translateZ, translate3d
 
 ## Perspective
 
 @docs perspective, perspectiveOrigin, perspectiveOrigin2
 @docs perspective_
 
+## 3D Rendering options
 
-## Rotation
-
-@docs rotate, rotate2, rotate_, rotateX, rotateY, rotateZ, rotate3d, vec3
-
-
-## Scaling (resizing)
-
-@docs scale, scale2, scale3, scale_, scale2_, scaleX, scaleY, scaleZ, scale3d
+@docs backfaceVisibility
 
 
-## Skewing (distortion)
-
-@docs skew, skew2, skewX, skewY
-
-
-## Translation (moving)
-
-@docs translate, translate2, translateX, translateY, translateZ, translate3d
+------------------------------------------------------
 
 
 # Animation
 
-@docs animationName, animationNames, animationDuration, animationDurations, animationTimingFunction, animationTimingFunctions, animationIterationCount, animationIterationCounts, animationDirection, animationDirections, animationPlayState, animationPlayStates, animationDelay, animationDelays, animationFillMode, animationFillModes
-@docs EasingFunction, EasingFunctionSupported, linear, ease, easeIn, easeOut, easeInOut, cubicBezier, stepStart, stepEnd, steps, steps2, jumpStart, jumpEnd, jumpNone, jumpBoth, infinite, reverse, alternate, alternateReverse, running, paused, forwards, backwards
+@docs animationName, animationNames
+@docs animationDuration, animationDurations
+@docs animationTimingFunction, animationTimingFunctions
+@docs animationIterationCount, animationIterationCounts
+@docs animationDirection, animationDirections
+@docs animationPlayState, animationPlayStates
+@docs animationDelay, animationDelays
+@docs animationFillMode, animationFillModes
+@docs EasingFunction, EasingFunctionSupported
+@docs linear, ease, easeIn, easeOut, easeInOut, cubicBezier, stepStart, stepEnd, steps, steps2, jumpStart, jumpEnd, jumpNone, jumpBoth, infinite, reverse, alternate, alternateReverse, running, paused, forwards, backwards
 
 
-# Opacity
+------------------------------------------------------
+
+
+# Visual stuff
 
 @docs opacity
-
-# Rendering
-
-@docs mixBlendMode
-@docs imageRendering, crispEdges, pixelated
-@docs backfaceVisibility
-@docs clipPath, clipPath2
-
-
-# Other / stuff I'm adding to make the compiled result valid while I work on this rewrite
-
-
-@docs BoxShadowConfig, boxShadow, boxShadows, defaultBoxShadow, Image, ImageSupported, LineStyle, LineStyleSupported
-@docs LineWidth, LineWidthSupported
-@docs TextShadowConfig, color, defaultTextShadow
-@docs linearGradient, linearGradient2, stop, stop2, stop3, textShadow
-@docs toBottom, toBottomLeft, toBottomRight, toLeft, toRight, toTop, toTopLeft, toTopRight
 @docs visibility
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+@docs mixBlendMode
+@docs imageRendering
+@docs crispEdges, pixelated
+@docs clipPath, clipPath2
 
 
 ------------------------------------------------------
@@ -10757,35 +10755,6 @@ columnGap (Value widthVal) =
 ------------------------------------------------------------------------
 ------------------------------------------------------------------------
 ------------------------------------------------------------------------
---------------------------------- COLOR --------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-
-
-{-| Sets [`color`](https://css-tricks.com/almanac/properties/c/color/).
-
-    color (hex "#60b5cc")
-
-    color (rgb 96 181 204)
-
-    color (rgba 96 181 204 0.5)
-
--}
-color : BaseValue Color -> Style
-color (Value val) =
-    AppendProperty ("color:" ++ val)
-
-
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
 --------------------------- BACKGROUND ---------------------------------
 ------------------------------------------------------------------------
 ------------------------------------------------------------------------
@@ -11510,6 +11479,20 @@ backgroundSize2 (Value widthVal) (Value heightVal) =
 ------------------------------------------------------------------------
 ------------------------------------------------------------------------
 ------------------------------------------------------------------------
+
+
+{-| Sets [`color`](https://css-tricks.com/almanac/properties/c/color/).
+
+    color (hex "#60b5cc")
+
+    color (rgb 96 181 204)
+
+    color (rgba 96 181 204 0.5)
+
+-}
+color : BaseValue Color -> Style
+color (Value val) =
+    AppendProperty ("color:" ++ val)
 
 
 {-| Sets [`font-size`](https://css-tricks.com/almanac/properties/f/font-size/)
@@ -17947,285 +17930,6 @@ caretColor (Value val) =
 ------------------------------------------------------------------------
 ------------------------------------------------------------------------
 ------------------------------------------------------------------------
------------------------------- BOX-SHADOW ------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-
-
-{-| Configuration for [`boxShadow`](#boxShadow).
--}
-type alias BoxShadowConfig =
-    { offsetX :
-        Value
-            (LengthSupported
-                { pct : Supported
-                }
-            )
-    , offsetY :
-        Value
-            (LengthSupported
-                { pct : Supported
-                }
-            )
-    , blurRadius :
-        Maybe
-            (Value
-                (LengthSupported
-                    { pct : Supported
-                    }
-                )
-            )
-    , spreadRadius :
-        Maybe
-            (Value
-                (LengthSupported
-                    { pct : Supported
-                    }
-                )
-            )
-    , color :
-        Maybe (Value Color)
-    , inset : Bool
-    }
-
-
-{-| Default [`boxShadow`](#boxShadow) configuration.
-
-It is equivalent to the following CSS:
-
-    box-shadow: 0 0;
-
--}
-defaultBoxShadow : BoxShadowConfig
-defaultBoxShadow =
-    { offsetX = zero
-    , offsetY = zero
-    , blurRadius = Nothing
-    , spreadRadius = Nothing
-    , color = Nothing
-    , inset = False
-    }
-
-
-{-| The [`box-shadow`](https://css-tricks.com/almanac/properties/b/box-shadow/) property.
-
-    boxShadow initial
-
-    boxShadow none
-
-For defining shadows look at [`boxShadows`](#boxShadows).
-
--}
-boxShadow : BaseValue { none : Supported } -> Style
-boxShadow (Value val) =
-    AppendProperty ("box-shadow:" ++ val)
-
-
-{-| Sets [`box-shadow`](https://css-tricks.com/almanac/properties/b/box-shadow/).
-
-    boxShadows [] -- "box-shadow: none"
-
-    -- "box-shadow: 3px 5px #aabbcc"
-    button
-        [ css
-            [ boxShadows
-                [ { defaultBoxShadow
-                    | offsetX = px 3
-                    , offsetY = px 5
-                    , color = Just (hex "#aabbcc")
-                  }
-                ]
-            ]
-        ]
-        [ text "Zap!" ]
-
--}
-boxShadows : List BoxShadowConfig -> Style
-boxShadows configs =
-    let
-        value =
-            case configs of
-                [] ->
-                    "none"
-
-                _ ->
-                    configs
-                        |> List.map boxShadowConfigToString
-                        |> String.join ", "
-    in
-    AppendProperty ("box-shadow:" ++ value)
-
-
-boxShadowConfigToString : BoxShadowConfig -> String
-boxShadowConfigToString config =
-    let
-        (Value offsetX) =
-            config.offsetX
-
-        (Value offsetY) =
-            config.offsetY
-
-        blurRadius =
-            case config.blurRadius of
-                Just (Value value) ->
-                    " " ++ value
-
-                Nothing ->
-                    case config.spreadRadius of
-                        Just _ ->
-                            " 0"
-
-                        Nothing ->
-                            ""
-
-        spreadRadius =
-            case config.spreadRadius of
-                Just (Value value) ->
-                    " " ++ value
-
-                Nothing ->
-                    ""
-
-        insetStr =
-            if config.inset then
-                "inset "
-
-            else
-                ""
-
-        colorVal =
-            config.color
-                |> Maybe.map (unpackValue >> (++) " ")
-                |> Maybe.withDefault ""
-    in
-    insetStr ++ offsetX ++ " " ++ offsetY ++ blurRadius ++ spreadRadius ++ colorVal
-
-
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
------------------------------ TEXT SHADOW ------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-
-
-{-| Configuration for [`textShadow`](#textShadow).
--}
-type alias TextShadowConfig =
-    { offsetX :
-        Value
-            (LengthSupported
-                { pct : Supported
-                }
-            )
-    , offsetY :
-        Value
-            (LengthSupported
-                { pct : Supported
-                }
-            )
-    , blurRadius :
-        Maybe
-            (Value
-                (LengthSupported
-                    { pct : Supported
-                    }
-                )
-            )
-    , color : Maybe (Value Color)
-    }
-
-
-{-| Default [`textShadow`](#textShadow) configuration.
-
-It is equivalent to the following CSS:
-
-    text-shadow: 0 0;
-
--}
-defaultTextShadow : TextShadowConfig
-defaultTextShadow =
-    { offsetX = zero
-    , offsetY = zero
-    , blurRadius = Nothing
-    , color = Nothing
-    }
-
-
-{-| Sets [`text-shadow`](https://css-tricks.com/almanac/properties/t/text-shadow/).
-
-    textShadow [] -- "text-shadow: none"
-
-    -- "text-shadow: 3px 5px #aabbcc"
-    span
-        [ css
-            [ textShadow
-                [ { defaultTextShadow
-                    | offsetX = px 3
-                    , offsetY = px 5
-                    , color = Just (hex "#aabbcc")
-                  }
-                ]
-            ]
-        ]
-        [ text "Zap!" ]
-
--}
-textShadow : List TextShadowConfig -> Style
-textShadow configs =
-    let
-        values =
-            case configs of
-                [] ->
-                    "none"
-
-                _ ->
-                    configs
-                        |> List.map textShadowConfigToString
-                        |> String.join ","
-    in
-    AppendProperty ("text-shadow:" ++ values)
-
-
-textShadowConfigToString : TextShadowConfig -> String
-textShadowConfigToString config =
-    let
-        offsetX =
-            unpackValue config.offsetX
-
-        offsetY =
-            unpackValue config.offsetY
-
-        blurRadius =
-            config.blurRadius
-                |> Maybe.map (unpackValue >> (++) " ")
-                |> Maybe.withDefault ""
-
-        colorSetting =
-            config.color
-                |> Maybe.map (unpackValue >> (++) " ")
-                |> Maybe.withDefault ""
-    in
-    offsetX ++ " " ++ offsetY ++ blurRadius ++ colorSetting
-
-
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
 ------------------------------ GRADIENTS -------------------------------
 ------------------------------------------------------------------------
 ------------------------------------------------------------------------
@@ -18464,6 +18168,270 @@ If you want your gradient to go to a side, use [`toTop`](#toTop) or [`toRight`](
 toTopRight : Value { provides | toTopRight : Supported }
 toTopRight =
     Value "to top right"
+
+
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+-------------------------------- SHADOWS -------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+
+
+{-| Configuration for [`boxShadow`](#boxShadow).
+-}
+type alias BoxShadowConfig =
+    { offsetX :
+        Value
+            (LengthSupported
+                { pct : Supported
+                }
+            )
+    , offsetY :
+        Value
+            (LengthSupported
+                { pct : Supported
+                }
+            )
+    , blurRadius :
+        Maybe
+            (Value
+                (LengthSupported
+                    { pct : Supported
+                    }
+                )
+            )
+    , spreadRadius :
+        Maybe
+            (Value
+                (LengthSupported
+                    { pct : Supported
+                    }
+                )
+            )
+    , color :
+        Maybe (Value Color)
+    , inset : Bool
+    }
+
+
+{-| Default [`boxShadow`](#boxShadow) configuration.
+
+It is equivalent to the following CSS:
+
+    box-shadow: 0 0;
+
+-}
+defaultBoxShadow : BoxShadowConfig
+defaultBoxShadow =
+    { offsetX = zero
+    , offsetY = zero
+    , blurRadius = Nothing
+    , spreadRadius = Nothing
+    , color = Nothing
+    , inset = False
+    }
+
+
+{-| The [`box-shadow`](https://css-tricks.com/almanac/properties/b/box-shadow/) property.
+
+    boxShadow initial
+
+    boxShadow none
+
+For defining shadows look at [`boxShadows`](#boxShadows).
+
+-}
+boxShadow : BaseValue { none : Supported } -> Style
+boxShadow (Value val) =
+    AppendProperty ("box-shadow:" ++ val)
+
+
+{-| Sets [`box-shadow`](https://css-tricks.com/almanac/properties/b/box-shadow/).
+
+    boxShadows [] -- "box-shadow: none"
+
+    -- "box-shadow: 3px 5px #aabbcc"
+    button
+        [ css
+            [ boxShadows
+                [ { defaultBoxShadow
+                    | offsetX = px 3
+                    , offsetY = px 5
+                    , color = Just (hex "#aabbcc")
+                  }
+                ]
+            ]
+        ]
+        [ text "Zap!" ]
+
+-}
+boxShadows : List BoxShadowConfig -> Style
+boxShadows configs =
+    let
+        value =
+            case configs of
+                [] ->
+                    "none"
+
+                _ ->
+                    configs
+                        |> List.map boxShadowConfigToString
+                        |> String.join ", "
+    in
+    AppendProperty ("box-shadow:" ++ value)
+
+
+boxShadowConfigToString : BoxShadowConfig -> String
+boxShadowConfigToString config =
+    let
+        (Value offsetX) =
+            config.offsetX
+
+        (Value offsetY) =
+            config.offsetY
+
+        blurRadius =
+            case config.blurRadius of
+                Just (Value value) ->
+                    " " ++ value
+
+                Nothing ->
+                    case config.spreadRadius of
+                        Just _ ->
+                            " 0"
+
+                        Nothing ->
+                            ""
+
+        spreadRadius =
+            case config.spreadRadius of
+                Just (Value value) ->
+                    " " ++ value
+
+                Nothing ->
+                    ""
+
+        insetStr =
+            if config.inset then
+                "inset "
+
+            else
+                ""
+
+        colorVal =
+            config.color
+                |> Maybe.map (unpackValue >> (++) " ")
+                |> Maybe.withDefault ""
+    in
+    insetStr ++ offsetX ++ " " ++ offsetY ++ blurRadius ++ spreadRadius ++ colorVal
+
+
+{-| Configuration for [`textShadow`](#textShadow).
+-}
+type alias TextShadowConfig =
+    { offsetX :
+        Value
+            (LengthSupported
+                { pct : Supported
+                }
+            )
+    , offsetY :
+        Value
+            (LengthSupported
+                { pct : Supported
+                }
+            )
+    , blurRadius :
+        Maybe
+            (Value
+                (LengthSupported
+                    { pct : Supported
+                    }
+                )
+            )
+    , color : Maybe (Value Color)
+    }
+
+
+{-| Default [`textShadow`](#textShadow) configuration.
+
+It is equivalent to the following CSS:
+
+    text-shadow: 0 0;
+
+-}
+defaultTextShadow : TextShadowConfig
+defaultTextShadow =
+    { offsetX = zero
+    , offsetY = zero
+    , blurRadius = Nothing
+    , color = Nothing
+    }
+
+
+{-| Sets [`text-shadow`](https://css-tricks.com/almanac/properties/t/text-shadow/).
+
+    textShadow [] -- "text-shadow: none"
+
+    -- "text-shadow: 3px 5px #aabbcc"
+    span
+        [ css
+            [ textShadow
+                [ { defaultTextShadow
+                    | offsetX = px 3
+                    , offsetY = px 5
+                    , color = Just (hex "#aabbcc")
+                  }
+                ]
+            ]
+        ]
+        [ text "Zap!" ]
+
+-}
+textShadow : List TextShadowConfig -> Style
+textShadow configs =
+    let
+        values =
+            case configs of
+                [] ->
+                    "none"
+
+                _ ->
+                    configs
+                        |> List.map textShadowConfigToString
+                        |> String.join ","
+    in
+    AppendProperty ("text-shadow:" ++ values)
+
+
+textShadowConfigToString : TextShadowConfig -> String
+textShadowConfigToString config =
+    let
+        offsetX =
+            unpackValue config.offsetX
+
+        offsetY =
+            unpackValue config.offsetY
+
+        blurRadius =
+            config.blurRadius
+                |> Maybe.map (unpackValue >> (++) " ")
+                |> Maybe.withDefault ""
+
+        colorSetting =
+            config.color
+                |> Maybe.map (unpackValue >> (++) " ")
+                |> Maybe.withDefault ""
+    in
+    offsetX ++ " " ++ offsetY ++ blurRadius ++ colorSetting
 
 
 ------------------------------------------------------------------------
@@ -18980,60 +18948,6 @@ scale3d valX valY valZ =
     Value ("scale3d(" ++ String.fromFloat valX ++ "," ++ String.fromFloat valY ++ "," ++ String.fromFloat valZ ++ ")")
 
 
-
--- SKEWING (distortion)
-
-
-{-| Sets `skew` value for usage with [`transform`](#transform).
-
-    transform (skew (deg 30))
-
--}
-skew :
-    Value Angle
-    -> Value { provides | skew : Supported }
-skew (Value angle) =
-    Value ("skew(" ++ angle ++ ")")
-
-
-{-| Sets `skew` value for usage with [`transform`](#transform).
-
-    transform (skew2 (deg 30) (deg 10))
-
--}
-skew2 :
-    Value Angle
-    -> Value Angle
-    -> Value { provides | skew2 : Supported }
-skew2 (Value angle1) (Value angle2) =
-    Value ("skew(" ++ angle1 ++ "," ++ angle2 ++ ")")
-
-
-{-| Sets `skewX` value for usage with [`transform`](#transform).
-
-    transform (skewX (deg 30))
-
--}
-skewX :
-    Value Angle
-    -> Value { provides | skewX : Supported }
-skewX (Value angle) =
-    Value ("skewX(" ++ angle ++ ")")
-
-
-{-| Sets `skewY` value for usage with [`transform`](#transform).
-
-    transform (skewY (deg 30))
-
--}
-skewY :
-    Value Angle
-    -> Value { provides | skewY : Supported }
-skewY (Value angle) =
-    Value ("skewY(" ++ angle ++ ")")
-
-
-
 -- ROTATION
 
 
@@ -19180,6 +19094,58 @@ vec3 vec1Val vec2Val vec3Val =
             ++ " "
             ++ String.fromFloat vec3Val
         )
+
+
+-- SKEWING (distortion)
+
+
+{-| Sets `skew` value for usage with [`transform`](#transform).
+
+    transform (skew (deg 30))
+
+-}
+skew :
+    Value Angle
+    -> Value { provides | skew : Supported }
+skew (Value angle) =
+    Value ("skew(" ++ angle ++ ")")
+
+
+{-| Sets `skew` value for usage with [`transform`](#transform).
+
+    transform (skew2 (deg 30) (deg 10))
+
+-}
+skew2 :
+    Value Angle
+    -> Value Angle
+    -> Value { provides | skew2 : Supported }
+skew2 (Value angle1) (Value angle2) =
+    Value ("skew(" ++ angle1 ++ "," ++ angle2 ++ ")")
+
+
+{-| Sets `skewX` value for usage with [`transform`](#transform).
+
+    transform (skewX (deg 30))
+
+-}
+skewX :
+    Value Angle
+    -> Value { provides | skewX : Supported }
+skewX (Value angle) =
+    Value ("skewX(" ++ angle ++ ")")
+
+
+{-| Sets `skewY` value for usage with [`transform`](#transform).
+
+    transform (skewY (deg 30))
+
+-}
+skewY :
+    Value Angle
+    -> Value { provides | skewY : Supported }
+skewY (Value angle) =
+    Value ("skewY(" ++ angle ++ ")")
 
 
 -- PERSPECTIVE

--- a/src/Css.elm
+++ b/src/Css.elm
@@ -14,6 +14,7 @@ module Css exposing
     , Time, TimeSupported, s, ms
     , deg, grad, rad, turn
     , fr, minmax, fitContentTo
+    , customIdent
     , url
     , auto, none
     , left_, right_, top_, bottom_
@@ -95,6 +96,7 @@ module Css exposing
     , flexWrap, nowrap, wrap, wrapReverse
     , flex, flex2, flex3, flexFlow, flexFlow2
     , gridAutoRows, gridAutoColumns, gridAutoFlow, gridAutoFlow2, dense
+    , gridRowStart, gridRowStart2, gridRowStart3, gridRowEnd, gridRowEnd2, gridRowEnd3, gridColumnStart, gridColumnStart2, gridColumnStart3, gridColumnEnd, gridColumnEnd2, gridColumnEnd3, span
     , wordSpacing
     , tabSize
     , fontDisplay, fallback, swap, optional
@@ -122,7 +124,7 @@ module Css exposing
     , wResize, neResize, nwResize, seResize, swResize, ewResize, nsResize
     , neswResize, nwseResize, zoomIn, zoomOut, grab, grabbing
     , ListStyleType, ListStyleTypeSupported
-    , listStyle, listStyle2, listStyle3, listStylePosition, inside, outside, listStyleType, string, customIdent, listStyleImage
+    , listStyle, listStyle2, listStyle3, listStylePosition, inside, outside, listStyleType, string, listStyleImage
     , arabicIndic, armenian, bengali, cambodian, cjkDecimal, cjkEarthlyBranch, cjkHeavenlyStem, cjkIdeographic, decimal, decimalLeadingZero, devanagari, disclosureClosed, disclosureOpen, disc, ethiopicNumeric, georgian, gujarati, gurmukhi, hebrew, hiragana, hiraganaIroha, japaneseFormal, japaneseInformal, kannada, katakana, katakanaIroha, khmer, koreanHangulFormal, koreanHanjaFormal, koreanHanjaInformal, lao, lowerAlpha, lowerArmenian, lowerGreek, lowerLatin, lowerRoman, malayalam, monogolian, myanmar, oriya, persian, simpChineseFormal, simpChineseInformal, tamil, telugu, thai, tibetan, tradChineseFormal, tradChineseInformal, upperAlpha, upperArmenian, upperLatin, upperRoman
     , overflow, overflowX, overflowY, overflowBlock, overflowInline
     , overflowAnchor
@@ -287,6 +289,11 @@ All CSS properties can have the values `unset`, `initial`, `inherit` and `revert
 ## Flex
 
 @docs fr, minmax, fitContentTo
+
+
+## Ident
+
+@docs customIdent
 
 ## URLs
 
@@ -607,6 +614,7 @@ Other values you can use for flex item alignment:
 # Grid
 
 @docs gridAutoRows, gridAutoColumns, gridAutoFlow, gridAutoFlow2, dense
+@docs gridRowStart, gridRowStart2, gridRowStart3, gridRowEnd, gridRowEnd2, gridRowEnd3, gridColumnStart, gridColumnStart2, gridColumnStart3, gridColumnEnd, gridColumnEnd2, gridColumnEnd3, span
 
 
 # Typography
@@ -706,7 +714,7 @@ Other values you can use for flex item alignment:
 # List Style
 
 @docs ListStyleType, ListStyleTypeSupported
-@docs listStyle, listStyle2, listStyle3, listStylePosition, inside, outside, listStyleType, string, customIdent, listStyleImage
+@docs listStyle, listStyle2, listStyle3, listStylePosition, inside, outside, listStyleType, string, listStyleImage
 @docs arabicIndic, armenian, bengali, cambodian, cjkDecimal, cjkEarthlyBranch, cjkHeavenlyStem, cjkIdeographic, decimal, decimalLeadingZero, devanagari, disclosureClosed, disclosureOpen, disc, ethiopicNumeric, georgian, gujarati, gurmukhi, hebrew, hiragana, hiraganaIroha, japaneseFormal, japaneseInformal, kannada, katakana, katakanaIroha, khmer, koreanHangulFormal, koreanHanjaFormal, koreanHanjaInformal, lao, lowerAlpha, lowerArmenian, lowerGreek, lowerLatin, lowerRoman, malayalam, monogolian, myanmar, oriya, persian, simpChineseFormal, simpChineseInformal, tamil, telugu, thai, tibetan, tradChineseFormal, tradChineseInformal, upperAlpha, upperArmenian, upperLatin, upperRoman
 
 [`square`](#square) is also a supported value for [`listStyle`](#listStyle) and [`listStyleType`](#listStyleType).
@@ -1804,6 +1812,24 @@ fitContentTo (Value val) =
     Value <| "fit-content(" ++ val ++ ")"
 
 
+-- IDENT --
+
+{-| Produces an [`custom-ident`](https://developer.mozilla.org/en-US/docs/Web/CSS/custom-ident)
+value used by properties including (but not limited to) [`listStyle`](#listStyle),
+[`listStyleType`](#listStyleType) and [`gridColumnEnd2`](#gridColumnEnd2).
+
+    listStyleType (customIdent "hello-world")
+
+    gridColumnEnd2 span (customIdent "hello-world")
+
+**Note:** This method does not do any checking if the identifierer supplied is valid.
+
+-}
+customIdent : String -> Value { provides | customIdent : Supported }
+customIdent =
+    Value
+
+    
 -- SHARED VALUES --
 
 
@@ -6942,6 +6968,7 @@ gridAutoFlow2 (Value val1) (Value val2) =
         ++ val2
 
 
+
 {-| The `dense` value for the [`grid-auto-flow`](#gridAutoFlow) property.
 
     gridAutoFlow dense
@@ -6952,6 +6979,309 @@ gridAutoFlow2 (Value val1) (Value val2) =
 dense : Value { provides | dense : Supported }
 dense =
     Value "dense"
+
+
+{-| The 1-argument version of the [`grid-row-start`](https://css-tricks.com/almanac/properties/g/grid-row-start/)
+property.
+
+    gridRowStart (customIdent "big-grid")
+
+    gridRowStart auto
+
+    gridRowStart2 span (int 3)
+
+    gridRowStart2 (customIdent "big-grid") (int 2)
+
+    gridRowStart3 span (customIdent "big-grid") (int 2)
+-}
+gridRowStart :
+    BaseValue (
+        { auto : Supported
+        , customIdent : Supported
+        , int : Supported
+        }
+    )
+    -> Style
+gridRowStart (Value val) =
+    AppendProperty ("grid-row-start:" ++ val)
+
+
+{-| The 2-argument version of [`gridRowStart`](#gridRowStart).
+
+    gridRowStart2 span (customIdent "big-grid")
+
+    gridRowStart2 span (int 3)
+
+    gridRowStart2 (customIdent "big-grid") (int 2)
+-}
+gridRowStart2 :
+    Value
+        { customIdent : Supported
+        , span : Supported
+        }
+    -> Value
+        { int : Supported
+        , customIdent : Supported
+        }
+    -> Style
+gridRowStart2 (Value val1) (Value val2) =
+    AppendProperty ("grid-row-start:" ++ val1 ++ " " ++ val2)
+
+
+{-| The 3-argument version of [`gridRowStart`](#gridRowStart).
+
+    gridRowStart3 span (customIdent "big-grid") (int 2)
+-}
+gridRowStart3 :
+    Value
+        { span : Supported
+        }
+    -> Value
+        { customIdent : Supported
+        }
+    -> Value
+        { int : Supported }
+    -> Style
+gridRowStart3 (Value val1) (Value val2) (Value val3) =
+    AppendProperty <|
+        "grid-row-start:"
+        ++ val1
+        ++ " "
+        ++ val2
+        ++ " "
+        ++ val3
+
+
+{-| The 1-argument version of the [`grid-row-end`](https://css-tricks.com/almanac/properties/g/grid-row-end/)
+property.
+
+    gridRowEnd (customIdent "big-grid")
+
+    gridRowEnd auto
+
+    gridRowEnd2 span (int 3)
+
+    gridRowEnd2 (customIdent "big-grid") (int 2)
+
+    gridRowEnd3 span (customIdent "big-grid") (int 2)
+-}
+gridRowEnd :
+    BaseValue (
+        { auto : Supported
+        , customIdent : Supported
+        , int : Supported
+        }
+    )
+    -> Style
+gridRowEnd (Value val) =
+    AppendProperty ("grid-row-end:" ++ val)
+
+
+{-| The 2-argument version of [`gridRowEnd`](#gridRowEnd).
+
+    gridRowEnd2 span (customIdent "big-grid")
+
+    gridRowEnd2 span (int 3)
+
+    gridRowEnd2 (customIdent "big-grid") (int 2)
+-}
+gridRowEnd2 :
+    Value
+        { customIdent : Supported
+        , span : Supported
+        }
+    -> Value
+        { int : Supported
+        , customIdent : Supported
+        }
+    -> Style
+gridRowEnd2 (Value val1) (Value val2) =
+    AppendProperty ("grid-row-end:" ++ val1 ++ " " ++ val2)
+
+
+{-| The 3-argument version of [`gridRowEnd`](#gridRowEnd).
+
+    gridRowEnd3 span (customIdent "big-grid") (int 2)
+-}
+gridRowEnd3 :
+    Value
+        { span : Supported
+        }
+    -> Value
+        { customIdent : Supported
+        }
+    -> Value
+        { int : Supported }
+    -> Style
+gridRowEnd3 (Value val1) (Value val2) (Value val3) =
+    AppendProperty <|
+        "grid-row-end:"
+        ++ val1
+        ++ " "
+        ++ val2
+        ++ " "
+        ++ val3
+
+
+{-| The 1-argument version of the [`grid-column-start`](https://css-tricks.com/almanac/properties/g/grid-column-start/)
+property.
+
+    gridColumnStart (customIdent "big-grid")
+
+    gridColumnStart auto
+
+    gridColumnStart2 span (int 3)
+
+    gridColumnStart2 (customIdent "big-grid") (int 2)
+
+    gridColumnStart3 span (customIdent "big-grid") (int 2)
+-}
+gridColumnStart :
+    BaseValue (
+        { auto : Supported
+        , customIdent : Supported
+        , int : Supported
+        }
+    )
+    -> Style
+gridColumnStart (Value val) =
+    AppendProperty ("grid-column-start:" ++ val)
+
+
+{-| The 2-argument version of [`gridColumnStart`](#gridColumnStart).
+
+    gridColumnStart2 span (customIdent "big-grid")
+
+    gridColumnStart2 span (int 3)
+
+    gridColumnStart2 (customIdent "big-grid") (int 2)
+-}
+gridColumnStart2 :
+    Value
+        { customIdent : Supported
+        , span : Supported
+        }
+    -> Value
+        { int : Supported
+        , customIdent : Supported
+        }
+    -> Style
+gridColumnStart2 (Value val1) (Value val2) =
+    AppendProperty ("grid-column-start:" ++ val1 ++ " " ++ val2)
+
+
+{-| The 3-argument version of [`gridColumnStart`](#gridColumnStart).
+
+    gridColumnStart3 span (customIdent "big-grid") (int 2)
+-}
+gridColumnStart3 :
+    Value
+        { span : Supported
+        }
+    -> Value
+        { customIdent : Supported
+        }
+    -> Value
+        { int : Supported }
+    -> Style
+gridColumnStart3 (Value val1) (Value val2) (Value val3) =
+    AppendProperty <|
+        "grid-column-start:"
+        ++ val1
+        ++ " "
+        ++ val2
+        ++ " "
+        ++ val3
+
+
+{-| The 1-argument version of the [`grid-column-end`](https://css-tricks.com/almanac/properties/g/grid-column-end/)
+property.
+
+    gridColumnEnd (customIdent "big-grid")
+
+    gridColumnEnd auto
+
+    gridColumnEnd2 span (int 3)
+
+    gridColumnEnd2 (customIdent "big-grid") (int 2)
+
+    gridColumnEnd3 span (customIdent "big-grid") (int 2)
+-}
+gridColumnEnd :
+    BaseValue (
+        { auto : Supported
+        , customIdent : Supported
+        , int : Supported
+        }
+    )
+    -> Style
+gridColumnEnd (Value val) =
+    AppendProperty ("grid-column-end:" ++ val)
+
+
+{-| The 2-argument version of [`gridColumnEnd`](#gridColumnEnd).
+
+    gridColumnEnd2 span (customIdent "big-grid")
+
+    gridColumnEnd2 span (int 3)
+
+    gridColumnEnd2 (customIdent "big-grid") (int 2)
+-}
+gridColumnEnd2 :
+    Value
+        { customIdent : Supported
+        , span : Supported
+        }
+    -> Value
+        { int : Supported
+        , customIdent : Supported
+        }
+    -> Style
+gridColumnEnd2 (Value val1) (Value val2) =
+    AppendProperty ("grid-column-end:" ++ val1 ++ " " ++ val2)
+
+
+{-| The 3-argument version of [`gridColumnEnd`](#gridColumnEnd).
+
+    gridColumnEnd3 span (customIdent "big-grid") (int 2)
+-}
+gridColumnEnd3 :
+    Value
+        { span : Supported
+        }
+    -> Value
+        { customIdent : Supported
+        }
+    -> Value
+        { int : Supported }
+    -> Style
+gridColumnEnd3 (Value val1) (Value val2) (Value val3) =
+    AppendProperty <|
+        "grid-column-end:"
+        ++ val1
+        ++ " "
+        ++ val2
+        ++ " "
+        ++ val3
+
+
+{-| The `span` value for the following properties:
+
+-   [`gridRowStart2`](#gridRowStart2)
+-   [`gridRowStart3`](#gridRowStart3)
+-   [`gridRowEnd2`](#gridRowEnd2)
+-   [`gridRowEnd3`](#gridRowEnd3)
+-   [`gridColumnStart2`](#gridColumnStart2)
+-   [`gridColumnStart3`](#gridColumnStart3)
+-   [`gridColumnEnd2`](#gridColumnEnd2)
+-   [`gridColumnEnd3`](#gridColumnEnd3)
+```
+    gridColumnEnd3 span (customIdent "big-grid") (int 2)
+```
+-}
+span : Value { provides | span : Supported }
+span =
+    Value "span"
 
 
 -- FONT SIZE --
@@ -9668,18 +9998,6 @@ listStyleType (Value val) =
     AppendProperty ("list-style-type:" ++ val)
 
 
-{-| Produces an [`custom-ident`](https://developer.mozilla.org/en-US/docs/Web/CSS/custom-ident)
-value used by properties such as [`listStyle`](#listStyle),
-and [`listStyleType`](#listStyleType)
-
-    listStyleType (customIdent "hello-world")
-
-**Note:** This method does not do any checking if the identifierer supplied is valid.
-
--}
-customIdent : String -> Value { provides | customIdent : Supported }
-customIdent =
-    Value
 
 
 {-| The [`list-style-image`](https://developer.mozilla.org/en-US/docs/Web/CSS/list-style-image) property.
@@ -13556,8 +13874,8 @@ columnSpan :
         , all_ : Supported
         }
     -> Style
-columnSpan (Value span) =
-    AppendProperty ("column-span:" ++ span)
+columnSpan (Value spanVal) =
+    AppendProperty ("column-span:" ++ spanVal)
 
 
 {-| Sets [`column-rule-width`](https://www.w3.org/TR/css-multicol-1/#propdef-column-rule-width)

--- a/src/Css.elm
+++ b/src/Css.elm
@@ -55,7 +55,7 @@ module Css exposing
     , thin, thick
     , borderStyle, borderStyle2, borderStyle3, borderStyle4, borderTopStyle, borderRightStyle, borderBottomStyle, borderLeftStyle
     , borderBlockStyle, borderBlockStartStyle, borderBlockEndStyle, borderInlineStyle, borderInlineStartStyle, borderInlineEndStyle
-    , dotted, dashed, solid, double, groove, ridge, inset, outset
+    , dotted, dashed, solid, double, groove, ridge, inset_, outset
     , borderColor, borderColor2, borderColor3, borderColor4, borderTopColor, borderRightColor, borderBottomColor, borderLeftColor
     , borderBlockColor, borderBlockStartColor, borderBlockEndColor, borderInlineColor, borderInlineStartColor, borderInlineEndColor
     , borderRadius, borderRadius2, borderRadius3, borderRadius4, borderTopLeftRadius, borderTopLeftRadius2, borderTopRightRadius, borderTopRightRadius2, borderBottomRightRadius, borderBottomRightRadius2, borderBottomLeftRadius, borderBottomLeftRadius2
@@ -388,7 +388,7 @@ Many different kinds of CSS properties use these keyword values.
 
 @docs borderBlockStyle, borderBlockStartStyle, borderBlockEndStyle, borderInlineStyle, borderInlineStartStyle, borderInlineEndStyle
 
-@docs dotted, dashed, solid, double, groove, ridge, inset, outset
+@docs dotted, dashed, solid, double, groove, ridge, inset_, outset
 
 
 ## Border Color
@@ -9710,8 +9710,8 @@ borderBlock (Value widthVal) =
 
 -}
 borderBlock2 : Value LineWidth -> Value LineStyle -> Style
-borderBlock2 (Value widthVal) (Value style) =
-    AppendProperty ("border-block:" ++ widthVal ++ " " ++ style)
+borderBlock2 (Value widthVal) (Value styleVal) =
+    AppendProperty ("border-block:" ++ widthVal ++ " " ++ styleVal)
 
 
 {-| Sets [`border-block`](https://css-tricks.com/almanac/properties/b/border-block/) property.
@@ -9724,8 +9724,8 @@ borderBlock2 (Value widthVal) (Value style) =
 
 -}
 borderBlock3 : Value LineWidth -> Value LineStyle -> Value Color -> Style
-borderBlock3 (Value widthVal) (Value style) (Value colorVal) =
-    AppendProperty ("border-block:" ++ widthVal ++ " " ++ style ++ " " ++ colorVal)
+borderBlock3 (Value widthVal) (Value styleVal) (Value colorVal) =
+    AppendProperty ("border-block:" ++ widthVal ++ " " ++ styleVal ++ " " ++ colorVal)
 
 
 {-| Sets [`border-block-start`](https://css-tricks.com/almanac/properties/b/border-block-start/) property.
@@ -9752,8 +9752,8 @@ borderBlockStart (Value widthVal) =
 
 -}
 borderBlockStart2 : Value LineWidth -> Value LineStyle -> Style
-borderBlockStart2 (Value widthVal) (Value style) =
-    AppendProperty ("border-block-start:" ++ widthVal ++ " " ++ style)
+borderBlockStart2 (Value widthVal) (Value styleVal) =
+    AppendProperty ("border-block-start:" ++ widthVal ++ " " ++ styleVal)
 
 
 {-| Sets [`border-block-start`](https://css-tricks.com/almanac/properties/b/border-block-start/) property.
@@ -9766,8 +9766,8 @@ borderBlockStart2 (Value widthVal) (Value style) =
 
 -}
 borderBlockStart3 : Value LineWidth -> Value LineStyle -> Value Color -> Style
-borderBlockStart3 (Value widthVal) (Value style) (Value colorVal) =
-    AppendProperty ("border-block-start:" ++ widthVal ++ " " ++ style ++ " " ++ colorVal)
+borderBlockStart3 (Value widthVal) (Value styleVal) (Value colorVal) =
+    AppendProperty ("border-block-start:" ++ widthVal ++ " " ++ styleVal ++ " " ++ colorVal)
 
 
 {-| Sets [`border-block-end`](https://css-tricks.com/almanac/properties/b/border-block-end/) property.
@@ -9794,8 +9794,8 @@ borderBlockEnd (Value widthVal) =
 
 -}
 borderBlockEnd2 : Value LineWidth -> Value LineStyle -> Style
-borderBlockEnd2 (Value widthVal) (Value style) =
-    AppendProperty ("border-block-end:" ++ widthVal ++ " " ++ style)
+borderBlockEnd2 (Value widthVal) (Value styleVal) =
+    AppendProperty ("border-block-end:" ++ widthVal ++ " " ++ styleVal)
 
 
 {-| Sets [`border-block-end`](https://css-tricks.com/almanac/properties/b/border-block-end/) property.
@@ -9808,8 +9808,8 @@ borderBlockEnd2 (Value widthVal) (Value style) =
 
 -}
 borderBlockEnd3 : Value LineWidth -> Value LineStyle -> Value Color -> Style
-borderBlockEnd3 (Value widthVal) (Value style) (Value colorVal) =
-    AppendProperty ("border-block-end:" ++ widthVal ++ " " ++ style ++ " " ++ colorVal)
+borderBlockEnd3 (Value widthVal) (Value styleVal) (Value colorVal) =
+    AppendProperty ("border-block-end:" ++ widthVal ++ " " ++ styleVal ++ " " ++ colorVal)
 
 
 {-| Sets [`border-inline`](https://css-tricks.com/almanac/properties/b/border-inline/) property.
@@ -9836,8 +9836,8 @@ borderInline (Value widthVal) =
 
 -}
 borderInline2 : Value LineWidth -> Value LineStyle -> Style
-borderInline2 (Value widthVal) (Value style) =
-    AppendProperty ("border-inline:" ++ widthVal ++ " " ++ style)
+borderInline2 (Value widthVal) (Value styleVal) =
+    AppendProperty ("border-inline:" ++ widthVal ++ " " ++ styleVal)
 
 
 {-| Sets [`border-inline`](https://css-tricks.com/almanac/properties/b/border-inline/) property.
@@ -9850,8 +9850,8 @@ borderInline2 (Value widthVal) (Value style) =
 
 -}
 borderInline3 : Value LineWidth -> Value LineStyle -> Value Color -> Style
-borderInline3 (Value widthVal) (Value style) (Value colorVal) =
-    AppendProperty ("border-inline:" ++ widthVal ++ " " ++ style ++ " " ++ colorVal)
+borderInline3 (Value widthVal) (Value styleVal) (Value colorVal) =
+    AppendProperty ("border-inline:" ++ widthVal ++ " " ++ styleVal ++ " " ++ colorVal)
 
 
 {-| Sets [`border-inline-start`](https://css-tricks.com/almanac/properties/b/border-inline-start/) property.
@@ -9878,8 +9878,8 @@ borderInlineStart (Value widthVal) =
 
 -}
 borderInlineStart2 : Value LineWidth -> Value LineStyle -> Style
-borderInlineStart2 (Value widthVal) (Value style) =
-    AppendProperty ("border-inline-start:" ++ widthVal ++ " " ++ style)
+borderInlineStart2 (Value widthVal) (Value styleVal) =
+    AppendProperty ("border-inline-start:" ++ widthVal ++ " " ++ styleVal)
 
 
 {-| Sets [`border-inline-start`](https://css-tricks.com/almanac/properties/b/border-inline-start/) property.
@@ -9892,8 +9892,8 @@ borderInlineStart2 (Value widthVal) (Value style) =
 
 -}
 borderInlineStart3 : Value LineWidth -> Value LineStyle -> Value Color -> Style
-borderInlineStart3 (Value widthVal) (Value style) (Value colorVal) =
-    AppendProperty ("border-inline-start:" ++ widthVal ++ " " ++ style ++ " " ++ colorVal)
+borderInlineStart3 (Value widthVal) (Value styleVal) (Value colorVal) =
+    AppendProperty ("border-inline-start:" ++ widthVal ++ " " ++ styleVal ++ " " ++ colorVal)
 
 
 {-| Sets [`border-inline-end`](https://css-tricks.com/almanac/properties/b/border-inline-end/) property.
@@ -9920,8 +9920,8 @@ borderInlineEnd (Value widthVal) =
 
 -}
 borderInlineEnd2 : Value LineWidth -> Value LineStyle -> Style
-borderInlineEnd2 (Value widthVal) (Value style) =
-    AppendProperty ("border-inline-end:" ++ widthVal ++ " " ++ style)
+borderInlineEnd2 (Value widthVal) (Value styleVal) =
+    AppendProperty ("border-inline-end:" ++ widthVal ++ " " ++ styleVal)
 
 
 {-| Sets [`border-inline-end`](https://css-tricks.com/almanac/properties/b/border-inline-end/) property.
@@ -9934,8 +9934,8 @@ borderInlineEnd2 (Value widthVal) (Value style) =
 
 -}
 borderInlineEnd3 : Value LineWidth -> Value LineStyle -> Value Color -> Style
-borderInlineEnd3 (Value widthVal) (Value style) (Value colorVal) =
-    AppendProperty ("border-inline-end:" ++ widthVal ++ " " ++ style ++ " " ++ colorVal)
+borderInlineEnd3 (Value widthVal) (Value styleVal) (Value colorVal) =
+    AppendProperty ("border-inline-end:" ++ widthVal ++ " " ++ styleVal ++ " " ++ colorVal)
 
 
 {-| Sets [`border-width`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-width) property.
@@ -10194,8 +10194,8 @@ borderLeftStyle (Value styleVal) =
 
 -}
 borderBlockStyle : BaseValue LineStyle -> Style
-borderBlockStyle (Value style) =
-    AppendProperty ("border-block-style:" ++ style)
+borderBlockStyle (Value styleVal) =
+    AppendProperty ("border-block-style:" ++ styleVal)
 
 
 {-| Sets [`border-block-start-style`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-block-start-style) property.
@@ -10204,8 +10204,8 @@ borderBlockStyle (Value style) =
 
 -}
 borderBlockStartStyle : BaseValue LineStyle -> Style
-borderBlockStartStyle (Value style) =
-    AppendProperty ("border-block-start-style:" ++ style)
+borderBlockStartStyle (Value styleVal) =
+    AppendProperty ("border-block-start-style:" ++ styleVal)
 
 
 {-| Sets [`border-block-end-style`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-block-end-style) property.
@@ -10214,8 +10214,8 @@ borderBlockStartStyle (Value style) =
 
 -}
 borderBlockEndStyle : BaseValue LineStyle -> Style
-borderBlockEndStyle (Value style) =
-    AppendProperty ("border-block-end-style:" ++ style)
+borderBlockEndStyle (Value styleVal) =
+    AppendProperty ("border-block-end-style:" ++ styleVal)
 
 
 {-| Sets [`border-inline-style`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-inline-style) property.
@@ -10224,8 +10224,8 @@ borderBlockEndStyle (Value style) =
 
 -}
 borderInlineStyle : BaseValue LineStyle -> Style
-borderInlineStyle (Value style) =
-    AppendProperty ("border-inline-style:" ++ style)
+borderInlineStyle (Value styleVal) =
+    AppendProperty ("border-inline-style:" ++ styleVal)
 
 
 {-| Sets [`border-inline-start-style`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-inline-start-style) property.
@@ -10234,8 +10234,8 @@ borderInlineStyle (Value style) =
 
 -}
 borderInlineStartStyle : BaseValue LineStyle -> Style
-borderInlineStartStyle (Value style) =
-    AppendProperty ("border-inline-start-style:" ++ style)
+borderInlineStartStyle (Value styleVal) =
+    AppendProperty ("border-inline-start-style:" ++ styleVal)
 
 
 {-| Sets [`border-inline-end-style`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-inline-end-style) property.
@@ -10244,8 +10244,8 @@ borderInlineStartStyle (Value style) =
 
 -}
 borderInlineEndStyle : BaseValue LineStyle -> Style
-borderInlineEndStyle (Value style) =
-    AppendProperty ("border-inline-end-style:" ++ style)
+borderInlineEndStyle (Value styleVal) =
+    AppendProperty ("border-inline-end-style:" ++ styleVal)
 
 
 {-| Sets [`border-color`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-color) property.

--- a/src/Css.elm
+++ b/src/Css.elm
@@ -6515,11 +6515,17 @@ backgroundSize2 (Value widthVal) (Value heightVal) =
     AppendProperty ("background-size:" ++ widthVal ++ " " ++ heightVal)
 
 
-{-| Sets [`contain`](https://css-tricks.com/almanac/properties/b/background-size/)
-for [`backgroundSize`](#backgroundSize). It always show the whole background
-image, even if it leaves empty spaces on the sides.
+{-| Sets `contain` for [`backgroundSize`](#backgroundSize) and [`overscrollBehavior`](#overscrollBehavior).
+
+For `backgroundSize`, this means this always shows the whole background image,
+even if it leaves empty spaces on the sides.
+
+For `overscrollBehavior`, this means that default scroll overflow behavior
+is observed inside the element, but scroll chaining will not happen to neighbouring elements.
 
     backgroundSize contain
+
+    overscrollBehavior contain
 
 -}
 contain : Value { provides | contain : Supported }

--- a/src/Css.elm
+++ b/src/Css.elm
@@ -131,7 +131,8 @@ module Css exposing
     , transform, transforms, transformOrigin, transformOrigin2
     , TransformFunction, TransformFunctionSupported
     , matrix, matrix3d
-    , perspective, perspective_
+    , perspective, perspectiveOrigin, perspectiveOrigin2
+    , perspective_
     , rotate, rotateX, rotateY, rotateZ, rotate3d
     , scale, scale2, scaleX, scaleY, scaleZ, scale3d
     , skew, skew2, skewX, skewY
@@ -626,8 +627,11 @@ Multiple CSS properties use these values.
 @docs strokeLinejoin, strokeLinejoin2, crop, arcs, miter, bevel
 @docs strokeDashJustify, compress, dashes, gaps
 
+
 ## Other
+
 @docs paintOrder, paintOrder2, paintOrder3, markers
+
 
 # Columns
 
@@ -641,6 +645,7 @@ Multiple CSS properties use these values.
 @docs transform, transforms, transformOrigin, transformOrigin2
 @docs TransformFunction, TransformFunctionSupported
 
+
 ## Matrix transformation
 
 @docs matrix, matrix3d
@@ -648,7 +653,7 @@ Multiple CSS properties use these values.
 
 ## Perspective
 
-@docs perspective
+@docs perspective, perspectiveOrigin, perspectiveOrigin2
 @docs perspective_
 
 
@@ -1323,8 +1328,6 @@ overflowY (Value val) =
 clip : Value { provides | clip : Supported }
 clip =
     Value "clip"
-
-
 
 
 {-| Sets [`overflow-wrap`](https://css-tricks.com/almanac/properties/o/overflow-wrap/)
@@ -10654,9 +10657,10 @@ painted first, followed by the other two in their relative default order.
 
     paintOrder normal -- normal paint order.
 
-    paintOrder2 fill_ stroke  -- fill, stroke, then markers.
+    paintOrder2 fill_ stroke -- fill, stroke, then markers.
 
-    paintOrder3 markers stroke fill_  -- markers, stroke, then fill.
+    paintOrder3 markers stroke fill_ -- markers, stroke, then fill.
+
 -}
 paintOrder :
     BaseValue
@@ -10675,6 +10679,7 @@ This two-argument version indicates which parts of text and shape graphics are
 painted first, followed by the other remaining one.
 
     paintOrder2 fill_ stroke -- fill, stroke, then markers.
+
 -}
 paintOrder2 :
     Value
@@ -10682,11 +10687,12 @@ paintOrder2 :
         , stroke : Supported
         , markers : Supported
         }
-    -> Value
-        { fill_ : Supported
-        , stroke : Supported
-        , markers : Supported
-        }
+    ->
+        Value
+            { fill_ : Supported
+            , stroke : Supported
+            , markers : Supported
+            }
     -> Style
 paintOrder2 (Value val1) (Value val2) =
     AppendProperty ("paint-order:" ++ val1 ++ " " ++ val2)
@@ -10697,7 +10703,8 @@ paintOrder2 (Value val1) (Value val2) =
 This three-argument version explicitly indicates in which order should all the parts of text
 and shape graphics be painted.
 
-    paintOrder3 markers stroke fill_  -- markers, stroke, then fill.
+    paintOrder3 markers stroke fill_ -- markers, stroke, then fill.
+
 -}
 paintOrder3 :
     Value
@@ -10705,16 +10712,18 @@ paintOrder3 :
         , stroke : Supported
         , markers : Supported
         }
-    -> Value
-        { fill_ : Supported
-        , stroke : Supported
-        , markers : Supported
-        }
-    -> Value
-        { fill_ : Supported
-        , stroke : Supported
-        , markers : Supported
-        }
+    ->
+        Value
+            { fill_ : Supported
+            , stroke : Supported
+            , markers : Supported
+            }
+    ->
+        Value
+            { fill_ : Supported
+            , stroke : Supported
+            , markers : Supported
+            }
     -> Style
 paintOrder3 (Value val1) (Value val2) (Value val3) =
     AppendProperty ("paint-order:" ++ val1 ++ " " ++ val2 ++ " " ++ val3)
@@ -10723,11 +10732,11 @@ paintOrder3 (Value val1) (Value val2) (Value val3) =
 {-| Provides the `markers` value for [`paintOrder`](#paintOrder).
 
     paintOrder markers
+
 -}
 markers : Value { provides | markers : Supported }
 markers =
     Value "markers"
-
 
 
 {-| Sets [`column-rule`](https://css-tricks.com/almanac/properties/c/column-rule/).
@@ -10878,6 +10887,7 @@ plusListToString head rest =
     (head :: rest)
         |> List.map unpackValue
         |> String.join " "
+
 
 
 -- MATRIX TRANSFORMATION
@@ -11278,10 +11288,11 @@ Negative values are not supported and any value smaller than 1px is clamped to 1
     perspective (px 100)
 
     perspective (rem 50)
+
 -}
 perspective :
     BaseValue
-        ( LengthSupported
+        (LengthSupported
             { none : Supported
             }
         )
@@ -11290,12 +11301,74 @@ perspective (Value val) =
     AppendProperty ("perspective:" ++ val)
 
 
+{-| The [`perspective-origin`](https://css-tricks.com/almanac/properties/p/perspective-origin/) property.
+
+This one-argument version either supports a global value or the x-position.
+
+    perspectiveOrigin inherit
+
+    perspectiveOrigin left_
+
+    perspectiveOrigin (pct 50)
+
+    perspectiveOrigin2 left_ center
+
+    perspectiveOrigin2 (rem 50) (pct 20)
+
+-}
+perspectiveOrigin :
+    BaseValue
+        (LengthSupported
+            { pct : Supported
+            , left_ : Supported
+            , center : Supported
+            , right_ : Supported
+            }
+        )
+    -> Style
+perspectiveOrigin (Value val) =
+    AppendProperty ("perspective-origin:" ++ val)
+
+
+{-| The [`perspective-origin`](https://css-tricks.com/almanac/properties/p/perspective-origin/) property.
+
+This two-argument version takes an X position and then a Y position.
+
+    pperspectiveOrigin2 left_ center
+
+    perspectiveOrigin2 (rem 50) (pct 20)
+
+-}
+perspectiveOrigin2 :
+    Value
+        (LengthSupported
+            { pct : Supported
+            , left_ : Supported
+            , center : Supported
+            , right_ : Supported
+            }
+        )
+    ->
+        Value
+            (LengthSupported
+                { pct : Supported
+                , top_ : Supported
+                , center : Supported
+                , bottom_ : Supported
+                }
+            )
+    -> Style
+perspectiveOrigin2 (Value xVal) (Value yVal) =
+    AppendProperty ("perspective-origin:" ++ xVal ++ " " ++ yVal)
+
+
 {-| Sets `perspective` value for usage with [`transform`](#transform).
 
     transform (perspective_ (px 17))
 
 The value is called `perspective_` instead of `perspective` because
 [`perspective`](#perspective) is already a function.
+
 -}
 perspective_ :
     Value Length
@@ -12787,7 +12860,7 @@ mixBlendMode (Value val) =
 
 
 {-| The `fill` value used in properties such as [`objectFit`](#objectFit),
- [`pointerEvents`](#pointerEvents) and [`paintOrder`](#paintOrder)
+[`pointerEvents`](#pointerEvents) and [`paintOrder`](#paintOrder)
 
     objectFit fill_
 

--- a/src/Css.elm
+++ b/src/Css.elm
@@ -113,7 +113,7 @@ module Css exposing
     , geometricPrecision, optimizeLegibility, optimizeSpeed
     , textTransform
     , capitalize, uppercase, lowercase, fullSizeKana
-    , textDecoration, textDecoration2, textDecoration3, textDecorationLine, textDecorationLine2, textDecorationLine3, textDecorationStyle, textDecorationColor
+    , textDecoration, textDecoration2, textDecoration3, textDecorationLine, textDecorationLine2, textDecorationLine3, textDecorationStyle, textDecorationColor, textDecorationThickness, fromFont
     , textDecorationSkip, textDecorationSkipInk, objects, spaces, ink, edges, boxDecoration
     , wavy, underline, overline, lineThrough
     , textStroke, textStroke2, textStrokeColor, textStrokeWidth
@@ -628,7 +628,7 @@ Other values you can use for flex item alignment:
 
 # Text Decoration
 
-@docs textDecoration, textDecoration2, textDecoration3, textDecorationLine, textDecorationLine2, textDecorationLine3, textDecorationStyle, textDecorationColor
+@docs textDecoration, textDecoration2, textDecoration3, textDecorationLine, textDecorationLine2, textDecorationLine3, textDecorationStyle, textDecorationColor, textDecorationThickness, fromFont
 @docs textDecorationSkip, textDecorationSkipInk, objects, spaces, ink, edges, boxDecoration
 
 @docs wavy, underline, overline, lineThrough
@@ -10739,16 +10739,42 @@ textDecorationStyle (Value styleVal) =
     AppendProperty ("text-decoration-style:" ++ styleVal)
 
 
-{-| Sets [`text-decoration-color`][text-decoration-color] property.
+{-| Sets [`text-decoration-color`](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-color) property.
 
     textDecorationColor (hex "#0cf")
-
-[text-decoration-color]: https://css-tricks.com/almanac/properties/t/text-decoration-color/
 
 -}
 textDecorationColor : BaseValue Color -> Style
 textDecorationColor (Value colorVal) =
     AppendProperty ("text-decoration-color:" ++ colorVal)
+
+
+{-| Sets the [`text-decoration-thickness`](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration-thickness) property.
+
+    textDecorationThickness (pct 10)
+
+-}
+textDecorationThickness :
+    BaseValue
+        ( LengthSupported
+            { pct : Supported
+            , auto : Supported
+            , fromFont : Supported
+            }
+        )
+    -> Style
+textDecorationThickness (Value value) =
+    AppendProperty ("text-decoration-thickness:" ++ value)
+
+
+{-| Sets the `from-font` value for usage with [`textDecorationThickness`](#textDecorationThickness).
+
+    textDecorationThickness fromFont
+
+-}
+fromFont : Value { provides | fromFont : Supported }
+fromFont =
+    Value "from-font"
 
 
 {-| Sets [`text-decoration-skip`](https://css-tricks.com/almanac/properties/t/text-decoration-skip/) property.

--- a/src/Css.elm
+++ b/src/Css.elm
@@ -346,12 +346,9 @@ All CSS properties can have the values `unset`, `initial`, and `inherit`
 @docs padding, padding2, padding3, padding4, paddingTop, paddingRight, paddingBottom, paddingLeft
 
 
-## Block Paddings
+## Logical Paddings
 
 @docs paddingBlock, paddingBlock2, paddingBlockStart, paddingBlockEnd
-
-
-## Inline Paddings
 
 @docs paddingInline, paddingInline2, paddingInlineStart, paddingInlineEnd
 
@@ -361,12 +358,9 @@ All CSS properties can have the values `unset`, `initial`, and `inherit`
 @docs margin, margin2, margin3, margin4, marginTop, marginRight, marginBottom, marginLeft
 
 
-## Block Margins
+## Logical Margins
 
 @docs marginBlock, marginBlock2, marginBlockStart, marginBlockEnd
-
-
-## Inline Margins
 
 @docs marginInline, marginInline2, marginInlineStart, marginInlineEnd
 

--- a/src/Css.elm
+++ b/src/Css.elm
@@ -17,9 +17,8 @@ module Css exposing
     , contentBox, borderBox, paddingBox
     , left_, right_, top_, bottom_, block, inline, start, end
     , x, y
-    , clip
     , stretch, center, content, fill_, stroke, text, style
-    , cover, contain_
+    , clip, cover, contain_
     , baseline, sub, super, ruby, fullWidth
     , pseudoClass, active, checked, disabled, empty, enabled
     , firstChild, firstOfType, focus, fullscreen, hover, inRange
@@ -265,9 +264,8 @@ Many different kinds of CSS properties use these values.
 @docs contentBox, borderBox, paddingBox
 @docs left_, right_, top_, bottom_, block, inline, start, end
 @docs x, y
-@docs clip
 @docs stretch, center, content, fill_, stroke, text, style
-@docs cover, contain_
+@docs clip, cover, contain_
 @docs baseline, sub, super, ruby, fullWidth
 
 

--- a/src/Css.elm
+++ b/src/Css.elm
@@ -345,9 +345,16 @@ module Css exposing
     , pointerEvents
     , visiblePainted, visibleFill, visibleStroke, painted
 
-    -- scrolling
+    -- scrollbar customisation
     , scrollbarColor, scrollbarWidth
+
+    -- scrolling behavior
     , scrollBehavior, smooth
+    , overscrollBehavior, overscrollBehavior2
+    , overscrollBehaviorX, overscrollBehaviorY
+    , overscrollBehaviorBlock, overscrollBehaviorInline
+
+    -- scroll snapping
     , scrollSnapAlign
     , scrollSnapStop
     , scrollSnapType, scrollSnapType2
@@ -360,9 +367,6 @@ module Css exposing
     , scrollPaddingTop, scrollPaddingLeft, scrollPaddingRight, scrollPaddingBottom
     , scrollPaddingBlock, scrollPaddingBlock2, scrollPaddingInline, scrollPaddingInline2
     , scrollPaddingBlockStart, scrollPaddingBlockEnd, scrollPaddingInlineStart, scrollPaddingInlineEnd
-    , overscrollBehavior, overscrollBehavior2
-    , overscrollBehaviorX, overscrollBehaviorY
-    , overscrollBehaviorBlock, overscrollBehaviorInline
     
     -- cursors
     , CursorKeyword
@@ -1123,27 +1127,121 @@ Other values you can use for flex item alignment:
 ------------------------------------------------------
 
 
+# Columns
+
+@docs columns, columns2
+@docs columnWidth
+@docs columnCount
+@docs columnFill
+@docs balance, balanceAll
+@docs columnSpan
+@docs columnRule, columnRule2, columnRule3
+@docs columnRuleWidth
+@docs columnRuleStyle
+@docs columnRuleColor
 
 
+------------------------------------------------------
 
 
+# Tables
+
+@docs borderCollapse
+@docs collapse, separate
+@docs borderSpacing, borderSpacing2
+@docs captionSide
+@docs emptyCells
+@docs show, hide
+@docs tableLayout
 
 
+------------------------------------------------------
 
 
+# Content fragmentation
+
+@docs breakBefore, breakAfter, breakInside
+@docs avoid, avoidPage, avoidColumn, page
+@docs pageBreakBefore, pageBreakAfter, pageBreakInside
+@docs orphans, widows
+@docs boxDecorationBreak
 
 
+------------------------------------------------------
 
 
+# Arranging inline/block stuff
+
+@docs float
+@docs clear
+@docs verticalAlign
+@docs textTop, textBottom, middle
 
 
+------------------------------------------------------
 
 
+# Replaced elements
+
+@docs objectFit
+@docs scaleDown
+@docs objectPosition, objectPosition2, objectPosition4
 
 
+------------------------------------------------------
 
 
+# pointer-events
 
+@docs pointerEvents
+@docs visiblePainted, visibleFill, visibleStroke, painted
+
+
+------------------------------------------------------
+
+
+# Scrollbar customisation
+
+@docs scrollbarColor, scrollbarWidth
+
+
+------------------------------------------------------
+
+
+# Scrolling behavior
+
+@docs scrollBehavior, smooth
+@docs overscrollBehavior, overscrollBehavior2
+@docs overscrollBehaviorX, overscrollBehaviorY
+@docs overscrollBehaviorBlock, overscrollBehaviorInline
+
+
+------------------------------------------------------
+
+
+# Scroll snapping
+
+@docs scrollSnapType, scrollSnapType2
+@docs scrollSnapAlign
+@docs scrollSnapStop
+@docs mandatory, proximity
+
+### Margin
+
+@docs scrollMargin, scrollMargin2, scrollMargin3, scrollMargin4
+@docs scrollMarginTop, scrollMarginLeft, scrollMarginRight, scrollMarginBottom
+@docs scrollMarginBlock, scrollMarginBlock2, scrollMarginInline, scrollMarginInline2
+@docs scrollMarginBlockStart, scrollMarginBlockEnd, scrollMarginInlineStart, scrollMarginInlineEnd
+
+### Padding
+
+@docs scrollPadding, scrollPadding2, scrollPadding3, scrollPadding4
+@docs scrollPaddingTop, scrollPaddingLeft, scrollPaddingRight, scrollPaddingBottom
+@docs scrollPaddingBlock, scrollPaddingBlock2, scrollPaddingInline, scrollPaddingInline2
+@docs scrollPaddingBlockStart, scrollPaddingBlockEnd, scrollPaddingInlineStart, scrollPaddingInlineEnd
+
+
+------------------------------------------------------
 
 
 # Cursors
@@ -1163,46 +1261,25 @@ Other values you can use for flex item alignment:
 @docs neswResize, nwseResize, zoomIn, zoomOut, grab, grabbing
 
 
-
-# Tables
-
-
-## Border Collapse
-
-@docs borderCollapse
-@docs collapse, separate
+---------
 
 
-## Border Spacing
-
-@docs borderSpacing, borderSpacing2
 
 
-## Caption Side
-
-@docs captionSide
 
 
-## Empty Cells
-
-@docs emptyCells
-@docs show, hide
 
 
-## Table Layout
-
-@docs tableLayout
 
 
-## Float
-
-@docs float
-@docs clear
 
 
-# Visibility
 
-@docs visibility
+
+
+
+
+
 
 
 # SVG
@@ -1226,13 +1303,6 @@ Other values you can use for flex item alignment:
 ## Other
 
 @docs paintOrder, paintOrder2, paintOrder3, markers
-
-
-# Columns
-
-@docs columns, columns2, columnWidth, columnCount, columnRuleWidth, columnRuleStyle, columnRuleColor, columnRule, columnRule2, columnRule3
-@docs columnFill, balance, balanceAll
-@docs columnSpan
 
 
 # Transformation
@@ -1282,37 +1352,15 @@ Other values you can use for flex item alignment:
 
 @docs opacity
 
-
-# Scroll
-
-@docs scrollbarColor, scrollbarWidth
-@docs scrollBehavior, smooth, scrollSnapAlign, scrollSnapStop
-@docs scrollSnapType, scrollSnapType2, mandatory, proximity
-@docs scrollMargin, scrollMargin2, scrollMargin3, scrollMargin4, scrollMarginTop, scrollMarginLeft, scrollMarginRight, scrollMarginBottom
-@docs scrollMarginBlock, scrollMarginBlock2, scrollMarginInline, scrollMarginInline2
-@docs scrollMarginBlockStart, scrollMarginBlockEnd, scrollMarginInlineStart, scrollMarginInlineEnd
-@docs scrollPadding, scrollPadding2, scrollPadding3, scrollPadding4, scrollPaddingTop, scrollPaddingLeft, scrollPaddingRight, scrollPaddingBottom
-@docs scrollPaddingBlock, scrollPaddingBlock2, scrollPaddingInline, scrollPaddingInline2
-@docs scrollPaddingBlockStart, scrollPaddingBlockEnd, scrollPaddingInlineStart, scrollPaddingInlineEnd
-@docs overscrollBehavior, overscrollBehavior2, overscrollBehaviorX, overscrollBehaviorY, overscrollBehaviorBlock, overscrollBehaviorInline
-
-
 # Printing
 
 @docs bleed
-@docs orphans, widows
-@docs breakBefore, breakAfter, breakInside, avoid, avoidPage, avoidColumn, page
-@docs pageBreakBefore, pageBreakAfter, pageBreakInside
-
 
 # Rendering
 
 @docs mixBlendMode
 @docs imageRendering, crispEdges, pixelated
 @docs backfaceVisibility
-@docs objectFit, scaleDown
-@docs objectPosition, objectPosition2, objectPosition4
-@docs boxDecorationBreak
 @docs clipPath, clipPath2
 
 # Masks
@@ -1324,14 +1372,12 @@ Other values you can use for flex item alignment:
 # Other / stuff I'm adding to make the compiled result valid while I work on this rewrite
 
 @docs caretColor
-@docs pointerEvents
-@docs visiblePainted, visibleFill, visibleStroke, painted
 @docs BoxShadowConfig, boxShadow, boxShadows, defaultBoxShadow, Image, ImageSupported, LineStyle, LineStyleSupported
 @docs LineWidth, LineWidthSupported
 @docs TextShadowConfig, color, defaultTextShadow
 @docs linearGradient, linearGradient2, stop, stop2, stop3, textShadow
 @docs toBottom, toBottomLeft, toBottomRight, toLeft, toRight, toTop, toTopLeft, toTopRight
-@docs lineClamp, middle, textTop, textBottom, verticalAlign
+@docs lineClamp, visibility
 
 -}
 
@@ -16475,7 +16521,7 @@ painted =
 ------------------------------------------------------------------------
 ------------------------------------------------------------------------
 ------------------------------------------------------------------------
------------------------------- SCROLLING ------------------------------
+----------------------- SCROLLBAR CUSTOMISATION ------------------------
 ------------------------------------------------------------------------
 ------------------------------------------------------------------------
 ------------------------------------------------------------------------
@@ -16483,15 +16529,6 @@ painted =
 ------------------------------------------------------------------------
 ------------------------------------------------------------------------
 
-
-{-| Sets `smooth` value for usage with [`scrollBehavior`](#scrollBehavior).
-
-    scrollBehavior smooth
-
--}
-smooth : Value { provides | smooth : Supported }
-smooth =
-    Value "smooth"
 
 
 {-| Sets the
@@ -16529,6 +16566,21 @@ scrollbarWidth (Value val) =
     AppendProperty ("scrollbar-width:" ++ val)
 
 
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+-------------------------- SCROLLING BEHAVIOR --------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+
+
 {-| Sets [`scroll-behavior`](https://css-tricks.com/almanac/properties/s/scroll-behavior/)
 
     scrollBehavior auto
@@ -16544,6 +16596,191 @@ scrollBehavior :
     -> Style
 scrollBehavior (Value val) =
     AppendProperty ("scroll-behavior:" ++ val)
+
+
+{-| Sets `smooth` value for usage with [`scrollBehavior`](#scrollBehavior).
+
+    scrollBehavior smooth
+
+-}
+smooth : Value { provides | smooth : Supported }
+smooth =
+    Value "smooth"
+
+
+{-| Sets the [`overscroll-behavior`](https://css-tricks.com/almanac/properties/o/overscroll-behavior/) property.
+
+This property is a shorthand for setting both `overscroll-behavior-x` and `overscroll-behavior-y`.
+
+    overscrollBehavior auto -- sets both X and Y to auto
+
+    overscrollBehavior2 auto contain -- X = auto, Y = contain.
+
+-}
+overscrollBehavior :
+    BaseValue
+        { auto : Supported
+        , contain_ : Supported
+        , none : Supported
+        }
+    -> Style
+overscrollBehavior (Value value) =
+    AppendProperty ("overscroll-behavior:" ++ value)
+
+
+{-| Sets the [`overscroll-behavior`](https://css-tricks.com/almanac/properties/o/overscroll-behavior/) property.
+
+This property is a shorthand for setting both `overscroll-behavior-x` and `overscroll-behavior-y`.
+
+    overscrollBehavior2 auto contain_ -- X = auto, Y = contain.
+
+-}
+overscrollBehavior2 :
+    Value
+        { auto : Supported
+        , contain_ : Supported
+        , none : Supported
+        }
+    ->
+        Value
+            { auto : Supported
+            , contain_ : Supported
+            , none : Supported
+            }
+    -> Style
+overscrollBehavior2 (Value xValue) (Value yValue) =
+    AppendProperty ("overscroll-behavior:" ++ xValue ++ " " ++ yValue)
+
+
+{-| Sets the [`overscroll-behavior-x`](https://css-tricks.com/almanac/properties/o/overscroll-behavior/) property.
+
+    overscrollBehaviorX auto
+
+    overscrollBehaviorX contain_
+
+-}
+overscrollBehaviorX :
+    BaseValue
+        { auto : Supported
+        , contain_ : Supported
+        , none : Supported
+        }
+    -> Style
+overscrollBehaviorX (Value value) =
+    AppendProperty ("overscroll-behavior-x:" ++ value)
+
+
+{-| Sets the [`overscroll-behavior-y`](https://css-tricks.com/almanac/properties/o/overscroll-behavior/) property.
+
+    overscrollBehaviorY auto
+
+    overscrollBehaviorY contain_
+
+-}
+overscrollBehaviorY :
+    BaseValue
+        { auto : Supported
+        , contain_ : Supported
+        , none : Supported
+        }
+    -> Style
+overscrollBehaviorY (Value value) =
+    AppendProperty ("overscroll-behavior-y:" ++ value)
+
+
+{-| Sets the [`overscroll-behavior-block`](https://developer.mozilla.org/en-US/docs/Web/CSS/overscroll-behavior-block) property.
+
+    overscrollBehaviorBlock auto
+
+    overscrollBehaviorBlock contain_
+
+-}
+overscrollBehaviorBlock :
+    BaseValue
+        { auto : Supported
+        , contain_ : Supported
+        , none : Supported
+        }
+    -> Style
+overscrollBehaviorBlock (Value value) =
+    AppendProperty ("overscroll-behavior-block:" ++ value)
+
+
+{-| Sets the [`overscroll-behavior-inline`](https://developer.mozilla.org/en-US/docs/Web/CSS/overscroll-behavior-inline) property.
+
+    overscrollBehaviorInline auto
+
+    overscrollBehaviorInline contain_
+
+-}
+overscrollBehaviorInline :
+    BaseValue
+        { auto : Supported
+        , contain_ : Supported
+        , none : Supported
+        }
+    -> Style
+overscrollBehaviorInline (Value value) =
+    AppendProperty ("overscroll-behavior-inline:" ++ value)
+
+
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+-------------------------- SCROLL SNAPPING -----------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+
+
+{-| Sets [`scroll-snap-type`](https://css-tricks.com/almanac/properties/s/scroll-snap-type/)
+
+    scrollSnapType none
+
+-}
+scrollSnapType :
+    BaseValue
+        { none : Supported
+        , x : Supported
+        , y : Supported
+        , block : Supported
+        , inline : Supported
+        , both : Supported
+        }
+    -> Style
+scrollSnapType (Value val) =
+    AppendProperty ("scroll-snap-type:" ++ val)
+
+
+{-| Sets [`scroll-snap-type`](https://css-tricks.com/almanac/properties/s/scroll-snap-type/)
+
+    scrollSnapType2 x mandatory
+
+    scrollSnapType2 both proximity
+
+-}
+scrollSnapType2 :
+    Value
+        { x : Supported
+        , y : Supported
+        , block : Supported
+        , inline : Supported
+        , both : Supported
+        }
+    ->
+        Value
+            { mandatory : Supported
+            , proximity : Supported
+            }
+    -> Style
+scrollSnapType2 (Value val1) (Value val2) =
+    AppendProperty ("scroll-snap-type:" ++ val1 ++ " " ++ val2)
 
 
 {-| Sets [`scroll-snap-align`](https://css-tricks.com/almanac/properties/s/scroll-snap-align/)
@@ -16584,51 +16821,6 @@ scrollSnapStop :
     -> Style
 scrollSnapStop (Value val) =
     AppendProperty ("scroll-snap-stop:" ++ val)
-
-
-{-| Sets [`scroll-snap-type`](https://css-tricks.com/almanac/properties/s/scroll-snap-type/)
-
-    scrollSnapType none
-
--}
-scrollSnapType :
-    BaseValue
-        { none : Supported
-        , x : Supported
-        , y : Supported
-        , block : Supported
-        , inline : Supported
-        , both : Supported
-        }
-    -> Style
-scrollSnapType (Value val) =
-    AppendProperty ("scroll-snap-type:" ++ val)
-
-
-
-{-| Sets [`scroll-snap-type`](https://css-tricks.com/almanac/properties/s/scroll-snap-type/)
-
-    scrollSnapType2 x mandatory
-
-    scrollSnapType2 both proximity
-
--}
-scrollSnapType2 :
-    Value
-        { x : Supported
-        , y : Supported
-        , block : Supported
-        , inline : Supported
-        , both : Supported
-        }
-    ->
-        Value
-            { mandatory : Supported
-            , proximity : Supported
-            }
-    -> Style
-scrollSnapType2 (Value val1) (Value val2) =
-    AppendProperty ("scroll-snap-type:" ++ val1 ++ " " ++ val2)
 
 
 {-| Sets `mandatory` value for usage with [`scrollSnapType2`](#scrollSnapType2).
@@ -17327,123 +17519,6 @@ scrollPaddingInlineEnd :
     -> Style
 scrollPaddingInlineEnd (Value value) =
     AppendProperty ("scroll-padding-inline-end:" ++ value)
-
-
-{-| Sets the [`overscroll-behavior`](https://css-tricks.com/almanac/properties/o/overscroll-behavior/) property.
-
-This property is a shorthand for setting both `overscroll-behavior-x` and `overscroll-behavior-y`.
-
-    overscrollBehavior auto -- sets both X and Y to auto
-
-    overscrollBehavior2 auto contain -- X = auto, Y = contain.
-
--}
-overscrollBehavior :
-    BaseValue
-        { auto : Supported
-        , contain_ : Supported
-        , none : Supported
-        }
-    -> Style
-overscrollBehavior (Value value) =
-    AppendProperty ("overscroll-behavior:" ++ value)
-
-
-{-| Sets the [`overscroll-behavior`](https://css-tricks.com/almanac/properties/o/overscroll-behavior/) property.
-
-This property is a shorthand for setting both `overscroll-behavior-x` and `overscroll-behavior-y`.
-
-    overscrollBehavior2 auto contain_ -- X = auto, Y = contain.
-
--}
-overscrollBehavior2 :
-    Value
-        { auto : Supported
-        , contain_ : Supported
-        , none : Supported
-        }
-    ->
-        Value
-            { auto : Supported
-            , contain_ : Supported
-            , none : Supported
-            }
-    -> Style
-overscrollBehavior2 (Value xValue) (Value yValue) =
-    AppendProperty ("overscroll-behavior:" ++ xValue ++ " " ++ yValue)
-
-
-{-| Sets the [`overscroll-behavior-x`](https://css-tricks.com/almanac/properties/o/overscroll-behavior/) property.
-
-    overscrollBehaviorX auto
-
-    overscrollBehaviorX contain_
-
--}
-overscrollBehaviorX :
-    BaseValue
-        { auto : Supported
-        , contain_ : Supported
-        , none : Supported
-        }
-    -> Style
-overscrollBehaviorX (Value value) =
-    AppendProperty ("overscroll-behavior-x:" ++ value)
-
-
-{-| Sets the [`overscroll-behavior-y`](https://css-tricks.com/almanac/properties/o/overscroll-behavior/) property.
-
-    overscrollBehaviorY auto
-
-    overscrollBehaviorY contain_
-
--}
-overscrollBehaviorY :
-    BaseValue
-        { auto : Supported
-        , contain_ : Supported
-        , none : Supported
-        }
-    -> Style
-overscrollBehaviorY (Value value) =
-    AppendProperty ("overscroll-behavior-y:" ++ value)
-
-
-{-| Sets the [`overscroll-behavior-block`](https://developer.mozilla.org/en-US/docs/Web/CSS/overscroll-behavior-block) property.
-
-    overscrollBehaviorBlock auto
-
-    overscrollBehaviorBlock contain_
-
--}
-overscrollBehaviorBlock :
-    BaseValue
-        { auto : Supported
-        , contain_ : Supported
-        , none : Supported
-        }
-    -> Style
-overscrollBehaviorBlock (Value value) =
-    AppendProperty ("overscroll-behavior-block:" ++ value)
-
-
-{-| Sets the [`overscroll-behavior-inline`](https://developer.mozilla.org/en-US/docs/Web/CSS/overscroll-behavior-inline) property.
-
-    overscrollBehaviorInline auto
-
-    overscrollBehaviorInline contain_
-
--}
-overscrollBehaviorInline :
-    BaseValue
-        { auto : Supported
-        , contain_ : Supported
-        , none : Supported
-        }
-    -> Style
-overscrollBehaviorInline (Value value) =
-    AppendProperty ("overscroll-behavior-inline:" ++ value)
-
 
 
 ------------------------------------------------------------------------

--- a/src/Css.elm
+++ b/src/Css.elm
@@ -14925,9 +14925,11 @@ contain3 (Value value1) (Value value2) (Value value3) =
 {-| The [`contain`](https://css-tricks.com/almanac/properties/c/contain/) property.
 
 This version uses all 4 multiple choice values that can be used with this
-property, no values required.
+property. Because there is only one possible combination, this does not take values.
 
 Equivalent to `contain: size layout style paint;`.
+
+**Note: The `style` value is considered at-risk from being depreciated.**
 
     contain4
 
@@ -14982,6 +14984,8 @@ layout =
 For properties that can have effects on more than its
 element and descendenants, this indicates that those effects
 are contained by the containing element.
+
+**This value is considered at-risk from being depreciated.**
 
     contain style
 

--- a/src/Css.elm
+++ b/src/Css.elm
@@ -79,7 +79,7 @@ module Css exposing
     , fontVariantEastAsian, fontVariantEastAsian2, fontVariantEastAsian3, jis78, jis83, jis90, jis04, simplified, traditional, proportionalWidth
     , fontVariantLigatures, commonLigatures, noCommonLigatures, discretionaryLigatures, noDiscretionaryLigatures, historicalLigatures, noHistoricalLigatures, contextual, noContextual
     , fontVariantNumeric, fontVariantNumeric4, ordinal, slashedZero, liningNums, oldstyleNums, proportionalNums, tabularNums, diagonalFractions, stackedFractions
-    , fontOpticalSizing
+    , fontKerning, fontLanguageOverride, fontSynthesis, fontSynthesis2, fontSynthesis3, fontOpticalSizing, fontVariantPosition
     , stretch, center, start, end, flexStart, flexEnd, selfStart, selfEnd, spaceBetween, spaceAround, spaceEvenly, left_, right_, top_, bottom_, baseline, firstBaseline, lastBaseline, safe, unsafe, legacy, legacyLeft, legacyRight, legacyCenter
     , url
     , CursorKeyword
@@ -501,7 +501,7 @@ See this [complete guide](https://css-tricks.com/snippets/css/a-guide-to-flexbox
 
 ## Font Optical Sizing
 
-@docs fontOpticalSizing
+@docs fontKerning, fontLanguageOverride, fontSynthesis, fontSynthesis2, fontSynthesis3, fontOpticalSizing, fontVariantPosition
 
 
 # Align Items
@@ -1032,18 +1032,23 @@ type alias Time =
     TimeSupported {}
 
 
-{-| Produces an [`string`](https://developer.mozilla.org/en-US/docs/Web/CSS/string)
+{-| Produces a [`string`](https://developer.mozilla.org/en-US/docs/Web/CSS/string)
 value used by properties such as:
 
-  - [`listStyle`](#listStyle),
+  - [`listStyle`](#listStyle)
 
   - [`listStyleType`](#listStyleType)
 
   - [`quotes2`](#quotes2)
 
+  - [`fontLanguageOverride`](#fontLanguageOverride)
+
+
     listStyleType (string "> ")
 
     quotes2 (string "«") (string "»")
+
+    fontLanguageOverride (string "ENG")
 
 -}
 string : String -> Value { provides | string : Supported }
@@ -5510,6 +5515,8 @@ fontVariantCaps (Value str) =
 {-| The `normal` value, which can be used with such properties as:
 
   - [`fontVariantCaps`](#fontVariantCaps)
+  - [`fontKerning`](#fontKerning)
+  - [`fontLanguageOverride`](#fontLanguageOverride)
   - [`whiteSpace`](#whiteSpace)
   - [`wordBreak`](#wordBreak)
   - [`columnGap`](#columnGap)
@@ -5517,6 +5524,7 @@ fontVariantCaps (Value str) =
   - [`animationDirection`](#animationDirection)
   - [`alignItems`](#alignItems)
   - [`lineBreak`](#lineBreak)
+
 
 ```
 alignItems normal
@@ -5538,10 +5546,13 @@ normal =
     Value "normal"
 
 
-{-| The `small-caps` [`font-variant-caps` value](https://developer.mozilla.org/en-US/docs/Web/CSS/font-variant-caps#Values).
+{-| The `small-caps` value used in
+    - [`fontVariantCaps`](#fontVariantCaps)
+    - [`fontSynthesis`](#fontSynthesis)
 
     fontVariantCaps smallCaps
 
+    fontSynthesis2 smallCaps style
 -}
 smallCaps : Value { provides | smallCaps : Supported }
 smallCaps =
@@ -6065,10 +6076,123 @@ stackedFractions =
 -- FONT OPTICAL SIZING --
 
 
+{-| The [`font-kerning`](https://developer.mozilla.org/en-US/docs/Web/CSS/font-kerning) property.
+
+    fontKerning none
+-}
+fontKerning :
+    BaseValue
+        { none : Supported
+        , auto : Supported
+        , normal : Supported
+        }
+    -> Style
+fontKerning (Value val) =
+    AppendProperty ("font-kerning:" ++ val)
+
+
+{-| The [`font-language-override`](https://developer.mozilla.org/en-US/docs/Web/CSS/font-language-override) property.
+
+    fontLanguageOverride normal
+
+    fontLanguageOverride (string "ENG")
+-}
+fontLanguageOverride :
+    BaseValue
+        { normal : Supported
+        , string : Supported
+        }
+    -> Style
+fontLanguageOverride (Value val) =
+    AppendProperty ("font-language-override:" ++ val)
+
+
+{-| The [`font-synthesis`](https://developer.mozilla.org/en-US/docs/Web/CSS/font-synthesis) property.
+
+    fontSynthesis none
+
+    fontSynthesis smallCaps
+
+    fontSynthesis2 smallCaps weight
+
+    fontSynthesis3 weight style smallCaps
+-}
+fontSynthesis :
+    BaseValue
+        { none : Supported
+        , weight : Supported
+        , style : Supported
+        , smallCaps : Supported
+        }
+    -> Style
+fontSynthesis (Value val) =
+    AppendProperty ("font-synthesis:" ++ val)
+
+
+{-| The [`font-synthesis`](https://developer.mozilla.org/en-US/docs/Web/CSS/font-synthesis) property.
+
+This is the two-argument variant, in which you can indicate
+two different font properties to be synthesised by the browser.
+
+    fontSynthesis2 smallCaps weight
+-}
+fontSynthesis2 :
+    Value
+        { weight : Supported
+        , style : Supported
+        , smallCaps : Supported
+        }
+    -> Value
+        { weight : Supported
+        , style : Supported
+        , smallCaps : Supported
+        }
+    -> Style
+fontSynthesis2 (Value val1) (Value val2) =
+    AppendProperty ("font-synthesis:" ++ val1 ++ " " ++ val2)
+
+
+{-| The [`font-synthesis`](https://developer.mozilla.org/en-US/docs/Web/CSS/font-synthesis) property.
+
+This is the three-argument variant, in which you can indicate
+all three different font properties to be synthesised by the browser.
+
+    fontSynthesis3 weight style smallCaps
+-}
+fontSynthesis3 :
+    Value
+        { weight : Supported
+        , style : Supported
+        , smallCaps : Supported
+        }
+    -> Value
+        { weight : Supported
+        , style : Supported
+        , smallCaps : Supported
+        }
+    -> Value
+        { weight : Supported
+        , style : Supported
+        , smallCaps : Supported
+        }
+    -> Style
+fontSynthesis3 (Value val1) (Value val2) (Value val3) =
+    AppendProperty ("font-synthesis:" ++ val1 ++ " " ++ val2 ++ " " ++ val3)
+
+
+{-| The `weight` value for the [`fontSynthesis`](#fontSynthesis) property.
+
+    fontSynthesis weight
+-}
+weight : Value { provides | weight : Supported }
+weight =
+    Value "weight"
+
+
+
 {-| The [`font-optical-sizing`](https://developer.mozilla.org/en-US/docs/Web/CSS/font-optical-sizing) property.
 
     fontOpticalSizing none
-
 -}
 fontOpticalSizing :
     BaseValue
@@ -6079,6 +6203,22 @@ fontOpticalSizing :
 fontOpticalSizing (Value val) =
     AppendProperty ("font-optical-sizing:" ++ val)
 
+
+{-| The [`font-variant-position`](https://developer.mozilla.org/en-US/docs/Web/CSS/font-variant-position) property.
+
+    fontVariantPosition sub
+
+    fontVariantPosition normal
+-}
+fontVariantPosition :
+    BaseValue
+        { normal : Supported
+        , sub : Supported
+        , super : Supported
+        }
+    -> Style
+fontVariantPosition (Value val) =
+    AppendProperty ("font-variant-position:" ++ val)
 
 
 -- CURSOR --
@@ -10000,15 +10140,12 @@ lowercase =
 
 {-| A `full-width` value for:
 
-
 ### [`textTransform`](#textTransform)
-
 Forces the writing of characters in a square so they can be aligned in East Asian scripts.
 
-
 ### [`fontVariantEastAsian`](#fontVariantEastAsian)
-
 Activates the East Asian characters that are roughly be the same width.
+
 
     textTransform fullWidth
 
@@ -10575,7 +10712,13 @@ verticalAlign (Value str) =
     AppendProperty ("vertical-align:" ++ str)
 
 
-{-| A `sub` value for the [`vertical-align`](https://css-tricks.com/almanac/properties/v/vertical-align/) property.
+{-| A `sub` value for the following properties:
+
+    - [`fontVariantPosition](#fontVariantPosition)
+    - [`verticalAlign`](#verticalAlign)
+
+
+    fontVariantPosition sub
 
     verticalAlign sub
 
@@ -10585,8 +10728,14 @@ sub =
     Value "sub"
 
 
-{-| A `super` value for the [`vertical-align`](https://css-tricks.com/almanac/properties/v/vertical-align/) property.
+{-|  A `super` value for the following properties:
 
+    - [`fontVariantPosition](#fontVariantPosition)
+    - [`verticalAlign`](#verticalAlign)
+
+
+    fontVariantPosition super
+    
     verticalAlign super
 
 -}
@@ -16567,19 +16716,44 @@ contain3 (Value value1) (Value value2) (Value value3) =
 
 {-| The [`contain`](https://css-tricks.com/almanac/properties/c/contain/) property.
 
-This version uses all 4 multiple choice values that can be used with this
-property. Because there is only one possible combination, this does not take values.
+This two-argument version lets you use all 4 multiple choice values you
+can use for this property.
 
-Equivalent to `contain: size layout style paint;`.
+    contain4 size layout style paint
 
 **Note: The `style` value is considered at-risk from being depreciated.**
-
-    contain4
-
 -}
-contain4 : Style
-contain4 =
-    AppendProperty "contain:size layout style paint"
+contain4 :
+    Value
+        { size : Supported
+        , layout : Supported
+        , style : Supported
+        , paint : Supported
+        }
+    ->
+        Value
+            { size : Supported
+            , layout : Supported
+            , style : Supported
+            , paint : Supported
+            }
+    ->
+        Value
+            { size : Supported
+            , layout : Supported
+            , style : Supported
+            , paint : Supported
+            }
+    ->
+        Value
+            { size : Supported
+            , layout : Supported
+            , style : Supported
+            , paint : Supported
+            }
+    -> Style
+contain4 (Value value1) (Value value2) (Value value3) (Value value4) =
+    AppendProperty ("contain:" ++ value1 ++ " " ++ value2 ++ " " ++ value3 ++ " " ++ value4)
 
 
 {-| Sets the `size` value for [`contain`](#contain).
@@ -16608,16 +16782,14 @@ layout =
     Value "layout"
 
 
-{-| Sets the `style` value for [`contain`](#contain).
+{-| Sets the `style` value for:
 
-For properties that can have effects on more than its
-element and descendenants, this indicates that those effects
-are contained by the containing element.
-
-**This value is considered at-risk from being depreciated.**
+    - [`contain`](#contain). **(This value is considered at-risk from being depreciated for this property.)**
+    - [`fontSynthesis`](#fontSynthesis)
 
     contain style
 
+    fontSynthesis style
 -}
 style : Value { provides | style : Supported }
 style =

--- a/src/Css.elm
+++ b/src/Css.elm
@@ -11150,6 +11150,7 @@ scale3 (Value xVal) (Value yVal) (Value zVal) =
 
     transform (scale_ 0.7)
 
+This is called `scale_` instead of `scale` because [`scale` is already a function](#scale).
 -}
 scale_ : Float -> Value { provides | scale_ : Supported }
 scale_ val =
@@ -11160,6 +11161,7 @@ scale_ val =
 
     transform (scale2_ 0.7 0.7)
 
+This is called `scale2_` instead of `scale2` because [`scale2` is already a function](#scale2).
 -}
 scale2_ : Float -> Float -> Value { provides | scale2_ : Supported }
 scale2_ valX valY =
@@ -11320,7 +11322,7 @@ rotate2 (Value axisOrVecVal) (Value angleVal)=
 
     transform (rotate_ (deg 30))
 
-This is called `rotate_` instead of `rotate` because [`rotate` is already a function.](#rotate)
+This is called `rotate_` instead of `rotate` because [`rotate` is already a function](#rotate).
 -}
 rotate_ :
     Value Angle

--- a/src/Css.elm
+++ b/src/Css.elm
@@ -41,7 +41,7 @@ module Css exposing
     , circle, circleAt, circleAt2, ellipse, ellipseAt, ellipseAt2, closestSide, farthestSide, polygon, path
     , dpi, dpcm, dppx
 
-    -- common keyword values
+    -- common/shared/grouped keyword values
     , unset, initial, inherit, revert
     , auto, none
     , left_, right_, top_, bottom_
@@ -56,6 +56,7 @@ module Css exposing
     , normal, strict, all_, both, always, scroll, column
     , content, fill_, stroke, text, style
     , clip, cover, contain_
+    , repeat, noRepeat, repeatX, repeatY, space, round
 
     -- all
     , all
@@ -171,11 +172,6 @@ module Css exposing
     , backgroundBlendMode, backgroundBlendModes, multiply, screen, overlay, darken, lighten, colorDodge, colorBurn, hardLight, softLight, difference, exclusion, hue, saturation, color_, luminosity
     , backgroundClip, backgroundClips, backgroundOrigin, backgroundOrigins
     , backgroundImage, backgroundImages, backgroundPosition, backgroundPosition2, backgroundPosition3, backgroundPosition4, backgroundRepeat, backgroundRepeat2, backgroundSize, backgroundSize2
-    , linearGradient, linearGradient2, stop, stop2, stop3, toBottom, toBottomLeft, toBottomRight, toLeft, toRight, toTop, toTopLeft, toTopRight
-    , repeat, noRepeat, repeatX, repeatY, space, round
-    , BoxShadowConfig, boxShadow, boxShadows, defaultBoxShadow
-    , TextShadowConfig, textShadow, defaultTextShadow
-    , LineWidth, LineWidthSupported, LineStyle, LineStyleSupported
 
     -- font size
     , fontSize
@@ -205,15 +201,6 @@ module Css exposing
     -- variable fonts (not to be confused with variants)
     , fontVariationSettings, fontVariationSettingsList
 
-    -- cursors
-    , CursorKeyword
-    , cursor, cursor2, cursor4
-    , pointer, default, contextMenu, help, progress, wait, cell
-    , crosshair, verticalText, alias, copy, move, noDrop
-    , notAllowed, allScroll, colResize, rowResize, nResize, eResize, sResize
-    , wResize, neResize, nwResize, seResize, swResize, ewResize, nsResize
-    , neswResize, nwseResize, zoomIn, zoomOut, grab, grabbing
-
     -- list styles
     , ListStyleType, ListStyleTypeSupported
     , listStyle, listStyle2, listStyle3, listStylePosition, inside, outside, listStyleType, listStyleImage
@@ -225,6 +212,20 @@ module Css exposing
     , textDecoration, textDecoration2, textDecoration3, textDecorationLine, textDecorationLine2, textDecorationLine3, textDecorationStyle, textDecorationColor, textDecorationThickness, fromFont
     , textDecorationSkip, textDecorationSkipInk, objects, spaces, ink, edges, boxDecoration
     , wavy, underline, overline, lineThrough
+
+    -- cursors
+    , CursorKeyword
+    , cursor, cursor2, cursor4
+    , pointer, default, contextMenu, help, progress, wait, cell
+    , crosshair, verticalText, alias, copy, move, noDrop
+    , notAllowed, allScroll, colResize, rowResize, nResize, eResize, sResize
+    , wResize, neResize, nwResize, seResize, swResize, ewResize, nsResize
+    , neswResize, nwseResize, zoomIn, zoomOut, grab, grabbing
+
+    -- shadows and gradients
+    , BoxShadowConfig, boxShadow, boxShadows, defaultBoxShadow
+    , TextShadowConfig, textShadow, defaultTextShadow
+    , linearGradient, linearGradient2, stop, stop2, stop3, toBottom, toBottomLeft, toBottomRight, toLeft, toRight, toTop, toTopLeft, toTopRight
 
     -- ??
     , textStroke, textStroke2, textStrokeColor, textStrokeWidth
@@ -248,7 +249,8 @@ module Css exposing
     , hyphens, quotes, quotes2, quotes4, textOverflow, textOverflow2, lineBreak, manual, ellipsis, loose
     , hangingPunctuation, hangingPunctuation2, hangingPunctuation3, first, last, forceEnd, allowEnd
     , lineClamp
-
+    , LineWidth, LineWidthSupported, LineStyle, LineStyleSupported
+    
     -- ??
     , borderCollapse
     , collapse, separate
@@ -1254,6 +1256,13 @@ makeImportant str =
         str ++ " !important"
 
 
+{-| Named after the hash mark in the CSS specification [CSS-VALUES-3].
+-}
+hashListToString : Value a -> List (Value a) -> String
+hashListToString head rest =
+    (head :: rest)
+        |> List.map unpackValue
+        |> String.join ","
 
 
 ------------------------------------------------------------------------
@@ -4113,6 +4122,95 @@ The value is called `contain_` instead of `contain` because [`contain`](#contain
 contain_ : Value { provides | contain_ : Supported }
 contain_ =
     Value "contain"
+
+
+{-| The `repeat` value for [background properties](#backgroundRepeat)
+and [`strokeRepeat`](#strokeRepeat).
+
+    backgroundRepeat repeat
+
+    strokeRepeat repeat
+
+-}
+repeat : Value { provides | repeat : Supported }
+repeat =
+    Value "repeat"
+
+
+{-| The `no-repeat` value for [background properties](#backgroundRepeat)
+and [`strokeRepeat`](#strokeRepeat).
+
+    backgroundRepeat noRepeat
+
+    strokeRpeat noRepeat
+
+-}
+noRepeat : Value { provides | repeat : Supported }
+noRepeat =
+    Value "no-repeat"
+
+
+{-| The `repeat-x` value for [repeating backgrounds](#backgroundRepeat)
+and [`strokeRepeat`](#strokeRepeat).
+
+    backgroundRepeat repeatX
+
+    strokeRepeat repeatX
+
+-}
+repeatX : Value { provides | repeatX : Supported }
+repeatX =
+    Value "repeat-x"
+
+
+{-| The `repeat-y` value for [repeating backgrounds](#backgroundRepeat)
+and [`strokeRepeat`](#strokeRepeat).
+
+    backgroundRepeat repeatY
+
+    strokeRepeat repeatY
+
+-}
+repeatY : Value { provides | repeatY : Supported }
+repeatY =
+    Value "repeat-y"
+
+
+{-| The `space` value for [repeating backgrounds](#backgroundRepeat)
+and [`strokeRepeat`](#strokeRepeat).
+
+    backgroundRepeat space
+
+    strokeRepeat space
+
+-}
+space : Value { provides | space : Supported }
+space =
+    Value "space"
+
+
+{-| The `round` value used for properties such as:
+
+  - [repeating backgrounds](#backgroundRepeat)
+  - [`strokeLinecap`](#strokeLinecap)
+  - [`strokeRepeat`](#strokeRepeat)
+  - [`strokeLinejoin`](#strokeLinejoin2)
+
+```
+    backgroundRepeat round
+
+    strokeLineCap round
+
+    strokeLinejoin2 miter round
+
+    strokeRepeat round
+```
+
+-}
+round : Value { provides | round : Supported }
+round =
+    Value "round"
+
 
 
 ------------------------------------------------------------------------
@@ -10733,94 +10831,6 @@ backgroundRepeat2 (Value horiz) (Value vert) =
     AppendProperty ("background-repeat:" ++ horiz ++ " " ++ vert)
 
 
-{-| The `repeat` value for [background properties](#backgroundRepeat)
-and [`strokeRepeat`](#strokeRepeat).
-
-    backgroundRepeat repeat
-
-    strokeRepeat repeat
-
--}
-repeat : Value { provides | repeat : Supported }
-repeat =
-    Value "repeat"
-
-
-{-| The `no-repeat` value for [background properties](#backgroundRepeat)
-and [`strokeRepeat`](#strokeRepeat).
-
-    backgroundRepeat noRepeat
-
-    strokeRpeat noRepeat
-
--}
-noRepeat : Value { provides | repeat : Supported }
-noRepeat =
-    Value "no-repeat"
-
-
-{-| The `repeat-x` value for [repeating backgrounds](#backgroundRepeat)
-and [`strokeRepeat`](#strokeRepeat).
-
-    backgroundRepeat repeatX
-
-    strokeRepeat repeatX
-
--}
-repeatX : Value { provides | repeatX : Supported }
-repeatX =
-    Value "repeat-x"
-
-
-{-| The `repeat-y` value for [repeating backgrounds](#backgroundRepeat)
-and [`strokeRepeat`](#strokeRepeat).
-
-    backgroundRepeat repeatY
-
-    strokeRepeat repeatY
-
--}
-repeatY : Value { provides | repeatY : Supported }
-repeatY =
-    Value "repeat-y"
-
-
-{-| The `space` value for [repeating backgrounds](#backgroundRepeat)
-and [`strokeRepeat`](#strokeRepeat).
-
-    backgroundRepeat space
-
-    strokeRepeat space
-
--}
-space : Value { provides | space : Supported }
-space =
-    Value "space"
-
-
-{-| The `round` value used for properties such as:
-
-  - [repeating backgrounds](#backgroundRepeat)
-  - [`strokeLinecap`](#strokeLinecap)
-  - [`strokeRepeat`](#strokeRepeat)
-  - [`strokeLinejoin`](#strokeLinejoin2)
-
-```
-    backgroundRepeat round
-
-    strokeLineCap round
-
-    strokeLinejoin2 miter round
-
-    strokeRepeat round
-```
-
--}
-round : Value { provides | round : Supported }
-round =
-    Value "round"
-
-
 {-| Sets [`background-size`](https://css-tricks.com/almanac/properties/b/background-size/).
 
     backgroundSize cover
@@ -12235,8 +12245,6 @@ weight =
     Value "weight"
 
 
-
-
 ------------------------------------------------------------------------
 ------------------------------------------------------------------------
 ------------------------------------------------------------------------
@@ -12296,877 +12304,6 @@ fontVariationSettingsList list =
             )
         |> String.join ", "
         )
-
-
-
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
------------------------------- BOX-SHADOW ------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-
-
-{-| Configuration for [`boxShadow`](#boxShadow).
--}
-type alias BoxShadowConfig =
-    { offsetX :
-        Value
-            (LengthSupported
-                { pct : Supported
-                }
-            )
-    , offsetY :
-        Value
-            (LengthSupported
-                { pct : Supported
-                }
-            )
-    , blurRadius :
-        Maybe
-            (Value
-                (LengthSupported
-                    { pct : Supported
-                    }
-                )
-            )
-    , spreadRadius :
-        Maybe
-            (Value
-                (LengthSupported
-                    { pct : Supported
-                    }
-                )
-            )
-    , color :
-        Maybe (Value Color)
-    , inset : Bool
-    }
-
-
-{-| Default [`boxShadow`](#boxShadow) configuration.
-
-It is equivalent to the following CSS:
-
-    box-shadow: 0 0;
-
--}
-defaultBoxShadow : BoxShadowConfig
-defaultBoxShadow =
-    { offsetX = zero
-    , offsetY = zero
-    , blurRadius = Nothing
-    , spreadRadius = Nothing
-    , color = Nothing
-    , inset = False
-    }
-
-
-{-| The [`box-shadow`](https://css-tricks.com/almanac/properties/b/box-shadow/) property.
-
-    boxShadow initial
-
-    boxShadow none
-
-For defining shadows look at [`boxShadows`](#boxShadows).
-
--}
-boxShadow : BaseValue { none : Supported } -> Style
-boxShadow (Value val) =
-    AppendProperty ("box-shadow:" ++ val)
-
-
-{-| Sets [`box-shadow`](https://css-tricks.com/almanac/properties/b/box-shadow/).
-
-    boxShadows [] -- "box-shadow: none"
-
-    -- "box-shadow: 3px 5px #aabbcc"
-    button
-        [ css
-            [ boxShadows
-                [ { defaultBoxShadow
-                    | offsetX = px 3
-                    , offsetY = px 5
-                    , color = Just (hex "#aabbcc")
-                  }
-                ]
-            ]
-        ]
-        [ text "Zap!" ]
-
--}
-boxShadows : List BoxShadowConfig -> Style
-boxShadows configs =
-    let
-        value =
-            case configs of
-                [] ->
-                    "none"
-
-                _ ->
-                    configs
-                        |> List.map boxShadowConfigToString
-                        |> String.join ", "
-    in
-    AppendProperty ("box-shadow:" ++ value)
-
-
-boxShadowConfigToString : BoxShadowConfig -> String
-boxShadowConfigToString config =
-    let
-        (Value offsetX) =
-            config.offsetX
-
-        (Value offsetY) =
-            config.offsetY
-
-        blurRadius =
-            case config.blurRadius of
-                Just (Value value) ->
-                    " " ++ value
-
-                Nothing ->
-                    case config.spreadRadius of
-                        Just _ ->
-                            " 0"
-
-                        Nothing ->
-                            ""
-
-        spreadRadius =
-            case config.spreadRadius of
-                Just (Value value) ->
-                    " " ++ value
-
-                Nothing ->
-                    ""
-
-        insetStr =
-            if config.inset then
-                "inset "
-
-            else
-                ""
-
-        colorVal =
-            config.color
-                |> Maybe.map (unpackValue >> (++) " ")
-                |> Maybe.withDefault ""
-    in
-    insetStr ++ offsetX ++ " " ++ offsetY ++ blurRadius ++ spreadRadius ++ colorVal
-
-
-
-
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
--------------------------------- CURSORS -------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-
-
-{-| A type alias used for the various [`cursor`](#cursor) properties
--}
-type alias CursorKeyword =
-    { pointer : Supported
-    , auto : Supported
-    , default : Supported
-    , none : Supported
-    , contextMenu : Supported
-    , help : Supported
-    , progress : Supported
-    , wait : Supported
-    , cell : Supported
-    , crosshair : Supported
-    , text : Supported
-    , verticalText : Supported
-    , alias : Supported
-    , copy : Supported
-    , move : Supported
-    , noDrop : Supported
-    , notAllowed : Supported
-    , allScroll : Supported
-    , colResize : Supported
-    , rowResize : Supported
-    , nResize : Supported
-    , eResize : Supported
-    , sResize : Supported
-    , wResize : Supported
-    , neResize : Supported
-    , nwResize : Supported
-    , seResize : Supported
-    , swResize : Supported
-    , ewResize : Supported
-    , nsResize : Supported
-    , neswResize : Supported
-    , nwseResize : Supported
-    , zoomIn : Supported
-    , zoomOut : Supported
-    , grab : Supported
-    , grabbing : Supported
-    }
-
-
-{-| The [`cursor`](https://css-tricks.com/almanac/properties/c/cursor/)
-property.
-
-    cursor notAllowed
-
--}
-cursor : BaseValue CursorKeyword -> Style
-cursor (Value val) =
-    AppendProperty ("cursor:" ++ val)
-
-
-{-| The [`cursor`](https://css-tricks.com/almanac/properties/c/cursor/)
-property.
-
-    cursor2 (url "https://example.com") move
-
--}
-cursor2 : Value { url : Supported } -> Value CursorKeyword -> Style
-cursor2 (Value urlVal) (Value fallbackVal) =
-    AppendProperty ("cursor:" ++ urlVal ++ "," ++ fallbackVal)
-
-
-{-| The [`cursor`](https://css-tricks.com/almanac/properties/c/cursor/)
-property.
-
-    cursor4 (url "https://example.com") (num 34) zero move
-
--}
-cursor4 :
-    Value { url : Supported }
-    ->
-        Value
-            { num : Supported
-            , zero : Supported
-            }
-    ->
-        Value
-            { num : Supported
-            , zero : Supported
-            }
-    -> Value CursorKeyword
-    -> Style
-cursor4 (Value urlVal) (Value xVal) (Value yVal) (Value fallbackVal) =
-    AppendProperty
-        ("cursor:"
-            ++ urlVal
-            ++ " "
-            ++ xVal
-            ++ " "
-            ++ yVal
-            ++ ","
-            ++ fallbackVal
-        )
-
-
-{-| The `pointer` value for the [`cursor`](#cursor) property.
--}
-pointer : Value { provides | pointer : Supported }
-pointer =
-    Value "pointer"
-
-
-{-| The `default` value for the [`cursor`](#cursor) property.
--}
-default : Value { provides | default : Supported }
-default =
-    Value "default"
-
-
-{-| The `context-menu` value for the [`cursor`](#cursor) property.
--}
-contextMenu : Value { provides | contextMenu : Supported }
-contextMenu =
-    Value "context-menu"
-
-
-{-| The `help` value for the [`cursor`](#cursor) property.
--}
-help : Value { provides | help : Supported }
-help =
-    Value "help"
-
-
-{-| The `progress` value for the [`cursor`](#cursor) property.
--}
-progress : Value { provides | progress : Supported }
-progress =
-    Value "progress"
-
-
-{-| The `wait` value for the [`cursor`](#cursor) property.
--}
-wait : Value { provides | wait : Supported }
-wait =
-    Value "wait"
-
-
-{-| The `cell` value for the [`cursor`](#cursor) property.
--}
-cell : Value { provides | cell : Supported }
-cell =
-    Value "cell"
-
-
-{-| The `crosshair` value for the [`cursor`](#cursor) property.
--}
-crosshair : Value { provides | crosshair : Supported }
-crosshair =
-    Value "crosshair"
-
-
-{-| The `vertical-text` value for the [`cursor`](#cursor) property.
--}
-verticalText : Value { provides | verticalText : Supported }
-verticalText =
-    Value "vertical-text"
-
-
-{-| The `alias` value for the [`cursor`](#cursor) property.
--}
-alias : Value { provides | alias : Supported }
-alias =
-    Value "alias"
-
-
-{-| The `copy` value for the [`cursor`](#cursor) property.
--}
-copy : Value { provides | copy : Supported }
-copy =
-    Value "copy"
-
-
-{-| The `move` value for the [`cursor`](#cursor) property.
--}
-move : Value { provides | move : Supported }
-move =
-    Value "move"
-
-
-{-| The `no-drop` value for the [`cursor`](#cursor) property.
--}
-noDrop : Value { provides | noDrop : Supported }
-noDrop =
-    Value "no-drop"
-
-
-{-| The `notAllowed` value for the [`cursor`](#cursor) property.
--}
-notAllowed : Value { provides | notAllowed : Supported }
-notAllowed =
-    Value "not-allowed"
-
-
-{-| The `all-scroll` value for the [`cursor`](#cursor) property.
--}
-allScroll : Value { provides | allScroll : Supported }
-allScroll =
-    Value "all-scroll"
-
-
-{-| The `col-resize` value for the [`cursor`](#cursor) property.
--}
-colResize : Value { provides | colResize : Supported }
-colResize =
-    Value "col-resize"
-
-
-{-| The `row-resize` value for the [`cursor`](#cursor) property.
--}
-rowResize : Value { provides | rowResize : Supported }
-rowResize =
-    Value "row-resize"
-
-
-{-| The `n-resize` value for the [`cursor`](#cursor) property.
--}
-nResize : Value { provides | nResize : Supported }
-nResize =
-    Value "n-resize"
-
-
-{-| The `e-resize` value for the [`cursor`](#cursor) property.
--}
-eResize : Value { provides | eResize : Supported }
-eResize =
-    Value "e-resize"
-
-
-{-| The `s-resize` value for the [`cursor`](#cursor) property.
--}
-sResize : Value { provides | sResize : Supported }
-sResize =
-    Value "s-resize"
-
-
-{-| The `w-resize` value for the [`cursor`](#cursor) property.
--}
-wResize : Value { provides | wResize : Supported }
-wResize =
-    Value "w-resize"
-
-
-{-| The `ne-resize` value for the [`cursor`](#cursor) property.
--}
-neResize : Value { provides | neResize : Supported }
-neResize =
-    Value "ne-resize"
-
-
-{-| The `nw-resize` value for the [`cursor`](#cursor) property.
--}
-nwResize : Value { provides | nwResize : Supported }
-nwResize =
-    Value "nw-resize"
-
-
-{-| The `se-resize` value for the [`cursor`](#cursor) property.
--}
-seResize : Value { provides | seResize : Supported }
-seResize =
-    Value "se-resize"
-
-
-{-| The `sw-resize` value for the [`cursor`](#cursor) property.
--}
-swResize : Value { provides | swResize : Supported }
-swResize =
-    Value "sw-resize"
-
-
-{-| The `ew-resize` value for the [`cursor`](#cursor) property.
--}
-ewResize : Value { provides | ewResize : Supported }
-ewResize =
-    Value "ew-resize"
-
-
-{-| The `ns-resize` value for the [`cursor`](#cursor) property.
--}
-nsResize : Value { provides | nsResize : Supported }
-nsResize =
-    Value "ns-resize"
-
-
-{-| The `nesw-resize` value for the [`cursor`](#cursor) property.
--}
-neswResize : Value { provides | neswResize : Supported }
-neswResize =
-    Value "nesw-resize"
-
-
-{-| The `nwse-resize` value for the [`cursor`](#cursor) property.
--}
-nwseResize : Value { provides | nwseResize : Supported }
-nwseResize =
-    Value "nwse-resize"
-
-
-{-| The `zoom-in` value for the [`cursor`](#cursor) property.
--}
-zoomIn : Value { provides | zoomIn : Supported }
-zoomIn =
-    Value "zoom-in"
-
-
-{-| The `zoom-out` value for the [`cursor`](#cursor) property.
--}
-zoomOut : Value { provides | zoomOut : Supported }
-zoomOut =
-    Value "zoom-out"
-
-
-{-| The `grab` value for the [`cursor`](#cursor) property.
--}
-grab : Value { provides | grab : Supported }
-grab =
-    Value "grab"
-
-
-{-| The `grabbing` value for the [`cursor`](#cursor) property.
--}
-grabbing : Value { provides | grabbing : Supported }
-grabbing =
-    Value "grabbing"
-
-
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
------------------------------ TEXT SHADOW ------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-
-
-{-| Configuration for [`textShadow`](#textShadow).
--}
-type alias TextShadowConfig =
-    { offsetX :
-        Value
-            (LengthSupported
-                { pct : Supported
-                }
-            )
-    , offsetY :
-        Value
-            (LengthSupported
-                { pct : Supported
-                }
-            )
-    , blurRadius :
-        Maybe
-            (Value
-                (LengthSupported
-                    { pct : Supported
-                    }
-                )
-            )
-    , color : Maybe (Value Color)
-    }
-
-
-{-| Default [`textShadow`](#textShadow) configuration.
-
-It is equivalent to the following CSS:
-
-    text-shadow: 0 0;
-
--}
-defaultTextShadow : TextShadowConfig
-defaultTextShadow =
-    { offsetX = zero
-    , offsetY = zero
-    , blurRadius = Nothing
-    , color = Nothing
-    }
-
-
-{-| Sets [`text-shadow`](https://css-tricks.com/almanac/properties/t/text-shadow/).
-
-    textShadow [] -- "text-shadow: none"
-
-    -- "text-shadow: 3px 5px #aabbcc"
-    span
-        [ css
-            [ textShadow
-                [ { defaultTextShadow
-                    | offsetX = px 3
-                    , offsetY = px 5
-                    , color = Just (hex "#aabbcc")
-                  }
-                ]
-            ]
-        ]
-        [ text "Zap!" ]
-
--}
-textShadow : List TextShadowConfig -> Style
-textShadow configs =
-    let
-        values =
-            case configs of
-                [] ->
-                    "none"
-
-                _ ->
-                    configs
-                        |> List.map textShadowConfigToString
-                        |> String.join ","
-    in
-    AppendProperty ("text-shadow:" ++ values)
-
-
-textShadowConfigToString : TextShadowConfig -> String
-textShadowConfigToString config =
-    let
-        offsetX =
-            unpackValue config.offsetX
-
-        offsetY =
-            unpackValue config.offsetY
-
-        blurRadius =
-            config.blurRadius
-                |> Maybe.map (unpackValue >> (++) " ")
-                |> Maybe.withDefault ""
-
-        colorSetting =
-            config.color
-                |> Maybe.map (unpackValue >> (++) " ")
-                |> Maybe.withDefault ""
-    in
-    offsetX ++ " " ++ offsetY ++ blurRadius ++ colorSetting
-
-
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
------------------------------- GRADIENTS -------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-
-
-{-| Produces [`linear-gradient()`](https://developer.mozilla.org/en-US/docs/Web/CSS/linear-gradient())
-values used by properties such as [`backgroundImage`](#backgroundImage),
-and [`listStyleImage`](#listStyleImage)
-
-    linearGradient (stop red) (stop blue) []
-
-    linearGradient (stop red) (stop blue) [ stop green ]
-
--}
-linearGradient :
-    Value { colorStop : Supported }
-    -> Value { colorStop : Supported }
-    -> List (Value { colorStop : Supported })
-    -> Value { provides | linearGradient : Supported }
-linearGradient (Value firstStop) (Value secondStop) moreStops =
-    let
-        peeledStops =
-            List.map unpackValue moreStops
-
-        stops =
-            String.join "," (firstStop :: secondStop :: peeledStops)
-    in
-    Value ("linear-gradient(" ++ stops ++ ")")
-
-
-{-| Produces [`linear-gradient()`](https://developer.mozilla.org/en-US/docs/Web/CSS/linear-gradient())
-values used by properties such as [`backgroundImage`](#backgroundImage),
-and [`listStyleImage`](#listStyleImage)
-
-    linearGradient2 toTop (stop red) (stop blue) []
-
-    linearGradient2 toTop (stop red) (stop blue) [ stop green ]
-
--}
-linearGradient2 :
-    Value
-        (AngleSupported
-            { toBottom : Supported
-            , toBottomLeft : Supported
-            , toBottomRight : Supported
-            , toLeft : Supported
-            , toRight : Supported
-            , toTop : Supported
-            , toTopLeft : Supported
-            , toTopRight : Supported
-            }
-        )
-    -> Value { colorStop : Supported }
-    -> Value { colorStop : Supported }
-    -> List (Value { colorStop : Supported })
-    -> Value { provides | linearGradient : Supported }
-linearGradient2 (Value angle) (Value firstStop) (Value secondStop) moreStops =
-    let
-        peeledStops =
-            List.map unpackValue moreStops
-
-        stops =
-            String.join "," (firstStop :: secondStop :: peeledStops)
-    in
-    Value ("linear-gradient(" ++ angle ++ "," ++ stops ++ ")")
-
-
-{-| Provides a stop for a [gradient](https://css-tricks.com/snippets/css/css-linear-gradient/).
-
-    linearGradient toTop (stop red) (stop blue) []
-
-See also [`stop2`](#stop2) for controlling stop positioning.
-
--}
-stop : Value Color -> Value { provides | colorStop : Supported }
-stop (Value colorVal) =
-    Value colorVal
-
-
-{-| Provides a stop for a [gradient](https://css-tricks.com/snippets/css/css-linear-gradient/).
-
-    linearGradient toTop (stop2 red (px 20)) (stop blue) []
-
-See also [`stop`](#stop) if you don't need to control the stop position.
-
--}
-stop2 :
-    Value Color
-    -> Value (LengthSupported { pct : Supported })
-    -> Value { provides | colorStop : Supported }
-stop2 (Value colorVal) (Value positionVal) =
-    Value (colorVal ++ " " ++ positionVal)
-
-
-{-| Provides a stop for a [gradient](https://css-tricks.com/snippets/css/css-linear-gradient/).
-
-    linearGradient (stop3 (hex "111") zero (pt 1)) (stop3 (hex "6454") (pt 2) (pct 45))
-
--}
-stop3 :
-    Value Color
-    -> Value (LengthSupported { pct : Supported })
-    -> Value (LengthSupported { pct : Supported })
-    -> Value { provides | colorStop : Supported }
-stop3 (Value colorVal) (Value positionStart) (Value positionEnd) =
-    Value (colorVal ++ " " ++ positionStart ++ "," ++ positionEnd)
-
-
-{-| Provides the [`to bottom` side angle](https://css-tricks.com/snippets/css/css-linear-gradient/) for gradients.
-
-    linearGradient toBottom (stop red) (stop blue) []
-
-If you want your gradient to go to a corner, use [`toBottomLeft`](#toBottomLeft) or [`toBottomRight`](#toBottomRight):
-
-    linearGradient toBottomLeft (stop red) (stop blue) []
-
-    linearGradient toBottomRight (stop red) (stop blue) []
-
--}
-toBottom : Value { provides | toBottom : Supported }
-toBottom =
-    Value "to bottom"
-
-
-{-| Provides the [`to bottom left` corner angle](https://css-tricks.com/snippets/css/css-linear-gradient/) for gradients.
-
-    linearGradient toBottomLeft (stop red) (stop blue) []
-
-If you want your gradient to go to a side, use [`toBottom`](#toBottom) or [`toLeft`](#toLeft) instead:
-
-    linearGradient toBottom (stop red) (stop blue) []
-
-    linearGradient toLeft (stop red) (stop blue) []
-
--}
-toBottomLeft : Value { provides | toBottomLeft : Supported }
-toBottomLeft =
-    Value "to bottom left"
-
-
-{-| Provides the [`to bottom right` corner angle](https://css-tricks.com/snippets/css/css-linear-gradient/) for gradients.
-
-    linearGradient toBottomRight (stop red) (stop blue) []
-
-If you want your gradient to go to a side, use [`toBottom`](#toBottom) or [`toRight`](#toRight) instead:
-
-    linearGradient toBottom (stop red) (stop blue) []
-
-    linearGradient toRight (stop red) (stop blue) []
-
--}
-toBottomRight : Value { provides | toBottomRight : Supported }
-toBottomRight =
-    Value "to bottom right"
-
-
-{-| Provides the [`to left` side angle](https://css-tricks.com/snippets/css/css-linear-gradient/) for gradients.
-
-    linearGradient toLeft (stop red) (stop blue) []
-
-If you want your gradient to go to a corner, use [`toTopLeft`](#toTopLeft) or [`toBottomLeft`](#toBottomLeft):
-
-    linearGradient toTopLeft (stop red) (stop blue) []
-
-    linearGradient toBottomLeft (stop red) (stop blue) []
-
--}
-toLeft : Value { provides | toLeft : Supported }
-toLeft =
-    Value "to left"
-
-
-{-| Provides the [`to right` side angle](https://css-tricks.com/snippets/css/css-linear-gradient/) for gradients.
-
-    linearGradient toRight (stop red) (stop blue) []
-
-If you want your gradient to go to a corner, use [`toTopRight`](#toTopRight) or [`toBottomRight`](#toBottomRight):
-
-    linearGradient toTopRight (stop red) (stop blue) []
-
-    linearGradient toBottomRight (stop red) (stop blue) []
-
--}
-toRight : Value { provides | toRight : Supported }
-toRight =
-    Value "to right"
-
-
-{-| Provides the [`to top` side angle](https://css-tricks.com/snippets/css/css-linear-gradient/) for gradients.
-
-    linearGradient toTop (stop red) (stop blue) []
-
-If you want your gradient to go to a corner, use [`toTopLeft`](#toTopLeft) or [`toTopRight`](#toTopRight):
-
-    linearGradient toTopLeft (stop red) (stop blue) []
-
-    linearGradient toTopRight (stop red) (stop blue) []
-
--}
-toTop : Value { provides | toTop : Supported }
-toTop =
-    Value "to top"
-
-
-{-| Provides the [`to top left` corner angle](https://css-tricks.com/snippets/css/css-linear-gradient/) for gradients.
-
-    linearGradient toTopLeft (stop red) (stop blue) []
-
-If you want your gradient to go to a side, use [`toTop`](#toTop) or [`toLeft`](#toLeft) instead:
-
-    linearGradient toTop (stop red) (stop blue) []
-
-    linearGradient toLeft (stop red) (stop blue) []
-
--}
-toTopLeft : Value { provides | toTopLeft : Supported }
-toTopLeft =
-    Value "to top left"
-
-
-{-| Provides the [`to top right` corner angle](https://css-tricks.com/snippets/css/css-linear-gradient/) for gradients.
-
-    linearGradient toTopRight (stop red) (stop blue) []
-
-If you want your gradient to go to a side, use [`toTop`](#toTop) or [`toRight`](#toRight) instead:
-
-    linearGradient toTop (stop red) (stop blue) []
-
-    linearGradient toRight (stop red) (stop blue) []
-
--}
-toTopRight : Value { provides | toTopRight : Supported }
-toTopRight =
-    Value "to top right"
 
 
 ------------------------------------------------------------------------
@@ -13964,149 +13101,6 @@ upperRoman =
 
 
 
--- TEXT ORIENTATION --
-
-
-{-| Sets [`text-orientation`](https://developer.mozilla.org/en-US/docs/Web/CSS/text-orientation).
-
-    textOrientation sideways
-
-    textOrientation upright
-
--}
-textOrientation :
-    BaseValue
-        { mixed : Supported
-        , sideways : Supported
-        , sidewaysRight : Supported
-        , upright : Supported
-        , useGlyphOrientation : Supported
-        }
-    -> Style
-textOrientation (Value str) =
-    AppendProperty ("text-orientation:" ++ str)
-
-
-{-| A `mixed` value for the
-[`textOrientation`](#textOrientation) property.
-
-    textOrientation mixed
-
--}
-mixed : Value { provides | mixed : Supported }
-mixed =
-    Value "mixed"
-
-
-{-| A `sideways` value for the
-[`textOrientation`](#textOrientation) property.
-
-    textOrientation sideways
-
--}
-sideways : Value { provides | sideways : Supported }
-sideways =
-    Value "sideways"
-
-
-{-| A `sideways-right` value for the
-[`textOrientation`](#textOrientation) property.
-
-    textOrientation sidewaysRight
-
--}
-sidewaysRight : Value { provides | sidewaysRight : Supported }
-sidewaysRight =
-    Value "sideways-right"
-
-
-{-| A `upright` value for the
-[`textOrientation`](#textOrientation) property.
-
-    textOrientation upright
-
--}
-upright : Value { provides | upright : Supported }
-upright =
-    Value "upright"
-
-
-{-| A `use-glyph-orientation` value for the
-[`textOrientation`](#textOrientation) property.
-
-    textOrientation useGlyphOrientation
-
--}
-useGlyphOrientation : Value { provides | useGlyphOrientation : Supported }
-useGlyphOrientation =
-    Value "use-glyph-orientation"
-
-
-
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
---------------------------- TEXT RENDERING -----------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-
-
-{-| Sets [`text-rendering`](https://css-tricks.com/almanac/properties/t/text-rendering/).
-
-    textRendering geometricPrecision
-
-    textRendering optimizeSpeed
-
--}
-textRendering :
-    BaseValue
-        { auto : Supported
-        , geometricPrecision : Supported
-        , optimizeLegibility : Supported
-        , optimizeSpeed : Supported
-        }
-    -> Style
-textRendering (Value str) =
-    AppendProperty ("text-rendering:" ++ str)
-
-
-{-| A `geometricPrecision` value for the [`text-rendering`](https://css-tricks.com/almanac/properties/t/text-rendering/) property.
-
-    textRendering geometricPrecision
-
--}
-geometricPrecision : Value { provides | geometricPrecision : Supported }
-geometricPrecision =
-    Value "geometricPrecision"
-
-
-{-| An `optimizeLegibility` value for the [`text-rendering`](https://css-tricks.com/almanac/properties/t/text-rendering/) property.
-
-    textRendering optimizeLegibility
-
--}
-optimizeLegibility : Value { provides | optimizeLegibility : Supported }
-optimizeLegibility =
-    Value "optimizeLegibility"
-
-
-{-| An `optimizeSpeed` value for the [`text-rendering`](https://css-tricks.com/almanac/properties/t/text-rendering/) property.
-
-    textRendering optimizeSpeed
-
--}
-optimizeSpeed : Value { provides | optimizeSpeed : Supported }
-optimizeSpeed =
-    Value "optimizeSpeed"
-
-
 ------------------------------------------------------------------------
 ------------------------------------------------------------------------
 ------------------------------------------------------------------------
@@ -14533,6 +13527,1016 @@ lineThrough =
     Value "line-through"
 
 
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+-------------------------------- CURSORS -------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+
+
+{-| A type alias used for the various [`cursor`](#cursor) properties
+-}
+type alias CursorKeyword =
+    { pointer : Supported
+    , auto : Supported
+    , default : Supported
+    , none : Supported
+    , contextMenu : Supported
+    , help : Supported
+    , progress : Supported
+    , wait : Supported
+    , cell : Supported
+    , crosshair : Supported
+    , text : Supported
+    , verticalText : Supported
+    , alias : Supported
+    , copy : Supported
+    , move : Supported
+    , noDrop : Supported
+    , notAllowed : Supported
+    , allScroll : Supported
+    , colResize : Supported
+    , rowResize : Supported
+    , nResize : Supported
+    , eResize : Supported
+    , sResize : Supported
+    , wResize : Supported
+    , neResize : Supported
+    , nwResize : Supported
+    , seResize : Supported
+    , swResize : Supported
+    , ewResize : Supported
+    , nsResize : Supported
+    , neswResize : Supported
+    , nwseResize : Supported
+    , zoomIn : Supported
+    , zoomOut : Supported
+    , grab : Supported
+    , grabbing : Supported
+    }
+
+
+{-| The [`cursor`](https://css-tricks.com/almanac/properties/c/cursor/)
+property.
+
+    cursor notAllowed
+
+-}
+cursor : BaseValue CursorKeyword -> Style
+cursor (Value val) =
+    AppendProperty ("cursor:" ++ val)
+
+
+{-| The [`cursor`](https://css-tricks.com/almanac/properties/c/cursor/)
+property.
+
+    cursor2 (url "https://example.com") move
+
+-}
+cursor2 : Value { url : Supported } -> Value CursorKeyword -> Style
+cursor2 (Value urlVal) (Value fallbackVal) =
+    AppendProperty ("cursor:" ++ urlVal ++ "," ++ fallbackVal)
+
+
+{-| The [`cursor`](https://css-tricks.com/almanac/properties/c/cursor/)
+property.
+
+    cursor4 (url "https://example.com") (num 34) zero move
+
+-}
+cursor4 :
+    Value { url : Supported }
+    ->
+        Value
+            { num : Supported
+            , zero : Supported
+            }
+    ->
+        Value
+            { num : Supported
+            , zero : Supported
+            }
+    -> Value CursorKeyword
+    -> Style
+cursor4 (Value urlVal) (Value xVal) (Value yVal) (Value fallbackVal) =
+    AppendProperty
+        ("cursor:"
+            ++ urlVal
+            ++ " "
+            ++ xVal
+            ++ " "
+            ++ yVal
+            ++ ","
+            ++ fallbackVal
+        )
+
+
+{-| The `pointer` value for the [`cursor`](#cursor) property.
+-}
+pointer : Value { provides | pointer : Supported }
+pointer =
+    Value "pointer"
+
+
+{-| The `default` value for the [`cursor`](#cursor) property.
+-}
+default : Value { provides | default : Supported }
+default =
+    Value "default"
+
+
+{-| The `context-menu` value for the [`cursor`](#cursor) property.
+-}
+contextMenu : Value { provides | contextMenu : Supported }
+contextMenu =
+    Value "context-menu"
+
+
+{-| The `help` value for the [`cursor`](#cursor) property.
+-}
+help : Value { provides | help : Supported }
+help =
+    Value "help"
+
+
+{-| The `progress` value for the [`cursor`](#cursor) property.
+-}
+progress : Value { provides | progress : Supported }
+progress =
+    Value "progress"
+
+
+{-| The `wait` value for the [`cursor`](#cursor) property.
+-}
+wait : Value { provides | wait : Supported }
+wait =
+    Value "wait"
+
+
+{-| The `cell` value for the [`cursor`](#cursor) property.
+-}
+cell : Value { provides | cell : Supported }
+cell =
+    Value "cell"
+
+
+{-| The `crosshair` value for the [`cursor`](#cursor) property.
+-}
+crosshair : Value { provides | crosshair : Supported }
+crosshair =
+    Value "crosshair"
+
+
+{-| The `vertical-text` value for the [`cursor`](#cursor) property.
+-}
+verticalText : Value { provides | verticalText : Supported }
+verticalText =
+    Value "vertical-text"
+
+
+{-| The `alias` value for the [`cursor`](#cursor) property.
+-}
+alias : Value { provides | alias : Supported }
+alias =
+    Value "alias"
+
+
+{-| The `copy` value for the [`cursor`](#cursor) property.
+-}
+copy : Value { provides | copy : Supported }
+copy =
+    Value "copy"
+
+
+{-| The `move` value for the [`cursor`](#cursor) property.
+-}
+move : Value { provides | move : Supported }
+move =
+    Value "move"
+
+
+{-| The `no-drop` value for the [`cursor`](#cursor) property.
+-}
+noDrop : Value { provides | noDrop : Supported }
+noDrop =
+    Value "no-drop"
+
+
+{-| The `notAllowed` value for the [`cursor`](#cursor) property.
+-}
+notAllowed : Value { provides | notAllowed : Supported }
+notAllowed =
+    Value "not-allowed"
+
+
+{-| The `all-scroll` value for the [`cursor`](#cursor) property.
+-}
+allScroll : Value { provides | allScroll : Supported }
+allScroll =
+    Value "all-scroll"
+
+
+{-| The `col-resize` value for the [`cursor`](#cursor) property.
+-}
+colResize : Value { provides | colResize : Supported }
+colResize =
+    Value "col-resize"
+
+
+{-| The `row-resize` value for the [`cursor`](#cursor) property.
+-}
+rowResize : Value { provides | rowResize : Supported }
+rowResize =
+    Value "row-resize"
+
+
+{-| The `n-resize` value for the [`cursor`](#cursor) property.
+-}
+nResize : Value { provides | nResize : Supported }
+nResize =
+    Value "n-resize"
+
+
+{-| The `e-resize` value for the [`cursor`](#cursor) property.
+-}
+eResize : Value { provides | eResize : Supported }
+eResize =
+    Value "e-resize"
+
+
+{-| The `s-resize` value for the [`cursor`](#cursor) property.
+-}
+sResize : Value { provides | sResize : Supported }
+sResize =
+    Value "s-resize"
+
+
+{-| The `w-resize` value for the [`cursor`](#cursor) property.
+-}
+wResize : Value { provides | wResize : Supported }
+wResize =
+    Value "w-resize"
+
+
+{-| The `ne-resize` value for the [`cursor`](#cursor) property.
+-}
+neResize : Value { provides | neResize : Supported }
+neResize =
+    Value "ne-resize"
+
+
+{-| The `nw-resize` value for the [`cursor`](#cursor) property.
+-}
+nwResize : Value { provides | nwResize : Supported }
+nwResize =
+    Value "nw-resize"
+
+
+{-| The `se-resize` value for the [`cursor`](#cursor) property.
+-}
+seResize : Value { provides | seResize : Supported }
+seResize =
+    Value "se-resize"
+
+
+{-| The `sw-resize` value for the [`cursor`](#cursor) property.
+-}
+swResize : Value { provides | swResize : Supported }
+swResize =
+    Value "sw-resize"
+
+
+{-| The `ew-resize` value for the [`cursor`](#cursor) property.
+-}
+ewResize : Value { provides | ewResize : Supported }
+ewResize =
+    Value "ew-resize"
+
+
+{-| The `ns-resize` value for the [`cursor`](#cursor) property.
+-}
+nsResize : Value { provides | nsResize : Supported }
+nsResize =
+    Value "ns-resize"
+
+
+{-| The `nesw-resize` value for the [`cursor`](#cursor) property.
+-}
+neswResize : Value { provides | neswResize : Supported }
+neswResize =
+    Value "nesw-resize"
+
+
+{-| The `nwse-resize` value for the [`cursor`](#cursor) property.
+-}
+nwseResize : Value { provides | nwseResize : Supported }
+nwseResize =
+    Value "nwse-resize"
+
+
+{-| The `zoom-in` value for the [`cursor`](#cursor) property.
+-}
+zoomIn : Value { provides | zoomIn : Supported }
+zoomIn =
+    Value "zoom-in"
+
+
+{-| The `zoom-out` value for the [`cursor`](#cursor) property.
+-}
+zoomOut : Value { provides | zoomOut : Supported }
+zoomOut =
+    Value "zoom-out"
+
+
+{-| The `grab` value for the [`cursor`](#cursor) property.
+-}
+grab : Value { provides | grab : Supported }
+grab =
+    Value "grab"
+
+
+{-| The `grabbing` value for the [`cursor`](#cursor) property.
+-}
+grabbing : Value { provides | grabbing : Supported }
+grabbing =
+    Value "grabbing"
+
+
+
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------ BOX-SHADOW ------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+
+
+{-| Configuration for [`boxShadow`](#boxShadow).
+-}
+type alias BoxShadowConfig =
+    { offsetX :
+        Value
+            (LengthSupported
+                { pct : Supported
+                }
+            )
+    , offsetY :
+        Value
+            (LengthSupported
+                { pct : Supported
+                }
+            )
+    , blurRadius :
+        Maybe
+            (Value
+                (LengthSupported
+                    { pct : Supported
+                    }
+                )
+            )
+    , spreadRadius :
+        Maybe
+            (Value
+                (LengthSupported
+                    { pct : Supported
+                    }
+                )
+            )
+    , color :
+        Maybe (Value Color)
+    , inset : Bool
+    }
+
+
+{-| Default [`boxShadow`](#boxShadow) configuration.
+
+It is equivalent to the following CSS:
+
+    box-shadow: 0 0;
+
+-}
+defaultBoxShadow : BoxShadowConfig
+defaultBoxShadow =
+    { offsetX = zero
+    , offsetY = zero
+    , blurRadius = Nothing
+    , spreadRadius = Nothing
+    , color = Nothing
+    , inset = False
+    }
+
+
+{-| The [`box-shadow`](https://css-tricks.com/almanac/properties/b/box-shadow/) property.
+
+    boxShadow initial
+
+    boxShadow none
+
+For defining shadows look at [`boxShadows`](#boxShadows).
+
+-}
+boxShadow : BaseValue { none : Supported } -> Style
+boxShadow (Value val) =
+    AppendProperty ("box-shadow:" ++ val)
+
+
+{-| Sets [`box-shadow`](https://css-tricks.com/almanac/properties/b/box-shadow/).
+
+    boxShadows [] -- "box-shadow: none"
+
+    -- "box-shadow: 3px 5px #aabbcc"
+    button
+        [ css
+            [ boxShadows
+                [ { defaultBoxShadow
+                    | offsetX = px 3
+                    , offsetY = px 5
+                    , color = Just (hex "#aabbcc")
+                  }
+                ]
+            ]
+        ]
+        [ text "Zap!" ]
+
+-}
+boxShadows : List BoxShadowConfig -> Style
+boxShadows configs =
+    let
+        value =
+            case configs of
+                [] ->
+                    "none"
+
+                _ ->
+                    configs
+                        |> List.map boxShadowConfigToString
+                        |> String.join ", "
+    in
+    AppendProperty ("box-shadow:" ++ value)
+
+
+boxShadowConfigToString : BoxShadowConfig -> String
+boxShadowConfigToString config =
+    let
+        (Value offsetX) =
+            config.offsetX
+
+        (Value offsetY) =
+            config.offsetY
+
+        blurRadius =
+            case config.blurRadius of
+                Just (Value value) ->
+                    " " ++ value
+
+                Nothing ->
+                    case config.spreadRadius of
+                        Just _ ->
+                            " 0"
+
+                        Nothing ->
+                            ""
+
+        spreadRadius =
+            case config.spreadRadius of
+                Just (Value value) ->
+                    " " ++ value
+
+                Nothing ->
+                    ""
+
+        insetStr =
+            if config.inset then
+                "inset "
+
+            else
+                ""
+
+        colorVal =
+            config.color
+                |> Maybe.map (unpackValue >> (++) " ")
+                |> Maybe.withDefault ""
+    in
+    insetStr ++ offsetX ++ " " ++ offsetY ++ blurRadius ++ spreadRadius ++ colorVal
+
+
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+----------------------------- TEXT SHADOW ------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+
+
+{-| Configuration for [`textShadow`](#textShadow).
+-}
+type alias TextShadowConfig =
+    { offsetX :
+        Value
+            (LengthSupported
+                { pct : Supported
+                }
+            )
+    , offsetY :
+        Value
+            (LengthSupported
+                { pct : Supported
+                }
+            )
+    , blurRadius :
+        Maybe
+            (Value
+                (LengthSupported
+                    { pct : Supported
+                    }
+                )
+            )
+    , color : Maybe (Value Color)
+    }
+
+
+{-| Default [`textShadow`](#textShadow) configuration.
+
+It is equivalent to the following CSS:
+
+    text-shadow: 0 0;
+
+-}
+defaultTextShadow : TextShadowConfig
+defaultTextShadow =
+    { offsetX = zero
+    , offsetY = zero
+    , blurRadius = Nothing
+    , color = Nothing
+    }
+
+
+{-| Sets [`text-shadow`](https://css-tricks.com/almanac/properties/t/text-shadow/).
+
+    textShadow [] -- "text-shadow: none"
+
+    -- "text-shadow: 3px 5px #aabbcc"
+    span
+        [ css
+            [ textShadow
+                [ { defaultTextShadow
+                    | offsetX = px 3
+                    , offsetY = px 5
+                    , color = Just (hex "#aabbcc")
+                  }
+                ]
+            ]
+        ]
+        [ text "Zap!" ]
+
+-}
+textShadow : List TextShadowConfig -> Style
+textShadow configs =
+    let
+        values =
+            case configs of
+                [] ->
+                    "none"
+
+                _ ->
+                    configs
+                        |> List.map textShadowConfigToString
+                        |> String.join ","
+    in
+    AppendProperty ("text-shadow:" ++ values)
+
+
+textShadowConfigToString : TextShadowConfig -> String
+textShadowConfigToString config =
+    let
+        offsetX =
+            unpackValue config.offsetX
+
+        offsetY =
+            unpackValue config.offsetY
+
+        blurRadius =
+            config.blurRadius
+                |> Maybe.map (unpackValue >> (++) " ")
+                |> Maybe.withDefault ""
+
+        colorSetting =
+            config.color
+                |> Maybe.map (unpackValue >> (++) " ")
+                |> Maybe.withDefault ""
+    in
+    offsetX ++ " " ++ offsetY ++ blurRadius ++ colorSetting
+
+
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------ GRADIENTS -------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+
+
+{-| Produces [`linear-gradient()`](https://developer.mozilla.org/en-US/docs/Web/CSS/linear-gradient())
+values used by properties such as [`backgroundImage`](#backgroundImage),
+and [`listStyleImage`](#listStyleImage)
+
+    linearGradient (stop red) (stop blue) []
+
+    linearGradient (stop red) (stop blue) [ stop green ]
+
+-}
+linearGradient :
+    Value { colorStop : Supported }
+    -> Value { colorStop : Supported }
+    -> List (Value { colorStop : Supported })
+    -> Value { provides | linearGradient : Supported }
+linearGradient (Value firstStop) (Value secondStop) moreStops =
+    let
+        peeledStops =
+            List.map unpackValue moreStops
+
+        stops =
+            String.join "," (firstStop :: secondStop :: peeledStops)
+    in
+    Value ("linear-gradient(" ++ stops ++ ")")
+
+
+{-| Produces [`linear-gradient()`](https://developer.mozilla.org/en-US/docs/Web/CSS/linear-gradient())
+values used by properties such as [`backgroundImage`](#backgroundImage),
+and [`listStyleImage`](#listStyleImage)
+
+    linearGradient2 toTop (stop red) (stop blue) []
+
+    linearGradient2 toTop (stop red) (stop blue) [ stop green ]
+
+-}
+linearGradient2 :
+    Value
+        (AngleSupported
+            { toBottom : Supported
+            , toBottomLeft : Supported
+            , toBottomRight : Supported
+            , toLeft : Supported
+            , toRight : Supported
+            , toTop : Supported
+            , toTopLeft : Supported
+            , toTopRight : Supported
+            }
+        )
+    -> Value { colorStop : Supported }
+    -> Value { colorStop : Supported }
+    -> List (Value { colorStop : Supported })
+    -> Value { provides | linearGradient : Supported }
+linearGradient2 (Value angle) (Value firstStop) (Value secondStop) moreStops =
+    let
+        peeledStops =
+            List.map unpackValue moreStops
+
+        stops =
+            String.join "," (firstStop :: secondStop :: peeledStops)
+    in
+    Value ("linear-gradient(" ++ angle ++ "," ++ stops ++ ")")
+
+
+{-| Provides a stop for a [gradient](https://css-tricks.com/snippets/css/css-linear-gradient/).
+
+    linearGradient toTop (stop red) (stop blue) []
+
+See also [`stop2`](#stop2) for controlling stop positioning.
+
+-}
+stop : Value Color -> Value { provides | colorStop : Supported }
+stop (Value colorVal) =
+    Value colorVal
+
+
+{-| Provides a stop for a [gradient](https://css-tricks.com/snippets/css/css-linear-gradient/).
+
+    linearGradient toTop (stop2 red (px 20)) (stop blue) []
+
+See also [`stop`](#stop) if you don't need to control the stop position.
+
+-}
+stop2 :
+    Value Color
+    -> Value (LengthSupported { pct : Supported })
+    -> Value { provides | colorStop : Supported }
+stop2 (Value colorVal) (Value positionVal) =
+    Value (colorVal ++ " " ++ positionVal)
+
+
+{-| Provides a stop for a [gradient](https://css-tricks.com/snippets/css/css-linear-gradient/).
+
+    linearGradient (stop3 (hex "111") zero (pt 1)) (stop3 (hex "6454") (pt 2) (pct 45))
+
+-}
+stop3 :
+    Value Color
+    -> Value (LengthSupported { pct : Supported })
+    -> Value (LengthSupported { pct : Supported })
+    -> Value { provides | colorStop : Supported }
+stop3 (Value colorVal) (Value positionStart) (Value positionEnd) =
+    Value (colorVal ++ " " ++ positionStart ++ "," ++ positionEnd)
+
+
+{-| Provides the [`to bottom` side angle](https://css-tricks.com/snippets/css/css-linear-gradient/) for gradients.
+
+    linearGradient toBottom (stop red) (stop blue) []
+
+If you want your gradient to go to a corner, use [`toBottomLeft`](#toBottomLeft) or [`toBottomRight`](#toBottomRight):
+
+    linearGradient toBottomLeft (stop red) (stop blue) []
+
+    linearGradient toBottomRight (stop red) (stop blue) []
+
+-}
+toBottom : Value { provides | toBottom : Supported }
+toBottom =
+    Value "to bottom"
+
+
+{-| Provides the [`to bottom left` corner angle](https://css-tricks.com/snippets/css/css-linear-gradient/) for gradients.
+
+    linearGradient toBottomLeft (stop red) (stop blue) []
+
+If you want your gradient to go to a side, use [`toBottom`](#toBottom) or [`toLeft`](#toLeft) instead:
+
+    linearGradient toBottom (stop red) (stop blue) []
+
+    linearGradient toLeft (stop red) (stop blue) []
+
+-}
+toBottomLeft : Value { provides | toBottomLeft : Supported }
+toBottomLeft =
+    Value "to bottom left"
+
+
+{-| Provides the [`to bottom right` corner angle](https://css-tricks.com/snippets/css/css-linear-gradient/) for gradients.
+
+    linearGradient toBottomRight (stop red) (stop blue) []
+
+If you want your gradient to go to a side, use [`toBottom`](#toBottom) or [`toRight`](#toRight) instead:
+
+    linearGradient toBottom (stop red) (stop blue) []
+
+    linearGradient toRight (stop red) (stop blue) []
+
+-}
+toBottomRight : Value { provides | toBottomRight : Supported }
+toBottomRight =
+    Value "to bottom right"
+
+
+{-| Provides the [`to left` side angle](https://css-tricks.com/snippets/css/css-linear-gradient/) for gradients.
+
+    linearGradient toLeft (stop red) (stop blue) []
+
+If you want your gradient to go to a corner, use [`toTopLeft`](#toTopLeft) or [`toBottomLeft`](#toBottomLeft):
+
+    linearGradient toTopLeft (stop red) (stop blue) []
+
+    linearGradient toBottomLeft (stop red) (stop blue) []
+
+-}
+toLeft : Value { provides | toLeft : Supported }
+toLeft =
+    Value "to left"
+
+
+{-| Provides the [`to right` side angle](https://css-tricks.com/snippets/css/css-linear-gradient/) for gradients.
+
+    linearGradient toRight (stop red) (stop blue) []
+
+If you want your gradient to go to a corner, use [`toTopRight`](#toTopRight) or [`toBottomRight`](#toBottomRight):
+
+    linearGradient toTopRight (stop red) (stop blue) []
+
+    linearGradient toBottomRight (stop red) (stop blue) []
+
+-}
+toRight : Value { provides | toRight : Supported }
+toRight =
+    Value "to right"
+
+
+{-| Provides the [`to top` side angle](https://css-tricks.com/snippets/css/css-linear-gradient/) for gradients.
+
+    linearGradient toTop (stop red) (stop blue) []
+
+If you want your gradient to go to a corner, use [`toTopLeft`](#toTopLeft) or [`toTopRight`](#toTopRight):
+
+    linearGradient toTopLeft (stop red) (stop blue) []
+
+    linearGradient toTopRight (stop red) (stop blue) []
+
+-}
+toTop : Value { provides | toTop : Supported }
+toTop =
+    Value "to top"
+
+
+{-| Provides the [`to top left` corner angle](https://css-tricks.com/snippets/css/css-linear-gradient/) for gradients.
+
+    linearGradient toTopLeft (stop red) (stop blue) []
+
+If you want your gradient to go to a side, use [`toTop`](#toTop) or [`toLeft`](#toLeft) instead:
+
+    linearGradient toTop (stop red) (stop blue) []
+
+    linearGradient toLeft (stop red) (stop blue) []
+
+-}
+toTopLeft : Value { provides | toTopLeft : Supported }
+toTopLeft =
+    Value "to top left"
+
+
+{-| Provides the [`to top right` corner angle](https://css-tricks.com/snippets/css/css-linear-gradient/) for gradients.
+
+    linearGradient toTopRight (stop red) (stop blue) []
+
+If you want your gradient to go to a side, use [`toTop`](#toTop) or [`toRight`](#toRight) instead:
+
+    linearGradient toTop (stop red) (stop blue) []
+
+    linearGradient toRight (stop red) (stop blue) []
+
+-}
+toTopRight : Value { provides | toTopRight : Supported }
+toTopRight =
+    Value "to top right"
+
+
+-- TEXT ORIENTATION --
+
+
+{-| Sets [`text-orientation`](https://developer.mozilla.org/en-US/docs/Web/CSS/text-orientation).
+
+    textOrientation sideways
+
+    textOrientation upright
+
+-}
+textOrientation :
+    BaseValue
+        { mixed : Supported
+        , sideways : Supported
+        , sidewaysRight : Supported
+        , upright : Supported
+        , useGlyphOrientation : Supported
+        }
+    -> Style
+textOrientation (Value str) =
+    AppendProperty ("text-orientation:" ++ str)
+
+
+{-| A `mixed` value for the
+[`textOrientation`](#textOrientation) property.
+
+    textOrientation mixed
+
+-}
+mixed : Value { provides | mixed : Supported }
+mixed =
+    Value "mixed"
+
+
+{-| A `sideways` value for the
+[`textOrientation`](#textOrientation) property.
+
+    textOrientation sideways
+
+-}
+sideways : Value { provides | sideways : Supported }
+sideways =
+    Value "sideways"
+
+
+{-| A `sideways-right` value for the
+[`textOrientation`](#textOrientation) property.
+
+    textOrientation sidewaysRight
+
+-}
+sidewaysRight : Value { provides | sidewaysRight : Supported }
+sidewaysRight =
+    Value "sideways-right"
+
+
+{-| A `upright` value for the
+[`textOrientation`](#textOrientation) property.
+
+    textOrientation upright
+
+-}
+upright : Value { provides | upright : Supported }
+upright =
+    Value "upright"
+
+
+{-| A `use-glyph-orientation` value for the
+[`textOrientation`](#textOrientation) property.
+
+    textOrientation useGlyphOrientation
+
+-}
+useGlyphOrientation : Value { provides | useGlyphOrientation : Supported }
+useGlyphOrientation =
+    Value "use-glyph-orientation"
+
+
+
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+--------------------------- TEXT RENDERING -----------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+
+
+{-| Sets [`text-rendering`](https://css-tricks.com/almanac/properties/t/text-rendering/).
+
+    textRendering geometricPrecision
+
+    textRendering optimizeSpeed
+
+-}
+textRendering :
+    BaseValue
+        { auto : Supported
+        , geometricPrecision : Supported
+        , optimizeLegibility : Supported
+        , optimizeSpeed : Supported
+        }
+    -> Style
+textRendering (Value str) =
+    AppendProperty ("text-rendering:" ++ str)
+
+
+{-| A `geometricPrecision` value for the [`text-rendering`](https://css-tricks.com/almanac/properties/t/text-rendering/) property.
+
+    textRendering geometricPrecision
+
+-}
+geometricPrecision : Value { provides | geometricPrecision : Supported }
+geometricPrecision =
+    Value "geometricPrecision"
+
+
+{-| An `optimizeLegibility` value for the [`text-rendering`](https://css-tricks.com/almanac/properties/t/text-rendering/) property.
+
+    textRendering optimizeLegibility
+
+-}
+optimizeLegibility : Value { provides | optimizeLegibility : Supported }
+optimizeLegibility =
+    Value "optimizeLegibility"
+
+
+{-| An `optimizeSpeed` value for the [`text-rendering`](https://css-tricks.com/almanac/properties/t/text-rendering/) property.
+
+    textRendering optimizeSpeed
+
+-}
+optimizeSpeed : Value { provides | optimizeSpeed : Supported }
+optimizeSpeed =
+    Value "optimizeSpeed"
 
 
 
@@ -17437,13 +17441,7 @@ backwards =
 
 
 
-{-| Named after the hash mark in the CSS specification [CSS-VALUES-3].
--}
-hashListToString : Value a -> List (Value a) -> String
-hashListToString head rest =
-    (head :: rest)
-        |> List.map unpackValue
-        |> String.join ","
+
 
 
 {-| Sets [`clear`](https://css-tricks.com/almanac/properties/c/clear/) property.

--- a/src/Css.elm
+++ b/src/Css.elm
@@ -82,6 +82,9 @@ module Css exposing
     -- contain (DOM)
     , contain, contain2, contain3, contain4
     , size, layout, paint
+    , containIntrinsicSize, containIntrinsicSize2, containIntrinsicSize4
+    , containIntrinsicWidth, containIntrinsicWidth2, containIntrinsicHeight, containIntrinsicHeight2
+    , containIntrinsicInlineSize, containIntrinsicInlineSize2, containIntrinsicBlockSize, containIntrinsicBlockSize2
 
     -- sizing
     , width, minWidth, maxWidth, height, minHeight, maxHeight
@@ -693,6 +696,9 @@ Sometimes these keywords mean other things too.
 
 @docs contain, contain2, contain3, contain4
 @docs size, layout, paint
+@docs containIntrinsicSize, containIntrinsicSize2, containIntrinsicSize4
+@docs containIntrinsicWidth, containIntrinsicWidth2, containIntrinsicHeight, containIntrinsicHeight2
+@docs containIntrinsicInlineSize, containIntrinsicInlineSize2, containIntrinsicBlockSize, containIntrinsicBlockSize2
 
 
 ------------------------------------------------------
@@ -2073,7 +2079,7 @@ type alias LengthSupported supported =
         , px : Supported
         , cm : Supported
         , mm : Supported
-        , inches : Supported
+        , inch : Supported
         , pc : Supported
         , pt : Supported
         , q : Supported
@@ -5241,7 +5247,7 @@ contain3 (Value value1) (Value value2) (Value value3) =
 
 {-| The [`contain`](https://css-tricks.com/almanac/properties/c/contain/) property.
 
-This two-argument version lets you use all 4 multiple choice values you
+This 4-argument version lets you use all 4 multiple choice values you
 can use for this property.
 
     contain4 size layout style paint
@@ -5320,6 +5326,329 @@ by the browser if the containing box is offscreen.
 paint : Value { provides | paint : Supported }
 paint =
     Value "paint"
+
+
+{-| The [`contain-intrinsic-size`](https://developer.mozilla.org/en-US/docs/Web/CSS/contain-intrinsic-size)
+property.
+
+This 1-argument variant lets you use global values, `none` and lengths for width and height.
+
+    containIntrinsicSize revert
+
+    containIntrinsicSize none
+
+                    -- width + height
+    containIntrinsicSize (px 500)
+
+                        -- width | height
+    containIntrinsicSize2 (rem 5) (px 800)
+
+                    -- width + height w/ auto
+    containIntrinsicSize2 auto (px 800)
+
+                      -- width w/ auto | height w/ auto
+    containIntrinsicSize4 auto (rem 50) auto (px 250)
+
+-}
+containIntrinsicSize :
+    BaseValue
+        ( LengthSupported
+            { none : Supported
+            }
+        )
+    -> Style
+containIntrinsicSize (Value val) =
+    AppendProperty <| "contain-intrinsic-size:" ++ val
+
+
+{-| The [`contain-intrinsic-size`](https://developer.mozilla.org/en-US/docs/Web/CSS/contain-intrinsic-size)
+property.
+
+This 2-argument variant lets you use separate lengths for
+width and height or joined with and height with `auto`.
+
+    containIntrinsicSize revert
+
+    containIntrinsicSize none
+
+                    -- width + height
+    containIntrinsicSize (px 500)
+
+                        -- width | height
+    containIntrinsicSize2 (rem 5) (px 800)
+
+                    -- width + height w/ auto
+    containIntrinsicSize2 auto (px 800)
+
+                      -- width w/ auto | height w/ auto
+    containIntrinsicSize4 auto (rem 50) auto (px 250)
+
+-}
+containIntrinsicSize2 :
+    Value 
+        ( LengthSupported
+            { auto : Supported
+            }
+        )
+    -> Value (Length)
+    -> Style
+containIntrinsicSize2 (Value val1) (Value val2) =
+    AppendProperty <| "contain-intrinsic-size:" ++ val1 ++ " " ++ val2
+
+
+{-| The [`contain-intrinsic-size`](https://developer.mozilla.org/en-US/docs/Web/CSS/contain-intrinsic-size)
+property.
+
+This 4-argument variant lets you use separate lengths for
+width and height with `auto`.
+
+Note: The 1st and 3rd argument can only be `auto`.
+
+    containIntrinsicSize revert
+
+    containIntrinsicSize none
+
+                    -- width + height
+    containIntrinsicSize (px 500)
+
+                        -- width | height
+    containIntrinsicSize2 (rem 5) (px 800)
+
+                    -- width + height w/ auto
+    containIntrinsicSize2 auto (px 800)
+
+                      -- width w/ auto | height w/ auto
+    containIntrinsicSize4 auto (rem 50) auto (px 250)
+
+-}
+containIntrinsicSize4 :
+    Value { auto : Supported }
+    -> Value (Length)
+    -> Value { auto : Supported }
+    -> Value (Length)
+    -> Style
+containIntrinsicSize4 (Value valAutoX) (Value valX) (Value valAutoY) (Value valY) =
+    AppendProperty
+        <| "contain-intrinsic-size:"
+        ++ valAutoX
+        ++ " "
+        ++ valX
+        ++ " "
+        ++ valAutoY
+        ++ " "
+        ++ valY
+
+
+{-| The [`contain-intrinsic-width`](https://developer.mozilla.org/en-US/docs/Web/CSS/contain-intrinsic-width)
+property.
+
+This 1-argument variant lets you use global values, `none` and lengths.
+
+    containIntrinsicWidth revert
+
+    containIntrinsicWidth none
+
+                     -- specified width
+    containIntrinsicWidth (px 500)
+
+                     -- specified width w/ auto
+    containIntrinsicWidth2 auto (px 800)
+
+-}
+containIntrinsicWidth :
+    BaseValue
+        ( LengthSupported
+            { none : Supported
+            }
+        )
+    -> Style
+containIntrinsicWidth (Value val) =
+    AppendProperty <| "contain-intrinsic-width:" ++ val
+
+
+{-| The [`contain-intrinsic-width`](https://developer.mozilla.org/en-US/docs/Web/CSS/contain-intrinsic-width)
+property.
+
+This 2-argument variant lets you use lengths with `auto`.
+
+Note: The 1st argument can only be `auto`.
+
+    containIntrinsicWidth revert
+
+    containIntrinsicWidth none
+
+                     -- specified width
+    containIntrinsicWidth (px 500)
+
+                     -- specified width w/ auto
+    containIntrinsicWidth2 auto (px 800)
+
+-}
+containIntrinsicWidth2 :
+    Value { auto : Supported }
+    -> Value (Length)
+    -> Style
+containIntrinsicWidth2 (Value valAuto) (Value val) =
+    AppendProperty <| "contain-intrinsic-width:" ++ valAuto ++ " " ++ val
+
+
+{-| The [`contain-intrinsic-height`](https://developer.mozilla.org/en-US/docs/Web/CSS/contain-intrinsic-height)
+property.
+
+This 1-argument variant lets you use global values, `none` and lengths.
+
+    containIntrinsicHeight revert
+
+    containIntrinsicHeight none
+
+                     -- specified height
+    containIntrinsicHeight (px 500)
+
+                     -- specified height w/ auto
+    containIntrinsicHeight2 auto (px 800)
+
+-}
+containIntrinsicHeight :
+    BaseValue
+        ( LengthSupported
+            { none : Supported
+            }
+        )
+    -> Style
+containIntrinsicHeight (Value val) =
+    AppendProperty <| "contain-intrinsic-height:" ++ val
+
+
+{-| The [`contain-intrinsic-height`](https://developer.mozilla.org/en-US/docs/Web/CSS/contain-intrinsic-height)
+property.
+
+This 2-argument variant lets you use lengths with `auto`.
+
+Note: The 1st argument can only be `auto`.
+
+    containIntrinsicHeight revert
+
+    containIntrinsicHeight none
+
+                     -- specified height
+    containIntrinsicHeight (px 500)
+
+                     -- specified height w/ auto
+    containIntrinsicHeight2 auto (px 800)
+
+-}
+containIntrinsicHeight2 :
+    Value { auto : Supported }
+    -> Value (Length)
+    -> Style
+containIntrinsicHeight2 (Value valAuto) (Value val) =
+    AppendProperty <| "contain-intrinsic-height:" ++ valAuto ++ " " ++ val
+
+
+{-| The [`contain-intrinsic-inline-size`](https://developer.mozilla.org/en-US/docs/Web/CSS/contain-intrinsic-inline-size)
+property.
+
+This 1-argument variant lets you use global values, `none` and lengths.
+
+    containIntrinsicInlineSize revert
+
+    containIntrinsicInlineSize none
+
+                -- specified inline size
+    containIntrinsicInlineSize (px 500)
+
+                -- specified inline size w/ auto
+    containIntrinsicInlineSize2 auto (px 800)
+
+-}
+containIntrinsicInlineSize :
+    BaseValue
+        ( LengthSupported
+            { none : Supported
+            }
+        )
+    -> Style
+containIntrinsicInlineSize (Value val) =
+    AppendProperty <| "contain-intrinsic-inline-size:" ++ val
+
+
+{-| The [`contain-intrinsic-inline-size`](https://developer.mozilla.org/en-US/docs/Web/CSS/contain-intrinsic-inline-size)
+property.
+
+This 2-argument variant lets you use lengths with `auto`.
+
+Note: The 1st argument can only be `auto`.
+
+    containIntrinsicInlineSize revert
+
+    containIntrinsicInlineSize none
+
+                -- specified inline size
+    containIntrinsicInlineSize (px 500)
+
+                -- specified inline size w/ auto
+    containIntrinsicInlineSize2 auto (px 800)
+
+-}
+containIntrinsicInlineSize2 :
+    Value { auto : Supported }
+    -> Value (Length)
+    -> Style
+containIntrinsicInlineSize2 (Value valAuto) (Value val) =
+    AppendProperty <| "contain-intrinsic-inline-size:" ++ valAuto ++ " " ++ val
+
+
+{-| The [`contain-intrinsic-block-size`](https://developer.mozilla.org/en-US/docs/Web/CSS/contain-intrinsic-block-size)
+property.
+
+This 1-argument variant lets you use global values, `none` and lengths.
+
+    containIntrinsicBlockSize revert
+
+    containIntrinsicBlockSize none
+
+                -- specified block size
+    containIntrinsicBlockSize (px 500)
+
+                -- specified block size w/ auto
+    containIntrinsicBlockSize2 auto (px 800)
+
+-}
+containIntrinsicBlockSize :
+    BaseValue
+        ( LengthSupported
+            { none : Supported
+            }
+        )
+    -> Style
+containIntrinsicBlockSize (Value val) =
+    AppendProperty <| "contain-intrinsic-block-size:" ++ val
+
+
+{-| The [`contain-intrinsic-block-size`](https://developer.mozilla.org/en-US/docs/Web/CSS/contain-intrinsic-block-size)
+property.
+
+This 2-argument variant lets you use lengths with `auto`.
+
+Note: The 1st argument can only be `auto`.
+
+    containIntrinsicBlockSize revert
+
+    containIntrinsicBlockSize none
+
+                -- specified block size
+    containIntrinsicBlockSize (px 500)
+
+                -- specified block size w/ auto
+    containIntrinsicBlockSize2 auto (px 800)
+
+-}
+containIntrinsicBlockSize2 :
+    Value { auto : Supported }
+    -> Value (Length)
+    -> Style
+containIntrinsicBlockSize2 (Value valAuto) (Value val) =
+    AppendProperty <| "contain-intrinsic-block-size:" ++ valAuto ++ " " ++ val
 
 
 ------------------------------------------------------------------------

--- a/src/Css.elm
+++ b/src/Css.elm
@@ -59,7 +59,7 @@ module Css exposing
     , content, fill_, stroke, text, style
     , clip, cover, contain_
     , repeat, noRepeat, repeatX, repeatY, space, round_
-    , isolate, matchParent
+    , isolate, matchParent, nowrap
 
     -- all
     , all
@@ -176,7 +176,7 @@ module Css exposing
     , firstBaseline, lastBaseline
     , safe, unsafe
     , legacy, legacyLeft, legacyRight, legacyCenter
-    , nowrap, wrap, wrapReverse
+    , wrap, wrapReverse
     
     -- grid
     , gridAutoRows, gridAutoColumns, gridAutoFlow, gridAutoFlow2
@@ -250,7 +250,7 @@ module Css exposing
     -- Text wrapping, overflow and newlines
     , wordBreak, breakAll, keepAll
     , lineBreak, loose
-    , whiteSpace, pre, preWrap, preLine
+    , whiteSpace, pre, preWrap, preLine, breakSpaces
     , textOverflow, textOverflow2, ellipsis
     , hyphens, manual
     , hangingPunctuation, hangingPunctuation2, hangingPunctuation3
@@ -648,7 +648,7 @@ Sometimes these keywords mean other things too.
 @docs content, fill_, stroke, text, style
 @docs clip, cover, contain_
 @docs repeat, noRepeat, repeatX, repeatY, space, round_
-@docs isolate, matchParent
+@docs isolate, matchParent, nowrap
 
 
 ------------------------------------------------------
@@ -904,7 +904,7 @@ Other values you can use for flex item alignment:
 @docs firstBaseline, lastBaseline
 @docs safe, unsafe
 @docs legacy, legacyLeft, legacyRight, legacyCenter
-@docs nowrap, wrap, wrapReverse
+@docs wrap, wrapReverse, breakSpaces
 
 
 ------------------------------------------------------
@@ -4546,7 +4546,6 @@ round_ =
     Value "round"
 
 
-
 {-| Sets `isolate` value for usage with [`isolation`](#isolation), and
 [`unicodeBidi`](#unicodeBidi).
 
@@ -4571,6 +4570,19 @@ and [`strokeOrigin`](#strokeOrigin) properties.
 matchParent : Value { provides | matchParent : Supported }
 matchParent =
     Value "match-parent"
+
+
+{-| A `nowrap` value for the [`white-space`](#whiteSpace)
+and [`flex-wrap`](#flexWrap)properties.
+
+    whiteSpace nowrap
+
+    flexWrap nowrap
+
+-}
+nowrap : Value { provides | nowrap : Supported }
+nowrap =
+    Value "nowrap"
 
 
 ------------------------------------------------------------------------
@@ -13560,26 +13572,14 @@ whiteSpace :
         , pre : Supported
         , preWrap : Supported
         , preLine : Supported
+        , breakSpaces : Supported
         }
     -> Style
 whiteSpace (Value str) =
     AppendProperty ("white-space:" ++ str)
 
 
-{-| A `nowrap` value for the [`white-space`](https://css-tricks.com/almanac/properties/w/whitespace/)
-and [`flex-wrap`](https://css-tricks.com/almanac/properties/f/flex-wrap/) properties.
-
-    whiteSpace nowrap
-
-    flexWrap nowrap
-
--}
-nowrap : Value { provides | nowrap : Supported }
-nowrap =
-    Value "nowrap"
-
-
-{-| A `pre` value for the [`white-space`](https://css-tricks.com/almanac/properties/w/whitespace/) property.
+{-| A `pre` value for the [`white-space`](#whiteSpace) property.
 
     whiteSpace pre
 
@@ -13589,7 +13589,7 @@ pre =
     Value "pre"
 
 
-{-| A `pre-wrap` value for the [`white-space`](https://css-tricks.com/almanac/properties/w/whitespace/) property.
+{-| A `pre-wrap` value for the [`white-space`](#whiteSpace) property.
 
     whiteSpace preWrap
 
@@ -13599,7 +13599,7 @@ preWrap =
     Value "pre-wrap"
 
 
-{-| A `pre-line` value for the [`white-space`](https://css-tricks.com/almanac/properties/w/whitespace/) property.
+{-| A `pre-line` value for the [`white-space`](#whiteSpace) property.
 
     whiteSpace preLine
 
@@ -13607,6 +13607,15 @@ preWrap =
 preLine : Value { provides | preLine : Supported }
 preLine =
     Value "pre-line"
+
+{-| A `break-spaces` value for the [`white-space`](#whiteSpace) property.
+
+    whiteSpace breakSpaces
+
+-}
+breakSpaces : Value { provides | breakSpaces : Supported }
+breakSpaces =
+    Value "break-spaces"
 
 
 {-| Sets the [`text-overflow`](https://css-tricks.com/almanac/properties/t/text-overflow/) property.

--- a/src/Css.elm
+++ b/src/Css.elm
@@ -44,6 +44,7 @@ module Css exposing
     , position, zIndex
     , absolute, fixed, relative, static, sticky
     , inset, inset2, inset3, inset4, top, right, bottom, left
+    , insetBlock, insetBlock2, insetInline, insetInline2
     , padding, padding2, padding3, padding4, paddingTop, paddingRight, paddingBottom, paddingLeft
     , margin, margin2, margin3, margin4, marginTop, marginRight, marginBottom, marginLeft
     , boxSizing
@@ -342,7 +343,7 @@ All CSS properties can have the values `unset`, `initial`, and `inherit`
 
 @docs inset, inset2, inset3, inset4, top, right, bottom, left
 
--- @docs insetBlock, insetBlock2, insetInline, insetInline2, insetBlockStart, insetBlockEnd, insetInlineStart, insetInlineEnd
+@docs insetBlock, insetBlock2, insetInline, insetInline2
 
 
 ## Paddings
@@ -1759,6 +1760,104 @@ right :
     -> Style
 right (Value val) =
     AppendProperty ("right:" ++ val)
+
+
+{-| Sets the [`inset-block`](https://developer.mozilla.org/en-US/docs/Web/CSS/inset-block) property.
+
+`inset-block` sets the `inset-block-start` and `inset-block-end` properties.
+
+    insetBlock (px 10) -- block start and block end are both 10px.
+
+    insetBlock2 (pct 5) (pct 5) -- block start = 5%, block end = 5%
+
+-}
+insetBlock :
+    Value
+        (LengthSupported
+            { pct : Supported
+            , auto : Supported
+            }
+        )
+    -> Style
+insetBlock (Value val) =
+    AppendProperty ("inset-block:" ++ val)
+
+
+{-| Sets the [`inset-block`](https://developer.mozilla.org/en-US/docs/Web/CSS/inset-block) property.
+
+`inset-block` sets the `inset-block-start` and `inset-block-end` properties.
+
+    insetBlock (px 10) -- block start and block end are both 10px.
+
+    insetBlock2 (pct 5) (pct 5) -- block start = 5%, block end = 5%
+
+-}
+insetBlock2 :
+    Value
+        (LengthSupported
+            { pct : Supported
+            , auto : Supported
+            }
+        )
+    ->
+        Value
+            (LengthSupported
+                { pct : Supported
+                , auto : Supported
+                }
+            )
+    -> Style
+insetBlock2 (Value valStart) (Value valEnd) =
+    AppendProperty ("inset-block:" ++ valStart ++ " " ++ valEnd)
+
+
+{-| Sets the [`inset-inline`](https://developer.mozilla.org/en-US/docs/Web/CSS/inset-inline) property.
+
+`inset-inline` sets the `inset-inline-start` and `inset-inline-end` properties.
+
+    insetInline (px 10) -- inline start and inline end are both 10px.
+
+    insetInline2 (pct 5) (pct 5) -- inline start = 5%, inline end = 5%
+
+-}
+insetInline :
+    Value
+        (LengthSupported
+            { pct : Supported
+            , auto : Supported
+            }
+        )
+    -> Style
+insetInline (Value val) =
+    AppendProperty ("inset-inline:" ++ val)
+
+
+{-| Sets the [`inset-inline`](https://developer.mozilla.org/en-US/docs/Web/CSS/inset-inline) property.
+
+`inset-inline` sets the `inset-inline-start` and `inset-inline-end` properties.
+
+    insetInline (px 10) -- inline start and inline end are both 10px.
+
+    insetInline2 (pct 5) (pct 5) -- inline start = 5%, inline end = 5%
+
+-}
+insetInline2 :
+    Value
+        (LengthSupported
+            { pct : Supported
+            , auto : Supported
+            }
+        )
+    ->
+        Value
+            (LengthSupported
+                { pct : Supported
+                , auto : Supported
+                }
+            )
+    -> Style
+insetInline2 (Value valStart) (Value valEnd) =
+    AppendProperty ("inset-inline:" ++ valStart ++ " " ++ valEnd)
 
 
 {-| An [`absolute` `position`](https://developer.mozilla.org/en-US/docs/Web/CSS/position#relative).

--- a/src/Css.elm
+++ b/src/Css.elm
@@ -84,7 +84,7 @@ module Css exposing
     , auto, none
     , hidden, visible
     , contentBox, borderBox
-    , overflow, overflowX, overflowY
+    , overflow, overflowX, overflowY, overflowBlock, overflowInline
     , overflowAnchor
     , overflowWrap
     , breakWord, anywhere
@@ -501,7 +501,7 @@ Multiple CSS properties use these values.
 
 ## Overflow
 
-@docs overflow, overflowX, overflowY
+@docs overflow, overflowX, overflowY, overflowBlock, overflowInline
 @docs overflowAnchor
 
 @docs overflowWrap
@@ -1305,6 +1305,52 @@ overflowY :
     -> Style
 overflowY (Value val) =
     AppendProperty ("overflow-y:" ++ val)
+
+
+{-| Sets [`overflow-block`](https://developer.mozilla.org/en-US/docs/Web/CSS/overflow-block).
+
+    overflowBlock visible
+
+    overflowBlock hidden
+
+    overflowBlock scroll
+
+    overflowBlock auto
+
+-}
+overflowBlock :
+    BaseValue
+        { visible : Supported
+        , hidden : Supported
+        , scroll : Supported
+        , auto : Supported
+        }
+    -> Style
+overflowBlock (Value val) =
+    AppendProperty ("overflow-block:" ++ val)
+
+
+{-| Sets [`overflow-inline`](https://developer.mozilla.org/en-US/docs/Web/CSS/overflow-inline).
+
+    overflowInline visible
+
+    overflowInline hidden
+
+    overflowInline scroll
+
+    overflowInline auto
+
+-}
+overflowInline :
+    BaseValue
+        { visible : Supported
+        , hidden : Supported
+        , scroll : Supported
+        , auto : Supported
+        }
+    -> Style
+overflowInline (Value val) =
+    AppendProperty ("overflow-inline:" ++ val)
 
 
 {-| Sets [`overflow-wrap`](https://css-tricks.com/almanac/properties/o/overflow-wrap/)

--- a/src/Css.elm
+++ b/src/Css.elm
@@ -133,8 +133,8 @@ module Css exposing
     , matrix, matrix3d
     , perspective, perspectiveOrigin, perspectiveOrigin2
     , perspective_
-    , rotate, rotateX, rotateY, rotateZ, rotate3d
-    , scale, scale2, scaleX, scaleY, scaleZ, scale3d
+    , rotate, rotate2, rotate_, rotateX, rotateY, rotateZ, rotate3d, vec3, z
+    , scale, scale2, scale3, scale_, scale2_, scaleX, scaleY, scaleZ, scale3d
     , skew, skew2, skewX, skewY
     , translate, translate2, translateX, translateY, translateZ, translate3d
     , animationName, animationNames, animationDuration, animationDurations, animationTimingFunction, animationTimingFunctions, animationIterationCount, animationIterationCounts, animationDirection, animationDirections, animationPlayState, animationPlayStates, animationDelay, animationDelays, animationFillMode, animationFillModes
@@ -659,12 +659,12 @@ Multiple CSS properties use these values.
 
 ## Rotation
 
-@docs rotate, rotateX, rotateY, rotateZ, rotate3d
+@docs rotate, rotate2, rotate_, rotateX, rotateY, rotateZ, rotate3d, vec3, z
 
 
 ## Scaling (resizing)
 
-@docs scale, scale2, scaleX, scaleY, scaleZ, scale3d
+@docs scale, scale2, scale3, scale_, scale2_, scaleX, scaleY, scaleZ, scale3d
 
 
 ## Skewing (distortion)
@@ -10807,8 +10807,8 @@ type alias TransformFunctionSupported supported =
         , translateY : Supported
         , translateZ : Supported
         , translate3d : Supported
-        , scale : Supported
-        , scale2 : Supported
+        , scale_ : Supported
+        , scale2_ : Supported
         , scaleX : Supported
         , scaleY : Supported
         , scaleZ : Supported
@@ -10817,7 +10817,7 @@ type alias TransformFunctionSupported supported =
         , skew2 : Supported
         , skewX : Supported
         , skewY : Supported
-        , rotate : Supported
+        , rotate_ : Supported
         , rotateX : Supported
         , rotateY : Supported
         , rotateZ : Supported
@@ -10843,8 +10843,8 @@ type alias TransformFunction =
     transform (translateY (in 3))
     transform (translateZ (px 2))
     transform (translate3d (px 12) (pct 50) (em 3))
-    transform (scale 2)
-    transform (scale2 2, 0.5)
+    transform (scale_ 2)
+    transform (scale2_ 2, 0.5)
     transform (scaleX 2)
     transform (scaleY 0.5)
     transform (scaleZ 0.3)
@@ -10853,7 +10853,7 @@ type alias TransformFunction =
     transform (skew2 (deg 30) (deg 20))
     transform (skewX (deg 30))
     transform (skewY (rad 1.07))
-    transform (rotate (turn 0.5))
+    transform (rotate_ (turn 0.5))
     transform (rotateX (deg 10))
     transform (rotateY (deg 10))
     transform (rotateZ (deg 10))
@@ -10869,7 +10869,7 @@ transform (Value val) =
 {-| Sets [`transform`](https://css-tricks.com/almanac/properties/t/transform/)
 with a series of transform-functions.
 
-    transforms (translate (px 12)) [ scale 2, skew (deg 20) ]
+    transforms (translate (px 12)) [ scale_ 2, skew (deg 20) ]
 
 -}
 transforms :
@@ -11050,8 +11050,8 @@ translateY (Value valY) =
 translateZ :
     Value Length
     -> Value { provides | translateZ : Supported }
-translateZ (Value z) =
-    Value ("translateZ(" ++ z ++ ")")
+translateZ (Value valZ) =
+    Value ("translateZ(" ++ valZ ++ ")")
 
 
 {-| Sets `translate3d` value for usage with [`transform`](#transform).
@@ -11073,31 +11073,96 @@ translate3d :
             )
     -> Value Length
     -> Value { provides | translate3d : Supported }
-translate3d (Value valX) (Value valY) (Value z) =
-    Value ("translate3d(" ++ valX ++ "," ++ valY ++ "," ++ z ++ ")")
+translate3d (Value valX) (Value valY) (Value valZ) =
+    Value ("translate3d(" ++ valX ++ "," ++ valY ++ "," ++ valZ ++ ")")
 
 
 
 -- SCALING (resizing)
 
 
+{-| The [`scale`](https://css-tricks.com/almanac/properties/s/scale) property.
+
+This one-argument version lets you set a global value, `none` or
+a `num` that will scale the element by both X and Y axes
+(equivalent to [`scale_`](#scale_)).
+
+    scale none
+
+    scale (num 3)
+
+    scale2 (num 1) (num 3)
+
+    scale3 (num 1) (num 3) (num 4)
+-}
+scale :
+    BaseValue
+        { num : Supported
+        , none : Supported
+        }
+    -> Style
+scale (Value val) =
+    AppendProperty ("scale:" ++ val)
+
+
+{-| The [`scale`](https://css-tricks.com/almanac/properties/s/scale) property.
+
+This two-argument version lets you specify scaling in X and Y axes
+(equivalent to [`scale2_`](#scale2_)).
+
+    scale2 (num 1) (num 3)
+-}
+scale2 :
+    Value
+        { num : Supported
+        }
+    -> Value
+        { num : Supported
+        }
+    -> Style
+scale2 (Value xVal) (Value yVal) =
+    AppendProperty ("scale:" ++ xVal ++ " " ++ yVal)
+
+
+{-| The [`scale`](https://css-tricks.com/almanac/properties/s/scale) property.
+
+This three-argument version lets you specify scaling in X, Y and Z axes
+(equivalent to [`scale3d`](#scale3d)).
+
+    scale3 (num 1) (num 3) (num 4)
+-}
+scale3 :
+    Value
+        { num : Supported
+        }
+    -> Value
+        { num : Supported
+        }
+    -> Value
+        { num : Supported
+        }
+    -> Style
+scale3 (Value xVal) (Value yVal) (Value zVal) =
+    AppendProperty ("scale:" ++ xVal ++ " " ++ yVal ++ " " ++ zVal)
+
+
 {-| Sets `scale` value for usage with [`transform`](#transform).
 
-    transform (scale 0.7)
+    transform (scale_ 0.7)
 
 -}
-scale : Float -> Value { provides | scale : Supported }
-scale val =
+scale_ : Float -> Value { provides | scale_ : Supported }
+scale_ val =
     Value ("scale(" ++ String.fromFloat val ++ ")")
 
 
 {-| Sets `scale` value for usage with [`transform`](#transform).
 
-    transform (scale 0.7 0.7)
+    transform (scale2_ 0.7 0.7)
 
 -}
-scale2 : Float -> Float -> Value { provides | scale2 : Supported }
-scale2 valX valY =
+scale2_ : Float -> Float -> Value { provides | scale2_ : Supported }
+scale2_ valX valY =
     Value ("scale(" ++ String.fromFloat valX ++ ", " ++ String.fromFloat valY ++ ")")
 
 
@@ -11127,8 +11192,8 @@ scaleY valY =
 
 -}
 scaleZ : Float -> Value { provides | scaleZ : Supported }
-scaleZ z =
-    Value ("scaleZ(" ++ String.fromFloat z ++ ")")
+scaleZ valZ =
+    Value ("scaleZ(" ++ String.fromFloat valZ ++ ")")
 
 
 {-| Sets `scale3d` value for usage with [`transform`](#transform).
@@ -11141,8 +11206,8 @@ scale3d :
     -> Float
     -> Float
     -> Value { provides | scale3d : Supported }
-scale3d valX valY z =
-    Value ("scale3d(" ++ String.fromFloat valX ++ "," ++ String.fromFloat valY ++ "," ++ String.fromFloat z ++ ")")
+scale3d valX valY valZ =
+    Value ("scale3d(" ++ String.fromFloat valX ++ "," ++ String.fromFloat valY ++ "," ++ String.fromFloat valZ ++ ")")
 
 
 
@@ -11201,16 +11266,66 @@ skewY (Value angle) =
 
 -- ROTATION
 
+{-| The [`rotate`](https://css-tricks.com/almanac/properties/r/rotate/) property.
+
+This one-argument version lets you set a global variable, `none`, or angle.
+
+    rotate none
+
+    rotate inherit
+
+    rotate (deg 60)
+
+    rotate2 x (deg 50)
+
+    rotate2 y (deg 100)
+
+    rotate2 (vec3 1 2 10) (deg 100)
+-}
+rotate :
+    BaseValue
+        (AngleSupported
+            { none : Supported
+            }
+        )
+    -> Style
+rotate (Value value) =
+    AppendProperty ("rotate:" ++ value)
+
+
+{-| The [`rotate`](https://css-tricks.com/almanac/properties/r/rotate/) property.
+
+This two-argument version lets you set an axis or a vector, then an angle value.
+
+    rotate2 x (deg 50)
+
+    rotate2 y (deg 100)
+
+    rotate2 (vec3 1 2 10) (deg 100)
+-}
+rotate2 :
+    Value
+        { x : Supported
+        , y : Supported
+        , z : Supported
+        , vec3 : Supported
+        }
+    -> Value Angle
+    -> Style
+rotate2 (Value axisOrVecVal) (Value angleVal)=
+    AppendProperty ("rotate:" ++ axisOrVecVal ++ " " ++ angleVal)
+
 
 {-| Sets `rotate` value for usage with [`transform`](#transform).
 
-    transform (rotate (deg 30))
+    transform (rotate_ (deg 30))
 
+This is called `rotate_` instead of `rotate` because [`rotate` is already a function.](#rotate)
 -}
-rotate :
+rotate_ :
     Value Angle
-    -> Value { provides | rotate : Supported }
-rotate (Value angle) =
+    -> Value { provides | rotate_ : Supported }
+rotate_ (Value angle) =
     Value ("rotate(" ++ angle ++ ")")
 
 
@@ -11261,19 +11376,45 @@ rotate3d :
     -> Float
     -> Value Angle
     -> Value { provides | rotate3d : Supported }
-rotate3d valX valY z (Value angle) =
+rotate3d valX valY valZ (Value angle) =
     Value
         ("rotate3d("
             ++ String.fromFloat valX
             ++ ","
             ++ String.fromFloat valY
             ++ ","
-            ++ String.fromFloat z
+            ++ String.fromFloat valZ
             ++ ","
             ++ angle
             ++ ")"
         )
 
+
+{-| A vector consisting of three values.
+
+Sets the vector values in [`rotate2`](#rotate2).
+
+    rotate2 (vec3 1 2 3) (deg 100)
+
+-}
+vec3 : Float -> Float -> Float -> Value { provides | vec3 : Supported }
+vec3 vec1Val vec2Val vec3Val =
+    Value
+        ( String.fromFloat vec1Val
+        ++ " "
+        ++ String.fromFloat vec2Val
+        ++ " "
+        ++ String.fromFloat vec3Val
+        )
+
+{-| Sets `z` value for usage with [`rotate2`](#rotate2).
+
+    rotate z (deg 100)
+
+-}
+z : Value { provides | z : Supported }
+z =
+    Value "z"
 
 
 -- PERSPECTIVE
@@ -13725,9 +13866,12 @@ scrollSnapType (Value val) =
     AppendProperty ("scroll-snap-type:" ++ val)
 
 
-{-| Sets `x` value for usage with [`scrollSnapType2`](#scrollSnapType2).
+{-| Sets `x` value for usage with [`scrollSnapType2`](#scrollSnapType2)
+and [`rotate2`](#rotate2).
 
     scrollSnapType2 x mandatory
+
+    rotate x (deg 10)
 
 -}
 x : Value { provides | x : Supported }
@@ -13735,9 +13879,12 @@ x =
     Value "x"
 
 
-{-| Sets `y` value for usage with [`scrollSnapType2`](#scrollSnapType2).
+{-| Sets `y` value for usage with [`scrollSnapType2`](#scrollSnapType2)
+and [`rotate2`](#rotate2).
 
     scrollSnapType2 y mandatory
+
+    rotate y (deg 50)
 
 -}
 y : Value { provides | y : Supported }

--- a/src/Css.elm
+++ b/src/Css.elm
@@ -232,6 +232,8 @@ module Css exposing
     , textUnderlinePosition, textUnderlinePosition2
     , textOrientation
     , mixed, sideways, sidewaysRight, upright, useGlyphOrientation
+    , wordBreak
+    , breakAll, keepAll
 
     -- script handling
     , direction, ltr, rtl
@@ -255,70 +257,6 @@ module Css exposing
     , BoxShadowConfig, boxShadow, boxShadows, defaultBoxShadow
     , TextShadowConfig, textShadow, defaultTextShadow
     , linearGradient, linearGradient2, stop, stop2, stop3, toBottom, toBottomLeft, toBottomRight, toLeft, toRight, toTop, toTopLeft, toTopRight
-
-
-    -- ??
-    , wordSpacing
-    , tabSize
-    , fontDisplay, fallback, swap, optional
-    , hyphens, quotes, quotes2, quotes4, textOverflow, textOverflow2, lineBreak, manual, ellipsis, loose
-    , hangingPunctuation, hangingPunctuation2, hangingPunctuation3, first, last, forceEnd, allowEnd
-    , lineClamp
-    , LineWidth, LineWidthSupported, LineStyle, LineStyleSupported
-    
-    -- ??
-    , borderCollapse
-    , collapse, separate
-    , borderSpacing, borderSpacing2
-    , captionSide
-    , emptyCells
-    , show, hide
-    , tableLayout
-    , verticalAlign
-    , textTop, textBottom, middle
-    , whiteSpace
-    , pre, preWrap, preLine
-    , wordBreak
-    , breakAll, keepAll
-    , float
-    , clear
-    , visibility
-    , fill
-
-    -- ??
-    , strokeDasharray, strokeDashoffset, strokeWidth, strokeAlign, strokeColor, strokeImage, strokeMiterlimit, strokeOpacity, strokePosition, strokePosition2, strokePosition4, strokeRepeat, strokeRepeat2, strokeSize, strokeSize2, strokeDashCorner
-    , strokeLinecap, butt, square
-    , strokeBreak, boundingBox, slice, clone
-    , strokeOrigin
-    , strokeLinejoin, strokeLinejoin2, crop, arcs, miter, bevel
-    , strokeDashJustify, compress, dashes, gaps
-
-    -- ??
-    , paintOrder, paintOrder2, paintOrder3, markers
-
-    -- ??
-    , columns, columns2, columnWidth, columnCount, columnRuleWidth, columnRuleStyle, columnRuleColor, columnRule, columnRule2, columnRule3
-    , columnFill, balance, balanceAll
-    , columnSpan
-
-    -- transformations and perspective
-    , transform, transforms, transformOrigin, transformOrigin2, transformBox
-    , TransformFunction, TransformFunctionSupported
-    , matrix, matrix3d
-    , scale, scale2, scale3, scale_, scale2_, scaleX, scaleY, scaleZ, scale3d
-    , skew, skew2, skewX, skewY
-    , rotate, rotate2, rotate_, rotateX, rotateY, rotateZ, rotate3d, vec3
-    , translate, translate2, translateX, translateY, translateZ, translate3d
-    , perspective, perspectiveOrigin, perspectiveOrigin2
-    , perspective_
-    
-    -- animation?
-    , animationName, animationNames, animationDuration, animationDurations, animationTimingFunction, animationTimingFunctions, animationIterationCount, animationIterationCounts, animationDirection, animationDirections, animationPlayState, animationPlayStates, animationDelay, animationDelays, animationFillMode, animationFillModes
-    , EasingFunction, EasingFunctionSupported, linear, ease, easeIn, easeOut, easeInOut, cubicBezier, stepStart, stepEnd, steps, steps2, jumpStart, jumpEnd, jumpNone, jumpBoth, infinite, reverse, alternate, alternateReverse, running, paused, forwards, backwards
-
-    -- ??
-    , opacity
-    , zoom
 
     -- break (page break)
     , breakBefore, breakAfter, breakInside, avoid, avoidPage, avoidColumn, page
@@ -344,6 +282,101 @@ module Css exposing
     , overscrollBehaviorX, overscrollBehaviorY
     , overscrollBehaviorBlock, overscrollBehaviorInline
     
+    -- transformations and perspective
+    , TransformFunction, TransformFunctionSupported
+    , transform, transforms, transformOrigin, transformOrigin2, transformBox
+    , matrix, matrix3d
+    , scale, scale2, scale3, scale_, scale2_, scaleX, scaleY, scaleZ, scale3d
+    , skew, skew2, skewX, skewY
+    , rotate, rotate2, rotate_, rotateX, rotateY, rotateZ, rotate3d, vec3
+    , translate, translate2, translateX, translateY, translateZ, translate3d
+    , perspective, perspectiveOrigin, perspectiveOrigin2
+    , perspective_
+    
+    -- animation
+    , animationName, animationNames
+    , animationDuration, animationDurations
+    , animationTimingFunction, animationTimingFunctions
+    , animationIterationCount, animationIterationCounts
+    , animationDirection, animationDirections
+    , animationPlayState, animationPlayStates
+    , animationDelay, animationDelays
+    , animationFillMode, animationFillModes
+    , EasingFunction, EasingFunctionSupported
+    , linear, ease, easeIn, easeOut, easeInOut, cubicBezier, stepStart, stepEnd, steps, steps2, jumpStart, jumpEnd, jumpNone, jumpBoth, infinite, reverse, alternate, alternateReverse, running, paused, forwards, backwards
+
+    -- masks
+    , maskBorderMode
+    , maskBorderRepeat, maskBorderRepeat2
+    , maskBorderOutset, maskBorderOutset2, maskBorderOutset3, maskBorderOutset4
+    , maskBorderSlice, maskBorderSlice2, maskBorderSlice3, maskBorderSlice4
+    , maskBorderWidth, maskBorderWidth2, maskBorderWidth3, maskBorderWidth4
+    , maskClip, maskClipList
+    , maskComposite
+    , maskMode, maskModeList
+    , maskOrigin, maskOriginList
+    , maskPosition
+    , maskRepeat, maskRepeat2
+    , maskSize, maskSize2
+    , maskType
+    , noClip, add, subtract, intersect, exclude, alpha, luminance, matchSource
+
+    -- ??
+    , wordSpacing
+    , tabSize
+    , fontDisplay, fallback, swap, optional
+    , hyphens, quotes, quotes2, quotes4, textOverflow, textOverflow2, lineBreak, manual, ellipsis, loose
+    , hangingPunctuation, hangingPunctuation2, hangingPunctuation3, first, last, forceEnd, allowEnd
+    , lineClamp
+    , LineWidth, LineWidthSupported, LineStyle, LineStyleSupported
+    
+    -- tables
+    , borderCollapse
+    , collapse, separate
+    , borderSpacing, borderSpacing2
+    , captionSide
+    , emptyCells
+    , show, hide
+    , tableLayout
+
+
+    , verticalAlign
+    , textTop, textBottom, middle
+    , whiteSpace
+    , pre, preWrap, preLine
+
+    , float
+    , clear
+    , visibility
+    , fill
+
+    -- ??
+    , strokeDasharray, strokeDashoffset, strokeWidth, strokeAlign, strokeColor, strokeImage, strokeMiterlimit, strokeOpacity, strokePosition, strokePosition2, strokePosition4, strokeRepeat, strokeRepeat2, strokeSize, strokeSize2, strokeDashCorner
+    , strokeLinecap, butt, square
+    , strokeBreak, boundingBox, slice, clone
+    , strokeOrigin
+    , strokeLinejoin, strokeLinejoin2, crop, arcs, miter, bevel
+    , strokeDashJustify, compress, dashes, gaps
+
+    -- ??
+    , paintOrder, paintOrder2, paintOrder3, markers
+
+    -- ??
+    , columns, columns2
+    , columnWidth
+    , columnCount
+    , columnRule, columnRule2, columnRule3
+    , columnRuleWidth
+    , columnRuleStyle
+    , columnRuleColor
+    , columnFill
+    , balance, balanceAll
+    , columnSpan
+
+    -- ??
+    , opacity
+    , zoom
+    
     -- ??
     , speak, spellOut
     , userSelect
@@ -356,9 +389,6 @@ module Css exposing
     , objectPosition, objectPosition2, objectPosition4
     , boxDecorationBreak
     , clipPath, clipPath2
-    , maskBorderMode, maskBorderRepeat, maskBorderRepeat2, maskBorderOutset, maskBorderOutset2, maskBorderOutset3, maskBorderOutset4, maskBorderSlice, maskBorderSlice2, maskBorderSlice3, maskBorderSlice4, maskBorderWidth, maskBorderWidth2, maskBorderWidth3, maskBorderWidth4
-    , maskClip, maskClipList, maskComposite, maskMode, maskModeList, maskOrigin, maskOriginList, maskPosition, maskRepeat, maskRepeat2, maskSize, maskSize2, maskType
-    , noClip, add, subtract, intersect, exclude, alpha, luminance, matchSource
     , caretColor
     , resize, horizontal, vertical
     , contain, contain2, contain3, contain4, size, layout, paint
@@ -14143,6 +14173,46 @@ useGlyphOrientation =
     Value "use-glyph-orientation"
 
 
+{-| Sets [`word-break`](https://css-tricks.com/almanac/properties/w/word-break/)
+
+      wordBreak normal
+      wordBreak breakAll
+      wordBreak keepAll
+      wordBreak breakWord
+
+-}
+wordBreak :
+    BaseValue
+        { normal : Supported
+        , breakAll : Supported
+        , keepAll : Supported
+        , breakWord : Supported
+        }
+    -> Style
+wordBreak (Value str) =
+    AppendProperty ("word-break:" ++ str)
+
+
+{-| A `breakAll` value for the [`word-break`](https://css-tricks.com/almanac/properties/w/word-break/) property.
+
+      wordBreak breakAll
+
+-}
+breakAll : Value { provides | breakAll : Supported }
+breakAll =
+    Value "break-all"
+
+
+{-| A `keepAll` value for the [`word-break`](https://css-tricks.com/almanac/properties/w/word-break/) property.
+
+      wordBreak keepAll
+
+-}
+keepAll : Value { provides | keepAll : Supported }
+keepAll =
+    Value "keep-all"
+
+
 ------------------------------------------------------------------------
 ------------------------------------------------------------------------
 ------------------------------------------------------------------------
@@ -15247,1427 +15317,1175 @@ toTopRight =
     Value "to top right"
 
 
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+-------------------------- BREAK (PAGE BREAK) --------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
 
 
+{-| Sets [`break-before`](https://css-tricks.com/almanac/properties/b/break-before/).
 
-
-
-
-
-
-
-
-
-
-
-
-{-| Sets [`border-collapse`](https://css-tricks.com/almanac/properties/b/border-collapse/).
-
-    borderCollapse collapse
-
-    borderCollapse separate
-
+    breakBefore auto
 -}
-borderCollapse :
-    BaseValue
-        { collapse : Supported
-        , separate : Supported
-        }
-    -> Style
-borderCollapse (Value str) =
-    AppendProperty ("border-collapse:" ++ str)
-
-
-{-| A `collapse` value for the [`border-collapse`](https://css-tricks.com/almanac/properties/b/border-collapse/) and
-[`visibility`](https://css-tricks.com/almanac/properties/v/visibility/) property.
-
-    borderCollapse collapse
-
-    visibility collapse
-
--}
-collapse : Value { provides | collapse : Supported }
-collapse =
-    Value "collapse"
-
-
-{-| A `separate` value for the [`border-separate`](https://css-tricks.com/almanac/properties/b/border-collapse/) property.
-
-    borderCollapse separate
-
--}
-separate : Value { provides | separate : Supported }
-separate =
-    Value "separate"
-
-
-
--- BORDER SPACING --
-
-
-{-| Sets [`border-spacing`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-spacing).
-
-    borderSpacing zero
-
-    borderSpacing (px 5)
-
--}
-borderSpacing : BaseValue Length -> Style
-borderSpacing (Value str) =
-    AppendProperty ("border-spacing:" ++ str)
-
-
-{-| Sets [`border-spacing`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-spacing), defining horizontal and vertical spacing separately.
-
-    borderSpacing2 (cm 1) (em 2)
-
--}
-borderSpacing2 : Value Length -> Value Length -> Style
-borderSpacing2 (Value valHorizontal) (Value valVertical) =
-    AppendProperty ("border-spacing:" ++ valHorizontal ++ " " ++ valVertical)
-
-
-
--- CAPTION SIDE --
-
-
-{-| Sets [`caption-side`](https://css-tricks.com/almanac/properties/c/caption-side/).
-
-    captionSide top_
-
-    captionSide bottom_
-
-    captionSide blockStart
-
-    captionSide inlineEnd
-
--}
-captionSide :
-    BaseValue
-        { top_ : Supported
-        , bottom_ : Supported
-        , blockStart : Supported
-        , blockEnd : Supported
-        , inlineStart : Supported
-        , inlineEnd : Supported
-        }
-    -> Style
-captionSide (Value str) =
-    AppendProperty ("caption-side:" ++ str)
-
-
-
--- EMPTY CELLS --
-
-
-{-| Sets [`empty-cells`](https://css-tricks.com/almanac/properties/e/empty-cells/).
-
-    emptyCells show
-
-    emptyCells hide
-
--}
-emptyCells :
-    BaseValue
-        { show : Supported
-        , hide : Supported
-        }
-    -> Style
-emptyCells (Value str) =
-    AppendProperty ("empty-cells:" ++ str)
-
-
-{-| A `show` value for the [`empty-cells`](https://css-tricks.com/almanac/properties/e/empty-cells/) property.
-
-    emptyCells show
-
--}
-show : Value { provides | show : Supported }
-show =
-    Value "show"
-
-
-{-| A `hide` value for the [`empty-cells`](https://css-tricks.com/almanac/properties/e/empty-cells/) property.
-
-    emptyCells hide
-
--}
-hide : Value { provides | hide : Supported }
-hide =
-    Value "hide"
-
-
-
--- TABLE LAYOUT --
-
-
-{-| Sets [`table-layout`](https://css-tricks.com/almanac/properties/t/table-layout/).
-
-    tableLayout auto
-
-    tableLayout fixed
-
--}
-tableLayout :
+breakBefore :
     BaseValue
         { auto : Supported
-        , fixed : Supported
-        }
-    -> Style
-tableLayout (Value str) =
-    AppendProperty ("table-layout:" ++ str)
-
-
-
--- VERTICAL ALIGN
-
-
-{-| Sets [`vertical-align`](https://css-tricks.com/almanac/properties/v/vertical-align/).
-
-    verticalAlign textBottom
-
-    verticalAlign (em 1)
-
--}
-verticalAlign :
-    BaseValue
-        (LengthSupported
-            { baseline : Supported
-            , sub : Supported
-            , super : Supported
-            , textTop : Supported
-            , textBottom : Supported
-            , middle : Supported
-            , top_ : Supported
-            , bottom_ : Supported
-            , pct : Supported
-            }
-        )
-    -> Style
-verticalAlign (Value str) =
-    AppendProperty ("vertical-align:" ++ str)
-
-
-{-| A `textTop` value for the [`vertical-align`](https://css-tricks.com/almanac/properties/v/vertical-align/) property.
-
-    verticalAlign textTop
-
--}
-textTop : Value { provides | textTop : Supported }
-textTop =
-    Value "text-top"
-
-
-{-| A `textBottom` value for the [`vertical-align`](https://css-tricks.com/almanac/properties/v/vertical-align/) property.
-
-    verticalAlign textBottom
-
--}
-textBottom : Value { provides | textBottom : Supported }
-textBottom =
-    Value "text-bottom"
-
-
-{-| A `middle` value for the [`vertical-align`](https://css-tricks.com/almanac/properties/v/vertical-align/) property.
-
-    verticalAlign middle
-
--}
-middle : Value { provides | middle : Supported }
-middle =
-    Value "middle"
-
-
--- WHITE-SPACE --
-
-
-{-| Sets [`white-space`](https://css-tricks.com/almanac/properties/w/whitespace/)
-
-    whiteSpace pre
-
-    whiteSpace nowrap
-
-    whiteSpace preWrap
-
-    whiteSpace preLine
-
--}
-whiteSpace :
-    BaseValue
-        { normal : Supported
-        , nowrap : Supported
-        , pre : Supported
-        , preWrap : Supported
-        , preLine : Supported
-        }
-    -> Style
-whiteSpace (Value str) =
-    AppendProperty ("white-space:" ++ str)
-
-
-{-| A `nowrap` value for the [`white-space`](https://css-tricks.com/almanac/properties/w/whitespace/)
-and [`flex-wrap`](https://css-tricks.com/almanac/properties/f/flex-wrap/) properties.
-
-    whiteSpace nowrap
-
-    flexWrap nowrap
-
--}
-nowrap : Value { provides | nowrap : Supported }
-nowrap =
-    Value "nowrap"
-
-
-{-| A `pre` value for the [`white-space`](https://css-tricks.com/almanac/properties/w/whitespace/) property.
-
-    whiteSpace pre
-
--}
-pre : Value { provides | pre : Supported }
-pre =
-    Value "pre"
-
-
-{-| A `pre-wrap` value for the [`white-space`](https://css-tricks.com/almanac/properties/w/whitespace/) property.
-
-    whiteSpace preWrap
-
--}
-preWrap : Value { provides | preWrap : Supported }
-preWrap =
-    Value "pre-wrap"
-
-
-{-| A `pre-line` value for the [`white-space`](https://css-tricks.com/almanac/properties/w/whitespace/) property.
-
-    whiteSpace preLine
-
--}
-preLine : Value { provides | preLine : Supported }
-preLine =
-    Value "pre-line"
-
-
-
---- WORD-BREAK ---
-
-
-{-| Sets [`word-break`](https://css-tricks.com/almanac/properties/w/word-break/)
-
-      wordBreak normal
-      wordBreak breakAll
-      wordBreak keepAll
-      wordBreak breakWord
-
--}
-wordBreak :
-    BaseValue
-        { normal : Supported
-        , breakAll : Supported
-        , keepAll : Supported
-        , breakWord : Supported
-        }
-    -> Style
-wordBreak (Value str) =
-    AppendProperty ("word-break:" ++ str)
-
-
-{-| A `breakAll` value for the [`word-break`](https://css-tricks.com/almanac/properties/w/word-break/) property.
-
-      wordBreak breakAll
-
--}
-breakAll : Value { provides | breakAll : Supported }
-breakAll =
-    Value "break-all"
-
-
-{-| A `keepAll` value for the [`word-break`](https://css-tricks.com/almanac/properties/w/word-break/) property.
-
-      wordBreak keepAll
-
--}
-keepAll : Value { provides | keepAll : Supported }
-keepAll =
-    Value "keep-all"
-
-
-
--- FLOAT --
-
-
-{-| Sets [`float`](https://css-tricks.com/almanac/properties/f/float/).
-
-    float none
-
-    float left_
-
-    float right_
-
-    float inlineStart
-
--}
-float :
-    BaseValue
-        { none : Supported
+        , always : Supported
+        , avoid : Supported
+        , all : Supported
+        , avoidPage : Supported
+        , page : Supported
         , left_ : Supported
         , right_ : Supported
-        , inlineStart : Supported
-        , inlineEnd : Supported
+        , avoidColumn : Supported
+        , column : Supported
         }
     -> Style
-float (Value str) =
-    AppendProperty ("float:" ++ str)
+breakBefore (Value val) =
+    AppendProperty ("break-before:" ++ val)
 
 
+{-| Sets [`break-after`](https://css-tricks.com/almanac/properties/b/break-after/).
 
--- VISIBILITY --
-
-
-{-| Sets [`visibility`](https://css-tricks.com/almanac/properties/v/visibility/)
-
-      visibility visible
-      visibility hidden
-      visibility collapse
-
+    breakAfter auto
 -}
-visibility :
-    BaseValue
-        { visible : Supported
-        , hidden : Supported
-        , collapse : Supported
-        }
-    -> Style
-visibility (Value str) =
-    AppendProperty ("visibility:" ++ str)
-
-
-
--- ORDER --
-
-
-{-| Sets [`order`](https://css-tricks.com/almanac/properties/o/order/)
-
-    order (num 2)
-
-    order (num -2)
-
--}
-order :
-    BaseValue
-        { int : Supported
-        , zero : Supported
-        }
-    -> Style
-order (Value val) =
-    AppendProperty ("order:" ++ val)
-
-
-{-| Sets [`fill`](https://css-tricks.com/almanac/properties/f/fill/)
-**Note:** `fill` also accepts the patterns of SVG shapes that are defined inside of a [`defs`](https://css-tricks.com/snippets/svg/svg-patterns/) element.
-
-    fill (hex "#60b5cc")
-
-    fill (rgb 96 181 204)
-
-    fill (rgba 96 181 204 0.5)
-
-    fill (url "#pattern")
-
--}
-fill :
-    BaseValue
-        (ColorSupported
-            { url : Supported
-            }
-        )
-    -> Style
-fill (Value val) =
-    AppendProperty ("fill:" ++ val)
-
-
-
--- COLUMNS --
-
-
-{-| Sets [`columns`](https://css-tricks.com/almanac/properties/c/columns/)
-
-    columns (px 300)
-
-    columns2 (px 300) (num 2)
-
--}
-columns :
-    BaseValue
-        (LengthSupported
-            { auto : Supported
-            }
-        )
-    -> Style
-columns (Value widthVal) =
-    AppendProperty ("columns:" ++ widthVal)
-
-
-{-| Sets [`columns`](https://css-tricks.com/almanac/properties/c/columns/)
-
-    columns (px 300)
-
-    columns2 (px 300) (num 2)
-
--}
-columns2 :
-    Value
-        (LengthSupported
-            { auto : Supported
-            }
-        )
-    ->
-        Value
-            { auto : Supported
-            , num : Supported
-            }
-    -> Style
-columns2 (Value widthVal) (Value count) =
-    AppendProperty ("columns:" ++ widthVal ++ " " ++ count)
-
-
-{-| Sets [`column-width`](https://css-tricks.com/almanac/properties/c/column-width/)
-
-    columnWidth auto
-
-    columnWidth (px 200)
-
--}
-columnWidth :
-    BaseValue
-        (LengthSupported
-            { auto : Supported
-            }
-        )
-    -> Style
-columnWidth (Value widthVal) =
-    AppendProperty ("column-width:" ++ widthVal)
-
-
-{-| Sets [`column-count`](https://css-tricks.com/almanac/properties/c/column-count/)
-
-    columnCount auto
-
-    columnCount (num 3)
-
--}
-columnCount :
+breakAfter :
     BaseValue
         { auto : Supported
-        , int : Supported
+        , always : Supported
+        , avoid : Supported
+        , all : Supported
+        , avoidPage : Supported
+        , page : Supported
+        , left_ : Supported
+        , right_ : Supported
+        , avoidColumn : Supported
+        , column : Supported
         }
     -> Style
-columnCount (Value count) =
-    AppendProperty ("column-count:" ++ count)
+breakAfter (Value val) =
+    AppendProperty ("break-after:" ++ val)
 
 
-{-| Sets [`column-fill`](https://css-tricks.com/almanac/properties/c/column-fill/)
+{-| Sets [`break-inside`](https://css-tricks.com/almanac/properties/b/break-inside/)
 
-    columnFill auto
+    breakInside auto
 
-    columnFill balance
+    breakInside avoid
 
-    columnFill balanceAll
+    breakInside avoidPage
+
+    breakInside avoidColumn
 
 -}
-columnFill :
+breakInside :
     BaseValue
         { auto : Supported
-        , balance : Supported
-        , balanceAll : Supported
+        , avoid : Supported
+        , avoidPage : Supported
+        , avoidColumn : Supported
         }
     -> Style
-columnFill (Value val) =
-    AppendProperty ("column-fill:" ++ val)
+breakInside (Value val) =
+    AppendProperty ("break-inside:" ++ val)
 
 
-{-| A `balance` value used in properties such as [`columnFill`](#columnFill)
 
-    columnFill balance
+{-| Sets `avoid` value for usage with [`breakAfter`](#breakAfter),
+[`breakBefore`](#breakBefore) and [`breakInside`](#breakInside).
 
--}
-balance : Value { provides | balance : Supported }
-balance =
-    Value "balance"
+    breakBefore avoid
 
+    breakAfter avoid
 
-{-| A `balance-all` value used in properties such as [`columnFill`](#columnFill)
-
-    columnFill balanceAll
+    breakInside avoid
 
 -}
-balanceAll : Value { provides | balanceAll : Supported }
-balanceAll =
-    Value "balance-all"
+avoid : Value { provides | avoid : Supported }
+avoid =
+    Value "avoid"
 
 
-{-| Sets [`column-span`](https://css-tricks.com/almanac/properties/c/column-span/)
+{-| Sets `avoid-page` value for usage with [`breakAfter`](#breakAfter),
+[`breakBefore`](#breakBefore) and [`breakInside`](#breakInside).
 
-    columnSpan all_
+    breakBefore avoidPage
 
-    columnSpan none
+    breakAfter avoidPage
+
+    breakInside avoidPage
 
 -}
-columnSpan :
+avoidPage : Value { provides | avoidPage : Supported }
+avoidPage =
+    Value "avoid-page"
+
+
+{-| Sets `avoid-column` value for usage with [`breakAfter`](#breakAfter),
+[`breakBefore`](#breakBefore) and [`breakInside`](#breakInside).
+
+    breakBefore avoidColumn
+
+    breakAfter avoidColumn
+
+    breakInside avoidColumn
+
+-}
+avoidColumn : Value { provides | avoidColumn : Supported }
+avoidColumn =
+    Value "avoid-column"
+
+
+
+{-| Sets `page` value for usage with [`breakAfter`](#breakAfter) and
+[`breakBefore`](#breakBefore).
+
+    breakBefore page
+
+    breakAfter page
+
+-}
+page : Value { provides | page : Supported }
+page =
+    Value "page"
+
+
+{-| Sets [`page-break-before`](https://css-tricks.com/almanac/properties/p/page-break/)
+
+**This property has been depreciated and replaced with
+[`breakBefore`](#breakBefore), but is still included for backwards
+compatibility.**
+
+    pageBreakBefore auto
+
+    pageBreakBefore always
+
+    pageBreakBefore avoid
+
+    pageBreakBefore left_
+
+    pageBreakBefore right_
+
+-}
+pageBreakBefore :
     BaseValue
-        { none : Supported
+        { auto : Supported
+        , always : Supported
+        , avoid : Supported
+        , left_ : Supported
+        , right_ : Supported
+        }
+    -> Style
+pageBreakBefore (Value val) =
+    AppendProperty ("page-break-before:" ++ val)
+
+
+{-| Sets [`page-break-after`](https://css-tricks.com/almanac/properties/p/page-break/)
+
+**This property has been depreciated and replaced with
+[`breakAfter`](#breakAfter), but is still included for backwards
+compatibility.**
+
+    pageBreakAfter auto
+
+    pageBreakAfter always
+
+    pageBreakAfter avoid
+
+    pageBreakAfter left_
+
+    pageBreakAfter right_
+
+-}
+pageBreakAfter :
+    BaseValue
+        { auto : Supported
+        , always : Supported
+        , avoid : Supported
+        , left_ : Supported
+        , right_ : Supported
+        }
+    -> Style
+pageBreakAfter (Value val) =
+    AppendProperty ("page-break-after:" ++ val)
+
+
+{-| Sets [`page-break-inside`](https://css-tricks.com/almanac/properties/p/page-break/)
+
+    pageBreakInside auto
+
+    pageBreakInside avoid
+
+-}
+pageBreakInside :
+    BaseValue
+        { auto : Supported
+        , avoid : Supported
+        }
+    -> Style
+pageBreakInside (Value val) =
+    AppendProperty ("page-break-inside:" ++ val)
+
+
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+---------------------------- POINTER-EVENTS-----------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+
+
+{-| Sets [`pointer-events`](https://css-tricks.com/almanac/properties/b/pointer-events/)
+
+    pointerEvents none
+
+    pointerEvents auto
+
+-}
+pointerEvents :
+    BaseValue
+        { auto : Supported
+        , none : Supported
+        , visiblePainted : Supported
+        , visibleFill : Supported
+        , visibleStroke : Supported
+        , visible : Supported
+        , painted : Supported
+        , fill_ : Supported
+        , stroke : Supported
         , all_ : Supported
         }
     -> Style
-columnSpan (Value spanVal) =
-    AppendProperty ("column-span:" ++ spanVal)
+pointerEvents (Value val) =
+    AppendProperty ("pointer-events:" ++ val)
 
 
-{-| Sets [`column-rule-width`](https://www.w3.org/TR/css-multicol-1/#propdef-column-rule-width)
+{-| The `visiblePainted` value used by [`pointerEvents`](#pointerEvents)
 
-    columnRuleWidth thin
-
-    columnRuleWidth (px 2)
+    pointerEvents visiblePainted
 
 -}
-columnRuleWidth : BaseValue LineWidth -> Style
-columnRuleWidth (Value widthVal) =
-    AppendProperty ("column-rule-width:" ++ widthVal)
+visiblePainted : Value { provides | visiblePainted : Supported }
+visiblePainted =
+    Value "visiblePainted"
 
 
-{-| Sets [`column-rule-style`](https://www.w3.org/TR/css-multicol-1/#propdef-column-rule-style)
+{-| The `visibleFill` value used by [`pointerEvents`](#pointerEvents)
 
-    columnRuleStyle solid
-
-    columnRuleStyle dotted
-
-    columnRuleStyle dashed
+    pointerEvents visibleFill
 
 -}
-columnRuleStyle : BaseValue LineStyle -> Style
-columnRuleStyle (Value styleVal) =
-    AppendProperty ("column-rule-style:" ++ styleVal)
+visibleFill : Value { provides | visibleFill : Supported }
+visibleFill =
+    Value "visibleFill"
 
 
-{-| Sets [`column-rule-color`](https://www.w3.org/TR/css-multicol-1/#propdef-column-rule-color)
+{-| The `visibleStroke` value used by [`pointerEvents`](#pointerEvents)
 
-    columnRuleColor (rgb 0 0 0)
-
-    columnRuleColor (hex "#fff")
+    pointerEvents visibleStroke
 
 -}
-columnRuleColor : BaseValue Color -> Style
-columnRuleColor (Value colorVal) =
-    AppendProperty ("column-rule-color:" ++ colorVal)
+visibleStroke : Value { provides | visibleStroke : Supported }
+visibleStroke =
+    Value "visibleStroke"
 
 
--- STROKE --
+{-| The `painted` value used by [`pointerEvents`](#pointerEvents)
 
-
-{-| Sets [`stroke-dasharray`](https://css-tricks.com/almanac/properties/s/stroke-dasharray/)
-
-    strokeDasharray (num 2)
-
-    strokeDasharray (num 2.5)
-
-    strokeDasharray (em 2)
-
-    strokeDasharray (pct 15)
+    pointerEvents painted
 
 -}
-strokeDasharray :
+painted : Value { provides | painted : Supported }
+painted =
+    Value "painted"
+
+
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------ SCROLLING ------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+
+
+{-| Sets `smooth` value for usage with [`scrollBehavior`](#scrollBehavior).
+
+    scrollBehavior smooth
+
+-}
+smooth : Value { provides | smooth : Supported }
+smooth =
+    Value "smooth"
+
+
+{-| Sets the
+[`scrollbar-color`](https://developer.mozilla.org/en-US/docs/Web/CSS/scrollbar-color) property.
+
+    scrollbarColor auto
+
+    scrollbarColor (hex "f35d93")
+-}
+scrollbarColor :
     BaseValue
-        (LengthSupported
-            { num : Supported
-            , pct : Supported
+        ( ColorSupported
+            { auto : Supported
             }
         )
     -> Style
-strokeDasharray (Value val) =
-    AppendProperty ("stroke-dasharray:" ++ val)
+scrollbarColor (Value val) =
+    AppendProperty ("scrollbar-color:" ++ val)
 
 
-{-| Sets [`stroke-dashoffset`](https://css-tricks.com/almanac/properties/s/stroke-dashoffset/)
+{-| Sets the [`scrollbar-width`](https://developer.mozilla.org/en-US/docs/Web/CSS/scrollbar-width) property.
 
-    strokeDashoffset zero
+    scrollbarWidth auto
 
-    strokeDashoffset (num 100)
-
-    strokeDashoffset (pct 25)
-
+    scrollbarWidth thin
 -}
-strokeDashoffset :
+scrollbarWidth :
     BaseValue
-        { zero : Supported
-        , calc : Supported
-        , num : Supported
-        , pct : Supported
-        }
-    -> Style
-strokeDashoffset (Value val) =
-    AppendProperty ("stroke-dashoffset:" ++ val)
-
-
-{-| Sets [`stroke-linecap`](https://css-tricks.com/almanac/properties/s/stroke-linecap/)
-
-    strokeLinecap butt
-
-    strokeLinecap square
-
-    strokeLinecap round
-
--}
-strokeLinecap :
-    BaseValue
-        { butt : Supported
-        , square : Supported
-        , round : Supported
-        }
-    -> Style
-strokeLinecap (Value val) =
-    AppendProperty ("stroke-linecap:" ++ val)
-
-
-{-| A `butt` value for the [`strokeLinecap`](#strokeLinecap) property.
-
-    strokeLinecap butt
-
--}
-butt : Value { provides | butt : Supported }
-butt =
-    Value "butt"
-
-
-{-| The `square` value used by properties such as [`strokeLinecap`](#strokeLinecap),
-[`listStyle`](#listStyle),
-and [`listStyleType`](#listStyleType).
-
-    strokeLinecap square
-
-    listStyleType square
-
--}
-square : Value { provides | square : Supported }
-square =
-    Value "square"
-
-
-{-| Sets [`stroke-width`](https://css-tricks.com/almanac/properties/s/stroke-width/)
-
-    strokeWidth zero
-
-    strokeWidth (px 2)
-
-    strokeWidth (em 2)
-
-    strokeWidth (num 2)
-
-    strokeWidth (num 2.5)
-
-    strokeWidth (pct 15)
-
--}
-strokeWidth :
-    BaseValue
-        (LengthSupported
-            { num : Supported
-            , pct : Supported
-            }
-        )
-    -> Style
-strokeWidth (Value val) =
-    AppendProperty ("stroke-width:" ++ val)
-
-
-{-| Sets [`stroke-align`](https://www.w3.org/TR/fill-stroke-3/#propdef-stroke-align)
-
-**Note:** This function accepts `inset_` rather than `inset` because
-[`inset` is already a property function](#inset).
-
-      strokeAlign center
-      strokeAlign inset_
-      strokeAlign outset
-
--}
-strokeAlign :
-    BaseValue
-        { center : Supported
-        , inset_ : Supported
-        , outset : Supported
-        }
-    -> Style
-strokeAlign (Value val) =
-    AppendProperty ("stroke-align:" ++ val)
-
-
-{-| Sets [`stroke-break`](https://www.w3.org/TR/fill-stroke-3/#propdef-stroke-break)
-
-      strokeBreak boundingBox
-      strokeBreak slice
-      strokeBreak clone
-
--}
-strokeBreak :
-    BaseValue
-        { boundingBox : Supported
-        , slice : Supported
-        , clone : Supported
-        }
-    -> Style
-strokeBreak (Value val) =
-    AppendProperty ("stroke-break:" ++ val)
-
-
-{-| A `boundingBox` value for the [`strokeBreak`](#strokeBreak) property.
-
-      strokeBreak boundingBox
-
--}
-boundingBox : Value { provides | boundingBox : Supported }
-boundingBox =
-    Value "bounding-box"
-
-
-{-| A `slice` value for the [`strokeBreak`](#strokeBreak) and [`boxDecorationBreak`](#boxDecorationBreak) properties.
-
-      strokeBreak slice
-
-      boxDecorationbreak clone
-
--}
-slice : Value { provides | slice : Supported }
-slice =
-    Value "slice"
-
-
-{-| A `clone` value for the [`strokeBreak`](#strokeBreak) and [`boxDecorationBreak`](#boxDecorationBreak) properties.
-
-      strokeBreak clone
-
-      boxDecorationBreak clone
-
--}
-clone : Value { provides | clone : Supported }
-clone =
-    Value "clone"
-
-
-{-| Sets [`stroke-color`](https://www.w3.org/TR/fill-stroke-3/#propdef-stroke-color)
-
-    strokeColor (rgb 0 100 44)
-
-    strokeColor (hex "#FF9E2C")
-
--}
-strokeColor : BaseValue Color -> Style
-strokeColor (Value val) =
-    AppendProperty ("stroke-color:" ++ val)
-
-
-{-| Sets [`stroke-image`](https://www.w3.org/TR/fill-stroke-3/#propdef-stroke-image)
-
-    strokeImage (url "#svg-pattern")
-
-    strokeImage (url "http://www.example.com/chicken.jpg")
-
--}
-strokeImage :
-    BaseValue
-        { url : Supported
+        { auto : Supported
+        , thin : Supported
         , none : Supported
         }
     -> Style
-strokeImage (Value value) =
-    AppendProperty ("stroke-image:" ++ value)
+scrollbarWidth (Value val) =
+    AppendProperty ("scrollbar-width:" ++ val)
 
 
-{-| Sets [`stroke-miterlimit`](https://www.w3.org/TR/fill-stroke-3/#propdef-stroke-miterlimit)
+{-| Sets [`scroll-behavior`](https://css-tricks.com/almanac/properties/s/scroll-behavior/)
 
-    strokeMiterlimit (num 4)
+    scrollBehavior auto
+
+    scrollBehavior smooth
 
 -}
-strokeMiterlimit :
+scrollBehavior :
     BaseValue
-        { num : Supported
+        { auto : Supported
+        , smooth : Supported
         }
     -> Style
-strokeMiterlimit (Value val) =
-    AppendProperty ("stroke-miterlimit:" ++ val)
+scrollBehavior (Value val) =
+    AppendProperty ("scroll-behavior:" ++ val)
 
 
-{-| Sets [`stroke-opacity`](https://www.w3.org/TR/fill-stroke-3/#propdef-stroke-opacity)
+{-| Sets [`scroll-margin`](https://css-tricks.com/almanac/properties/s/scroll-margin/) property.
+The `scrollMargin` property is a shorthand property for setting
+`scroll-margin-top`, `scroll-margin-right`, `scroll-margin-bottom`,
+and `scroll-margin-left` in a single declaration.
 
-    strokeOpacity (num 0.5)
+If there is only one argument value, it applies to all sides. If there are two
+values, the top and bottom margins are set to the first value and the right and
+left margins are set to the second. If there are three values, the top is set
+to the first value, the left and right are set to the second, and the bottom is
+set to the third. If there are four values they apply to the top, right,
+bottom, and left, respectively.
+
+    scrollMargin (em 4) -- set all margins to 4em
+
+    scrollMargin2 (em 4) (px 2) -- top & bottom = 4em, right & left = 2px
+
+    scrollMargin3 (em 4) (px 2) (pt 5) -- top = 4em, right = 2px, bottom = 5pt, left = 2px
+
+    scrollMargin4 (em 4) (px 2) (pt 5) (px 3) -- top = 4em, right = 2px, bottom = 5pt, left = 3px
 
 -}
-strokeOpacity :
+scrollMargin :
     BaseValue
-        { num : Supported
-        }
+        Length
     -> Style
-strokeOpacity (Value val) =
-    AppendProperty ("stroke-opacity:" ++ val)
+scrollMargin (Value value) =
+    AppendProperty ("scroll-margin:" ++ value)
 
 
-{-| Sets [`stroke-origin`](https://www.w3.org/TR/fill-stroke-3/#propdef-stroke-origin)
+{-| Sets [`scroll-margin`](https://css-tricks.com/almanac/properties/s/scroll-margin/) property.
+The `scrollMargin2` property is a shorthand property for setting
+`scroll-margin-top`, `scroll-margin-right`, `scroll-margin-bottom`,
+and `scroll-margin-left` in a single declaration.
 
-    strokeOrign matchParent
+The top and bottom margins are set to the first value and the right and left
+margins are set to the second.
 
-    strokeOrign fillBox
-
-    strokeOrign strokeBox
-
-    strokeOrign contentBox
-
-    strokeOrign paddingBox
-
-    strokeOrign borderBox
+    scrollMargin2 (em 4) (px 2) -- top & bottom = 4em, right & left = 2px
 
 -}
-strokeOrigin :
-    BaseValue
-        { matchParent : Supported
-        , fillBox : Supported
-        , strokeBox : Supported
-        , contentBox : Supported
-        , paddingBox : Supported
-        , borderBox : Supported
-        }
-    -> Style
-strokeOrigin (Value val) =
-    AppendProperty ("stroke-origin:" ++ val)
-
-
-
-{-| Sets [`stroke-position`](https://www.w3.org/TR/fill-stroke-3/#propdef-stroke-position).
-
-    strokePosition left_
-
-    strokePosition (px 45)
-
-`strokePosition` sets the horizontal direction. If you need the vertical
-direction instead, use [`strokePosition2`](#strokePosition2) like this:
-
-    strokePosition zero (px 45)
-
-If you need to set the offsets from the right or bottom, use
-[`strokePosition4`](#strokePosition4) like this:
-
-    strokePosition4 right_ (px 20) bottom_ (pct 25)
-
--}
-strokePosition :
-    BaseValue
-        (LengthSupported
-            { pct : Supported
-            , left_ : Supported
-            , right_ : Supported
-            , center : Supported
-            }
-        )
-    -> Style
-strokePosition (Value horiz) =
-    AppendProperty ("stroke-position:" ++ horiz)
-
-
-{-| Sets [`stroke-position`](https://www.w3.org/TR/fill-stroke-3/#propdef-stroke-position).
-
-    strokePosition2 left_ top_
-
-    strokePosition2 (px 45) (pct 50)
-
-`strokePosition2` sets both the horizontal and vertical directions (in that
-order, same as CSS.) If you need only the horizontal, you can use
-[`strokePosition`](#strokePosition) instead:
-
-    strokePosition left_
-
-If you need to set the offsets from the right or bottom, use
-[`strokePosition4`](#strokePosition4) like this:
-
-    strokePosition4 right_ (px 20) bottom_ (pct 25)
-
--}
-strokePosition2 :
+scrollMargin2 :
     Value
-        (LengthSupported
-            { pct : Supported
-            , left_ : Supported
-            , right_ : Supported
-            , center : Supported
-            }
-        )
+        Length
     ->
         Value
-            (LengthSupported
-                { pct : Supported
-                , top_ : Supported
-                , bottom_ : Supported
-                , center : Supported
-                }
-            )
+            Length
     -> Style
-strokePosition2 (Value horiz) (Value vert) =
-    AppendProperty ("stroke-position:" ++ horiz ++ " " ++ vert)
+scrollMargin2 (Value valueTopBottom) (Value valueRightLeft) =
+    AppendProperty ("scroll-margin:" ++ valueTopBottom ++ " " ++ valueRightLeft)
 
 
-{-| Sets [`stroke-position`](https://www.w3.org/TR/fill-stroke-3/#propdef-stroke-position).
+{-| Sets [`scroll-margin`](https://css-tricks.com/almanac/properties/s/scroll-margin/) property.
+The `scrollMargin3` property is a shorthand property for setting
+`scroll-margin-top`, `scroll-margin-right`, `scroll-margin-bottom`,
+and `scroll-margin-left` in a single declaration.
 
-    strokePosition4 right_ (px 20) bottom_ (pct 30)
+The top margin is set to the first value, the left and right are set to the
+second, and the bottom is set to the third.
 
-The four-argument form of stroke-position alternates sides and offets. So the
-example above would position the stroke-image 20px from the right, and 30%
-from the bottom.
-
-See also [`strokePosition`](#strokePosition) for horizontal alignment and
-[`strokePosition2`](#strokePosition2) for horizontal (from left) and
-vertical (from top) alignment.
+    scrollMargin3 (em 4) (px 2) (pt 5) -- top = 4em, right = 2px, bottom = 5pt, left = 2px
 
 -}
-strokePosition4 :
+scrollMargin3 :
     Value
-        { left_ : Supported
-        , right_ : Supported
-        }
+        Length
     ->
         Value
-            (LengthSupported
-                { pct : Supported
-                }
-            )
+            Length
     ->
         Value
-            { top_ : Supported
-            , bottom_ : Supported
-            }
-    ->
-        Value
-            (LengthSupported
-                { pct : Supported
-                }
-            )
+            Length
     -> Style
-strokePosition4 (Value horiz) (Value horizAmount) (Value vert) (Value vertAmount) =
-    AppendProperty
-        ("stroke-position:"
-            ++ horiz
-            ++ " "
-            ++ horizAmount
-            ++ " "
-            ++ vert
-            ++ " "
-            ++ vertAmount
-        )
+scrollMargin3 (Value valueTop) (Value valueRightLeft) (Value valueBottom) =
+    AppendProperty ("scroll-margin:" ++ valueTop ++ " " ++ valueRightLeft ++ " " ++ valueBottom)
 
 
-{-| Sets [`stroke-repeat`](https://www.w3.org/TR/fill-stroke-3/#propdef-stroke-repeat)
+{-| Sets [`scroll-margin`](https://css-tricks.com/almanac/properties/s/scroll-margin/) property.
+The `scrollMargin4` property is a shorthand property for setting
+`scroll-margin-top`, `scroll-margin-right`, `scroll-margin-bottom`,
+and `scroll-margin-left` in a single declaration.
 
-    strokeRepeat repeat
+The four values apply to the top, right, bottom, and left margins.
 
-    strokeRepeat repeatX
-
-If you need to set horizontal and vertical direction separately, see
-[`strokeRepeat2`](#strokeRepeat2)
+    scrollMargin4 (em 4) (px 2) (pt 5) (px 3) -- top = 4em, right = 2px, bottom = 5pt, left = 3px
 
 -}
-strokeRepeat :
-    BaseValue
-        { repeat : Supported
-        , repeatX : Supported
-        , repeatY : Supported
-        , space : Supported
-        , round : Supported
-        , noRepeat : Supported
-        }
-    -> Style
-strokeRepeat (Value repeatVal) =
-    AppendProperty ("stroke-repeat:" ++ repeatVal)
-
-
-{-| Sets [`stroke-repeat`](https://www.w3.org/TR/fill-stroke-3/#propdef-stroke-repeat) along the horizontal axis, then the vertical axis.
-
-    strokeRepeat2 repeat space
-
-    strokeRepeat2 space round
-
-If you only need to set one value for both, see
-[`strokeRepeat`](#strokeRepeat) instead.
-
--}
-strokeRepeat2 :
+scrollMargin4 :
     Value
-        { repeat : Supported
-        , space : Supported
-        , round : Supported
-        , noRepeat : Supported
-        }
+        Length
     ->
         Value
-            { repeat : Supported
-            , space : Supported
-            , round : Supported
-            , noRepeat : Supported
-            }
+            Length
+    ->
+        Value
+            Length
+    ->
+        Value
+            Length
     -> Style
-strokeRepeat2 (Value horiz) (Value vert) =
-    AppendProperty ("stroke-repeat:" ++ horiz ++ " " ++ vert)
+scrollMargin4 (Value valueTop) (Value valueRight) (Value valueBottom) (Value valueLeft) =
+    AppendProperty ("scroll-margin:" ++ valueTop ++ " " ++ valueRight ++ " " ++ valueBottom ++ " " ++ valueLeft)
 
 
-{-| Sets [`stroke-size`](https://www.w3.org/TR/fill-stroke-3/#propdef-stroke-size).
+{-| Sets [`scroll-margin-top`](https://css-tricks.com/almanac/properties/s/scroll-margin/) property.
 
-    strokeSize cover
-
-    strokeSize (px 400)
-
-If you give a length value, it will be used for the width. The height will be set
-proportional to the size of the [`stroke-image`](#strokeImage). If you
-need to set both width and height explicitly, use
-[`strokeImage2`](#strokeImage2) instead.
+    scrollMarginTop (px 4)
 
 -}
-strokeSize :
+scrollMarginTop :
     BaseValue
-        (LengthSupported
-            { pct : Supported
-            , auto : Supported
-            , cover : Supported
-            }
-        )
+        Length
     -> Style
-strokeSize (Value sizeVal) =
-    AppendProperty ("stroke-size:" ++ sizeVal)
+scrollMarginTop (Value value) =
+    AppendProperty ("scroll-margin-top:" ++ value)
 
 
-{-| Sets [`stroke-size`](https://www.w3.org/TR/fill-stroke-3/#propdef-stroke-size).
+{-| Sets [`scroll-margin-right`](https://css-tricks.com/almanac/properties/s/scroll-margin/) property.
 
-    strokeSize2 (px 300) (px 100)
-
-    strokeSize2 auto (px 400)
-
-If you only want to set the width, use [`strokeImage`](#strokeImage) instead.
+    scrollMarginRight (px 4)
 
 -}
-strokeSize2 :
+scrollMarginRight :
+    BaseValue
+        Length
+    -> Style
+scrollMarginRight (Value value) =
+    AppendProperty ("scroll-margin-right:" ++ value)
+
+
+{-| Sets [`scroll-margin-bottom`](https://css-tricks.com/almanac/properties/s/scroll-margin/) property.
+
+    scrollMarginBottom (px 4)
+
+-}
+scrollMarginBottom :
+    BaseValue
+        Length
+    -> Style
+scrollMarginBottom (Value value) =
+    AppendProperty ("scroll-margin-bottom:" ++ value)
+
+
+{-| Sets [`scroll-margin-left`](https://css-tricks.com/almanac/properties/s/scroll-margin/) property.
+
+    scrollMarginLeft (px 4)
+
+-}
+scrollMarginLeft :
+    BaseValue
+        Length
+    -> Style
+scrollMarginLeft (Value value) =
+    AppendProperty ("scroll-margin-left:" ++ value)
+
+
+{-| Sets [`scroll-margin-block`](https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-margin-block) property.
+The `scrollMarginBlock` property is a shorthand property for setting
+`scroll-margin-block-start` and `scroll-margin-block-end` in a single declaration.
+
+If there is only one argument value, it applies to both sides. If there are two
+values, the block start margin is set to the first value and the block end margin is
+set to the second.
+
+    scrollMarginBlock (em 4) -- set both block margins to 4em
+
+    scrollMarginBlock2 (em 4) (px 2) -- block start = 4em, block end = 2px
+
+-}
+scrollMarginBlock :
+    BaseValue
+        Length
+    -> Style
+scrollMarginBlock (Value value) =
+    AppendProperty ("scroll-margin-block:" ++ value)
+
+
+{-| Sets [`scroll-margin-block`](https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-margin-block) property.
+The `scrollMarginBlock2` property is a shorthand property for setting
+`scroll-margin-block-start` and `scroll-margin-block-end` in a single declaration.
+
+The block start margin is set to the first value and the block end margin is
+set to the second.
+
+    scrollMarginBlock2 (em 4) (px 2) -- block start = 4em, block end = 2px
+
+-}
+scrollMarginBlock2 :
     Value
-        (LengthSupported
-            { pct : Supported
-            , auto : Supported
-            }
-        )
+        Length
     ->
         Value
-            (LengthSupported
-                { pct : Supported
-                , auto : Supported
-                }
-            )
+            Length
     -> Style
-strokeSize2 (Value widthVal) (Value heightVal) =
-    AppendProperty ("stroke-size:" ++ widthVal ++ " " ++ heightVal)
+scrollMarginBlock2 (Value valueStart) (Value valueEnd) =
+    AppendProperty ("scroll-margin-block:" ++ valueStart ++ " " ++ valueEnd)
 
 
-{-| Sets [`stroke-dash-corner`](https://www.w3.org/TR/fill-stroke-3/#propdef-stroke-dash-corner).
+{-| Sets [`scroll-margin-inline`](https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-margin-inline) property.
+The `scrollMarginInline` property is a shorthand property for setting
+`scroll-margin-inline-start` and `scroll-margin-inline-end` in a single declaration.
 
-    strokeDashCorner none
+If there is only one argument value, it applies to both sides. If there are two
+values, the inline start margin is set to the first value and the inline end margin is
+set to the second.
 
-    strokeDashCorner (px 10)
+    scrollMarginInline (em 4) -- set both inline margins to 4em
 
-    strokeDashCorner (em 5)
+    scrollMarginInline2 (em 4) (px 2) -- inline start = 4em, inline end = 2px
 
 -}
-strokeDashCorner :
+scrollMarginInline :
+    BaseValue
+        Length
+    -> Style
+scrollMarginInline (Value value) =
+    AppendProperty ("scroll-margin-inline:" ++ value)
+
+
+{-| Sets [`scroll-margin-inline`](https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-margin-inline) property.
+The `scrollMarginInline2` property is a shorthand property for setting
+`scroll-margin-inline-start` and `scroll-margin-inline-end` in a single declaration.
+
+The inline start margin is set to the first value and the inline end margin is
+set to the second.
+
+    scrollMarginInline2 (em 4) (px 2) -- inline start = 4em, inline end = 2px
+
+-}
+scrollMarginInline2 :
+    Value
+        Length
+    ->
+        Value
+            Length
+    -> Style
+scrollMarginInline2 (Value valueStart) (Value valueEnd) =
+    AppendProperty ("scroll-margin-inline:" ++ valueStart ++ " " ++ valueEnd)
+
+
+{-| Sets [`scroll-margin-block-start`](https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-margin-block-start) property.
+
+    scrollMarginBlockStart (px 4)
+
+-}
+scrollMarginBlockStart :
+    BaseValue
+        Length
+    -> Style
+scrollMarginBlockStart (Value value) =
+    AppendProperty ("scroll-margin-block-start:" ++ value)
+
+
+{-| Sets [`scroll-margin-block-end`](https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-margin-block-end) property.
+
+    scrollMarginBlockEnd (px 4)
+
+-}
+scrollMarginBlockEnd :
+    BaseValue
+        Length
+    -> Style
+scrollMarginBlockEnd (Value value) =
+    AppendProperty ("scroll-margin-block-end:" ++ value)
+
+
+{-| Sets [`scroll-margin-inline-start`](https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-margin-inline-start) property.
+
+    scrollMarginInlineStart (px 4)
+
+-}
+scrollMarginInlineStart :
+    BaseValue
+        Length
+    -> Style
+scrollMarginInlineStart (Value value) =
+    AppendProperty ("scroll-margin-inline-start:" ++ value)
+
+
+{-| Sets [`scroll-margin-inline-end`](https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-margin-inline-end) property.
+
+    scrollMarginInlineEnd (px 4)
+
+-}
+scrollMarginInlineEnd :
+    BaseValue
+        Length
+    -> Style
+scrollMarginInlineEnd (Value value) =
+    AppendProperty ("scroll-margin-inline-end:" ++ value)
+
+
+{-| Sets [`scroll-padding`](https://css-tricks.com/almanac/properties/s/scroll-padding/) property.
+The `scrollPadding` property is a shorthand property for setting
+`scroll-padding-top`, `scroll-padding-right`, `scroll-padding-bottom`,
+and `scroll-padding-left` in a single declaration.
+
+If there is only one argument value, it applies to all sides. If there are two
+values, the top and bottom paddings are set to the first value and the right and
+left paddings are set to the second. If there are three values, the top is set
+to the first value, the left and right are set to the second, and the bottom is
+set to the third. If there are four values they apply to the top, right,
+bottom, and left, respectively.
+
+    scrollPadding (em 4) -- set all paddings to 4em
+
+    scrollPadding2 (em 4) (px 2) -- top & bottom = 4em, right & left = 2px
+
+    scrollPadding3 (em 4) (px 2) (pct 5) -- top = 4em, right = 2px, bottom = 5%, left = 2px
+
+    scrollPadding4 (em 4) (px 2) (pct 5) (px 3) -- top = 4em, right = 2px, bottom = 5%, left = 3px
+
+-}
+scrollPadding :
     BaseValue
         (LengthSupported
-            { none : Supported
+            { auto : Supported
             , pct : Supported
-            , auto : Supported
-            , cover : Supported
             }
         )
     -> Style
-strokeDashCorner (Value sizeVal) =
-    AppendProperty ("stroke-dash-corner:" ++ sizeVal)
+scrollPadding (Value value) =
+    AppendProperty ("scroll-padding:" ++ value)
 
 
-{-| Sets [`stroke-linejoin`](https://www.w3.org/TR/fill-stroke-3/#propdef-stroke-linejoin).
+{-| Sets [`scroll-padding`](https://css-tricks.com/almanac/properties/s/scroll-padding/) property.
+The `scrollPadding2` property is a shorthand property for setting
+`scroll-padding-top`, `scroll-padding-right`, `scroll-padding-bottom`,
+and `scroll-padding-left` in a single declaration.
 
-    strokeLinejoin crop
+The top and bottom margins are set to the first value and the right and left
+margins are set to the second.
 
-    strokeLinejoin arcs
-
-    strokeLinejoin miter
-
-**Note:** if you only want to specifiy the rendering of the cap of a corner you need to use [`strokeLinejoin2`](#strokeLinejoin2)
-and set it's first value to `miter` like so: `strokeLinejoin2 miter bevel`.
-
--}
-strokeLinejoin :
-    BaseValue
-        { crop : Supported
-        , arcs : Supported
-        , miter : Supported
-        }
-    -> Style
-strokeLinejoin (Value val) =
-    AppendProperty ("stroke-linejoin:" ++ val)
-
-
-{-| Sets [`stroke-linejoin`](https://www.w3.org/TR/fill-stroke-3/#propdef-stroke-linejoin).
-
-    strokeLinejoin crop bevel
-
-    strokeLinejoin arcs round
-
-    strokeLinejoin miter fallback
+    scrollPadding2 (em 4) (px 2) -- top & bottom = 4em, right & left = 2px
 
 -}
-strokeLinejoin2 :
+scrollPadding2 :
     Value
-        { crop : Supported
-        , arcs : Supported
-        , miter : Supported
-        }
+        (LengthSupported
+            { auto : Supported
+            , pct : Supported
+            }
+        )
     ->
         Value
-            { bevel : Supported
-            , round : Supported
-            , fallback : Supported
-            }
+            (LengthSupported
+                { auto : Supported
+                , pct : Supported
+                }
+            )
     -> Style
-strokeLinejoin2 (Value extendCorner) (Value capRender) =
-    AppendProperty ("stroke-linejoin:" ++ extendCorner ++ " " ++ capRender)
+scrollPadding2 (Value valueTopBottom) (Value valueRightLeft) =
+    AppendProperty ("scroll-padding:" ++ valueTopBottom ++ " " ++ valueRightLeft)
 
 
-{-| Sets `crop` value for usage with [`strokeLinejoin`](#strokeLinejoin).
+{-| Sets [`scroll-padding`](https://css-tricks.com/almanac/properties/s/scroll-padding/) property.
+The `scrollPadding3` property is a shorthand property for setting
+`scroll-padding-top`, `scroll-padding-right`, `scroll-padding-bottom`,
+and `scroll-padding-left` in a single declaration.
 
-    strokeLinejoin crop
+The top padding is set to the first value, the left and right are set to the
+second, and the bottom is set to the third.
 
--}
-crop : Value { provides | crop : Supported }
-crop =
-    Value "crop"
-
-
-{-| Sets `arcs` value for usage with [`strokeLinejoin`](#strokeLinejoin).
-
-    strokeLinejoin arcs
+    scrollPadding3 (em 4) (px 2) (pct 5) -- top = 4em, right = 2px, bottom = 5%, left = 2px
 
 -}
-arcs : Value { provides | arcs : Supported }
-arcs =
-    Value "arcs"
-
-
-{-| Sets `miter` value for usage with [`strokeLinejoin`](#strokeLinejoin).
-
-    strokeLinejoin miter
-
--}
-miter : Value { provides | miter : Supported }
-miter =
-    Value "miter"
-
-
-{-| Sets `bevel` value for usage with [`strokeLinejoin`](#strokeLinejoins2).
-
-    strokeLinejoin miter bevel
-
--}
-bevel : Value { provides | bevel : Supported }
-bevel =
-    Value "bevel"
-
-
-{-| Sets [`stroke-dash-justify`](https://www.w3.org/TR/fill-stroke-3/#propdef-stroke-dash-justify).
-
-      strokeDashJustify none
-      strokeDashJustify stretch
-      strokeDashJustify compress
-      strokeDashJustify dashes
-      strokeDashJustify gaps
-
--}
-strokeDashJustify :
-    BaseValue
-        { none : Supported
-        , stretch : Supported
-        , compress : Supported
-        , dashes : Supported
-        , gaps : Supported
-        }
-    -> Style
-strokeDashJustify (Value val) =
-    AppendProperty ("stroke-dash-justify:" ++ val)
-
-
-{-| Sets `compress` value for usage with [`strokeDashJustify`](#strokeDashJustify).
-
-      strokeDashJustify compress
-
--}
-compress : Value { provides | compress : Supported }
-compress =
-    Value "compress"
-
-
-{-| Sets `dashes` value for usage with [`strokeDashJustify`](#strokeDashJustify).
-
-      strokeDashJustify dashes
-
--}
-dashes : Value { provides | dashes : Supported }
-dashes =
-    Value "dashes"
-
-
-{-| Sets `gaps` value for usage with [`strokeDashJustify`](#strokeDashJustify).
-
-      strokeDashJustify gaps
-
--}
-gaps : Value { provides | gaps : Supported }
-gaps =
-    Value "gaps"
-
-
-{-| The [`paint-order`](https://css-tricks.com/almanac/properties/p/paint-order/) property.
-
-This one-argument version indicates which parts of text and shape graphics are
-painted first, followed by the other two in their relative default order.
-
-    paintOrder normal -- normal paint order.
-
-    paintOrder2 fill_ stroke -- fill, stroke, then markers.
-
-    paintOrder3 markers stroke fill_ -- markers, stroke, then fill.
-
--}
-paintOrder :
-    BaseValue
-        { normal : Supported
-        , stroke : Supported
-        , markers : Supported
-        }
-    -> Style
-paintOrder (Value val) =
-    AppendProperty ("paint-order:" ++ val)
-
-
-{-| The [`paint-order`](https://css-tricks.com/almanac/properties/p/paint-order/) property.
-
-This two-argument version indicates which parts of text and shape graphics are
-painted first, followed by the other remaining one.
-
-    paintOrder2 fill_ stroke -- fill, stroke, then markers.
-
--}
-paintOrder2 :
+scrollPadding3 :
     Value
-        { fill_ : Supported
-        , stroke : Supported
-        , markers : Supported
-        }
+        (LengthSupported
+            { auto : Supported
+            , pct : Supported
+            }
+        )
     ->
         Value
-            { fill_ : Supported
-            , stroke : Supported
-            , markers : Supported
-            }
+            (LengthSupported
+                { auto : Supported
+                , pct : Supported
+                }
+            )
+    ->
+        Value
+            (LengthSupported
+                { auto : Supported
+                , pct : Supported
+                }
+            )
     -> Style
-paintOrder2 (Value val1) (Value val2) =
-    AppendProperty ("paint-order:" ++ val1 ++ " " ++ val2)
+scrollPadding3 (Value valueTop) (Value valueRightLeft) (Value valueBottom) =
+    AppendProperty ("scroll-padding:" ++ valueTop ++ " " ++ valueRightLeft ++ " " ++ valueBottom)
 
 
-{-| The [`paint-order`](https://css-tricks.com/almanac/properties/p/paint-order/) property.
+{-| Sets [`scroll-padding`](https://css-tricks.com/almanac/properties/s/scroll-padding/) property.
+The `scrollPadding4` property is a shorthand property for setting
+`scroll-padding-top`, `scroll-padding-right`, `scroll-padding-bottom`,
+and `scroll-padding-left` in a single declaration.
 
-This three-argument version explicitly indicates in which order should all the parts of text
-and shape graphics be painted.
+The four values apply to the top, right, bottom, and left paddings.
 
-    paintOrder3 markers stroke fill_ -- markers, stroke, then fill.
+    scrollPadding4 (em 4) (px 2) (pct 5) (px 3) -- top = 4em, right = 2px, bottom = 5%, left = 3px
 
 -}
-paintOrder3 :
+scrollPadding4 :
     Value
-        { fill_ : Supported
-        , stroke : Supported
-        , markers : Supported
+        (LengthSupported
+            { auto : Supported
+            , pct : Supported
+            }
+        )
+    ->
+        Value
+            (LengthSupported
+                { auto : Supported
+                , pct : Supported
+                }
+            )
+    ->
+        Value
+            (LengthSupported
+                { auto : Supported
+                , pct : Supported
+                }
+            )
+    ->
+        Value
+            (LengthSupported
+                { auto : Supported
+                , pct : Supported
+                }
+            )
+    -> Style
+scrollPadding4 (Value valueTop) (Value valueRight) (Value valueBottom) (Value valueLeft) =
+    AppendProperty ("scroll-padding:" ++ valueTop ++ " " ++ valueRight ++ " " ++ valueBottom ++ " " ++ valueLeft)
+
+
+{-| Sets [`scroll-padding-top`](https://css-tricks.com/almanac/properties/s/scroll-padding/) property.
+
+    scrollPaddingTop (px 4)
+
+-}
+scrollPaddingTop :
+    BaseValue
+        (LengthSupported
+            { auto : Supported
+            , pct : Supported
+            }
+        )
+    -> Style
+scrollPaddingTop (Value value) =
+    AppendProperty ("scroll-padding-top:" ++ value)
+
+
+{-| Sets [`scroll-padding-right`](https://css-tricks.com/almanac/properties/s/scroll-padding/) property.
+
+    scrollPaddingRight (px 4)
+
+-}
+scrollPaddingRight :
+    BaseValue
+        (LengthSupported
+            { auto : Supported
+            , pct : Supported
+            }
+        )
+    -> Style
+scrollPaddingRight (Value value) =
+    AppendProperty ("scroll-padding-right:" ++ value)
+
+
+{-| Sets [`scroll-padding-bottom`](https://css-tricks.com/almanac/properties/s/scroll-padding/) property.
+
+    scrollPaddingBottom (px 4)
+
+-}
+scrollPaddingBottom :
+    BaseValue
+        (LengthSupported
+            { auto : Supported
+            , pct : Supported
+            }
+        )
+    -> Style
+scrollPaddingBottom (Value value) =
+    AppendProperty ("scroll-padding-bottom:" ++ value)
+
+
+{-| Sets [`scroll-padding-left`](https://css-tricks.com/almanac/properties/s/scroll-padding/) property.
+
+    scrollPaddingLeft (px 4)
+
+-}
+scrollPaddingLeft :
+    BaseValue
+        (LengthSupported
+            { auto : Supported
+            , pct : Supported
+            }
+        )
+    -> Style
+scrollPaddingLeft (Value value) =
+    AppendProperty ("scroll-padding-left:" ++ value)
+
+
+{-| Sets [`scroll-padding-block`](https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-padding-block) property.
+The `scroll-padding-block` property is a shorthand property for setting
+`scroll-padding-block-start` and `scroll-padding-block-end` in a single declaration.
+
+If there is only one argument value, it applies to both sides. If there are two
+values, the block start padding is set to the first value and the block end padding
+is set to the second.
+
+    scrollPaddingBlock (em 4) -- set both block paddings to 4em
+
+    scrollPaddingBlock2 (em 4) (px 2) -- block start = 4em, block end = 2px
+
+-}
+scrollPaddingBlock :
+    BaseValue
+        (LengthSupported
+            { auto : Supported
+            , pct : Supported
+            }
+        )
+    -> Style
+scrollPaddingBlock (Value value) =
+    AppendProperty ("scroll-padding-block:" ++ value)
+
+
+{-| Sets [`scroll-padding-block`](https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-padding-block) property.
+The `scroll-padding-block` property is a shorthand property for setting
+`scroll-padding-block-start` and `scroll-padding-block-end` in a single declaration.
+
+The block start padding is set to the first value and the block end padding
+is set to the second.
+
+    scrollPaddingBlock2 (em 4) (px 2) -- block start = 4em, block end = 2px
+
+-}
+scrollPaddingBlock2 :
+    Value
+        (LengthSupported
+            { auto : Supported
+            , pct : Supported
+            }
+        )
+    ->
+        Value
+            (LengthSupported
+                { auto : Supported
+                , pct : Supported
+                }
+            )
+    -> Style
+scrollPaddingBlock2 (Value valueStart) (Value valueEnd) =
+    AppendProperty ("scroll-padding-block:" ++ valueStart ++ " " ++ valueEnd)
+
+
+{-| Sets [`scroll-padding-inline`](https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-padding-inline) property.
+The `scroll-padding-inline` property is a shorthand property for setting
+`scroll-padding-inline-start` and `scroll-padding-inline-end` in a single declaration.
+
+If there is only one argument value, it applies to both sides. If there are two
+values, the inline start padding is set to the first value and the inline end padding
+is set to the second.
+
+    scrollPaddingInline (em 4) -- set both inline paddings to 4em
+
+    scrollPaddingInline2 (em 4) (px 2) -- inline start = 4em, inline end = 2px
+
+-}
+scrollPaddingInline :
+    BaseValue
+        (LengthSupported
+            { auto : Supported
+            , pct : Supported
+            }
+        )
+    -> Style
+scrollPaddingInline (Value value) =
+    AppendProperty ("scroll-padding-inline:" ++ value)
+
+
+{-| Sets [`scroll-padding-inline`](https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-padding-inline) property.
+The `scroll-padding-inline` property is a shorthand property for setting
+`scroll-padding-inline-start` and `scroll-padding-inline-end` in a single declaration.
+
+The inline start padding is set to the first value and the inline end padding
+is set to the second.
+
+    scrollPaddingInline2 (em 4) (px 2) -- inline start = 4em, inline end = 2px
+
+-}
+scrollPaddingInline2 :
+    Value
+        (LengthSupported
+            { auto : Supported
+            , pct : Supported
+            }
+        )
+    ->
+        Value
+            (LengthSupported
+                { auto : Supported
+                , pct : Supported
+                }
+            )
+    -> Style
+scrollPaddingInline2 (Value valueStart) (Value valueEnd) =
+    AppendProperty ("scroll-padding-inline:" ++ valueStart ++ " " ++ valueEnd)
+
+
+{-| Sets [`scroll-padding-block-start`](https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-padding-block-start) property.
+
+    scrollPaddingBlockStart (px 4)
+
+-}
+scrollPaddingBlockStart :
+    BaseValue
+        (LengthSupported
+            { auto : Supported
+            , pct : Supported
+            }
+        )
+    -> Style
+scrollPaddingBlockStart (Value value) =
+    AppendProperty ("scroll-padding-block-start:" ++ value)
+
+
+{-| Sets [`scroll-padding-block-end`](https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-padding-block-end) property.
+
+    scrollPaddingBlockEnd (px 4)
+
+-}
+scrollPaddingBlockEnd :
+    BaseValue
+        (LengthSupported
+            { auto : Supported
+            , pct : Supported
+            }
+        )
+    -> Style
+scrollPaddingBlockEnd (Value value) =
+    AppendProperty ("scroll-padding-block-end:" ++ value)
+
+
+{-| Sets [`scroll-padding-inline-start`](https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-padding-inline-start) property.
+
+    scrollPaddingInlineStart (px 4)
+
+-}
+scrollPaddingInlineStart :
+    BaseValue
+        (LengthSupported
+            { auto : Supported
+            , pct : Supported
+            }
+        )
+    -> Style
+scrollPaddingInlineStart (Value value) =
+    AppendProperty ("scroll-padding-inline-start:" ++ value)
+
+
+{-| Sets [`scroll-padding-inline-end`](https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-padding-inline-end) property.
+
+    scrollPaddingInlineEnd (px 4)
+
+-}
+scrollPaddingInlineEnd :
+    BaseValue
+        (LengthSupported
+            { auto : Supported
+            , pct : Supported
+            }
+        )
+    -> Style
+scrollPaddingInlineEnd (Value value) =
+    AppendProperty ("scroll-padding-inline-end:" ++ value)
+
+
+{-| Sets the [`overscroll-behavior`](https://css-tricks.com/almanac/properties/o/overscroll-behavior/) property.
+
+This property is a shorthand for setting both `overscroll-behavior-x` and `overscroll-behavior-y`.
+
+    overscrollBehavior auto -- sets both X and Y to auto
+
+    overscrollBehavior2 auto contain -- X = auto, Y = contain.
+
+-}
+overscrollBehavior :
+    BaseValue
+        { auto : Supported
+        , contain : Supported
+        , none : Supported
+        }
+    -> Style
+overscrollBehavior (Value value) =
+    AppendProperty ("overscroll-behavior:" ++ value)
+
+
+{-| Sets the [`overscroll-behavior`](https://css-tricks.com/almanac/properties/o/overscroll-behavior/) property.
+
+This property is a shorthand for setting both `overscroll-behavior-x` and `overscroll-behavior-y`.
+
+    overscrollBehavior2 auto contain -- X = auto, Y = contain.
+
+-}
+overscrollBehavior2 :
+    Value
+        { auto : Supported
+        , contain : Supported
+        , none : Supported
         }
     ->
         Value
-            { fill_ : Supported
-            , stroke : Supported
-            , markers : Supported
-            }
-    ->
-        Value
-            { fill_ : Supported
-            , stroke : Supported
-            , markers : Supported
+            { auto : Supported
+            , contain : Supported
+            , none : Supported
             }
     -> Style
-paintOrder3 (Value val1) (Value val2) (Value val3) =
-    AppendProperty ("paint-order:" ++ val1 ++ " " ++ val2 ++ " " ++ val3)
+overscrollBehavior2 (Value xValue) (Value yValue) =
+    AppendProperty ("overscroll-behavior:" ++ xValue ++ " " ++ yValue)
 
 
-{-| Provides the `markers` value for [`paintOrder`](#paintOrder).
+{-| Sets the [`overscroll-behavior-x`](https://css-tricks.com/almanac/properties/o/overscroll-behavior/) property.
 
-    paintOrder markers
+    overscrollBehaviorX auto
 
--}
-markers : Value { provides | markers : Supported }
-markers =
-    Value "markers"
-
-
-{-| Sets [`column-rule`](https://css-tricks.com/almanac/properties/c/column-rule/).
-This is a shorthand for the [`columnRuleWidth`](#columnRuleWidth),
-[`columnRuleStyle`](#columnRuleStyle), and [`columnRuleColor`](#columnRuleColor)
-properties.
-
-    columnRule thin
-
-    columnRule2 thin solid
-
-    columnRule3 thin solid (hex "#000000")
+    overscrollBehaviorX contain
 
 -}
-columnRule : BaseValue LineWidth -> Style
-columnRule (Value widthVal) =
-    AppendProperty ("column-rule:" ++ widthVal)
+overscrollBehaviorX :
+    BaseValue
+        { auto : Supported
+        , contain : Supported
+        , none : Supported
+        }
+    -> Style
+overscrollBehaviorX (Value value) =
+    AppendProperty ("overscroll-behavior-x:" ++ value)
 
 
-{-| Sets [`column-rule`](https://css-tricks.com/almanac/properties/c/column-rule/).
-This is a shorthand for the [`columnRuleWidth`](#columnRuleWidth),
-[`columnRuleStyle`](#columnRuleStyle), and [`columnRuleColor`](#columnRuleColor)
-properties.
+{-| Sets the [`overscroll-behavior-y`](https://css-tricks.com/almanac/properties/o/overscroll-behavior/) property.
 
-    columnRule thin
+    overscrollBehaviorY auto
 
-    columnRule2 thin solid
-
-    columnRule3 thin solid (hex "#000000")
-
--}
-columnRule2 : Value LineWidth -> Value LineStyle -> Style
-columnRule2 (Value widthVal) (Value styleVal) =
-    AppendProperty ("column-rule:" ++ widthVal ++ " " ++ styleVal)
-
-
-{-| Sets [`column-rule`](https://css-tricks.com/almanac/properties/c/column-rule/).
-This is a shorthand for the [`columnRuleWidth`](#columnRuleWidth),
-[`columnRuleStyle`](#columnRuleStyle), and [`columnRuleColor`](#columnRuleColor)
-properties.
-
-    columnRule thin
-
-    columnRule2 thin solid
-
-    columnRule3 thin solid (hex "#000000")
+    overscrollBehaviorY contain
 
 -}
-columnRule3 : Value LineWidth -> Value LineStyle -> Value Color -> Style
-columnRule3 (Value widthVal) (Value styleVal) (Value colorVal) =
-    AppendProperty ("column-rule:" ++ widthVal ++ " " ++ styleVal ++ " " ++ colorVal)
+overscrollBehaviorY :
+    BaseValue
+        { auto : Supported
+        , contain : Supported
+        , none : Supported
+        }
+    -> Style
+overscrollBehaviorY (Value value) =
+    AppendProperty ("overscroll-behavior-y:" ++ value)
+
+
+{-| Sets the [`overscroll-behavior-block`](https://developer.mozilla.org/en-US/docs/Web/CSS/overscroll-behavior-block) property.
+
+    overscrollBehaviorBlock auto
+
+    overscrollBehaviorBlock contain
+
+-}
+overscrollBehaviorBlock :
+    BaseValue
+        { auto : Supported
+        , contain : Supported
+        , none : Supported
+        }
+    -> Style
+overscrollBehaviorBlock (Value value) =
+    AppendProperty ("overscroll-behavior-block:" ++ value)
+
+
+{-| Sets the [`overscroll-behavior-inline`](https://developer.mozilla.org/en-US/docs/Web/CSS/overscroll-behavior-inline) property.
+
+    overscrollBehaviorInline auto
+
+    overscrollBehaviorInline contain
+
+-}
+overscrollBehaviorInline :
+    BaseValue
+        { auto : Supported
+        , contain : Supported
+        , none : Supported
+        }
+    -> Style
+overscrollBehaviorInline (Value value) =
+    AppendProperty ("overscroll-behavior-inline:" ++ value)
+
 
 
 ------------------------------------------------------------------------
@@ -16683,6 +16501,13 @@ columnRule3 (Value widthVal) (Value styleVal) (Value colorVal) =
 ------------------------------------------------------------------------
 ------------------------------------------------------------------------
 ------------------------------------------------------------------------
+
+
+{-| A type alias used to accept a [transform-function](https://developer.mozilla.org/en-US/docs/Web/CSS/transform-function).
+-}
+type alias TransformFunction =
+    TransformFunctionSupported {}
+
 
 
 {-| A type alias used to accept a [transform-function](https://developer.mozilla.org/en-US/docs/Web/CSS/transform-function)
@@ -16715,12 +16540,6 @@ type alias TransformFunctionSupported supported =
         , rotate3d : Supported
         , perspective_ : Supported
     }
-
-
-{-| A type alias used to accept a [transform-function](https://developer.mozilla.org/en-US/docs/Web/CSS/transform-function).
--}
-type alias TransformFunction =
-    TransformFunctionSupported {}
 
 
 {-| The [`transform`](https://css-tricks.com/almanac/properties/t/transform/) property.
@@ -17967,174 +17786,20 @@ backwards =
 
 
 
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+-------------------------------- MASKS ---------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
 
-
-
-
-
-
-
-
-
-
-
-
-{-| Sets [`clear`](https://css-tricks.com/almanac/properties/c/clear/) property.
-
-    clear none
-
-    clear both
-
-    clear left_
-
-    clear right_
-
-    clear inlineStart
-
-    clear inlineEnd
-
--}
-clear :
-    BaseValue
-        { none : Supported
-        , left_ : Supported
-        , right_ : Supported
-        , both : Supported
-        , inlineStart : Supported
-        , inlineEnd : Supported
-        }
-    -> Style
-clear (Value val) =
-    AppendProperty ("clear:" ++ val)
-
-
-{-| Sets [`opacity`](https://css-tricks.com/almanac/properties/o/opacity/)
-
-    opacity (num 0.5)
-
-    opacity (num 1.0)
-
-    opacity zero
-
--}
-opacity :
-    BaseValue
-        { num : Supported
-        , zero : Supported
-        , calc : Supported
-        , pct : Supported
-        }
-    -> Style
-opacity (Value val) =
-    AppendProperty ("opacity:" ++ val)
-
-
-{-| Sets [`zoom`](https://css-tricks.com/almanac/properties/z/zoom/)
-
-    zoom (pct 150)
-
-    zoom (num 1.5)
-
-    zoom normal
-
--}
-zoom :
-    BaseValue
-        { pct : Supported
-        , zero : Supported
-        , num : Supported
-        , normal : Supported
-        , calc : Supported
-        , auto : Supported
-        }
-    -> Style
-zoom (Value val) =
-    AppendProperty ("zoom:" ++ val)
-
-
-{-| Sets [`line-height`](https://css-tricks.com/almanac/properties/l/line-height/)
-
-    lineHeight (pct 150)
-
-    lineHeight (em 2)
-
-    lineHeight (num 1.5)
-
-    lineHeight normal
-
--}
-lineHeight :
-    BaseValue
-        (LengthSupported
-            { pct : Supported
-            , normal : Supported
-            , num : Supported
-            }
-        )
-    -> Style
-lineHeight (Value val) =
-    AppendProperty ("line-height:" ++ val)
-
-
-{-| Sets [`letter-spacing`](https://css-tricks.com/almanac/properties/l/letter-spacing/)
-
-    letterSpacing (pct 150)
-
-    letterSpacing (em 2)
-
-    letterSpacing (num 1.5)
-
-    letterSpacing normal
-
--}
-letterSpacing :
-    BaseValue
-        (LengthSupported
-            { normal : Supported
-            }
-        )
-    -> Style
-letterSpacing (Value val) =
-    AppendProperty ("letter-spacing:" ++ val)
-
-
-
-{-| Sets [`backface-visibility`](https://css-tricks.com/almanac/properties/b/backface-visibility/)
-
-    backfaceVisibility visible
-
-    backfaceVisibility hidden
-
--}
-backfaceVisibility :
-    BaseValue
-        { visible : Supported
-        , hidden : Supported
-        }
-    -> Style
-backfaceVisibility (Value val) =
-    AppendProperty ("backface-visibility" ++ val)
-
-
-{-| Sets [`bleed`](https://css-tricks.com/almanac/properties/b/bleed/)
-
-    bleed auto
-
-    bleed (pt 10)
-
--}
-bleed :
-    BaseValue
-        (LengthSupported
-            { auto : Supported
-            }
-        )
-    -> Style
-bleed (Value val) =
-    AppendProperty ("bleed:" ++ val)
-
-
--- MASKS --
 
 {-| Sets the [`mask-border-mode`](https://developer.mozilla.org/en-US/docs/Web/CSS/mask-border-mode)
 property.
@@ -19039,6 +18704,1575 @@ matchSource =
     Value "match-source"
 
 
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------- TABLES ---------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+
+
+{-| Sets [`border-collapse`](https://css-tricks.com/almanac/properties/b/border-collapse/).
+
+    borderCollapse collapse
+
+    borderCollapse separate
+
+-}
+borderCollapse :
+    BaseValue
+        { collapse : Supported
+        , separate : Supported
+        }
+    -> Style
+borderCollapse (Value str) =
+    AppendProperty ("border-collapse:" ++ str)
+
+
+{-| A `collapse` value for the [`border-collapse`](https://css-tricks.com/almanac/properties/b/border-collapse/) and
+[`visibility`](https://css-tricks.com/almanac/properties/v/visibility/) property.
+
+    borderCollapse collapse
+
+    visibility collapse
+
+-}
+collapse : Value { provides | collapse : Supported }
+collapse =
+    Value "collapse"
+
+
+{-| A `separate` value for the [`border-separate`](https://css-tricks.com/almanac/properties/b/border-collapse/) property.
+
+    borderCollapse separate
+
+-}
+separate : Value { provides | separate : Supported }
+separate =
+    Value "separate"
+
+
+
+-- BORDER SPACING --
+
+
+{-| Sets [`border-spacing`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-spacing).
+
+    borderSpacing zero
+
+    borderSpacing (px 5)
+
+-}
+borderSpacing : BaseValue Length -> Style
+borderSpacing (Value str) =
+    AppendProperty ("border-spacing:" ++ str)
+
+
+{-| Sets [`border-spacing`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-spacing), defining horizontal and vertical spacing separately.
+
+    borderSpacing2 (cm 1) (em 2)
+
+-}
+borderSpacing2 : Value Length -> Value Length -> Style
+borderSpacing2 (Value valHorizontal) (Value valVertical) =
+    AppendProperty ("border-spacing:" ++ valHorizontal ++ " " ++ valVertical)
+
+
+
+-- CAPTION SIDE --
+
+
+{-| Sets [`caption-side`](https://css-tricks.com/almanac/properties/c/caption-side/).
+
+    captionSide top_
+
+    captionSide bottom_
+
+    captionSide blockStart
+
+    captionSide inlineEnd
+
+-}
+captionSide :
+    BaseValue
+        { top_ : Supported
+        , bottom_ : Supported
+        , blockStart : Supported
+        , blockEnd : Supported
+        , inlineStart : Supported
+        , inlineEnd : Supported
+        }
+    -> Style
+captionSide (Value str) =
+    AppendProperty ("caption-side:" ++ str)
+
+
+
+-- EMPTY CELLS --
+
+
+{-| Sets [`empty-cells`](https://css-tricks.com/almanac/properties/e/empty-cells/).
+
+    emptyCells show
+
+    emptyCells hide
+
+-}
+emptyCells :
+    BaseValue
+        { show : Supported
+        , hide : Supported
+        }
+    -> Style
+emptyCells (Value str) =
+    AppendProperty ("empty-cells:" ++ str)
+
+
+{-| A `show` value for the [`empty-cells`](https://css-tricks.com/almanac/properties/e/empty-cells/) property.
+
+    emptyCells show
+
+-}
+show : Value { provides | show : Supported }
+show =
+    Value "show"
+
+
+{-| A `hide` value for the [`empty-cells`](https://css-tricks.com/almanac/properties/e/empty-cells/) property.
+
+    emptyCells hide
+
+-}
+hide : Value { provides | hide : Supported }
+hide =
+    Value "hide"
+
+
+
+-- TABLE LAYOUT --
+
+
+{-| Sets [`table-layout`](https://css-tricks.com/almanac/properties/t/table-layout/).
+
+    tableLayout auto
+
+    tableLayout fixed
+
+-}
+tableLayout :
+    BaseValue
+        { auto : Supported
+        , fixed : Supported
+        }
+    -> Style
+tableLayout (Value str) =
+    AppendProperty ("table-layout:" ++ str)
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+{-| Sets [`vertical-align`](https://css-tricks.com/almanac/properties/v/vertical-align/).
+
+    verticalAlign textBottom
+
+    verticalAlign (em 1)
+
+-}
+verticalAlign :
+    BaseValue
+        (LengthSupported
+            { baseline : Supported
+            , sub : Supported
+            , super : Supported
+            , textTop : Supported
+            , textBottom : Supported
+            , middle : Supported
+            , top_ : Supported
+            , bottom_ : Supported
+            , pct : Supported
+            }
+        )
+    -> Style
+verticalAlign (Value str) =
+    AppendProperty ("vertical-align:" ++ str)
+
+
+{-| A `textTop` value for the [`vertical-align`](https://css-tricks.com/almanac/properties/v/vertical-align/) property.
+
+    verticalAlign textTop
+
+-}
+textTop : Value { provides | textTop : Supported }
+textTop =
+    Value "text-top"
+
+
+{-| A `textBottom` value for the [`vertical-align`](https://css-tricks.com/almanac/properties/v/vertical-align/) property.
+
+    verticalAlign textBottom
+
+-}
+textBottom : Value { provides | textBottom : Supported }
+textBottom =
+    Value "text-bottom"
+
+
+{-| A `middle` value for the [`vertical-align`](https://css-tricks.com/almanac/properties/v/vertical-align/) property.
+
+    verticalAlign middle
+
+-}
+middle : Value { provides | middle : Supported }
+middle =
+    Value "middle"
+
+
+-- WHITE-SPACE --
+
+
+{-| Sets [`white-space`](https://css-tricks.com/almanac/properties/w/whitespace/)
+
+    whiteSpace pre
+
+    whiteSpace nowrap
+
+    whiteSpace preWrap
+
+    whiteSpace preLine
+
+-}
+whiteSpace :
+    BaseValue
+        { normal : Supported
+        , nowrap : Supported
+        , pre : Supported
+        , preWrap : Supported
+        , preLine : Supported
+        }
+    -> Style
+whiteSpace (Value str) =
+    AppendProperty ("white-space:" ++ str)
+
+
+{-| A `nowrap` value for the [`white-space`](https://css-tricks.com/almanac/properties/w/whitespace/)
+and [`flex-wrap`](https://css-tricks.com/almanac/properties/f/flex-wrap/) properties.
+
+    whiteSpace nowrap
+
+    flexWrap nowrap
+
+-}
+nowrap : Value { provides | nowrap : Supported }
+nowrap =
+    Value "nowrap"
+
+
+{-| A `pre` value for the [`white-space`](https://css-tricks.com/almanac/properties/w/whitespace/) property.
+
+    whiteSpace pre
+
+-}
+pre : Value { provides | pre : Supported }
+pre =
+    Value "pre"
+
+
+{-| A `pre-wrap` value for the [`white-space`](https://css-tricks.com/almanac/properties/w/whitespace/) property.
+
+    whiteSpace preWrap
+
+-}
+preWrap : Value { provides | preWrap : Supported }
+preWrap =
+    Value "pre-wrap"
+
+
+{-| A `pre-line` value for the [`white-space`](https://css-tricks.com/almanac/properties/w/whitespace/) property.
+
+    whiteSpace preLine
+
+-}
+preLine : Value { provides | preLine : Supported }
+preLine =
+    Value "pre-line"
+
+
+
+
+-- FLOAT --
+
+
+{-| Sets [`float`](https://css-tricks.com/almanac/properties/f/float/).
+
+    float none
+
+    float left_
+
+    float right_
+
+    float inlineStart
+
+-}
+float :
+    BaseValue
+        { none : Supported
+        , left_ : Supported
+        , right_ : Supported
+        , inlineStart : Supported
+        , inlineEnd : Supported
+        }
+    -> Style
+float (Value str) =
+    AppendProperty ("float:" ++ str)
+
+
+
+-- VISIBILITY --
+
+
+{-| Sets [`visibility`](https://css-tricks.com/almanac/properties/v/visibility/)
+
+      visibility visible
+      visibility hidden
+      visibility collapse
+
+-}
+visibility :
+    BaseValue
+        { visible : Supported
+        , hidden : Supported
+        , collapse : Supported
+        }
+    -> Style
+visibility (Value str) =
+    AppendProperty ("visibility:" ++ str)
+
+
+
+-- ORDER --
+
+
+{-| Sets [`order`](https://css-tricks.com/almanac/properties/o/order/)
+
+    order (num 2)
+
+    order (num -2)
+
+-}
+order :
+    BaseValue
+        { int : Supported
+        , zero : Supported
+        }
+    -> Style
+order (Value val) =
+    AppendProperty ("order:" ++ val)
+
+
+{-| Sets [`fill`](https://css-tricks.com/almanac/properties/f/fill/)
+**Note:** `fill` also accepts the patterns of SVG shapes that are defined inside of a [`defs`](https://css-tricks.com/snippets/svg/svg-patterns/) element.
+
+    fill (hex "#60b5cc")
+
+    fill (rgb 96 181 204)
+
+    fill (rgba 96 181 204 0.5)
+
+    fill (url "#pattern")
+
+-}
+fill :
+    BaseValue
+        (ColorSupported
+            { url : Supported
+            }
+        )
+    -> Style
+fill (Value val) =
+    AppendProperty ("fill:" ++ val)
+
+
+
+-- COLUMNS --
+
+
+{-| Sets [`columns`](https://css-tricks.com/almanac/properties/c/columns/)
+
+    columns (px 300)
+
+    columns2 (px 300) (num 2)
+
+-}
+columns :
+    BaseValue
+        (LengthSupported
+            { auto : Supported
+            }
+        )
+    -> Style
+columns (Value widthVal) =
+    AppendProperty ("columns:" ++ widthVal)
+
+
+{-| Sets [`columns`](https://css-tricks.com/almanac/properties/c/columns/)
+
+    columns (px 300)
+
+    columns2 (px 300) (num 2)
+
+-}
+columns2 :
+    Value
+        (LengthSupported
+            { auto : Supported
+            }
+        )
+    ->
+        Value
+            { auto : Supported
+            , num : Supported
+            }
+    -> Style
+columns2 (Value widthVal) (Value count) =
+    AppendProperty ("columns:" ++ widthVal ++ " " ++ count)
+
+
+{-| Sets [`column-width`](https://css-tricks.com/almanac/properties/c/column-width/)
+
+    columnWidth auto
+
+    columnWidth (px 200)
+
+-}
+columnWidth :
+    BaseValue
+        (LengthSupported
+            { auto : Supported
+            }
+        )
+    -> Style
+columnWidth (Value widthVal) =
+    AppendProperty ("column-width:" ++ widthVal)
+
+
+{-| Sets [`column-count`](https://css-tricks.com/almanac/properties/c/column-count/)
+
+    columnCount auto
+
+    columnCount (num 3)
+
+-}
+columnCount :
+    BaseValue
+        { auto : Supported
+        , int : Supported
+        }
+    -> Style
+columnCount (Value count) =
+    AppendProperty ("column-count:" ++ count)
+
+
+{-| Sets [`column-fill`](https://css-tricks.com/almanac/properties/c/column-fill/)
+
+    columnFill auto
+
+    columnFill balance
+
+    columnFill balanceAll
+
+-}
+columnFill :
+    BaseValue
+        { auto : Supported
+        , balance : Supported
+        , balanceAll : Supported
+        }
+    -> Style
+columnFill (Value val) =
+    AppendProperty ("column-fill:" ++ val)
+
+
+{-| A `balance` value used in properties such as [`columnFill`](#columnFill)
+
+    columnFill balance
+
+-}
+balance : Value { provides | balance : Supported }
+balance =
+    Value "balance"
+
+
+{-| A `balance-all` value used in properties such as [`columnFill`](#columnFill)
+
+    columnFill balanceAll
+
+-}
+balanceAll : Value { provides | balanceAll : Supported }
+balanceAll =
+    Value "balance-all"
+
+
+{-| Sets [`column-span`](https://css-tricks.com/almanac/properties/c/column-span/)
+
+    columnSpan all_
+
+    columnSpan none
+
+-}
+columnSpan :
+    BaseValue
+        { none : Supported
+        , all_ : Supported
+        }
+    -> Style
+columnSpan (Value spanVal) =
+    AppendProperty ("column-span:" ++ spanVal)
+
+
+{-| Sets [`column-rule-width`](https://www.w3.org/TR/css-multicol-1/#propdef-column-rule-width)
+
+    columnRuleWidth thin
+
+    columnRuleWidth (px 2)
+
+-}
+columnRuleWidth : BaseValue LineWidth -> Style
+columnRuleWidth (Value widthVal) =
+    AppendProperty ("column-rule-width:" ++ widthVal)
+
+
+{-| Sets [`column-rule-style`](https://www.w3.org/TR/css-multicol-1/#propdef-column-rule-style)
+
+    columnRuleStyle solid
+
+    columnRuleStyle dotted
+
+    columnRuleStyle dashed
+
+-}
+columnRuleStyle : BaseValue LineStyle -> Style
+columnRuleStyle (Value styleVal) =
+    AppendProperty ("column-rule-style:" ++ styleVal)
+
+
+{-| Sets [`column-rule-color`](https://www.w3.org/TR/css-multicol-1/#propdef-column-rule-color)
+
+    columnRuleColor (rgb 0 0 0)
+
+    columnRuleColor (hex "#fff")
+
+-}
+columnRuleColor : BaseValue Color -> Style
+columnRuleColor (Value colorVal) =
+    AppendProperty ("column-rule-color:" ++ colorVal)
+
+
+-- STROKE --
+
+
+{-| Sets [`stroke-dasharray`](https://css-tricks.com/almanac/properties/s/stroke-dasharray/)
+
+    strokeDasharray (num 2)
+
+    strokeDasharray (num 2.5)
+
+    strokeDasharray (em 2)
+
+    strokeDasharray (pct 15)
+
+-}
+strokeDasharray :
+    BaseValue
+        (LengthSupported
+            { num : Supported
+            , pct : Supported
+            }
+        )
+    -> Style
+strokeDasharray (Value val) =
+    AppendProperty ("stroke-dasharray:" ++ val)
+
+
+{-| Sets [`stroke-dashoffset`](https://css-tricks.com/almanac/properties/s/stroke-dashoffset/)
+
+    strokeDashoffset zero
+
+    strokeDashoffset (num 100)
+
+    strokeDashoffset (pct 25)
+
+-}
+strokeDashoffset :
+    BaseValue
+        { zero : Supported
+        , calc : Supported
+        , num : Supported
+        , pct : Supported
+        }
+    -> Style
+strokeDashoffset (Value val) =
+    AppendProperty ("stroke-dashoffset:" ++ val)
+
+
+{-| Sets [`stroke-linecap`](https://css-tricks.com/almanac/properties/s/stroke-linecap/)
+
+    strokeLinecap butt
+
+    strokeLinecap square
+
+    strokeLinecap round
+
+-}
+strokeLinecap :
+    BaseValue
+        { butt : Supported
+        , square : Supported
+        , round : Supported
+        }
+    -> Style
+strokeLinecap (Value val) =
+    AppendProperty ("stroke-linecap:" ++ val)
+
+
+{-| A `butt` value for the [`strokeLinecap`](#strokeLinecap) property.
+
+    strokeLinecap butt
+
+-}
+butt : Value { provides | butt : Supported }
+butt =
+    Value "butt"
+
+
+{-| The `square` value used by properties such as [`strokeLinecap`](#strokeLinecap),
+[`listStyle`](#listStyle),
+and [`listStyleType`](#listStyleType).
+
+    strokeLinecap square
+
+    listStyleType square
+
+-}
+square : Value { provides | square : Supported }
+square =
+    Value "square"
+
+
+{-| Sets [`stroke-width`](https://css-tricks.com/almanac/properties/s/stroke-width/)
+
+    strokeWidth zero
+
+    strokeWidth (px 2)
+
+    strokeWidth (em 2)
+
+    strokeWidth (num 2)
+
+    strokeWidth (num 2.5)
+
+    strokeWidth (pct 15)
+
+-}
+strokeWidth :
+    BaseValue
+        (LengthSupported
+            { num : Supported
+            , pct : Supported
+            }
+        )
+    -> Style
+strokeWidth (Value val) =
+    AppendProperty ("stroke-width:" ++ val)
+
+
+{-| Sets [`stroke-align`](https://www.w3.org/TR/fill-stroke-3/#propdef-stroke-align)
+
+**Note:** This function accepts `inset_` rather than `inset` because
+[`inset` is already a property function](#inset).
+
+      strokeAlign center
+      strokeAlign inset_
+      strokeAlign outset
+
+-}
+strokeAlign :
+    BaseValue
+        { center : Supported
+        , inset_ : Supported
+        , outset : Supported
+        }
+    -> Style
+strokeAlign (Value val) =
+    AppendProperty ("stroke-align:" ++ val)
+
+
+{-| Sets [`stroke-break`](https://www.w3.org/TR/fill-stroke-3/#propdef-stroke-break)
+
+      strokeBreak boundingBox
+      strokeBreak slice
+      strokeBreak clone
+
+-}
+strokeBreak :
+    BaseValue
+        { boundingBox : Supported
+        , slice : Supported
+        , clone : Supported
+        }
+    -> Style
+strokeBreak (Value val) =
+    AppendProperty ("stroke-break:" ++ val)
+
+
+{-| A `boundingBox` value for the [`strokeBreak`](#strokeBreak) property.
+
+      strokeBreak boundingBox
+
+-}
+boundingBox : Value { provides | boundingBox : Supported }
+boundingBox =
+    Value "bounding-box"
+
+
+{-| A `slice` value for the [`strokeBreak`](#strokeBreak) and [`boxDecorationBreak`](#boxDecorationBreak) properties.
+
+      strokeBreak slice
+
+      boxDecorationbreak clone
+
+-}
+slice : Value { provides | slice : Supported }
+slice =
+    Value "slice"
+
+
+{-| A `clone` value for the [`strokeBreak`](#strokeBreak) and [`boxDecorationBreak`](#boxDecorationBreak) properties.
+
+      strokeBreak clone
+
+      boxDecorationBreak clone
+
+-}
+clone : Value { provides | clone : Supported }
+clone =
+    Value "clone"
+
+
+{-| Sets [`stroke-color`](https://www.w3.org/TR/fill-stroke-3/#propdef-stroke-color)
+
+    strokeColor (rgb 0 100 44)
+
+    strokeColor (hex "#FF9E2C")
+
+-}
+strokeColor : BaseValue Color -> Style
+strokeColor (Value val) =
+    AppendProperty ("stroke-color:" ++ val)
+
+
+{-| Sets [`stroke-image`](https://www.w3.org/TR/fill-stroke-3/#propdef-stroke-image)
+
+    strokeImage (url "#svg-pattern")
+
+    strokeImage (url "http://www.example.com/chicken.jpg")
+
+-}
+strokeImage :
+    BaseValue
+        { url : Supported
+        , none : Supported
+        }
+    -> Style
+strokeImage (Value value) =
+    AppendProperty ("stroke-image:" ++ value)
+
+
+{-| Sets [`stroke-miterlimit`](https://www.w3.org/TR/fill-stroke-3/#propdef-stroke-miterlimit)
+
+    strokeMiterlimit (num 4)
+
+-}
+strokeMiterlimit :
+    BaseValue
+        { num : Supported
+        }
+    -> Style
+strokeMiterlimit (Value val) =
+    AppendProperty ("stroke-miterlimit:" ++ val)
+
+
+{-| Sets [`stroke-opacity`](https://www.w3.org/TR/fill-stroke-3/#propdef-stroke-opacity)
+
+    strokeOpacity (num 0.5)
+
+-}
+strokeOpacity :
+    BaseValue
+        { num : Supported
+        }
+    -> Style
+strokeOpacity (Value val) =
+    AppendProperty ("stroke-opacity:" ++ val)
+
+
+{-| Sets [`stroke-origin`](https://www.w3.org/TR/fill-stroke-3/#propdef-stroke-origin)
+
+    strokeOrign matchParent
+
+    strokeOrign fillBox
+
+    strokeOrign strokeBox
+
+    strokeOrign contentBox
+
+    strokeOrign paddingBox
+
+    strokeOrign borderBox
+
+-}
+strokeOrigin :
+    BaseValue
+        { matchParent : Supported
+        , fillBox : Supported
+        , strokeBox : Supported
+        , contentBox : Supported
+        , paddingBox : Supported
+        , borderBox : Supported
+        }
+    -> Style
+strokeOrigin (Value val) =
+    AppendProperty ("stroke-origin:" ++ val)
+
+
+
+{-| Sets [`stroke-position`](https://www.w3.org/TR/fill-stroke-3/#propdef-stroke-position).
+
+    strokePosition left_
+
+    strokePosition (px 45)
+
+`strokePosition` sets the horizontal direction. If you need the vertical
+direction instead, use [`strokePosition2`](#strokePosition2) like this:
+
+    strokePosition zero (px 45)
+
+If you need to set the offsets from the right or bottom, use
+[`strokePosition4`](#strokePosition4) like this:
+
+    strokePosition4 right_ (px 20) bottom_ (pct 25)
+
+-}
+strokePosition :
+    BaseValue
+        (LengthSupported
+            { pct : Supported
+            , left_ : Supported
+            , right_ : Supported
+            , center : Supported
+            }
+        )
+    -> Style
+strokePosition (Value horiz) =
+    AppendProperty ("stroke-position:" ++ horiz)
+
+
+{-| Sets [`stroke-position`](https://www.w3.org/TR/fill-stroke-3/#propdef-stroke-position).
+
+    strokePosition2 left_ top_
+
+    strokePosition2 (px 45) (pct 50)
+
+`strokePosition2` sets both the horizontal and vertical directions (in that
+order, same as CSS.) If you need only the horizontal, you can use
+[`strokePosition`](#strokePosition) instead:
+
+    strokePosition left_
+
+If you need to set the offsets from the right or bottom, use
+[`strokePosition4`](#strokePosition4) like this:
+
+    strokePosition4 right_ (px 20) bottom_ (pct 25)
+
+-}
+strokePosition2 :
+    Value
+        (LengthSupported
+            { pct : Supported
+            , left_ : Supported
+            , right_ : Supported
+            , center : Supported
+            }
+        )
+    ->
+        Value
+            (LengthSupported
+                { pct : Supported
+                , top_ : Supported
+                , bottom_ : Supported
+                , center : Supported
+                }
+            )
+    -> Style
+strokePosition2 (Value horiz) (Value vert) =
+    AppendProperty ("stroke-position:" ++ horiz ++ " " ++ vert)
+
+
+{-| Sets [`stroke-position`](https://www.w3.org/TR/fill-stroke-3/#propdef-stroke-position).
+
+    strokePosition4 right_ (px 20) bottom_ (pct 30)
+
+The four-argument form of stroke-position alternates sides and offets. So the
+example above would position the stroke-image 20px from the right, and 30%
+from the bottom.
+
+See also [`strokePosition`](#strokePosition) for horizontal alignment and
+[`strokePosition2`](#strokePosition2) for horizontal (from left) and
+vertical (from top) alignment.
+
+-}
+strokePosition4 :
+    Value
+        { left_ : Supported
+        , right_ : Supported
+        }
+    ->
+        Value
+            (LengthSupported
+                { pct : Supported
+                }
+            )
+    ->
+        Value
+            { top_ : Supported
+            , bottom_ : Supported
+            }
+    ->
+        Value
+            (LengthSupported
+                { pct : Supported
+                }
+            )
+    -> Style
+strokePosition4 (Value horiz) (Value horizAmount) (Value vert) (Value vertAmount) =
+    AppendProperty
+        ("stroke-position:"
+            ++ horiz
+            ++ " "
+            ++ horizAmount
+            ++ " "
+            ++ vert
+            ++ " "
+            ++ vertAmount
+        )
+
+
+{-| Sets [`stroke-repeat`](https://www.w3.org/TR/fill-stroke-3/#propdef-stroke-repeat)
+
+    strokeRepeat repeat
+
+    strokeRepeat repeatX
+
+If you need to set horizontal and vertical direction separately, see
+[`strokeRepeat2`](#strokeRepeat2)
+
+-}
+strokeRepeat :
+    BaseValue
+        { repeat : Supported
+        , repeatX : Supported
+        , repeatY : Supported
+        , space : Supported
+        , round : Supported
+        , noRepeat : Supported
+        }
+    -> Style
+strokeRepeat (Value repeatVal) =
+    AppendProperty ("stroke-repeat:" ++ repeatVal)
+
+
+{-| Sets [`stroke-repeat`](https://www.w3.org/TR/fill-stroke-3/#propdef-stroke-repeat) along the horizontal axis, then the vertical axis.
+
+    strokeRepeat2 repeat space
+
+    strokeRepeat2 space round
+
+If you only need to set one value for both, see
+[`strokeRepeat`](#strokeRepeat) instead.
+
+-}
+strokeRepeat2 :
+    Value
+        { repeat : Supported
+        , space : Supported
+        , round : Supported
+        , noRepeat : Supported
+        }
+    ->
+        Value
+            { repeat : Supported
+            , space : Supported
+            , round : Supported
+            , noRepeat : Supported
+            }
+    -> Style
+strokeRepeat2 (Value horiz) (Value vert) =
+    AppendProperty ("stroke-repeat:" ++ horiz ++ " " ++ vert)
+
+
+{-| Sets [`stroke-size`](https://www.w3.org/TR/fill-stroke-3/#propdef-stroke-size).
+
+    strokeSize cover
+
+    strokeSize (px 400)
+
+If you give a length value, it will be used for the width. The height will be set
+proportional to the size of the [`stroke-image`](#strokeImage). If you
+need to set both width and height explicitly, use
+[`strokeImage2`](#strokeImage2) instead.
+
+-}
+strokeSize :
+    BaseValue
+        (LengthSupported
+            { pct : Supported
+            , auto : Supported
+            , cover : Supported
+            }
+        )
+    -> Style
+strokeSize (Value sizeVal) =
+    AppendProperty ("stroke-size:" ++ sizeVal)
+
+
+{-| Sets [`stroke-size`](https://www.w3.org/TR/fill-stroke-3/#propdef-stroke-size).
+
+    strokeSize2 (px 300) (px 100)
+
+    strokeSize2 auto (px 400)
+
+If you only want to set the width, use [`strokeImage`](#strokeImage) instead.
+
+-}
+strokeSize2 :
+    Value
+        (LengthSupported
+            { pct : Supported
+            , auto : Supported
+            }
+        )
+    ->
+        Value
+            (LengthSupported
+                { pct : Supported
+                , auto : Supported
+                }
+            )
+    -> Style
+strokeSize2 (Value widthVal) (Value heightVal) =
+    AppendProperty ("stroke-size:" ++ widthVal ++ " " ++ heightVal)
+
+
+{-| Sets [`stroke-dash-corner`](https://www.w3.org/TR/fill-stroke-3/#propdef-stroke-dash-corner).
+
+    strokeDashCorner none
+
+    strokeDashCorner (px 10)
+
+    strokeDashCorner (em 5)
+
+-}
+strokeDashCorner :
+    BaseValue
+        (LengthSupported
+            { none : Supported
+            , pct : Supported
+            , auto : Supported
+            , cover : Supported
+            }
+        )
+    -> Style
+strokeDashCorner (Value sizeVal) =
+    AppendProperty ("stroke-dash-corner:" ++ sizeVal)
+
+
+{-| Sets [`stroke-linejoin`](https://www.w3.org/TR/fill-stroke-3/#propdef-stroke-linejoin).
+
+    strokeLinejoin crop
+
+    strokeLinejoin arcs
+
+    strokeLinejoin miter
+
+**Note:** if you only want to specifiy the rendering of the cap of a corner you need to use [`strokeLinejoin2`](#strokeLinejoin2)
+and set it's first value to `miter` like so: `strokeLinejoin2 miter bevel`.
+
+-}
+strokeLinejoin :
+    BaseValue
+        { crop : Supported
+        , arcs : Supported
+        , miter : Supported
+        }
+    -> Style
+strokeLinejoin (Value val) =
+    AppendProperty ("stroke-linejoin:" ++ val)
+
+
+{-| Sets [`stroke-linejoin`](https://www.w3.org/TR/fill-stroke-3/#propdef-stroke-linejoin).
+
+    strokeLinejoin crop bevel
+
+    strokeLinejoin arcs round
+
+    strokeLinejoin miter fallback
+
+-}
+strokeLinejoin2 :
+    Value
+        { crop : Supported
+        , arcs : Supported
+        , miter : Supported
+        }
+    ->
+        Value
+            { bevel : Supported
+            , round : Supported
+            , fallback : Supported
+            }
+    -> Style
+strokeLinejoin2 (Value extendCorner) (Value capRender) =
+    AppendProperty ("stroke-linejoin:" ++ extendCorner ++ " " ++ capRender)
+
+
+{-| Sets `crop` value for usage with [`strokeLinejoin`](#strokeLinejoin).
+
+    strokeLinejoin crop
+
+-}
+crop : Value { provides | crop : Supported }
+crop =
+    Value "crop"
+
+
+{-| Sets `arcs` value for usage with [`strokeLinejoin`](#strokeLinejoin).
+
+    strokeLinejoin arcs
+
+-}
+arcs : Value { provides | arcs : Supported }
+arcs =
+    Value "arcs"
+
+
+{-| Sets `miter` value for usage with [`strokeLinejoin`](#strokeLinejoin).
+
+    strokeLinejoin miter
+
+-}
+miter : Value { provides | miter : Supported }
+miter =
+    Value "miter"
+
+
+{-| Sets `bevel` value for usage with [`strokeLinejoin`](#strokeLinejoins2).
+
+    strokeLinejoin miter bevel
+
+-}
+bevel : Value { provides | bevel : Supported }
+bevel =
+    Value "bevel"
+
+
+{-| Sets [`stroke-dash-justify`](https://www.w3.org/TR/fill-stroke-3/#propdef-stroke-dash-justify).
+
+      strokeDashJustify none
+      strokeDashJustify stretch
+      strokeDashJustify compress
+      strokeDashJustify dashes
+      strokeDashJustify gaps
+
+-}
+strokeDashJustify :
+    BaseValue
+        { none : Supported
+        , stretch : Supported
+        , compress : Supported
+        , dashes : Supported
+        , gaps : Supported
+        }
+    -> Style
+strokeDashJustify (Value val) =
+    AppendProperty ("stroke-dash-justify:" ++ val)
+
+
+{-| Sets `compress` value for usage with [`strokeDashJustify`](#strokeDashJustify).
+
+      strokeDashJustify compress
+
+-}
+compress : Value { provides | compress : Supported }
+compress =
+    Value "compress"
+
+
+{-| Sets `dashes` value for usage with [`strokeDashJustify`](#strokeDashJustify).
+
+      strokeDashJustify dashes
+
+-}
+dashes : Value { provides | dashes : Supported }
+dashes =
+    Value "dashes"
+
+
+{-| Sets `gaps` value for usage with [`strokeDashJustify`](#strokeDashJustify).
+
+      strokeDashJustify gaps
+
+-}
+gaps : Value { provides | gaps : Supported }
+gaps =
+    Value "gaps"
+
+
+{-| The [`paint-order`](https://css-tricks.com/almanac/properties/p/paint-order/) property.
+
+This one-argument version indicates which parts of text and shape graphics are
+painted first, followed by the other two in their relative default order.
+
+    paintOrder normal -- normal paint order.
+
+    paintOrder2 fill_ stroke -- fill, stroke, then markers.
+
+    paintOrder3 markers stroke fill_ -- markers, stroke, then fill.
+
+-}
+paintOrder :
+    BaseValue
+        { normal : Supported
+        , stroke : Supported
+        , markers : Supported
+        }
+    -> Style
+paintOrder (Value val) =
+    AppendProperty ("paint-order:" ++ val)
+
+
+{-| The [`paint-order`](https://css-tricks.com/almanac/properties/p/paint-order/) property.
+
+This two-argument version indicates which parts of text and shape graphics are
+painted first, followed by the other remaining one.
+
+    paintOrder2 fill_ stroke -- fill, stroke, then markers.
+
+-}
+paintOrder2 :
+    Value
+        { fill_ : Supported
+        , stroke : Supported
+        , markers : Supported
+        }
+    ->
+        Value
+            { fill_ : Supported
+            , stroke : Supported
+            , markers : Supported
+            }
+    -> Style
+paintOrder2 (Value val1) (Value val2) =
+    AppendProperty ("paint-order:" ++ val1 ++ " " ++ val2)
+
+
+{-| The [`paint-order`](https://css-tricks.com/almanac/properties/p/paint-order/) property.
+
+This three-argument version explicitly indicates in which order should all the parts of text
+and shape graphics be painted.
+
+    paintOrder3 markers stroke fill_ -- markers, stroke, then fill.
+
+-}
+paintOrder3 :
+    Value
+        { fill_ : Supported
+        , stroke : Supported
+        , markers : Supported
+        }
+    ->
+        Value
+            { fill_ : Supported
+            , stroke : Supported
+            , markers : Supported
+            }
+    ->
+        Value
+            { fill_ : Supported
+            , stroke : Supported
+            , markers : Supported
+            }
+    -> Style
+paintOrder3 (Value val1) (Value val2) (Value val3) =
+    AppendProperty ("paint-order:" ++ val1 ++ " " ++ val2 ++ " " ++ val3)
+
+
+{-| Provides the `markers` value for [`paintOrder`](#paintOrder).
+
+    paintOrder markers
+
+-}
+markers : Value { provides | markers : Supported }
+markers =
+    Value "markers"
+
+
+{-| Sets [`column-rule`](https://css-tricks.com/almanac/properties/c/column-rule/).
+This is a shorthand for the [`columnRuleWidth`](#columnRuleWidth),
+[`columnRuleStyle`](#columnRuleStyle), and [`columnRuleColor`](#columnRuleColor)
+properties.
+
+    columnRule thin
+
+    columnRule2 thin solid
+
+    columnRule3 thin solid (hex "#000000")
+
+-}
+columnRule : BaseValue LineWidth -> Style
+columnRule (Value widthVal) =
+    AppendProperty ("column-rule:" ++ widthVal)
+
+
+{-| Sets [`column-rule`](https://css-tricks.com/almanac/properties/c/column-rule/).
+This is a shorthand for the [`columnRuleWidth`](#columnRuleWidth),
+[`columnRuleStyle`](#columnRuleStyle), and [`columnRuleColor`](#columnRuleColor)
+properties.
+
+    columnRule thin
+
+    columnRule2 thin solid
+
+    columnRule3 thin solid (hex "#000000")
+
+-}
+columnRule2 : Value LineWidth -> Value LineStyle -> Style
+columnRule2 (Value widthVal) (Value styleVal) =
+    AppendProperty ("column-rule:" ++ widthVal ++ " " ++ styleVal)
+
+
+{-| Sets [`column-rule`](https://css-tricks.com/almanac/properties/c/column-rule/).
+This is a shorthand for the [`columnRuleWidth`](#columnRuleWidth),
+[`columnRuleStyle`](#columnRuleStyle), and [`columnRuleColor`](#columnRuleColor)
+properties.
+
+    columnRule thin
+
+    columnRule2 thin solid
+
+    columnRule3 thin solid (hex "#000000")
+
+-}
+columnRule3 : Value LineWidth -> Value LineStyle -> Value Color -> Style
+columnRule3 (Value widthVal) (Value styleVal) (Value colorVal) =
+    AppendProperty ("column-rule:" ++ widthVal ++ " " ++ styleVal ++ " " ++ colorVal)
+
+
+
+
+
+
+
+
+
+{-| Sets [`clear`](https://css-tricks.com/almanac/properties/c/clear/) property.
+
+    clear none
+
+    clear both
+
+    clear left_
+
+    clear right_
+
+    clear inlineStart
+
+    clear inlineEnd
+
+-}
+clear :
+    BaseValue
+        { none : Supported
+        , left_ : Supported
+        , right_ : Supported
+        , both : Supported
+        , inlineStart : Supported
+        , inlineEnd : Supported
+        }
+    -> Style
+clear (Value val) =
+    AppendProperty ("clear:" ++ val)
+
+
+{-| Sets [`opacity`](https://css-tricks.com/almanac/properties/o/opacity/)
+
+    opacity (num 0.5)
+
+    opacity (num 1.0)
+
+    opacity zero
+
+-}
+opacity :
+    BaseValue
+        { num : Supported
+        , zero : Supported
+        , calc : Supported
+        , pct : Supported
+        }
+    -> Style
+opacity (Value val) =
+    AppendProperty ("opacity:" ++ val)
+
+
+{-| Sets [`zoom`](https://css-tricks.com/almanac/properties/z/zoom/)
+
+    zoom (pct 150)
+
+    zoom (num 1.5)
+
+    zoom normal
+
+-}
+zoom :
+    BaseValue
+        { pct : Supported
+        , zero : Supported
+        , num : Supported
+        , normal : Supported
+        , calc : Supported
+        , auto : Supported
+        }
+    -> Style
+zoom (Value val) =
+    AppendProperty ("zoom:" ++ val)
+
+
+{-| Sets [`line-height`](https://css-tricks.com/almanac/properties/l/line-height/)
+
+    lineHeight (pct 150)
+
+    lineHeight (em 2)
+
+    lineHeight (num 1.5)
+
+    lineHeight normal
+
+-}
+lineHeight :
+    BaseValue
+        (LengthSupported
+            { pct : Supported
+            , normal : Supported
+            , num : Supported
+            }
+        )
+    -> Style
+lineHeight (Value val) =
+    AppendProperty ("line-height:" ++ val)
+
+
+{-| Sets [`letter-spacing`](https://css-tricks.com/almanac/properties/l/letter-spacing/)
+
+    letterSpacing (pct 150)
+
+    letterSpacing (em 2)
+
+    letterSpacing (num 1.5)
+
+    letterSpacing normal
+
+-}
+letterSpacing :
+    BaseValue
+        (LengthSupported
+            { normal : Supported
+            }
+        )
+    -> Style
+letterSpacing (Value val) =
+    AppendProperty ("letter-spacing:" ++ val)
+
+
+
+{-| Sets [`backface-visibility`](https://css-tricks.com/almanac/properties/b/backface-visibility/)
+
+    backfaceVisibility visible
+
+    backfaceVisibility hidden
+
+-}
+backfaceVisibility :
+    BaseValue
+        { visible : Supported
+        , hidden : Supported
+        }
+    -> Style
+backfaceVisibility (Value val) =
+    AppendProperty ("backface-visibility" ++ val)
+
+
+{-| Sets [`bleed`](https://css-tricks.com/almanac/properties/b/bleed/)
+
+    bleed auto
+
+    bleed (pt 10)
+
+-}
+bleed :
+    BaseValue
+        (LengthSupported
+            { auto : Supported
+            }
+        )
+    -> Style
+bleed (Value val) =
+    AppendProperty ("bleed:" ++ val)
+
+
+
+
+
+
 {-| Sets [`caret-color`](https://css-tricks.com/almanac/properties/c/caret-color/)
 
     caretColor (hex "#60b5cc")
@@ -19586,1175 +20820,6 @@ objectPosition4 (Value horiz) (Value horizAmount) (Value vert) (Value vertAmount
             ++ " "
             ++ vertAmount
         )
-
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
--------------------------- BREAK (PAGE BREAK) --------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-
-
-{-| Sets [`break-before`](https://css-tricks.com/almanac/properties/b/break-before/).
-
-    breakBefore auto
--}
-breakBefore :
-    BaseValue
-        { auto : Supported
-        , always : Supported
-        , avoid : Supported
-        , all : Supported
-        , avoidPage : Supported
-        , page : Supported
-        , left_ : Supported
-        , right_ : Supported
-        , avoidColumn : Supported
-        , column : Supported
-        }
-    -> Style
-breakBefore (Value val) =
-    AppendProperty ("break-before:" ++ val)
-
-
-{-| Sets [`break-after`](https://css-tricks.com/almanac/properties/b/break-after/).
-
-    breakAfter auto
--}
-breakAfter :
-    BaseValue
-        { auto : Supported
-        , always : Supported
-        , avoid : Supported
-        , all : Supported
-        , avoidPage : Supported
-        , page : Supported
-        , left_ : Supported
-        , right_ : Supported
-        , avoidColumn : Supported
-        , column : Supported
-        }
-    -> Style
-breakAfter (Value val) =
-    AppendProperty ("break-after:" ++ val)
-
-
-{-| Sets [`break-inside`](https://css-tricks.com/almanac/properties/b/break-inside/)
-
-    breakInside auto
-
-    breakInside avoid
-
-    breakInside avoidPage
-
-    breakInside avoidColumn
-
--}
-breakInside :
-    BaseValue
-        { auto : Supported
-        , avoid : Supported
-        , avoidPage : Supported
-        , avoidColumn : Supported
-        }
-    -> Style
-breakInside (Value val) =
-    AppendProperty ("break-inside:" ++ val)
-
-
-
-{-| Sets `avoid` value for usage with [`breakAfter`](#breakAfter),
-[`breakBefore`](#breakBefore) and [`breakInside`](#breakInside).
-
-    breakBefore avoid
-
-    breakAfter avoid
-
-    breakInside avoid
-
--}
-avoid : Value { provides | avoid : Supported }
-avoid =
-    Value "avoid"
-
-
-{-| Sets `avoid-page` value for usage with [`breakAfter`](#breakAfter),
-[`breakBefore`](#breakBefore) and [`breakInside`](#breakInside).
-
-    breakBefore avoidPage
-
-    breakAfter avoidPage
-
-    breakInside avoidPage
-
--}
-avoidPage : Value { provides | avoidPage : Supported }
-avoidPage =
-    Value "avoid-page"
-
-
-{-| Sets `avoid-column` value for usage with [`breakAfter`](#breakAfter),
-[`breakBefore`](#breakBefore) and [`breakInside`](#breakInside).
-
-    breakBefore avoidColumn
-
-    breakAfter avoidColumn
-
-    breakInside avoidColumn
-
--}
-avoidColumn : Value { provides | avoidColumn : Supported }
-avoidColumn =
-    Value "avoid-column"
-
-
-
-{-| Sets `page` value for usage with [`breakAfter`](#breakAfter) and
-[`breakBefore`](#breakBefore).
-
-    breakBefore page
-
-    breakAfter page
-
--}
-page : Value { provides | page : Supported }
-page =
-    Value "page"
-
-
-{-| Sets [`page-break-before`](https://css-tricks.com/almanac/properties/p/page-break/)
-
-**This property has been depreciated and replaced with
-[`breakBefore`](#breakBefore), but is still included for backwards
-compatibility.**
-
-    pageBreakBefore auto
-
-    pageBreakBefore always
-
-    pageBreakBefore avoid
-
-    pageBreakBefore left_
-
-    pageBreakBefore right_
-
--}
-pageBreakBefore :
-    BaseValue
-        { auto : Supported
-        , always : Supported
-        , avoid : Supported
-        , left_ : Supported
-        , right_ : Supported
-        }
-    -> Style
-pageBreakBefore (Value val) =
-    AppendProperty ("page-break-before:" ++ val)
-
-
-{-| Sets [`page-break-after`](https://css-tricks.com/almanac/properties/p/page-break/)
-
-**This property has been depreciated and replaced with
-[`breakAfter`](#breakAfter), but is still included for backwards
-compatibility.**
-
-    pageBreakAfter auto
-
-    pageBreakAfter always
-
-    pageBreakAfter avoid
-
-    pageBreakAfter left_
-
-    pageBreakAfter right_
-
--}
-pageBreakAfter :
-    BaseValue
-        { auto : Supported
-        , always : Supported
-        , avoid : Supported
-        , left_ : Supported
-        , right_ : Supported
-        }
-    -> Style
-pageBreakAfter (Value val) =
-    AppendProperty ("page-break-after:" ++ val)
-
-
-{-| Sets [`page-break-inside`](https://css-tricks.com/almanac/properties/p/page-break/)
-
-    pageBreakInside auto
-
-    pageBreakInside avoid
-
--}
-pageBreakInside :
-    BaseValue
-        { auto : Supported
-        , avoid : Supported
-        }
-    -> Style
-pageBreakInside (Value val) =
-    AppendProperty ("page-break-inside:" ++ val)
-
-
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
----------------------------- POINTER-EVENTS-----------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-
-
-{-| Sets [`pointer-events`](https://css-tricks.com/almanac/properties/b/pointer-events/)
-
-    pointerEvents none
-
-    pointerEvents auto
-
--}
-pointerEvents :
-    BaseValue
-        { auto : Supported
-        , none : Supported
-        , visiblePainted : Supported
-        , visibleFill : Supported
-        , visibleStroke : Supported
-        , visible : Supported
-        , painted : Supported
-        , fill_ : Supported
-        , stroke : Supported
-        , all_ : Supported
-        }
-    -> Style
-pointerEvents (Value val) =
-    AppendProperty ("pointer-events:" ++ val)
-
-
-{-| The `visiblePainted` value used by [`pointerEvents`](#pointerEvents)
-
-    pointerEvents visiblePainted
-
--}
-visiblePainted : Value { provides | visiblePainted : Supported }
-visiblePainted =
-    Value "visiblePainted"
-
-
-{-| The `visibleFill` value used by [`pointerEvents`](#pointerEvents)
-
-    pointerEvents visibleFill
-
--}
-visibleFill : Value { provides | visibleFill : Supported }
-visibleFill =
-    Value "visibleFill"
-
-
-{-| The `visibleStroke` value used by [`pointerEvents`](#pointerEvents)
-
-    pointerEvents visibleStroke
-
--}
-visibleStroke : Value { provides | visibleStroke : Supported }
-visibleStroke =
-    Value "visibleStroke"
-
-
-{-| The `painted` value used by [`pointerEvents`](#pointerEvents)
-
-    pointerEvents painted
-
--}
-painted : Value { provides | painted : Supported }
-painted =
-    Value "painted"
-
-
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
------------------------------- SCROLLING ------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-
-
-{-| Sets `smooth` value for usage with [`scrollBehavior`](#scrollBehavior).
-
-    scrollBehavior smooth
-
--}
-smooth : Value { provides | smooth : Supported }
-smooth =
-    Value "smooth"
-
-
-{-| Sets the
-[`scrollbar-color`](https://developer.mozilla.org/en-US/docs/Web/CSS/scrollbar-color) property.
-
-    scrollbarColor auto
-
-    scrollbarColor (hex "f35d93")
--}
-scrollbarColor :
-    BaseValue
-        ( ColorSupported
-            { auto : Supported
-            }
-        )
-    -> Style
-scrollbarColor (Value val) =
-    AppendProperty ("scrollbar-color:" ++ val)
-
-
-{-| Sets the [`scrollbar-width`](https://developer.mozilla.org/en-US/docs/Web/CSS/scrollbar-width) property.
-
-    scrollbarWidth auto
-
-    scrollbarWidth thin
--}
-scrollbarWidth :
-    BaseValue
-        { auto : Supported
-        , thin : Supported
-        , none : Supported
-        }
-    -> Style
-scrollbarWidth (Value val) =
-    AppendProperty ("scrollbar-width:" ++ val)
-
-
-{-| Sets [`scroll-behavior`](https://css-tricks.com/almanac/properties/s/scroll-behavior/)
-
-    scrollBehavior auto
-
-    scrollBehavior smooth
-
--}
-scrollBehavior :
-    BaseValue
-        { auto : Supported
-        , smooth : Supported
-        }
-    -> Style
-scrollBehavior (Value val) =
-    AppendProperty ("scroll-behavior:" ++ val)
-
-
-{-| Sets [`scroll-margin`](https://css-tricks.com/almanac/properties/s/scroll-margin/) property.
-The `scrollMargin` property is a shorthand property for setting
-`scroll-margin-top`, `scroll-margin-right`, `scroll-margin-bottom`,
-and `scroll-margin-left` in a single declaration.
-
-If there is only one argument value, it applies to all sides. If there are two
-values, the top and bottom margins are set to the first value and the right and
-left margins are set to the second. If there are three values, the top is set
-to the first value, the left and right are set to the second, and the bottom is
-set to the third. If there are four values they apply to the top, right,
-bottom, and left, respectively.
-
-    scrollMargin (em 4) -- set all margins to 4em
-
-    scrollMargin2 (em 4) (px 2) -- top & bottom = 4em, right & left = 2px
-
-    scrollMargin3 (em 4) (px 2) (pt 5) -- top = 4em, right = 2px, bottom = 5pt, left = 2px
-
-    scrollMargin4 (em 4) (px 2) (pt 5) (px 3) -- top = 4em, right = 2px, bottom = 5pt, left = 3px
-
--}
-scrollMargin :
-    BaseValue
-        Length
-    -> Style
-scrollMargin (Value value) =
-    AppendProperty ("scroll-margin:" ++ value)
-
-
-{-| Sets [`scroll-margin`](https://css-tricks.com/almanac/properties/s/scroll-margin/) property.
-The `scrollMargin2` property is a shorthand property for setting
-`scroll-margin-top`, `scroll-margin-right`, `scroll-margin-bottom`,
-and `scroll-margin-left` in a single declaration.
-
-The top and bottom margins are set to the first value and the right and left
-margins are set to the second.
-
-    scrollMargin2 (em 4) (px 2) -- top & bottom = 4em, right & left = 2px
-
--}
-scrollMargin2 :
-    Value
-        Length
-    ->
-        Value
-            Length
-    -> Style
-scrollMargin2 (Value valueTopBottom) (Value valueRightLeft) =
-    AppendProperty ("scroll-margin:" ++ valueTopBottom ++ " " ++ valueRightLeft)
-
-
-{-| Sets [`scroll-margin`](https://css-tricks.com/almanac/properties/s/scroll-margin/) property.
-The `scrollMargin3` property is a shorthand property for setting
-`scroll-margin-top`, `scroll-margin-right`, `scroll-margin-bottom`,
-and `scroll-margin-left` in a single declaration.
-
-The top margin is set to the first value, the left and right are set to the
-second, and the bottom is set to the third.
-
-    scrollMargin3 (em 4) (px 2) (pt 5) -- top = 4em, right = 2px, bottom = 5pt, left = 2px
-
--}
-scrollMargin3 :
-    Value
-        Length
-    ->
-        Value
-            Length
-    ->
-        Value
-            Length
-    -> Style
-scrollMargin3 (Value valueTop) (Value valueRightLeft) (Value valueBottom) =
-    AppendProperty ("scroll-margin:" ++ valueTop ++ " " ++ valueRightLeft ++ " " ++ valueBottom)
-
-
-{-| Sets [`scroll-margin`](https://css-tricks.com/almanac/properties/s/scroll-margin/) property.
-The `scrollMargin4` property is a shorthand property for setting
-`scroll-margin-top`, `scroll-margin-right`, `scroll-margin-bottom`,
-and `scroll-margin-left` in a single declaration.
-
-The four values apply to the top, right, bottom, and left margins.
-
-    scrollMargin4 (em 4) (px 2) (pt 5) (px 3) -- top = 4em, right = 2px, bottom = 5pt, left = 3px
-
--}
-scrollMargin4 :
-    Value
-        Length
-    ->
-        Value
-            Length
-    ->
-        Value
-            Length
-    ->
-        Value
-            Length
-    -> Style
-scrollMargin4 (Value valueTop) (Value valueRight) (Value valueBottom) (Value valueLeft) =
-    AppendProperty ("scroll-margin:" ++ valueTop ++ " " ++ valueRight ++ " " ++ valueBottom ++ " " ++ valueLeft)
-
-
-{-| Sets [`scroll-margin-top`](https://css-tricks.com/almanac/properties/s/scroll-margin/) property.
-
-    scrollMarginTop (px 4)
-
--}
-scrollMarginTop :
-    BaseValue
-        Length
-    -> Style
-scrollMarginTop (Value value) =
-    AppendProperty ("scroll-margin-top:" ++ value)
-
-
-{-| Sets [`scroll-margin-right`](https://css-tricks.com/almanac/properties/s/scroll-margin/) property.
-
-    scrollMarginRight (px 4)
-
--}
-scrollMarginRight :
-    BaseValue
-        Length
-    -> Style
-scrollMarginRight (Value value) =
-    AppendProperty ("scroll-margin-right:" ++ value)
-
-
-{-| Sets [`scroll-margin-bottom`](https://css-tricks.com/almanac/properties/s/scroll-margin/) property.
-
-    scrollMarginBottom (px 4)
-
--}
-scrollMarginBottom :
-    BaseValue
-        Length
-    -> Style
-scrollMarginBottom (Value value) =
-    AppendProperty ("scroll-margin-bottom:" ++ value)
-
-
-{-| Sets [`scroll-margin-left`](https://css-tricks.com/almanac/properties/s/scroll-margin/) property.
-
-    scrollMarginLeft (px 4)
-
--}
-scrollMarginLeft :
-    BaseValue
-        Length
-    -> Style
-scrollMarginLeft (Value value) =
-    AppendProperty ("scroll-margin-left:" ++ value)
-
-
-{-| Sets [`scroll-margin-block`](https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-margin-block) property.
-The `scrollMarginBlock` property is a shorthand property for setting
-`scroll-margin-block-start` and `scroll-margin-block-end` in a single declaration.
-
-If there is only one argument value, it applies to both sides. If there are two
-values, the block start margin is set to the first value and the block end margin is
-set to the second.
-
-    scrollMarginBlock (em 4) -- set both block margins to 4em
-
-    scrollMarginBlock2 (em 4) (px 2) -- block start = 4em, block end = 2px
-
--}
-scrollMarginBlock :
-    BaseValue
-        Length
-    -> Style
-scrollMarginBlock (Value value) =
-    AppendProperty ("scroll-margin-block:" ++ value)
-
-
-{-| Sets [`scroll-margin-block`](https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-margin-block) property.
-The `scrollMarginBlock2` property is a shorthand property for setting
-`scroll-margin-block-start` and `scroll-margin-block-end` in a single declaration.
-
-The block start margin is set to the first value and the block end margin is
-set to the second.
-
-    scrollMarginBlock2 (em 4) (px 2) -- block start = 4em, block end = 2px
-
--}
-scrollMarginBlock2 :
-    Value
-        Length
-    ->
-        Value
-            Length
-    -> Style
-scrollMarginBlock2 (Value valueStart) (Value valueEnd) =
-    AppendProperty ("scroll-margin-block:" ++ valueStart ++ " " ++ valueEnd)
-
-
-{-| Sets [`scroll-margin-inline`](https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-margin-inline) property.
-The `scrollMarginInline` property is a shorthand property for setting
-`scroll-margin-inline-start` and `scroll-margin-inline-end` in a single declaration.
-
-If there is only one argument value, it applies to both sides. If there are two
-values, the inline start margin is set to the first value and the inline end margin is
-set to the second.
-
-    scrollMarginInline (em 4) -- set both inline margins to 4em
-
-    scrollMarginInline2 (em 4) (px 2) -- inline start = 4em, inline end = 2px
-
--}
-scrollMarginInline :
-    BaseValue
-        Length
-    -> Style
-scrollMarginInline (Value value) =
-    AppendProperty ("scroll-margin-inline:" ++ value)
-
-
-{-| Sets [`scroll-margin-inline`](https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-margin-inline) property.
-The `scrollMarginInline2` property is a shorthand property for setting
-`scroll-margin-inline-start` and `scroll-margin-inline-end` in a single declaration.
-
-The inline start margin is set to the first value and the inline end margin is
-set to the second.
-
-    scrollMarginInline2 (em 4) (px 2) -- inline start = 4em, inline end = 2px
-
--}
-scrollMarginInline2 :
-    Value
-        Length
-    ->
-        Value
-            Length
-    -> Style
-scrollMarginInline2 (Value valueStart) (Value valueEnd) =
-    AppendProperty ("scroll-margin-inline:" ++ valueStart ++ " " ++ valueEnd)
-
-
-{-| Sets [`scroll-margin-block-start`](https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-margin-block-start) property.
-
-    scrollMarginBlockStart (px 4)
-
--}
-scrollMarginBlockStart :
-    BaseValue
-        Length
-    -> Style
-scrollMarginBlockStart (Value value) =
-    AppendProperty ("scroll-margin-block-start:" ++ value)
-
-
-{-| Sets [`scroll-margin-block-end`](https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-margin-block-end) property.
-
-    scrollMarginBlockEnd (px 4)
-
--}
-scrollMarginBlockEnd :
-    BaseValue
-        Length
-    -> Style
-scrollMarginBlockEnd (Value value) =
-    AppendProperty ("scroll-margin-block-end:" ++ value)
-
-
-{-| Sets [`scroll-margin-inline-start`](https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-margin-inline-start) property.
-
-    scrollMarginInlineStart (px 4)
-
--}
-scrollMarginInlineStart :
-    BaseValue
-        Length
-    -> Style
-scrollMarginInlineStart (Value value) =
-    AppendProperty ("scroll-margin-inline-start:" ++ value)
-
-
-{-| Sets [`scroll-margin-inline-end`](https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-margin-inline-end) property.
-
-    scrollMarginInlineEnd (px 4)
-
--}
-scrollMarginInlineEnd :
-    BaseValue
-        Length
-    -> Style
-scrollMarginInlineEnd (Value value) =
-    AppendProperty ("scroll-margin-inline-end:" ++ value)
-
-
-{-| Sets [`scroll-padding`](https://css-tricks.com/almanac/properties/s/scroll-padding/) property.
-The `scrollPadding` property is a shorthand property for setting
-`scroll-padding-top`, `scroll-padding-right`, `scroll-padding-bottom`,
-and `scroll-padding-left` in a single declaration.
-
-If there is only one argument value, it applies to all sides. If there are two
-values, the top and bottom paddings are set to the first value and the right and
-left paddings are set to the second. If there are three values, the top is set
-to the first value, the left and right are set to the second, and the bottom is
-set to the third. If there are four values they apply to the top, right,
-bottom, and left, respectively.
-
-    scrollPadding (em 4) -- set all paddings to 4em
-
-    scrollPadding2 (em 4) (px 2) -- top & bottom = 4em, right & left = 2px
-
-    scrollPadding3 (em 4) (px 2) (pct 5) -- top = 4em, right = 2px, bottom = 5%, left = 2px
-
-    scrollPadding4 (em 4) (px 2) (pct 5) (px 3) -- top = 4em, right = 2px, bottom = 5%, left = 3px
-
--}
-scrollPadding :
-    BaseValue
-        (LengthSupported
-            { auto : Supported
-            , pct : Supported
-            }
-        )
-    -> Style
-scrollPadding (Value value) =
-    AppendProperty ("scroll-padding:" ++ value)
-
-
-{-| Sets [`scroll-padding`](https://css-tricks.com/almanac/properties/s/scroll-padding/) property.
-The `scrollPadding2` property is a shorthand property for setting
-`scroll-padding-top`, `scroll-padding-right`, `scroll-padding-bottom`,
-and `scroll-padding-left` in a single declaration.
-
-The top and bottom margins are set to the first value and the right and left
-margins are set to the second.
-
-    scrollPadding2 (em 4) (px 2) -- top & bottom = 4em, right & left = 2px
-
--}
-scrollPadding2 :
-    Value
-        (LengthSupported
-            { auto : Supported
-            , pct : Supported
-            }
-        )
-    ->
-        Value
-            (LengthSupported
-                { auto : Supported
-                , pct : Supported
-                }
-            )
-    -> Style
-scrollPadding2 (Value valueTopBottom) (Value valueRightLeft) =
-    AppendProperty ("scroll-padding:" ++ valueTopBottom ++ " " ++ valueRightLeft)
-
-
-{-| Sets [`scroll-padding`](https://css-tricks.com/almanac/properties/s/scroll-padding/) property.
-The `scrollPadding3` property is a shorthand property for setting
-`scroll-padding-top`, `scroll-padding-right`, `scroll-padding-bottom`,
-and `scroll-padding-left` in a single declaration.
-
-The top padding is set to the first value, the left and right are set to the
-second, and the bottom is set to the third.
-
-    scrollPadding3 (em 4) (px 2) (pct 5) -- top = 4em, right = 2px, bottom = 5%, left = 2px
-
--}
-scrollPadding3 :
-    Value
-        (LengthSupported
-            { auto : Supported
-            , pct : Supported
-            }
-        )
-    ->
-        Value
-            (LengthSupported
-                { auto : Supported
-                , pct : Supported
-                }
-            )
-    ->
-        Value
-            (LengthSupported
-                { auto : Supported
-                , pct : Supported
-                }
-            )
-    -> Style
-scrollPadding3 (Value valueTop) (Value valueRightLeft) (Value valueBottom) =
-    AppendProperty ("scroll-padding:" ++ valueTop ++ " " ++ valueRightLeft ++ " " ++ valueBottom)
-
-
-{-| Sets [`scroll-padding`](https://css-tricks.com/almanac/properties/s/scroll-padding/) property.
-The `scrollPadding4` property is a shorthand property for setting
-`scroll-padding-top`, `scroll-padding-right`, `scroll-padding-bottom`,
-and `scroll-padding-left` in a single declaration.
-
-The four values apply to the top, right, bottom, and left paddings.
-
-    scrollPadding4 (em 4) (px 2) (pct 5) (px 3) -- top = 4em, right = 2px, bottom = 5%, left = 3px
-
--}
-scrollPadding4 :
-    Value
-        (LengthSupported
-            { auto : Supported
-            , pct : Supported
-            }
-        )
-    ->
-        Value
-            (LengthSupported
-                { auto : Supported
-                , pct : Supported
-                }
-            )
-    ->
-        Value
-            (LengthSupported
-                { auto : Supported
-                , pct : Supported
-                }
-            )
-    ->
-        Value
-            (LengthSupported
-                { auto : Supported
-                , pct : Supported
-                }
-            )
-    -> Style
-scrollPadding4 (Value valueTop) (Value valueRight) (Value valueBottom) (Value valueLeft) =
-    AppendProperty ("scroll-padding:" ++ valueTop ++ " " ++ valueRight ++ " " ++ valueBottom ++ " " ++ valueLeft)
-
-
-{-| Sets [`scroll-padding-top`](https://css-tricks.com/almanac/properties/s/scroll-padding/) property.
-
-    scrollPaddingTop (px 4)
-
--}
-scrollPaddingTop :
-    BaseValue
-        (LengthSupported
-            { auto : Supported
-            , pct : Supported
-            }
-        )
-    -> Style
-scrollPaddingTop (Value value) =
-    AppendProperty ("scroll-padding-top:" ++ value)
-
-
-{-| Sets [`scroll-padding-right`](https://css-tricks.com/almanac/properties/s/scroll-padding/) property.
-
-    scrollPaddingRight (px 4)
-
--}
-scrollPaddingRight :
-    BaseValue
-        (LengthSupported
-            { auto : Supported
-            , pct : Supported
-            }
-        )
-    -> Style
-scrollPaddingRight (Value value) =
-    AppendProperty ("scroll-padding-right:" ++ value)
-
-
-{-| Sets [`scroll-padding-bottom`](https://css-tricks.com/almanac/properties/s/scroll-padding/) property.
-
-    scrollPaddingBottom (px 4)
-
--}
-scrollPaddingBottom :
-    BaseValue
-        (LengthSupported
-            { auto : Supported
-            , pct : Supported
-            }
-        )
-    -> Style
-scrollPaddingBottom (Value value) =
-    AppendProperty ("scroll-padding-bottom:" ++ value)
-
-
-{-| Sets [`scroll-padding-left`](https://css-tricks.com/almanac/properties/s/scroll-padding/) property.
-
-    scrollPaddingLeft (px 4)
-
--}
-scrollPaddingLeft :
-    BaseValue
-        (LengthSupported
-            { auto : Supported
-            , pct : Supported
-            }
-        )
-    -> Style
-scrollPaddingLeft (Value value) =
-    AppendProperty ("scroll-padding-left:" ++ value)
-
-
-{-| Sets [`scroll-padding-block`](https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-padding-block) property.
-The `scroll-padding-block` property is a shorthand property for setting
-`scroll-padding-block-start` and `scroll-padding-block-end` in a single declaration.
-
-If there is only one argument value, it applies to both sides. If there are two
-values, the block start padding is set to the first value and the block end padding
-is set to the second.
-
-    scrollPaddingBlock (em 4) -- set both block paddings to 4em
-
-    scrollPaddingBlock2 (em 4) (px 2) -- block start = 4em, block end = 2px
-
--}
-scrollPaddingBlock :
-    BaseValue
-        (LengthSupported
-            { auto : Supported
-            , pct : Supported
-            }
-        )
-    -> Style
-scrollPaddingBlock (Value value) =
-    AppendProperty ("scroll-padding-block:" ++ value)
-
-
-{-| Sets [`scroll-padding-block`](https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-padding-block) property.
-The `scroll-padding-block` property is a shorthand property for setting
-`scroll-padding-block-start` and `scroll-padding-block-end` in a single declaration.
-
-The block start padding is set to the first value and the block end padding
-is set to the second.
-
-    scrollPaddingBlock2 (em 4) (px 2) -- block start = 4em, block end = 2px
-
--}
-scrollPaddingBlock2 :
-    Value
-        (LengthSupported
-            { auto : Supported
-            , pct : Supported
-            }
-        )
-    ->
-        Value
-            (LengthSupported
-                { auto : Supported
-                , pct : Supported
-                }
-            )
-    -> Style
-scrollPaddingBlock2 (Value valueStart) (Value valueEnd) =
-    AppendProperty ("scroll-padding-block:" ++ valueStart ++ " " ++ valueEnd)
-
-
-{-| Sets [`scroll-padding-inline`](https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-padding-inline) property.
-The `scroll-padding-inline` property is a shorthand property for setting
-`scroll-padding-inline-start` and `scroll-padding-inline-end` in a single declaration.
-
-If there is only one argument value, it applies to both sides. If there are two
-values, the inline start padding is set to the first value and the inline end padding
-is set to the second.
-
-    scrollPaddingInline (em 4) -- set both inline paddings to 4em
-
-    scrollPaddingInline2 (em 4) (px 2) -- inline start = 4em, inline end = 2px
-
--}
-scrollPaddingInline :
-    BaseValue
-        (LengthSupported
-            { auto : Supported
-            , pct : Supported
-            }
-        )
-    -> Style
-scrollPaddingInline (Value value) =
-    AppendProperty ("scroll-padding-inline:" ++ value)
-
-
-{-| Sets [`scroll-padding-inline`](https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-padding-inline) property.
-The `scroll-padding-inline` property is a shorthand property for setting
-`scroll-padding-inline-start` and `scroll-padding-inline-end` in a single declaration.
-
-The inline start padding is set to the first value and the inline end padding
-is set to the second.
-
-    scrollPaddingInline2 (em 4) (px 2) -- inline start = 4em, inline end = 2px
-
--}
-scrollPaddingInline2 :
-    Value
-        (LengthSupported
-            { auto : Supported
-            , pct : Supported
-            }
-        )
-    ->
-        Value
-            (LengthSupported
-                { auto : Supported
-                , pct : Supported
-                }
-            )
-    -> Style
-scrollPaddingInline2 (Value valueStart) (Value valueEnd) =
-    AppendProperty ("scroll-padding-inline:" ++ valueStart ++ " " ++ valueEnd)
-
-
-{-| Sets [`scroll-padding-block-start`](https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-padding-block-start) property.
-
-    scrollPaddingBlockStart (px 4)
-
--}
-scrollPaddingBlockStart :
-    BaseValue
-        (LengthSupported
-            { auto : Supported
-            , pct : Supported
-            }
-        )
-    -> Style
-scrollPaddingBlockStart (Value value) =
-    AppendProperty ("scroll-padding-block-start:" ++ value)
-
-
-{-| Sets [`scroll-padding-block-end`](https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-padding-block-end) property.
-
-    scrollPaddingBlockEnd (px 4)
-
--}
-scrollPaddingBlockEnd :
-    BaseValue
-        (LengthSupported
-            { auto : Supported
-            , pct : Supported
-            }
-        )
-    -> Style
-scrollPaddingBlockEnd (Value value) =
-    AppendProperty ("scroll-padding-block-end:" ++ value)
-
-
-{-| Sets [`scroll-padding-inline-start`](https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-padding-inline-start) property.
-
-    scrollPaddingInlineStart (px 4)
-
--}
-scrollPaddingInlineStart :
-    BaseValue
-        (LengthSupported
-            { auto : Supported
-            , pct : Supported
-            }
-        )
-    -> Style
-scrollPaddingInlineStart (Value value) =
-    AppendProperty ("scroll-padding-inline-start:" ++ value)
-
-
-{-| Sets [`scroll-padding-inline-end`](https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-padding-inline-end) property.
-
-    scrollPaddingInlineEnd (px 4)
-
--}
-scrollPaddingInlineEnd :
-    BaseValue
-        (LengthSupported
-            { auto : Supported
-            , pct : Supported
-            }
-        )
-    -> Style
-scrollPaddingInlineEnd (Value value) =
-    AppendProperty ("scroll-padding-inline-end:" ++ value)
-
-
-{-| Sets the [`overscroll-behavior`](https://css-tricks.com/almanac/properties/o/overscroll-behavior/) property.
-
-This property is a shorthand for setting both `overscroll-behavior-x` and `overscroll-behavior-y`.
-
-    overscrollBehavior auto -- sets both X and Y to auto
-
-    overscrollBehavior2 auto contain -- X = auto, Y = contain.
-
--}
-overscrollBehavior :
-    BaseValue
-        { auto : Supported
-        , contain : Supported
-        , none : Supported
-        }
-    -> Style
-overscrollBehavior (Value value) =
-    AppendProperty ("overscroll-behavior:" ++ value)
-
-
-{-| Sets the [`overscroll-behavior`](https://css-tricks.com/almanac/properties/o/overscroll-behavior/) property.
-
-This property is a shorthand for setting both `overscroll-behavior-x` and `overscroll-behavior-y`.
-
-    overscrollBehavior2 auto contain -- X = auto, Y = contain.
-
--}
-overscrollBehavior2 :
-    Value
-        { auto : Supported
-        , contain : Supported
-        , none : Supported
-        }
-    ->
-        Value
-            { auto : Supported
-            , contain : Supported
-            , none : Supported
-            }
-    -> Style
-overscrollBehavior2 (Value xValue) (Value yValue) =
-    AppendProperty ("overscroll-behavior:" ++ xValue ++ " " ++ yValue)
-
-
-{-| Sets the [`overscroll-behavior-x`](https://css-tricks.com/almanac/properties/o/overscroll-behavior/) property.
-
-    overscrollBehaviorX auto
-
-    overscrollBehaviorX contain
-
--}
-overscrollBehaviorX :
-    BaseValue
-        { auto : Supported
-        , contain : Supported
-        , none : Supported
-        }
-    -> Style
-overscrollBehaviorX (Value value) =
-    AppendProperty ("overscroll-behavior-x:" ++ value)
-
-
-{-| Sets the [`overscroll-behavior-y`](https://css-tricks.com/almanac/properties/o/overscroll-behavior/) property.
-
-    overscrollBehaviorY auto
-
-    overscrollBehaviorY contain
-
--}
-overscrollBehaviorY :
-    BaseValue
-        { auto : Supported
-        , contain : Supported
-        , none : Supported
-        }
-    -> Style
-overscrollBehaviorY (Value value) =
-    AppendProperty ("overscroll-behavior-y:" ++ value)
-
-
-{-| Sets the [`overscroll-behavior-block`](https://developer.mozilla.org/en-US/docs/Web/CSS/overscroll-behavior-block) property.
-
-    overscrollBehaviorBlock auto
-
-    overscrollBehaviorBlock contain
-
--}
-overscrollBehaviorBlock :
-    BaseValue
-        { auto : Supported
-        , contain : Supported
-        , none : Supported
-        }
-    -> Style
-overscrollBehaviorBlock (Value value) =
-    AppendProperty ("overscroll-behavior-block:" ++ value)
-
-
-{-| Sets the [`overscroll-behavior-inline`](https://developer.mozilla.org/en-US/docs/Web/CSS/overscroll-behavior-inline) property.
-
-    overscrollBehaviorInline auto
-
-    overscrollBehaviorInline contain
-
--}
-overscrollBehaviorInline :
-    BaseValue
-        { auto : Supported
-        , contain : Supported
-        , none : Supported
-        }
-    -> Style
-overscrollBehaviorInline (Value value) =
-    AppendProperty ("overscroll-behavior-inline:" ++ value)
 
 
 {-| Sets [`scroll-snap-align`](https://css-tricks.com/almanac/properties/s/scroll-snap-align/)

--- a/src/Css.elm
+++ b/src/Css.elm
@@ -14454,7 +14454,7 @@ string values.
     quotes4 (string "«") (string "»") (string "👏") (string "🤔")
 
     {- «Hey, this is a first-level quote.
-    👏And this is someone else I made up for
+    👏And this is something else I made up for
     a second-level quote!🤔 Yeah, I did that!»
     -}
 

--- a/src/Css.elm
+++ b/src/Css.elm
@@ -481,7 +481,7 @@ All CSS properties can have the values `unset`, `initial`, `inherit` and `revert
 
 @docs unset, initial, inherit
 
-@docs all, revert
+@docs revert
 
 @docs Angle, AngleSupported, Width, WidthSupported
 

--- a/src/Css.elm
+++ b/src/Css.elm
@@ -19,7 +19,7 @@ module Css exposing
     , x, y
     , stretch, center, content, fill_, stroke, text, style
     , clip, cover, contain_
-    , baseline, sub, super, ruby, fullWidth
+    , baseline, sub, super, ruby, fullWidth, under, circle
     , pseudoClass, active, checked, disabled, empty, enabled
     , firstChild, firstOfType, focus, fullscreen, hover, inRange
     , indeterminate, invalid, lastChild, lastOfType, link, onlyChild
@@ -90,7 +90,7 @@ module Css exposing
     , fontVariantEastAsian, fontVariantEastAsian2, fontVariantEastAsian3, jis78, jis83, jis90, jis04, simplified, traditional, proportionalWidth
     , fontVariantLigatures, commonLigatures, noCommonLigatures, discretionaryLigatures, noDiscretionaryLigatures, historicalLigatures, noHistoricalLigatures, contextual, noContextual
     , fontVariantNumeric, fontVariantNumeric4, ordinal, slashedZero, liningNums, oldstyleNums, proportionalNums, tabularNums, diagonalFractions, stackedFractions
-    , fontKerning, fontLanguageOverride, fontSynthesis, fontSynthesis2, fontSynthesis3, fontOpticalSizing, fontVariantPosition
+    , fontKerning, fontLanguageOverride, fontSynthesis, fontSynthesis2, fontSynthesis3, fontOpticalSizing, fontVariantPosition, weight
     , CursorKeyword
     , cursor, cursor2, cursor4
     , pointer, default, contextMenu, help, progress, wait, cell
@@ -100,13 +100,13 @@ module Css exposing
     , neswResize, nwseResize, zoomIn, zoomOut, grab, grabbing
     , ListStyleType, ListStyleTypeSupported
     , listStyle, listStyle2, listStyle3, listStylePosition, inside, outside, listStyleType, string, customIdent, listStyleImage
-    , arabicIndic, armenian, bengali, cambodian, circle, cjkDecimal, cjkEarthlyBranch, cjkHeavenlyStem, cjkIdeographic, decimal, decimalLeadingZero, devanagari, disclosureClosed, disclosureOpen, disc, ethiopicNumeric, georgian, gujarati, gurmukhi, hebrew, hiragana, hiraganaIroha, japaneseFormal, japaneseInformal, kannada, katakana, katakanaIroha, khmer, koreanHangulFormal, koreanHanjaFormal, koreanHanjaInformal, lao, lowerAlpha, lowerArmenian, lowerGreek, lowerLatin, lowerRoman, malayalam, monogolian, myanmar, oriya, persian, simpChineseFormal, simpChineseInformal, tamil, telugu, thai, tibetan, tradChineseFormal, tradChineseInformal, upperAlpha, upperArmenian, upperLatin, upperRoman
+    , arabicIndic, armenian, bengali, cambodian, cjkDecimal, cjkEarthlyBranch, cjkHeavenlyStem, cjkIdeographic, decimal, decimalLeadingZero, devanagari, disclosureClosed, disclosureOpen, disc, ethiopicNumeric, georgian, gujarati, gurmukhi, hebrew, hiragana, hiraganaIroha, japaneseFormal, japaneseInformal, kannada, katakana, katakanaIroha, khmer, koreanHangulFormal, koreanHanjaFormal, koreanHanjaInformal, lao, lowerAlpha, lowerArmenian, lowerGreek, lowerLatin, lowerRoman, malayalam, monogolian, myanmar, oriya, persian, simpChineseFormal, simpChineseInformal, tamil, telugu, thai, tibetan, tradChineseFormal, tradChineseInformal, upperAlpha, upperArmenian, upperLatin, upperRoman
     , overflow, overflowX, overflowY, overflowBlock, overflowInline
     , overflowAnchor
     , overflowWrap
     , breakWord, anywhere
     , direction, ltr, rtl
-    , justify, matchParent, textAlign, textJustify, interWord, interCharacter, textUnderlinePosition, textUnderlinePosition2, under
+    , justify, matchParent, textAlign, textJustify, interWord, interCharacter, textUnderlinePosition, textUnderlinePosition2
     , textOrientation
     , mixed, sideways, upright
     , textRendering
@@ -118,6 +118,7 @@ module Css exposing
     , wavy, underline, overline, lineThrough
     , textStroke, textStroke2, textStrokeColor, textStrokeWidth
     , textIndent, textIndent2, textIndent3, hanging, eachLine
+    , textEmphasis, textEmphasis2, textEmphasisStyle, textEmphasisStyle2, textEmphasisColor, textEmphasisPosition, textEmphasisPosition2, filled, open, dot, doubleCircle, triangle, sesame, over
     , borderCollapse
     , collapse, separate
     , borderSpacing, borderSpacing2
@@ -255,9 +256,9 @@ All CSS properties can have the values `unset`, `initial`, and `inherit`.
 @docs url
 
 
-# Shared Values
+# Shared Keywords
 
-Many different kinds of CSS properties use these values.
+Many different kinds of CSS properties use these keyword values.
 
 @docs auto, none, normal, strict, all_, both, always
 @docs hidden, visible
@@ -266,8 +267,7 @@ Many different kinds of CSS properties use these values.
 @docs x, y
 @docs stretch, center, content, fill_, stroke, text, style
 @docs clip, cover, contain_
-@docs baseline, sub, super, ruby, fullWidth
-
+@docs baseline, sub, super, ruby, fullWidth, under, circle
 
 # Pseudo-Classes
 
@@ -560,7 +560,7 @@ Other values you can use for flex item alignment:
 
 ## Font Optical Sizing
 
-@docs fontKerning, fontLanguageOverride, fontSynthesis, fontSynthesis2, fontSynthesis3, fontOpticalSizing, fontVariantPosition
+@docs fontKerning, fontLanguageOverride, fontSynthesis, fontSynthesis2, fontSynthesis3, fontOpticalSizing, fontVariantPosition, weight
 
 
 # Cursors
@@ -584,7 +584,7 @@ Other values you can use for flex item alignment:
 
 @docs ListStyleType, ListStyleTypeSupported
 @docs listStyle, listStyle2, listStyle3, listStylePosition, inside, outside, listStyleType, string, customIdent, listStyleImage
-@docs arabicIndic, armenian, bengali, cambodian, circle, cjkDecimal, cjkEarthlyBranch, cjkHeavenlyStem, cjkIdeographic, decimal, decimalLeadingZero, devanagari, disclosureClosed, disclosureOpen, disc, ethiopicNumeric, georgian, gujarati, gurmukhi, hebrew, hiragana, hiraganaIroha, japaneseFormal, japaneseInformal, kannada, katakana, katakanaIroha, khmer, koreanHangulFormal, koreanHanjaFormal, koreanHanjaInformal, lao, lowerAlpha, lowerArmenian, lowerGreek, lowerLatin, lowerRoman, malayalam, monogolian, myanmar, oriya, persian, simpChineseFormal, simpChineseInformal, tamil, telugu, thai, tibetan, tradChineseFormal, tradChineseInformal, upperAlpha, upperArmenian, upperLatin, upperRoman
+@docs arabicIndic, armenian, bengali, cambodian, cjkDecimal, cjkEarthlyBranch, cjkHeavenlyStem, cjkIdeographic, decimal, decimalLeadingZero, devanagari, disclosureClosed, disclosureOpen, disc, ethiopicNumeric, georgian, gujarati, gurmukhi, hebrew, hiragana, hiraganaIroha, japaneseFormal, japaneseInformal, kannada, katakana, katakanaIroha, khmer, koreanHangulFormal, koreanHanjaFormal, koreanHanjaInformal, lao, lowerAlpha, lowerArmenian, lowerGreek, lowerLatin, lowerRoman, malayalam, monogolian, myanmar, oriya, persian, simpChineseFormal, simpChineseInformal, tamil, telugu, thai, tibetan, tradChineseFormal, tradChineseInformal, upperAlpha, upperArmenian, upperLatin, upperRoman
 
 [`square`](#square) is also a supported value for [`listStyle`](#listStyle) and [`listStyleType`](#listStyleType).
 
@@ -605,7 +605,7 @@ Other values you can use for flex item alignment:
 
 # Text Align
 
-@docs justify, matchParent, textAlign, textJustify, interWord, interCharacter, textUnderlinePosition, textUnderlinePosition2, under
+@docs justify, matchParent, textAlign, textJustify, interWord, interCharacter, textUnderlinePosition, textUnderlinePosition2
 
 
 # Text Orientation
@@ -636,6 +636,8 @@ Other values you can use for flex item alignment:
 @docs textStroke, textStroke2, textStrokeColor, textStrokeWidth
 
 @docs textIndent, textIndent2, textIndent3, hanging, eachLine
+
+@docs textEmphasis, textEmphasis2, textEmphasisStyle, textEmphasisStyle2, textEmphasisColor, textEmphasisPosition, textEmphasisPosition2, filled, open, dot, doubleCircle, triangle, sesame, over
 
 
 # Tables
@@ -897,6 +899,7 @@ type alias BaseValue supported =
             | initial : Supported
             , inherit : Supported
             , unset : Supported
+            , revert : Supported
         }
 
 
@@ -1192,9 +1195,12 @@ unset =
     Value "unset"
 
 
-{-| The `revert` value for the [`all`](#all) property.
+{-| The [`revert`](https://css-tricks.com/what-does-revert-do-in-css/) value.
+Any CSS property can be set to this value.
 
     all revert
+
+    color revert
 
 -}
 revert : Value { provides | revert : Supported }
@@ -1207,7 +1213,7 @@ revert =
     all inherit
 
 -}
-all : BaseValue { revert : Supported } -> Style
+all : BaseValue a -> Style
 all (Value val) =
     AppendProperty ("all:" ++ val)
 
@@ -1773,7 +1779,7 @@ content =
 
     pointerEvents fill_
 
-    paintOrder2 fill markers
+    paintOrder2 fill_ markers
 
 -}
 fill_ : Value { provides | fill_ : Supported }
@@ -1970,6 +1976,34 @@ fullWidth : Value { provides | fullWidth : Supported }
 fullWidth =
     Value "full-width"
 
+
+
+{-| A `under` value for the [`textUnderlinePosition`](#textUnderlinePosition) property and the [`textEmphasisPosition2`](#textEmphasisPosition2) property.
+
+    textUnderlinePosition under
+
+    textEmphasisPosition2 under left_
+
+-}
+under : Value { provides | under : Supported }
+under =
+    Value "under"
+
+
+
+{-| The `circle` value used by properties such as [`listStyle`](#listStyle),
+[`listStyleType`](#listStyleType), [`textEmphasis`](#textEmphasis) and [`textEmphasisStyle`](#textEmphasisStyle).
+
+    listStyleType circle
+
+    textEmphasis2 circle (hex "ff0000")
+
+    textEmphasisStyle circle
+
+-}
+circle : Value { provides | circle : Supported }
+circle =
+    Value "circle"
 
 
 -- OVERFLOW --
@@ -8289,17 +8323,6 @@ cambodian =
     Value "cambodian"
 
 
-{-| The `circle` value used by properties such as [`listStyle`](#listStyle),
-and [`listStyleType`](#listStyleType)
-
-    listStyleType circle
-
--}
-circle : Value { provides | circle : Supported }
-circle =
-    Value "circle"
-
-
 {-| The `cjk-decimal` value used by properties such as [`listStyle`](#listStyle),
 and [`listStyleType`](#listStyleType)
 
@@ -11313,16 +11336,6 @@ textUnderlinePosition2 :
     -> Style
 textUnderlinePosition2 (Value underVal) (Value val) =
     AppendProperty ("text-underline-position:" ++ underVal ++ " " ++ val)
-
-
-{-| A `under` value for the [`textUnderlinePosition`](#textUnderlinePosition) property.
-
-    textUnderlinePosition under
-
--}
-under : Value { provides | under : Supported }
-under =
-    Value "under"
 
 
 
@@ -15028,7 +15041,7 @@ lineBreak :
         }
     -> Style
 lineBreak (Value value) =
-    AppendProperty ("line-break:" ++ "value")
+    AppendProperty ("line-break:" ++ value)
 
 
 {-| Sets `manual` value for usage with [`hyphens`](#hyphens).
@@ -16619,6 +16632,261 @@ hanging =
 eachLine : Value { provides | eachLine : Supported }
 eachLine =
     Value "each-line"
+
+
+{-| Sets the [`text-emphasis`](https://css-tricks.com/almanac/properties/t/text-emphasis/) property.
+
+This is for drawing attention towards textual elements in a way that is commonly
+used in East Asian languages.
+
+    textEmphasis (hex "ff0000")
+
+    textEmphasis sesame
+
+    textEmphasis2 triangle (hex "00ff00")
+
+-}
+textEmphasis :
+    BaseValue
+        (ColorSupported
+            { none : Supported
+            , filled : Supported
+            , open : Supported
+            , dot : Supported
+            , circle : Supported
+            , doubleCircle : Supported
+            , triangle : Supported
+            , sesame : Supported
+            , string : Supported
+            }
+        )
+    -> Style
+textEmphasis (Value value) =
+    AppendProperty ("text-emphasis:" ++ value)
+
+
+{-| Sets the [`text-emphasis`](https://css-tricks.com/almanac/properties/t/text-emphasis/) property.
+
+This 2-argument form sets [`text-emphasis-style`](#textEmphasisStyle) and [`textEmphasisColor`](#textEmphasisColor) in a single declaration.
+
+    textEmphasis2 filled (hex "ff0000")
+-}
+textEmphasis2 :
+    BaseValue
+        { none : Supported
+        , filled : Supported
+        , open : Supported
+        , dot : Supported
+        , circle : Supported
+        , doubleCircle : Supported
+        , triangle : Supported
+        , sesame : Supported
+        , string : Supported
+        }
+    ->
+        BaseValue
+            (ColorSupported a)
+    -> Style
+textEmphasis2 (Value value1) (Value value2) =
+    AppendProperty
+        ("text-emphasis:"
+            ++ value1
+            ++ " "
+            ++ value2
+        )
+
+
+{-| Sets the [`text-emphasis-style`](https://developer.mozilla.org/en-US/docs/Web/CSS/text-emphasis-style) property.
+
+    textEmphasisStyle none
+
+    textEmphasisStyle open
+
+    textEmphasisStyle (string "🐯")
+-}
+textEmphasisStyle :
+    BaseValue
+        { none : Supported
+        , filled : Supported
+        , open : Supported
+        , dot : Supported
+        , circle : Supported
+        , doubleCircle : Supported
+        , triangle : Supported
+        , sesame : Supported
+        , string : Supported
+        }
+    -> Style
+textEmphasisStyle (Value value) =
+    AppendProperty ("text-emphasis-style:" ++ value)
+
+
+{-| Sets the [`text-emphasis-color`](https://developer.mozilla.org/en-US/docs/Web/CSS/text-emphasis-color) property.
+
+    textEmphasisColor currentcolor
+
+    textemphasisColor (hex "0000ff")
+-}
+textEmphasisColor :
+    BaseValue
+        (ColorSupported a)
+    -> Style
+textEmphasisColor (Value value) =
+    AppendProperty ("text-emphasis-color:" ++ value)
+
+
+{-| Sets the [`text-emphasis-style`](https://developer.mozilla.org/en-US/docs/Web/CSS/text-emphasis-style) property when you want to use two arguments - one for `filled` or `open`, and one for the shape style.
+
+    textEmphasisStyle filled sesame
+
+    textEmphasisStyle open dot
+-}
+textEmphasisStyle2 :
+    BaseValue
+        { filled : Supported
+        , open : Supported
+        }
+    -> BaseValue
+        { dot : Supported
+        , circle : Supported
+        , doubleCircle : Supported
+        , triangle : Supported
+        , sesame : Supported
+        }
+    -> Style
+textEmphasisStyle2 (Value val1) (Value val2) =
+    AppendProperty
+        ("text-emphasis-style:"
+        ++ val1
+        ++ " "
+        ++ val2
+        )
+
+
+{-| Sets the [`text-emphasis-position`](https://developer.mozilla.org/en-US/docs/Web/CSS/text-emphasis-position) property.
+
+This is the one argument version, which is limited to setting global values.
+
+If you want to specify the positions of the text-emphasis, you must use the [2-argument form](#textEmphasisPosition2).
+
+    textEmphasisPosition inherit
+
+    textEmphasisPosition revert
+
+    textEmphasisPosition2 over left_
+
+    textEmphasisPosition2 under right_
+
+-}
+textEmphasisPosition :
+    BaseValue a
+    -> Style
+textEmphasisPosition (Value value) =
+    AppendProperty ("text-emphasis-position:" ++ value)
+
+
+{-| Sets the the [`text-emphasis-position`](https://developer.mozilla.org/en-US/docs/Web/CSS/text-emphasis-position) property.
+
+This is the 2-argument form that lets you specify the positions of the emphasis.
+
+if you want to apply global values, you must use the [1-argument form](#textEmphasisPosition).
+
+    textEmphasisPosition inherit
+
+    textEmphasisPosition revert
+
+    textEmphasisPosition2 over left_
+
+    textEmphasisPosition2 under right_
+
+-}
+textEmphasisPosition2 :
+    BaseValue
+        { over : Supported
+        , under : Supported
+        }
+    -> BaseValue
+        { left_ : Supported
+        , right_ : Supported
+        }
+    -> Style
+textEmphasisPosition2 (Value val1) (Value val2) =
+    AppendProperty
+        ("text-emphasis-position:"
+        ++ val1
+        ++ " "
+        ++ val2
+        )
+
+
+{-| The `filled` value used in [`textEmphasis`](#textEmphasis).
+
+    textEmphasis filled
+
+-}
+filled : Value { provides | filled : Supported }
+filled =
+    Value "filled"
+
+
+{-| The `open` value used in [`textEmphasis`](#textEmphasis).
+
+    textEmphasis open
+
+-}
+open : Value { provides | open : Supported }
+open =
+    Value "open"
+
+
+{-| The `dot` value used in [`textEmphasis`](#textEmphasis).
+
+    textEmphasis dot
+
+-}
+dot : Value { provides | dot : Supported }
+dot =
+    Value "dot"
+
+
+{-| The `doubleCircle` value used in [`textEmphasis`](#textEmphasis).
+
+    textEmphasis doubleCircle
+
+-}
+doubleCircle : Value { provides | doubleCircle : Supported }
+doubleCircle =
+    Value "double-circle"
+
+
+{-| The `triangle` value used in [`textEmphasis`](#textEmphasis).
+
+    textEmphasis triangle
+
+-}
+triangle : Value { provides | triangle : Supported }
+triangle =
+    Value "triangle"
+
+
+{-| The `sesame` value used in [`textEmphasis`](#textEmphasis).
+
+    textEmphasis sesame
+
+-}
+sesame : Value { provides | sesame : Supported }
+sesame =
+    Value "sesame"
+
+
+{-| The `over` value used in [`textEmphasisPosition2`](#textEmphasisPosition2).
+
+    textEmphasisPosition2 over left_
+
+-}
+over : Value { provides | over : Supported }
+over =
+    Value "over"
 
 
 {-| Sets [`transform-origin`](https://css-tricks.com/almanac/properties/t/transform-origin/).

--- a/src/Css.elm
+++ b/src/Css.elm
@@ -1,25 +1,38 @@
 module Css exposing
-    ( Value, BaseValue, Supported
-    , Style, batch
+    ( Style, batch
+    , Value, Supported
     , property
     , important
-    , unset, initial, inherit
-    , all, revert
+
+    -- common value groups
+    , BaseValue
+    , ImageSupported, Image
     , Angle, AngleSupported, Width, WidthSupported
     , BasicShape, BasicShapeSupported
-    , circle, circleAt, circleAt2, ellipse, ellipseAt, ellipseAt2, closestSide, farthestSide, polygon, path
-    , Length, LengthSupported, zero, px, em, ex, ch, rem, vh, vw, vmin, vmax, mm, cm, q, inches, pt, pc, pct, num, int
-    , calc, CalcOperation, minus, plus, times, dividedBy
-    , Color, ColorSupported, color, backgroundColor, hex, rgb, rgba, hsl, hsla, currentcolor
-    , Resolution, ResolutionSupported, dpi, dpcm, dppx
-    , Time, TimeSupported, s, ms
-    , deg, grad, rad, turn
+    , Length, LengthSupported
+    , calc, CalcOperation
+    , minus, plus, times, dividedBy
+    , Color, ColorSupported
+    , Resolution, ResolutionSupported
+    , Time, TimeSupported
+
+    -- common value types
+    , zero, px, em, ex, ch, rem, vh, vw, vmin, vmax, mm, cm, q, inches, pt, pc, pct
     , fr, minmax, fitContentTo
-    , customIdent
-    , url
+    , num, int 
+    , deg, grad, rad, turn
+    , s, ms
+    , rgb, rgba, hsl, hsla, hex, currentcolor
+    , string, customIdent, url
+    , circle, circleAt, circleAt2, ellipse, ellipseAt, ellipseAt2, closestSide, farthestSide, polygon, path
+    , dpi, dpcm, dppx
+
+    -- common keyword values
+    , unset, initial, inherit, revert
     , auto, none
     , left_, right_, top_, bottom_
     , block, inline, start, end, blockStart, blockEnd, inlineStart, inlineEnd
+    , minContent, maxContent, fitContent
     , x, y, z
     , stretch, center
     , marginBox, borderBox, paddingBox, contentBox, fillBox, strokeBox, viewBox
@@ -29,6 +42,8 @@ module Css exposing
     , normal, strict, all_, both, always, scroll, column
     , content, fill_, stroke, text, style
     , clip, cover, contain_
+
+    -- pseudo-classes
     , pseudoClass
     , active, checked, disabled, empty, enabled
     , firstChild, firstOfType, focus, fullscreen, hover, inRange
@@ -37,19 +52,25 @@ module Css exposing
     , root, scope, target, valid, visited
     , pseudoElement
     , before, after, backdrop, cue, marker, placeholder, selection
+
+    -- all
+    , all
+
+    -- sizing
     , width, minWidth, maxWidth, height, minHeight, maxHeight
     , blockSize, minBlockSize, maxBlockSize, inlineSize, minInlineSize, maxInlineSize
-    , minContent, maxContent, fitContent
-    , backgroundAttachment, backgroundAttachments, local
-    , backgroundBlendMode, backgroundBlendModes, multiply, screen, overlay, darken, lighten, colorDodge, colorBurn, hardLight, softLight, difference, exclusion, hue, saturation, color_, luminosity
-    , backgroundClip, backgroundClips, backgroundOrigin, backgroundOrigins
-    , ImageSupported, Image
-    , backgroundImage, backgroundImages, backgroundPosition, backgroundPosition2, backgroundPosition3, backgroundPosition4, backgroundRepeat, backgroundRepeat2, backgroundSize, backgroundSize2
-    , linearGradient, linearGradient2, stop, stop2, stop3, toBottom, toBottomLeft, toBottomRight, toLeft, toRight, toTop, toTopLeft, toTopRight
-    , repeat, noRepeat, repeatX, repeatY, space, round
-    , BoxShadowConfig, boxShadow, boxShadows, defaultBoxShadow
-    , TextShadowConfig, textShadow, defaultTextShadow
-    , LineWidth, LineWidthSupported, LineStyle, LineStyleSupported
+
+    -- paddings
+    , padding, padding2, padding3, padding4, paddingTop, paddingRight, paddingBottom, paddingLeft
+    , paddingBlock, paddingBlock2, paddingBlockStart, paddingBlockEnd
+    , paddingInline, paddingInline2, paddingInlineStart, paddingInlineEnd
+
+    -- margins
+    , margin, margin2, margin3, margin4, marginTop, marginRight, marginBottom, marginLeft
+    , marginBlock, marginBlock2, marginBlockStart, marginBlockEnd
+    , marginInline, marginInline2, marginInlineStart, marginInlineEnd
+
+    -- borders
     , border, border2, border3
     , borderTop, borderTop2, borderTop3
     , borderRight, borderRight2, borderRight3
@@ -72,20 +93,38 @@ module Css exposing
     , borderStartStartRadius, borderStartStartRadius2, borderStartEndRadius, borderStartEndRadius2, borderEndStartRadius, borderEndStartRadius2, borderEndEndRadius, borderEndEndRadius2
     , borderImageOutset, borderImageOutset2, borderImageOutset3, borderImageOutset4
     , borderImageWidth, borderImageWidth2, borderImageWidth3, borderImageWidth4
+
+    -- outlines
     , outline, outline3, outlineWidth, outlineColor, invert, outlineStyle, outlineOffset
+
+    -- color
+    , color, backgroundColor
+
+    -- ??
+    , backgroundAttachment, backgroundAttachments, local
+    , backgroundBlendMode, backgroundBlendModes, multiply, screen, overlay, darken, lighten, colorDodge, colorBurn, hardLight, softLight, difference, exclusion, hue, saturation, color_, luminosity
+    , backgroundClip, backgroundClips, backgroundOrigin, backgroundOrigins
+    , backgroundImage, backgroundImages, backgroundPosition, backgroundPosition2, backgroundPosition3, backgroundPosition4, backgroundRepeat, backgroundRepeat2, backgroundSize, backgroundSize2
+    , linearGradient, linearGradient2, stop, stop2, stop3, toBottom, toBottomLeft, toBottomRight, toLeft, toRight, toTop, toTopLeft, toTopRight
+    , repeat, noRepeat, repeatX, repeatY, space, round
+    , BoxShadowConfig, boxShadow, boxShadows, defaultBoxShadow
+    , TextShadowConfig, textShadow, defaultTextShadow
+    , LineWidth, LineWidthSupported, LineStyle, LineStyleSupported
+
+    -- ??
     , display, display2, displayListItem2, displayListItem3
     , flex_, flow, flowRoot, grid, contents, listItem, inlineBlock, inlineFlex, inlineTable, inlineGrid, rubyBase, rubyBaseContainer, rubyText, rubyTextContainer, runIn, table, tableCaption, tableCell, tableColumn, tableColumnGroup, tableFooterGroup, tableHeaderGroup, tableRow, tableRowGroup
     , position, zIndex
     , absolute, fixed, relative, static, sticky
+
+    -- insets
     , inset, inset2, inset3, inset4, top, right, bottom, left
     , insetBlock, insetBlock2, insetInline, insetInline2, insetBlockStart, insetBlockEnd, insetInlineStart, insetInlineEnd
-    , padding, padding2, padding3, padding4, paddingTop, paddingRight, paddingBottom, paddingLeft
-    , paddingBlock, paddingBlock2, paddingBlockStart, paddingBlockEnd
-    , paddingInline, paddingInline2, paddingInlineStart, paddingInlineEnd
-    , margin, margin2, margin3, margin4, marginTop, marginRight, marginBottom, marginLeft
+
+    -- gaps
     , gap, gap2, rowGap, columnGap
-    , marginBlock, marginBlock2, marginBlockStart, marginBlockEnd
-    , marginInline, marginInline2, marginInlineStart, marginInlineEnd
+
+    -- ??
     , boxSizing
     , alignContent, alignContent2, alignItems, alignItems2, alignSelf, alignSelf2, justifyContent, justifyContent2, justifyItems, justifyItems2, justifySelf, justifySelf2
     , placeContent, placeContent2, placeItems, placeItems2, placeSelf, placeSelf2
@@ -96,9 +135,13 @@ module Css exposing
     , flexGrow, flexShrink, flexBasis
     , flexWrap, nowrap, wrap, wrapReverse
     , flex, flex2, flex3, flexFlow, flexFlow2
+
+    -- grid
     , gridAutoRows, gridAutoColumns, gridAutoFlow, gridAutoFlow2, dense
     , gridRowStart, gridRowStart2, gridRowStart3, gridRowEnd, gridRowEnd2, gridRowEnd3, gridColumnStart, gridColumnStart2, gridColumnStart3, gridColumnEnd, gridColumnEnd2, gridColumnEnd3, span
     , gridTemplateAreas, gridTemplateAreasList
+
+    -- ??
     , wordSpacing
     , tabSize
     , fontDisplay, fallback, swap, optional
@@ -106,7 +149,10 @@ module Css exposing
     , hyphens, quotes, quotes2, quotes4, textOverflow, textOverflow2, lineBreak, manual, ellipsis, loose
     , hangingPunctuation, hangingPunctuation2, hangingPunctuation3, first, last, forceEnd, allowEnd
     , lineClamp
-    , fontSize, xxSmall, xSmall, small, medium, large, xLarge, xxLarge, smaller, larger, lineHeight, letterSpacing
+
+    -- fonts
+    , fontSize
+    , xxSmall, xSmall, small, medium, large, xLarge, xxLarge, smaller, larger, lineHeight, letterSpacing
     , fontSizeAdjust
     , fontFamily, fontFamilies, serif, sansSerif, monospace, cursive, fantasy, systemUi
     , fontStyle, italic, oblique
@@ -119,6 +165,8 @@ module Css exposing
     , fontVariantLigatures, commonLigatures, noCommonLigatures, discretionaryLigatures, noDiscretionaryLigatures, historicalLigatures, noHistoricalLigatures, contextual, noContextual
     , fontVariantNumeric, fontVariantNumeric4, ordinal, slashedZero, liningNums, oldstyleNums, proportionalNums, tabularNums, diagonalFractions, stackedFractions
     , fontKerning, fontLanguageOverride, fontSynthesis, fontSynthesis2, fontSynthesis3, fontOpticalSizing, fontVariantPosition, weight
+    
+    -- cursors
     , CursorKeyword
     , cursor, cursor2, cursor4
     , pointer, default, contextMenu, help, progress, wait, cell
@@ -126,13 +174,19 @@ module Css exposing
     , notAllowed, allScroll, colResize, rowResize, nResize, eResize, sResize
     , wResize, neResize, nwResize, seResize, swResize, ewResize, nsResize
     , neswResize, nwseResize, zoomIn, zoomOut, grab, grabbing
+
+    -- list styles
     , ListStyleType, ListStyleTypeSupported
-    , listStyle, listStyle2, listStyle3, listStylePosition, inside, outside, listStyleType, string, listStyleImage
+    , listStyle, listStyle2, listStyle3, listStylePosition, inside, outside, listStyleType, listStyleImage
     , arabicIndic, armenian, bengali, cambodian, cjkDecimal, cjkEarthlyBranch, cjkHeavenlyStem, cjkIdeographic, decimal, decimalLeadingZero, devanagari, disclosureClosed, disclosureOpen, disc, ethiopicNumeric, georgian, gujarati, gurmukhi, hebrew, hiragana, hiraganaIroha, japaneseFormal, japaneseInformal, kannada, katakana, katakanaIroha, khmer, koreanHangulFormal, koreanHanjaFormal, koreanHanjaInformal, lao, lowerAlpha, lowerArmenian, lowerGreek, lowerLatin, lowerRoman, malayalam, monogolian, myanmar, oriya, persian, simpChineseFormal, simpChineseInformal, tamil, telugu, thai, tibetan, tradChineseFormal, tradChineseInformal, upperAlpha, upperArmenian, upperLatin, upperRoman
+    
+    -- overflow
     , overflow, overflowX, overflowY, overflowBlock, overflowInline
     , overflowAnchor
     , overflowWrap
     , breakWord, anywhere
+
+    -- ??
     , direction, ltr, rtl
     , justify, matchParent, textAlign, textJustify, interWord, interCharacter, textUnderlinePosition, textUnderlinePosition2
     , textOrientation
@@ -175,6 +229,8 @@ module Css exposing
     , columns, columns2, columnWidth, columnCount, columnRuleWidth, columnRuleStyle, columnRuleColor, columnRule, columnRule2, columnRule3
     , columnFill, balance, balanceAll
     , columnSpan
+
+    -- transformations and perspective
     , transform, transforms, transformOrigin, transformOrigin2, transformBox
     , TransformFunction, TransformFunctionSupported
     , matrix, matrix3d
@@ -184,10 +240,14 @@ module Css exposing
     , scale, scale2, scale3, scale_, scale2_, scaleX, scaleY, scaleZ, scale3d
     , skew, skew2, skewX, skewY
     , translate, translate2, translateX, translateY, translateZ, translate3d
+    
+    -- ??
     , animationName, animationNames, animationDuration, animationDurations, animationTimingFunction, animationTimingFunctions, animationIterationCount, animationIterationCounts, animationDirection, animationDirections, animationPlayState, animationPlayStates, animationDelay, animationDelays, animationFillMode, animationFillModes
     , EasingFunction, EasingFunctionSupported, linear, ease, easeIn, easeOut, easeInOut, cubicBezier, stepStart, stepEnd, steps, steps2, jumpStart, jumpEnd, jumpNone, jumpBoth, infinite, reverse, alternate, alternateReverse, running, paused, forwards, backwards
     , opacity
     , zoom
+
+    -- scrolling
     , scrollbarColor, scrollbarWidth
     , scrollBehavior, smooth, scrollSnapAlign, scrollSnapStop
     , scrollSnapType, scrollSnapType2, mandatory, proximity
@@ -198,6 +258,8 @@ module Css exposing
     , scrollPaddingBlock, scrollPaddingBlock2, scrollPaddingInline, scrollPaddingInline2
     , scrollPaddingBlockStart, scrollPaddingBlockEnd, scrollPaddingInlineStart, scrollPaddingInlineEnd
     , overscrollBehavior, overscrollBehavior2, overscrollBehaviorX, overscrollBehaviorY, overscrollBehaviorBlock, overscrollBehaviorInline
+    
+    -- ??
     , speak, spellOut
     , userSelect
     , unicodeBidi, embed, bidiOverride, isolateOverride, plaintext
@@ -334,6 +396,10 @@ Sometimes these keywords mean other things too.
 
 @docs block, inline, start, end, blockStart, blockEnd, inlineStart, inlineEnd
 
+## Content sizing values
+
+@docs minContent, maxContent, fitContent
+
 ## Axis values
 
 @docs x, y, z
@@ -382,12 +448,14 @@ Sometimes these keywords mean other things too.
 @docs before, after, backdrop, cue, marker, placeholder, selection
 
 
+# All
+
+@docs all
+
 # Sizing
 
 @docs width, minWidth, maxWidth, height, minHeight, maxHeight
 @docs blockSize, minBlockSize, maxBlockSize, inlineSize, minInlineSize, maxInlineSize
-@docs minContent, maxContent, fitContent
-
 
 # Backgrounds
 
@@ -987,7 +1055,19 @@ import Css.Structure as Structure
 
 
 
--- TYPES --
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+----------------------------- BASIC STUFF ------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
 
 
 {-| A CSS property (such as `color`), or multiple properties grouped into one.
@@ -1041,6 +1121,96 @@ unpackValue (Value value) =
     value
 
 
+
+{-| A type used to specify which properties and which values work together.
+-}
+type Supported
+    = Supported
+
+
+-- CUSTOM PROPERTIES --
+
+
+{-| Define a custom property.
+
+    css [ property "-webkit-font-smoothing" "none" ]
+
+...outputs
+
+    -webkit-font-smoothing: none;
+
+-}
+property : String -> String -> Style
+property key value =
+    Preprocess.AppendProperty (key ++ ":" ++ value)
+
+
+
+-- STYLES --
+
+
+{-| Create a style from multiple other styles.
+
+    underlineOnHover =
+        batch
+            [ textDecoration none
+
+            , hover
+                [ textDecoration underline ]
+            ]
+
+    css
+        [ color (rgb 128 64 32)
+        , underlineOnHover
+        ]
+
+...has the same result as:
+
+    css
+        [ color (rgb 128 64 32)
+        , textDecoration none
+        , hover
+            [ textDecoration underline ]
+        ]
+
+-}
+batch : List Style -> Style
+batch =
+    Preprocess.ApplyStyles
+
+
+{-| Transforms the given property by adding !important to the end of its
+declaration.
+-}
+important : Style -> Style
+important =
+    Preprocess.mapProperties makeImportant
+
+
+makeImportant : Structure.Property -> Structure.Property
+makeImportant str =
+    if String.endsWith " !important" (String.toLower str) then
+        str
+
+    else
+        str ++ " !important"
+
+
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+-------------------------- VALUE TYPE GROUPS ---------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+
+
 {-| A type that is used in properties for CSS wide values.
 See [CSS-wide values](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Values_and_Units#css-wide_values).
 -}
@@ -1053,11 +1223,6 @@ type alias BaseValue supported =
             , revert : Supported
         }
 
-
-{-| A type used to specify which properties and which values work together.
--}
-type Supported
-    = Supported
 
 
 {-| A type alias used to accept a [length](https://developer.mozilla.org/en-US/docs/Web/CSS/length)
@@ -1270,6 +1435,551 @@ type alias Time =
     TimeSupported {}
 
 
+
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------- LENGTHS --------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+
+
+
+{-| Compiles to a `0` value with no units.
+
+    css [ padding zero ]
+
+...compiles to:
+
+    padding: 0;
+
+This conveniently lets you avoid doing things like `padding (px 0)`
+
+-}
+zero : Value { provides | zero : Supported }
+zero =
+    Value "0"
+
+
+{-| [`px`](https://css-tricks.com/the-lengths-of-css/) length units.
+
+    borderWidth (px 5)
+
+-}
+px : Float -> Value { provides | px : Supported }
+px value =
+    Value (String.fromFloat value ++ "px")
+
+
+{-| [`em`](https://css-tricks.com/the-lengths-of-css/) length units.
+
+    borderWidth (em 5)
+
+-}
+em : Float -> Value { provides | em : Supported }
+em value =
+    Value (String.fromFloat value ++ "em")
+
+
+{-| [`ex`](https://css-tricks.com/the-lengths-of-css/) length units.
+
+    borderWidth (ex 5)
+
+-}
+ex : Float -> Value { provides | ex : Supported }
+ex value =
+    Value (String.fromFloat value ++ "ex")
+
+
+{-| [`ch`](https://css-tricks.com/the-lengths-of-css/) length units.
+
+    borderWidth (ch 5)
+
+-}
+ch : Float -> Value { provides | ch : Supported }
+ch value =
+    Value (String.fromFloat value ++ "ch")
+
+
+{-| [`rem`](https://css-tricks.com/the-lengths-of-css/) length units.
+
+    borderWidth (rem 5)
+
+-}
+rem : Float -> Value { provides | rem : Supported }
+rem value =
+    Value (String.fromFloat value ++ "rem")
+
+
+{-| [`vh`](https://css-tricks.com/the-lengths-of-css/) length units.
+
+    borderWidth (vh 5)
+
+-}
+vh : Float -> Value { provides | vh : Supported }
+vh value =
+    Value (String.fromFloat value ++ "vh")
+
+
+{-| [`vw`](https://css-tricks.com/the-lengths-of-css/) length units.
+
+    borderWidth (vw 5)
+
+-}
+vw : Float -> Value { provides | vw : Supported }
+vw value =
+    Value (String.fromFloat value ++ "vw")
+
+
+{-| [`vmin`](https://css-tricks.com/the-lengths-of-css/) length units.
+
+    borderWidth (vmin 5)
+
+-}
+vmin : Float -> Value { provides | vmin : Supported }
+vmin value =
+    Value (String.fromFloat value ++ "vmin")
+
+
+{-| [`vmax`](https://css-tricks.com/the-lengths-of-css/) length units.
+
+    borderWidth (vmax 5)
+
+-}
+vmax : Float -> Value { provides | vmax : Supported }
+vmax value =
+    Value (String.fromFloat value ++ "vmax")
+
+
+{-| [`mm`](https://css-tricks.com/the-lengths-of-css/) length units.
+
+    borderWidth (mm 5)
+
+-}
+mm : Float -> Value { provides | mm : Supported }
+mm value =
+    Value (String.fromFloat value ++ "mm")
+
+
+{-| [`cm`](https://css-tricks.com/the-lengths-of-css/) length units.
+
+    borderWidth (cm 5)
+
+-}
+cm : Float -> Value { provides | cm : Supported }
+cm value =
+    Value (String.fromFloat value ++ "cm")
+
+
+{-| [`Q`](https://developer.mozilla.org/en-US/docs/Web/CSS/length) length units.
+
+    borderWidth (q 2.5)
+
+-}
+q : Float -> Value { provides | q : Supported }
+q value =
+    Value (String.fromFloat value ++ "Q")
+
+
+{-| [`in`](https://css-tricks.com/the-lengths-of-css/) length units.
+
+    borderWidth (inches 5)
+
+(This is `inches` instead of `in` because `in` is a reserved keyword in Elm.)
+
+-}
+inches : Float -> Value { provides | inches : Supported }
+inches value =
+    Value (String.fromFloat value ++ "in")
+
+
+{-| [`pt`](https://css-tricks.com/the-lengths-of-css/) length units.
+
+    borderWidth (pt 5)
+
+-}
+pt : Float -> Value { provides | pt : Supported }
+pt value =
+    Value (String.fromFloat value ++ "pt")
+
+
+{-| [`pc`](https://css-tricks.com/the-lengths-of-css/) length units.
+
+    borderWidth (pc 5)
+
+-}
+pc : Float -> Value { provides | pc : Supported }
+pc value =
+    Value (String.fromFloat value ++ "pc")
+
+
+{-| [`pct`](https://css-tricks.com/the-lengths-of-css/) length units.
+
+    borderWidth (pct 5)
+
+-}
+pct : Float -> Value { provides | pct : Supported }
+pct value =
+    Value (String.fromFloat value ++ "%")
+
+
+
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+----------------------------- FLEX VALUES ------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+
+
+{-| [`fr`](https://css-tricks.com/introduction-fr-css-unit/) flex units.
+
+    gridAutoColumns (fr 1)
+-}
+fr : Float -> Value { provides | fr : Supported }
+fr val =
+    Value <| String.fromFloat val ++ "fr"
+
+
+{-| The [`minmax()`](https://css-tricks.com/minmax-function-works/)
+value for grid properties.
+
+    gridAutoRows (minmax (px 2) (pct 100))
+-}
+minmax : 
+    Value (
+        LengthSupported
+            { pct : Supported
+            , fr : Supported
+            , maxContent : Supported
+            , minContent : Supported
+            , auto : Supported
+            }
+    )
+    -> Value (
+        LengthSupported
+            { pct : Supported
+            , fr : Supported
+            , maxContent : Supported
+            , minContent : Supported
+            , auto : Supported
+            }
+    )
+    -> Value { provides | minmax : Supported }
+minmax (Value minBreadth) (Value maxBreadth) =
+    Value <| "minmax(" ++ minBreadth ++ ", " ++ maxBreadth ++ ")"
+
+
+{-| The [`fit-content()`](https://developer.mozilla.org/en-US/docs/Web/CSS/fit-content_function)
+value that can have a length or percentage value that you want the property to be clamped to.
+
+Not to be confused with the [`fitContent`](#fitContent) value for flex properties.
+
+    gridAutoColumns (fitContentTo (pct 100))
+
+    height (fitContentTo (rem 20))
+-}
+fitContentTo :
+    Value (
+        LengthSupported
+            { pct : Supported
+            }
+        )
+    -> Value { provides | fitContentTo : Supported }
+fitContentTo (Value val) =
+    Value <| "fit-content(" ++ val ++ ")"
+
+
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------- NUMBERS --------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+
+
+{-| A unitless number. Useful with properties like
+[`flexGrow`](#flexGrow),
+and [`order`](#order)
+which accept unitless numbers.
+
+    flexGrow (num 2)
+
+    order (num -2)
+
+-}
+num : Float -> Value { provides | num : Supported }
+num value =
+    Value (String.fromFloat value)
+
+
+{-| A unitless integer. Useful with properties like [`zIndex`](#zIndex) which accept unitless integers.
+
+    zIndex (int 3)
+
+-}
+int : Int -> Value { provides | int : Supported }
+int value =
+    Value (String.fromInt value)
+
+
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------ ANGLES ----------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+
+
+{-| A [`deg` angle](https://developer.mozilla.org/en-US/docs/Web/CSS/angle)
+
+    deg 360 -- one full circle
+
+    deg 14.23
+
+-}
+deg : Float -> Value { provides | deg : Supported }
+deg degrees =
+    Value (String.fromFloat degrees ++ "deg")
+
+
+{-| A [`grad` angle](https://developer.mozilla.org/en-US/docs/Web/CSS/angle)
+
+    grad 400 -- one full circle
+
+    grad 38.8
+
+-}
+grad : Float -> Value { provides | grad : Supported }
+grad gradians =
+    Value (String.fromFloat gradians ++ "grad")
+
+
+{-| A [`rad` angle](https://developer.mozilla.org/en-US/docs/Web/CSS/angle)
+
+    rad 6.2832 -- approximately one full circle
+
+    rad 1
+
+-}
+rad : Float -> Value { provides | rad : Supported }
+rad radians =
+    Value (String.fromFloat radians ++ "rad")
+
+
+{-| A [`turn` angle](https://developer.mozilla.org/en-US/docs/Web/CSS/angle)
+
+    turn 1 -- one full circle
+
+    turn 0.25
+
+-}
+turn : Float -> Value { provides | turn : Supported }
+turn turns =
+    Value (String.fromFloat turns ++ "turn")
+
+
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+-------------------------------- TIME ----------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+
+
+{-| The [`s`](https://developer.mozilla.org/en-US/docs/Web/CSS/time) time unit.
+
+    animationDuration (s 1)
+
+-}
+s : Float -> Value { provides | s : Supported }
+s value =
+    Value (String.fromFloat value ++ "s")
+
+
+{-| The [`ms`](https://developer.mozilla.org/en-US/docs/Web/CSS/time) time unit.
+
+    animationDuration (ms 120)
+
+-}
+ms : Float -> Value { provides | ms : Supported }
+ms value =
+    Value (String.fromFloat value ++ "ms")
+
+
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------- COLOR ----------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+
+
+{-| [RGB color value](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value#rgb())
+in functional notation.
+
+    color (rgb 96 181 204)
+
+-}
+rgb : Int -> Int -> Int -> Value { provides | rgb : Supported }
+rgb red green blue =
+    Value <|
+        "rgb("
+            ++ String.fromInt red
+            ++ ","
+            ++ String.fromInt green
+            ++ ","
+            ++ String.fromInt blue
+            ++ ")"
+
+
+{-| [RGBA color value](https://css-tricks.com/the-power-of-rgba/).
+
+    color (rgba 96 181 204 0.25)
+
+-}
+rgba : Int -> Int -> Int -> Float -> Value { provides | rgba : Supported }
+rgba red green blue alphaVal =
+    Value <|
+        "rgba("
+            ++ String.fromInt red
+            ++ ","
+            ++ String.fromInt green
+            ++ ","
+            ++ String.fromInt blue
+            ++ ","
+            ++ String.fromFloat alphaVal
+            ++ ")"
+
+
+{-| [HSL color value](https://css-tricks.com/mother-effing-hsl/).
+
+The `s` and `l` values are expressed as a number between 0 and 1 and are converted to the appropriate percentage.
+
+    color (hsl 193 0.51 0.59) -- hsl(193, 51%, 59%)
+
+-}
+hsl : Float -> Float -> Float -> Value { provides | hsl : Supported }
+hsl hueVal sat lightness =
+    Value <|
+        "hsl("
+            ++ String.fromFloat hueVal
+            ++ ","
+            ++ String.fromFloat (sat * 100)
+            ++ "%,"
+            ++ String.fromFloat (lightness * 100)
+            ++ "%"
+            ++ ")"
+
+
+{-| [HSLA color value](https://css-tricks.com/yay-for-hsla/)
+
+The `s` and `l` values are expressed as a number between 0 and 1 and are converted to the appropriate percentage.
+
+    color (hsla 193 0.51 0.59 0.25) -- hsl(193, 51%, 59%, 0.25)
+
+-}
+hsla : Float -> Float -> Float -> Float -> Value { provides | hsla : Supported }
+hsla hueVal sat lightness alphaVal =
+    Value <|
+        "hsla("
+            ++ String.fromFloat hueVal
+            ++ ","
+            ++ String.fromFloat (sat * 100)
+            ++ "%,"
+            ++ String.fromFloat (lightness * 100)
+            ++ "%,"
+            ++ String.fromFloat alphaVal
+            ++ ")"
+
+
+{-| [RGB color value](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value#rgb()) in hexadecimal notation.
+
+You can optionally include `#` as the first character, for benefits like syntax highlighting in editors, ease of copy/pasting from tools which express these as e.g. `#abcdef0`, etc.
+
+    color (hex "#60b5cc")
+
+    color (hex "60b5cc")
+
+-}
+hex : String -> Value { provides | hex : Supported }
+hex str =
+    Value <|
+        if String.startsWith "#" str then
+            str
+
+        else
+            "#" ++ str
+
+
+{-| The [`currentcolor`](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value#currentcolor_keyword)
+value used by properties such as [`color`](#color), [`backgroundColor`](#backgroundColor)
+
+    color currentcolor
+
+-}
+currentcolor : Value { provides | currentcolor : Supported }
+currentcolor =
+    Value "currentcolor"
+
+
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+---------------------- STRINGS, IDENTS AND URLs ------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+
+
 {-| Produces a [`string`](https://developer.mozilla.org/en-US/docs/Web/CSS/string)
 value used by properties such as:
 
@@ -1295,60 +2005,46 @@ string =
     Value << enquoteString
 
 
+{-| Produces an [`custom-ident`](https://developer.mozilla.org/en-US/docs/Web/CSS/custom-ident)
+value used by properties including (but not limited to) [`listStyle`](#listStyle),
+[`listStyleType`](#listStyleType) and [`gridColumnEnd2`](#gridColumnEnd2).
 
--- CUSTOM PROPERTIES --
+    listStyleType (customIdent "hello-world")
 
+    gridColumnEnd2 span (customIdent "hello-world")
 
-{-| Define a custom property.
-
-    css [ property "-webkit-font-smoothing" "none" ]
-
-...outputs
-
-    -webkit-font-smoothing: none;
+**Note:** This method does not do any checking if the identifierer supplied is valid.
 
 -}
-property : String -> String -> Style
-property key value =
-    Preprocess.AppendProperty (key ++ ":" ++ value)
+customIdent : String -> Value { provides | customIdent : Supported }
+customIdent =
+    Value
 
 
-
--- STYLES --
-
-
-{-| Create a style from multiple other styles.
-
-    underlineOnHover =
-        batch
-            [ textDecoration none
-
-            , hover
-                [ textDecoration underline ]
-            ]
-
-    css
-        [ color (rgb 128 64 32)
-        , underlineOnHover
-        ]
-
-...has the same result as:
-
-    css
-        [ color (rgb 128 64 32)
-        , textDecoration none
-        , hover
-            [ textDecoration underline ]
-        ]
-
+{-| The `url` value for the [`cursor`](#cursor),
+[`fill`](#fill),
+[`strokeImage`](#strokeImage),
+and [`backgroundImage`](#backgroundImage) properties.
 -}
-batch : List Style -> Style
-batch =
-    Preprocess.ApplyStyles
+url : String -> Value { provides | url : Supported }
+url str =
+    Value ("url(" ++ str ++ ")")
 
 
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------- SHAPES --------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
 
--- SHAPES --
 
 {-| Provides a one-argument `circle()` value.
 
@@ -1650,8 +2346,55 @@ path svgPathDef =
     Value <| "path('" ++ svgPathDef ++ "')"
 
 
--- GLOBAL VALUES --
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+----------------------------- RESOLUTION -------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
 
+
+{-| [`dpi`](https://developer.mozilla.org/en-US/docs/Web/CSS/resolution) resolution units.
+-}
+dpi : Float -> Value { provides | dpi : Supported }
+dpi val =
+    Value <| String.fromFloat val ++ "dpi"
+
+
+{-| [`dpcm`](https://developer.mozilla.org/en-US/docs/Web/CSS/resolution) resolution units.
+-}
+dpcm : Float -> Value { provides | dpcm : Supported }
+dpcm val =
+    Value <| String.fromFloat val ++ "dpcm"
+
+
+{-| [`dppx`](https://developer.mozilla.org/en-US/docs/Web/CSS/resolution) resolution units.
+-}
+dppx : Float -> Value { provides | dppx : Supported }
+dppx val =
+    Value <| String.fromFloat val ++ "dppx"
+
+
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+---------------------------- GLOBAL VALUES -----------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
 
 {-| The [`inherit`](https://developer.mozilla.org/en-US/docs/Web/CSS/inherit) value.
 Any CSS property can be set to this value.
@@ -1703,151 +2446,19 @@ revert =
     Value "revert"
 
 
-{-| Sets an [`all`](https://css-tricks.com/almanac/properties/a/all/) property.
-
-    all inherit
-
--}
-all : BaseValue a -> Style
-all (Value val) =
-    AppendProperty ("all:" ++ val)
-
-
-{-| Transforms the given property by adding !important to the end of its
-declaration.
--}
-important : Style -> Style
-important =
-    Preprocess.mapProperties makeImportant
-
-
-makeImportant : Structure.Property -> Structure.Property
-makeImportant str =
-    if String.endsWith " !important" (String.toLower str) then
-        str
-
-    else
-        str ++ " !important"
-
-
-
--- SHARED VALUES --
-
-
-{-| The `url` value for the [`cursor`](#cursor),
-[`fill`](#fill),
-[`strokeImage`](#strokeImage),
-and [`backgroundImage`](#backgroundImage) properties.
--}
-url : String -> Value { provides | url : Supported }
-url str =
-    Value ("url(" ++ str ++ ")")
-
-
-
-
--- RESOLUTION --
-
-{-| [`dpi`](https://developer.mozilla.org/en-US/docs/Web/CSS/resolution) resolution units.
--}
-dpi : Float -> Value { provides | dpi : Supported }
-dpi val =
-    Value <| String.fromFloat val ++ "dpi"
-
-
-{-| [`dpcm`](https://developer.mozilla.org/en-US/docs/Web/CSS/resolution) resolution units.
--}
-dpcm : Float -> Value { provides | dpcm : Supported }
-dpcm val =
-    Value <| String.fromFloat val ++ "dpcm"
-
-
-{-| [`dppx`](https://developer.mozilla.org/en-US/docs/Web/CSS/resolution) resolution units.
--}
-dppx : Float -> Value { provides | dppx : Supported }
-dppx val =
-    Value <| String.fromFloat val ++ "dppx"
-
-
--- FLEX VALUES --
-
-{-| [`fr`](https://css-tricks.com/introduction-fr-css-unit/) flex units.
-
-    gridAutoColumns (fr 1)
--}
-fr : Float -> Value { provides | fr : Supported }
-fr val =
-    Value <| String.fromFloat val ++ "fr"
-
-
-{-| The [`minmax()`](https://css-tricks.com/minmax-function-works/)
-value for grid properties.
-
-    gridAutoRows (minmax (px 2) (pct 100))
--}
-minmax : 
-    Value (
-        LengthSupported
-            { pct : Supported
-            , fr : Supported
-            , maxContent : Supported
-            , minContent : Supported
-            , auto : Supported
-            }
-    )
-    -> Value (
-        LengthSupported
-            { pct : Supported
-            , fr : Supported
-            , maxContent : Supported
-            , minContent : Supported
-            , auto : Supported
-            }
-    )
-    -> Value { provides | minmax : Supported }
-minmax (Value minBreadth) (Value maxBreadth) =
-    Value <| "minmax(" ++ minBreadth ++ ", " ++ maxBreadth ++ ")"
-
-
-{-| The [`fit-content()`](https://developer.mozilla.org/en-US/docs/Web/CSS/fit-content_function)
-value that can have a length or percentage value that you want the property to be clamped to.
-
-Not to be confused with the [`fitContent`](#fitContent) value for flex properties.
-
-    gridAutoColumns (fitContentTo (pct 100))
-
-    height (fitContentTo (rem 20))
--}
-fitContentTo :
-    Value (
-        LengthSupported
-            { pct : Supported
-            }
-        )
-    -> Value { provides | fitContentTo : Supported }
-fitContentTo (Value val) =
-    Value <| "fit-content(" ++ val ++ ")"
-
-
--- IDENT --
-
-{-| Produces an [`custom-ident`](https://developer.mozilla.org/en-US/docs/Web/CSS/custom-ident)
-value used by properties including (but not limited to) [`listStyle`](#listStyle),
-[`listStyleType`](#listStyleType) and [`gridColumnEnd2`](#gridColumnEnd2).
-
-    listStyleType (customIdent "hello-world")
-
-    gridColumnEnd2 span (customIdent "hello-world")
-
-**Note:** This method does not do any checking if the identifierer supplied is valid.
-
--}
-customIdent : String -> Value { provides | customIdent : Supported }
-customIdent =
-    Value
-
-    
--- SHARED VALUES --
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------ COMMON KEYWORD VALUES -------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
 
 
 {-| The `auto` value used in many properties such as (but not limited to) [`width`](#width),
@@ -2176,6 +2787,60 @@ It can be used with the following properties:
 inlineEnd : Value { provides | inlineEnd : Supported }
 inlineEnd =
     Value "inline-end"
+
+
+{-| The `min-content` value used for properties such as:
+
+  - sizing (eg. [`width`](#width), [`height`](#height), [`inlineSize`](#inlineSize))
+
+  - min/max sizing (eg. [`minWidth`](#minWidth), [`maxBlockWidth`](#maxBlockWidth))
+
+  - [`flexBasis`](#flexBasis)
+
+```
+width minContent
+```
+
+-}
+minContent : Value { provides | minContent : Supported }
+minContent =
+    Value "min-content"
+
+
+{-| The `max-content` value used for properties such as:
+
+  - sizing (eg. [`width`](#width), [`height`](#height), [`inlineSize`](#inlineSize))
+
+  - min/max sizing (eg. [`minWidth`](#minWidth), [`maxBlockWidth`](#maxBlockWidth))
+
+  - [`flexBasis`](#flexBasis)
+
+```
+width maxContent
+```
+
+-}
+maxContent : Value { provides | maxContent : Supported }
+maxContent =
+    Value "max-content"
+
+
+{-| The `fit-content` value used for properties such as:
+
+  - sizing (eg. [`width`](#width), [`height`](#height), [`inlineSize`](#inlineSize))
+
+  - min/max sizing (eg. [`minWidth`](#minWidth), [`maxBlockWidth`](#maxBlockWidth))
+
+  - [`flexBasis`](#flexBasis)
+
+```
+width fitContent
+```
+
+-}
+fitContent : Value { provides | fitContent : Supported }
+fitContent =
+    Value "fit-content"
 
 
 {-| Sets `x` value for usage with [`scrollSnapType2`](#scrollSnapType2)
@@ -2804,8 +3469,20 @@ contain_ =
 
 
 
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------- OVERFLOW -------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
 
--- OVERFLOW --
 
 
 {-| Sets [`overflow`](https://css-tricks.com/almanac/properties/o/overflow/).
@@ -2969,145 +3646,6 @@ anywhere : Value { provides | anywhere : Supported }
 anywhere =
     Value "anywhere"
 
-
-
--- COLORS --
-
-
-{-| Sets [`color`](https://css-tricks.com/almanac/properties/c/color/).
-
-    color (hex "#60b5cc")
-
-    color (rgb 96 181 204)
-
-    color (rgba 96 181 204 0.5)
-
--}
-color : BaseValue Color -> Style
-color (Value val) =
-    AppendProperty ("color:" ++ val)
-
-
-{-| Sets [`background-color`](https://css-tricks.com/almanac/properties/b/background-color/).
-
-    backgroundColor (hex "#60b5cc")
-
-    backgroundColor (rgb 96 181 204)
-
-    backgroundColor (rgba 96 181 204 0.5)
-
--}
-backgroundColor : BaseValue Color -> Style
-backgroundColor (Value val) =
-    AppendProperty ("background-color:" ++ val)
-
-
-{-| [RGB color value](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value#rgb())
-in functional notation.
-
-    color (rgb 96 181 204)
-
--}
-rgb : Int -> Int -> Int -> Value { provides | rgb : Supported }
-rgb red green blue =
-    Value <|
-        "rgb("
-            ++ String.fromInt red
-            ++ ","
-            ++ String.fromInt green
-            ++ ","
-            ++ String.fromInt blue
-            ++ ")"
-
-
-{-| [RGBA color value](https://css-tricks.com/the-power-of-rgba/).
-
-    color (rgba 96 181 204 0.25)
-
--}
-rgba : Int -> Int -> Int -> Float -> Value { provides | rgba : Supported }
-rgba red green blue alphaVal =
-    Value <|
-        "rgba("
-            ++ String.fromInt red
-            ++ ","
-            ++ String.fromInt green
-            ++ ","
-            ++ String.fromInt blue
-            ++ ","
-            ++ String.fromFloat alphaVal
-            ++ ")"
-
-
-{-| [HSL color value](https://css-tricks.com/mother-effing-hsl/).
-
-The `s` and `l` values are expressed as a number between 0 and 1 and are converted to the appropriate percentage.
-
-    color (hsl 193 0.51 0.59) -- hsl(193, 51%, 59%)
-
--}
-hsl : Float -> Float -> Float -> Value { provides | hsl : Supported }
-hsl hueVal sat lightness =
-    Value <|
-        "hsl("
-            ++ String.fromFloat hueVal
-            ++ ","
-            ++ String.fromFloat (sat * 100)
-            ++ "%,"
-            ++ String.fromFloat (lightness * 100)
-            ++ "%"
-            ++ ")"
-
-
-{-| [HSLA color value](https://css-tricks.com/yay-for-hsla/)
-
-The `s` and `l` values are expressed as a number between 0 and 1 and are converted to the appropriate percentage.
-
-    color (hsla 193 0.51 0.59 0.25) -- hsl(193, 51%, 59%, 0.25)
-
--}
-hsla : Float -> Float -> Float -> Float -> Value { provides | hsla : Supported }
-hsla hueVal sat lightness alphaVal =
-    Value <|
-        "hsla("
-            ++ String.fromFloat hueVal
-            ++ ","
-            ++ String.fromFloat (sat * 100)
-            ++ "%,"
-            ++ String.fromFloat (lightness * 100)
-            ++ "%,"
-            ++ String.fromFloat alphaVal
-            ++ ")"
-
-
-{-| [RGB color value](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value#rgb()) in hexadecimal notation.
-
-You can optionally include `#` as the first character, for benefits like syntax highlighting in editors, ease of copy/pasting from tools which express these as e.g. `#abcdef0`, etc.
-
-    color (hex "#60b5cc")
-
-    color (hex "60b5cc")
-
--}
-hex : String -> Value { provides | hex : Supported }
-hex str =
-    Value <|
-        if String.startsWith "#" str then
-            str
-
-        else
-            "#" ++ str
-
-
-{-| The [`currentcolor`](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value#currentcolor_keyword)
-value used by properties such as [`color`](#color), [`backgroundColor`](#backgroundColor)
-
-    color currentcolor
-
--}
-currentcolor : Value { provides | currentcolor : Supported }
-currentcolor =
-    Value "currentcolor"
 
 
 
@@ -4951,213 +5489,6 @@ placeholder =
 selection : List Style -> Style
 selection =
     pseudoElement "selection"
-
-
-
--- NUMBERS --
-
-
-{-| Compiles to a 0 with no units.
-
-    css [ padding zero ]
-
-...compiles to:
-
-    padding: 0;
-
-This conveniently lets you avoid doing things like `padding (px 0)`
-
--}
-zero : Value { provides | zero : Supported }
-zero =
-    Value "0"
-
-
-{-| [`px`](https://css-tricks.com/the-lengths-of-css/) length units.
-
-    borderWidth (px 5)
-
--}
-px : Float -> Value { provides | px : Supported }
-px value =
-    Value (String.fromFloat value ++ "px")
-
-
-{-| [`em`](https://css-tricks.com/the-lengths-of-css/) length units.
-
-    borderWidth (em 5)
-
--}
-em : Float -> Value { provides | em : Supported }
-em value =
-    Value (String.fromFloat value ++ "em")
-
-
-{-| [`ex`](https://css-tricks.com/the-lengths-of-css/) length units.
-
-    borderWidth (ex 5)
-
--}
-ex : Float -> Value { provides | ex : Supported }
-ex value =
-    Value (String.fromFloat value ++ "ex")
-
-
-{-| [`ch`](https://css-tricks.com/the-lengths-of-css/) length units.
-
-    borderWidth (ch 5)
-
--}
-ch : Float -> Value { provides | ch : Supported }
-ch value =
-    Value (String.fromFloat value ++ "ch")
-
-
-{-| [`rem`](https://css-tricks.com/the-lengths-of-css/) length units.
-
-    borderWidth (rem 5)
-
--}
-rem : Float -> Value { provides | rem : Supported }
-rem value =
-    Value (String.fromFloat value ++ "rem")
-
-
-{-| [`vh`](https://css-tricks.com/the-lengths-of-css/) length units.
-
-    borderWidth (vh 5)
-
--}
-vh : Float -> Value { provides | vh : Supported }
-vh value =
-    Value (String.fromFloat value ++ "vh")
-
-
-{-| [`vw`](https://css-tricks.com/the-lengths-of-css/) length units.
-
-    borderWidth (vw 5)
-
--}
-vw : Float -> Value { provides | vw : Supported }
-vw value =
-    Value (String.fromFloat value ++ "vw")
-
-
-{-| [`vmin`](https://css-tricks.com/the-lengths-of-css/) length units.
-
-    borderWidth (vmin 5)
-
--}
-vmin : Float -> Value { provides | vmin : Supported }
-vmin value =
-    Value (String.fromFloat value ++ "vmin")
-
-
-{-| [`vmax`](https://css-tricks.com/the-lengths-of-css/) length units.
-
-    borderWidth (vmax 5)
-
--}
-vmax : Float -> Value { provides | vmax : Supported }
-vmax value =
-    Value (String.fromFloat value ++ "vmax")
-
-
-{-| [`mm`](https://css-tricks.com/the-lengths-of-css/) length units.
-
-    borderWidth (mm 5)
-
--}
-mm : Float -> Value { provides | mm : Supported }
-mm value =
-    Value (String.fromFloat value ++ "mm")
-
-
-{-| [`cm`](https://css-tricks.com/the-lengths-of-css/) length units.
-
-    borderWidth (cm 5)
-
--}
-cm : Float -> Value { provides | cm : Supported }
-cm value =
-    Value (String.fromFloat value ++ "cm")
-
-
-{-| [`Q`](https://developer.mozilla.org/en-US/docs/Web/CSS/length) length units.
-
-    borderWidth (q 2.5)
-
--}
-q : Float -> Value { provides | q : Supported }
-q value =
-    Value (String.fromFloat value ++ "Q")
-
-
-{-| [`in`](https://css-tricks.com/the-lengths-of-css/) length units.
-
-    borderWidth (inches 5)
-
-(This is `inches` instead of `in` because `in` is a reserved keyword in Elm.)
-
--}
-inches : Float -> Value { provides | inches : Supported }
-inches value =
-    Value (String.fromFloat value ++ "in")
-
-
-{-| [`pt`](https://css-tricks.com/the-lengths-of-css/) length units.
-
-    borderWidth (pt 5)
-
--}
-pt : Float -> Value { provides | pt : Supported }
-pt value =
-    Value (String.fromFloat value ++ "pt")
-
-
-{-| [`pc`](https://css-tricks.com/the-lengths-of-css/) length units.
-
-    borderWidth (pc 5)
-
--}
-pc : Float -> Value { provides | pc : Supported }
-pc value =
-    Value (String.fromFloat value ++ "pc")
-
-
-{-| [`pct`](https://css-tricks.com/the-lengths-of-css/) length units.
-
-    borderWidth (pct 5)
-
--}
-pct : Float -> Value { provides | pct : Supported }
-pct value =
-    Value (String.fromFloat value ++ "%")
-
-
-{-| A unitless number. Useful with properties like
-[`flexGrow`](#flexGrow),
-and [`order`](#order)
-which accept unitless numbers.
-
-    flexGrow (num 2)
-
-    order (num -2)
-
--}
-num : Float -> Value { provides | num : Supported }
-num value =
-    Value (String.fromFloat value)
-
-
-{-| A unitless integer. Useful with properties like [`zIndex`](#zIndex) which accept unitless integers.
-
-    zIndex (int 3)
-
--}
-int : Int -> Value { provides | int : Supported }
-int value =
-    Value (String.fromInt value)
 
 
 
@@ -8903,6 +9234,39 @@ grab =
 grabbing : Value { provides | grabbing : Supported }
 grabbing =
     Value "grabbing"
+
+
+
+
+
+
+{-| Sets [`color`](https://css-tricks.com/almanac/properties/c/color/).
+
+    color (hex "#60b5cc")
+
+    color (rgb 96 181 204)
+
+    color (rgba 96 181 204 0.5)
+
+-}
+color : BaseValue Color -> Style
+color (Value val) =
+    AppendProperty ("color:" ++ val)
+
+
+{-| Sets [`background-color`](https://css-tricks.com/almanac/properties/b/background-color/).
+
+    backgroundColor (hex "#60b5cc")
+
+    backgroundColor (rgb 96 181 204)
+
+    backgroundColor (rgba 96 181 204 0.5)
+
+-}
+backgroundColor : BaseValue Color -> Style
+backgroundColor (Value val) =
+    AppendProperty ("background-color:" ++ val)
+
 
 
 {-| Sets [`background-attachment`](https://css-tricks.com/almanac/properties/b/background-attachment/).
@@ -13148,58 +13512,6 @@ boxDecoration =
 
 
 
--- ANGLES --
-
-
-{-| A [`deg` angle](https://developer.mozilla.org/en-US/docs/Web/CSS/angle)
-
-    deg 360 -- one full circle
-
-    deg 14.23
-
--}
-deg : Float -> Value { provides | deg : Supported }
-deg degrees =
-    Value (String.fromFloat degrees ++ "deg")
-
-
-{-| A [`grad` angle](https://developer.mozilla.org/en-US/docs/Web/CSS/angle)
-
-    grad 400 -- one full circle
-
-    grad 38.8
-
--}
-grad : Float -> Value { provides | grad : Supported }
-grad gradians =
-    Value (String.fromFloat gradians ++ "grad")
-
-
-{-| A [`rad` angle](https://developer.mozilla.org/en-US/docs/Web/CSS/angle)
-
-    rad 6.2832 -- approximately one full circle
-
-    rad 1
-
--}
-rad : Float -> Value { provides | rad : Supported }
-rad radians =
-    Value (String.fromFloat radians ++ "rad")
-
-
-{-| A [`turn` angle](https://developer.mozilla.org/en-US/docs/Web/CSS/angle)
-
-    turn 1 -- one full circle
-
-    turn 0.25
-
--}
-turn : Float -> Value { provides | turn : Supported }
-turn turns =
-    Value (String.fromFloat turns ++ "turn")
-
-
-
 -- TEXT DECORATION --
 
 
@@ -15666,30 +15978,6 @@ perspective_ (Value length) =
 
 
 
--- TIME UNITS --
-
-
-{-| The [`s`](https://developer.mozilla.org/en-US/docs/Web/CSS/time) time unit.
-
-    animationDuration (s 1)
-
--}
-s : Float -> Value { provides | s : Supported }
-s value =
-    Value (String.fromFloat value ++ "s")
-
-
-{-| The [`ms`](https://developer.mozilla.org/en-US/docs/Web/CSS/time) time unit.
-
-    animationDuration (ms 120)
-
--}
-ms : Float -> Value { provides | ms : Supported }
-ms value =
-    Value (String.fromFloat value ++ "ms")
-
-
-
 -- ANIMATION --
 
 
@@ -16357,6 +16645,46 @@ letterSpacing (Value val) =
     AppendProperty ("letter-spacing:" ++ val)
 
 
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------- LENGTHS --------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+
+
+{-| Sets an [`all`](https://css-tricks.com/almanac/properties/a/all/) property.
+
+    all inherit
+
+-}
+all : BaseValue a -> Style
+all (Value val) =
+    AppendProperty ("all:" ++ val)
+
+
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------- SIZING --------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+
+
 {-| The [`width`](https://css-tricks.com/almanac/properties/w/width/) property.
 
     width (px 150)
@@ -16609,60 +16937,6 @@ maxInlineSize :
     -> Style
 maxInlineSize (Value val) =
     AppendProperty ("max-inline-size:" ++ val)
-
-
-{-| The `min-content` value used for properties such as:
-
-  - sizing (eg. [`width`](#width), [`height`](#height), [`inlineSize`](#inlineSize))
-
-  - min/max sizing (eg. [`minWidth`](#minWidth), [`maxBlockWidth`](#maxBlockWidth))
-
-  - [`flexBasis`](#flexBasis)
-
-```
-width minContent
-```
-
--}
-minContent : Value { provides | minContent : Supported }
-minContent =
-    Value "min-content"
-
-
-{-| The `max-content` value used for properties such as:
-
-  - sizing (eg. [`width`](#width), [`height`](#height), [`inlineSize`](#inlineSize))
-
-  - min/max sizing (eg. [`minWidth`](#minWidth), [`maxBlockWidth`](#maxBlockWidth))
-
-  - [`flexBasis`](#flexBasis)
-
-```
-width maxContent
-```
-
--}
-maxContent : Value { provides | maxContent : Supported }
-maxContent =
-    Value "max-content"
-
-
-{-| The `fit-content` value used for properties such as:
-
-  - sizing (eg. [`width`](#width), [`height`](#height), [`inlineSize`](#inlineSize))
-
-  - min/max sizing (eg. [`minWidth`](#minWidth), [`maxBlockWidth`](#maxBlockWidth))
-
-  - [`flexBasis`](#flexBasis)
-
-```
-width fitContent
-```
-
--}
-fitContent : Value { provides | fitContent : Supported }
-fitContent =
-    Value "fit-content"
 
 
 {-| Sets [`backface-visibility`](https://css-tricks.com/almanac/properties/b/backface-visibility/)

--- a/src/Css.elm
+++ b/src/Css.elm
@@ -146,6 +146,7 @@ module Css exposing
     , scrollMarginBlockStart, scrollMarginBlockEnd, scrollMarginInlineStart, scrollMarginInlineEnd
     , scrollPadding, scrollPadding2, scrollPadding3, scrollPadding4, scrollPaddingTop, scrollPaddingLeft, scrollPaddingRight, scrollPaddingBottom
     , scrollPaddingBlock, scrollPaddingBlock2, scrollPaddingInline, scrollPaddingInline2
+    , scrollPaddingBlockStart, scrollPaddingBlockEnd, scrollPaddingInlineStart, scrollPaddingInlineEnd
     , speak, spellOut
     , userSelect
     , unicodeBidi, embed, bidiOverride, isolateOverride, plaintext
@@ -695,6 +696,7 @@ Multiple CSS properties use these values.
 @docs scrollMarginBlockStart, scrollMarginBlockEnd, scrollMarginInlineStart, scrollMarginInlineEnd
 @docs scrollPadding, scrollPadding2, scrollPadding3, scrollPadding4, scrollPaddingTop, scrollPaddingLeft, scrollPaddingRight, scrollPaddingBottom
 @docs scrollPaddingBlock, scrollPaddingBlock2, scrollPaddingInline, scrollPaddingInline2
+@docs scrollPaddingBlockStart, scrollPaddingBlockEnd, scrollPaddingInlineStart, scrollPaddingInlineEnd
 
 
 # Accessibility
@@ -13584,6 +13586,74 @@ scrollPaddingInline2 :
     -> Style
 scrollPaddingInline2 (Value valueStart) (Value valueEnd) =
     AppendProperty ("scroll-padding-inline:" ++ valueStart ++ " " ++ valueEnd)
+
+
+{-| Sets [`scroll-padding-block-start`](https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-padding-block-start) property.
+
+    scrollPaddingBlockStart (px 4)
+
+-}
+scrollPaddingBlockStart :
+    BaseValue
+        (LengthSupported
+            { auto : Supported
+            , pct : Supported
+            }
+        )
+    -> Style
+scrollPaddingBlockStart (Value value) =
+    AppendProperty ("scroll-padding-block-start:" ++ value)
+
+
+{-| Sets [`scroll-padding-block-end`](https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-padding-block-end) property.
+
+    scrollPaddingBlockEnd (px 4)
+
+-}
+scrollPaddingBlockEnd :
+    BaseValue
+        (LengthSupported
+            { auto : Supported
+            , pct : Supported
+            }
+        )
+    -> Style
+scrollPaddingBlockEnd (Value value) =
+    AppendProperty ("scroll-padding-block-end:" ++ value)
+
+
+{-| Sets [`scroll-padding-inline-start`](https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-padding-inline-start) property.
+
+    scrollPaddingInlineStart (px 4)
+
+-}
+scrollPaddingInlineStart :
+    BaseValue
+        (LengthSupported
+            { auto : Supported
+            , pct : Supported
+            }
+        )
+    -> Style
+scrollPaddingInlineStart (Value value) =
+    AppendProperty ("scroll-padding-inline-start:" ++ value)
+
+
+{-| Sets [`scroll-padding-inline-end`](https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-padding-inline-end) property.
+
+    scrollPaddingInlineEnd (px 4)
+
+-}
+scrollPaddingInlineEnd :
+    BaseValue
+        (LengthSupported
+            { auto : Supported
+            , pct : Supported
+            }
+        )
+    -> Style
+scrollPaddingInlineEnd (Value value) =
+    AppendProperty ("scroll-padding-inline-end:" ++ value)
 
 
 {-| Sets [`scroll-snap-align`](https://css-tricks.com/almanac/properties/s/scroll-snap-align/)

--- a/src/Css.elm
+++ b/src/Css.elm
@@ -10,7 +10,6 @@ module Css exposing
     , calc, CalcOperation, minus, plus, times, dividedBy
     , Color, ColorSupported, color, backgroundColor, hex, rgb, rgba, hsl, hsla, currentcolor
     , Time, TimeSupported, s, ms
-    , string
     , pseudoClass, active, disabled
     , pseudoElement, before, after
     , width, minWidth, maxWidth, height, minHeight, maxHeight
@@ -62,7 +61,7 @@ module Css exposing
     , tabSize
     , fontDisplay, fallback, swap, optional
     , writingMode, verticalLr, verticalRl, horizontalTb
-    , hyphens, quotes, quotes2, quotes4, manual
+    , hyphens, quotes, quotes2, quotes4, textOverflow, textOverflow2, ellipsis, manual
     , hangingPunctuation, first, last, forceEnd, allowEnd
     , lineClamp
     , fontSize, xxSmall, xSmall, small, medium, large, xLarge, xxLarge, smaller, larger, lineHeight, letterSpacing
@@ -84,7 +83,7 @@ module Css exposing
     , wResize, neResize, nwResize, seResize, swResize, ewResize, nsResize
     , neswResize, nwseResize, zoomIn, zoomOut, grab, grabbing
     , ListStyleType, ListStyleTypeSupported
-    , listStyle, listStyle2, listStyle3, listStylePosition, inside, outside, listStyleType, customIdent, listStyleImage
+    , listStyle, listStyle2, listStyle3, listStylePosition, inside, outside, listStyleType, string, customIdent, listStyleImage
     , arabicIndic, armenian, bengali, cambodian, circle, cjkDecimal, cjkEarthlyBranch, cjkHeavenlyStem, cjkIdeographic, decimal, decimalLeadingZero, devanagari, disclosureClosed, disclosureOpen, disc, ethiopicNumeric, georgian, gujarati, gurmukhi, hebrew, hiragana, hiraganaIroha, japaneseFormal, japaneseInformal, kannada, katakana, katakanaIroha, khmer, koreanHangulFormal, koreanHanjaFormal, koreanHanjaInformal, lao, lowerAlpha, lowerArmenian, lowerGreek, lowerLatin, lowerRoman, malayalam, monogolian, myanmar, oriya, persian, simpChineseFormal, simpChineseInformal, tamil, telugu, thai, tibetan, tradChineseFormal, tradChineseInformal, upperAlpha, upperArmenian, upperLatin, upperRoman
     , auto, none
     , hidden, visible
@@ -427,7 +426,7 @@ See this [complete guide](https://css-tricks.com/snippets/css/a-guide-to-flexbox
 
 @docs fontDisplay, fallback, swap, optional
 @docs writingMode, verticalLr, verticalRl, horizontalTb
-@docs hyphens, quotes, quotes2, quotes4, manual
+@docs hyphens, quotes, quotes2, quotes4, textOverflow, textOverflow2, ellipsis, manual
 @docs hangingPunctuation, first, last, forceEnd, allowEnd
 @docs lineClamp
 
@@ -1003,9 +1002,12 @@ type alias Time =
 
 {-| Produces an [`string`](https://developer.mozilla.org/en-US/docs/Web/CSS/string)
 value used by properties such as:
-- [`listStyle`](#listStyle),
-- [`listStyleType`](#listStyleType)
-- [`quotes2`](#quotes2)
+
+  - [`listStyle`](#listStyle),
+
+  - [`listStyleType`](#listStyleType)
+
+  - [`quotes2`](#quotes2)
 
     listStyleType (string "> ")
 
@@ -1015,6 +1017,7 @@ value used by properties such as:
 string : String -> Value { provides | string : Supported }
 string =
     Value << enquoteString
+
 
 
 -- CUSTOM PROPERTIES --
@@ -12801,11 +12804,13 @@ maxInlineSize (Value val) =
     AppendProperty ("max-inline-size:" ++ val)
 
 
-{-| The `min-content` value used for properties such as: 
+{-| The `min-content` value used for properties such as:
 
-- sizing (eg. [`width`](#width), [`height`](#height), [`inlineSize`](#inlineSize))
-- min/max sizing (eg. [`minWidth`](#minWidth), [`maxBlockWidth`](#maxBlockWidth))
-- [`flexBasis`](#flexBasis)
+  - sizing (eg. [`width`](#width), [`height`](#height), [`inlineSize`](#inlineSize))
+
+  - min/max sizing (eg. [`minWidth`](#minWidth), [`maxBlockWidth`](#maxBlockWidth))
+
+  - [`flexBasis`](#flexBasis)
 
     width minContent
 
@@ -12817,9 +12822,11 @@ minContent =
 
 {-| The `max-content` value used for properties such as:
 
-- sizing (eg. [`width`](#width), [`height`](#height), [`inlineSize`](#inlineSize))
-- min/max sizing (eg. [`minWidth`](#minWidth), [`maxBlockWidth`](#maxBlockWidth))
-- [`flexBasis`](#flexBasis)
+  - sizing (eg. [`width`](#width), [`height`](#height), [`inlineSize`](#inlineSize))
+
+  - min/max sizing (eg. [`minWidth`](#minWidth), [`maxBlockWidth`](#maxBlockWidth))
+
+  - [`flexBasis`](#flexBasis)
 
     width maxContent
 
@@ -12831,9 +12838,11 @@ maxContent =
 
 {-| The `fit-content` value used for properties such as:
 
-- sizing (eg. [`width`](#width), [`height`](#height), [`inlineSize`](#inlineSize))
-- min/max sizing (eg. [`minWidth`](#minWidth), [`maxBlockWidth`](#maxBlockWidth))
-- [`flexBasis`](#flexBasis)
+  - sizing (eg. [`width`](#width), [`height`](#height), [`inlineSize`](#inlineSize))
+
+  - min/max sizing (eg. [`minWidth`](#minWidth), [`maxBlockWidth`](#maxBlockWidth))
+
+  - [`flexBasis`](#flexBasis)
 
     width fitContent
 
@@ -13283,12 +13292,12 @@ This one-argument version can only use keyword or global values.
 
     quotes2 (string "\"") (string "\"")
 
-    quotes4 (string "\"") (string "\"") (string "\'") (string "\'")
+    quotes4 (string "\"") (string "\"") (string "'") (string "'")
 
 -}
 quotes :
     BaseValue
-        { none : Supported 
+        { none : Supported
         , auto : Supported
         }
     -> Style
@@ -13299,24 +13308,26 @@ quotes (Value val) =
 {-| Sets the [`quotes`](https://css-tricks.com/almanac/properties/q/quotes/) property.
 
 This 2-argument version sets the starting and closing quotation marks for
-a top-level quote (a quote that is not nested within another quote). It only accepts 
+a top-level quote (a quote that is not nested within another quote). It only accepts
 string values.
 
     quotes auto
 
     quotes2 (string "\"") (string "\"") -- "Hey, this is a first-level quote."
 
-    quotes2 (string "\'") (string "\'") -- 'Hey, this is a first-level quote.'
+    quotes2 (string "'") (string "'") -- 'Hey, this is a first-level quote.'
 
     quotes2 (string "«") (string "»") -- «Hey, this is a first-level quote.»
+
 -}
 quotes2 :
     Value
         { string : Supported
         }
-    -> Value
-        { string : Supported
-        }
+    ->
+        Value
+            { string : Supported
+            }
     -> Style
 quotes2 (Value lv1StartQuote) (Value lv1EndQuote) =
     AppendProperty ("quotes:" ++ lv1StartQuote ++ " " ++ lv1EndQuote)
@@ -13325,13 +13336,13 @@ quotes2 (Value lv1StartQuote) (Value lv1EndQuote) =
 {-| Sets the [`quotes`](https://css-tricks.com/almanac/properties/q/quotes/) property.
 
 This 4-argument version sets the starting and closing quotation marks for both
-a top-level quote and a nested quote. It only accepts 
+a top-level quote and a nested quote. It only accepts
 string values.
 
     quotes auto
 
     quotes2 (string "\"") (string "\"")
-    
+
     -- "Hey, this is a first-level quote."
 
 
@@ -13354,18 +13365,81 @@ quotes4 :
     Value
         { string : Supported
         }
-    -> Value
-        { string : Supported
-        }
-    -> Value
-        { string : Supported
-        }
-    -> Value
-        { string : Supported
-        }
+    ->
+        Value
+            { string : Supported
+            }
+    ->
+        Value
+            { string : Supported
+            }
+    ->
+        Value
+            { string : Supported
+            }
     -> Style
 quotes4 (Value lv1StartQuote) (Value lv1EndQuote) (Value lv2StartQuote) (Value lv2EndQuote) =
     AppendProperty ("quotes:" ++ lv1StartQuote ++ " " ++ lv1EndQuote ++ " " ++ lv2StartQuote ++ " " ++ lv2EndQuote)
+
+
+{-| Sets the [`text-overflow`](https://css-tricks.com/almanac/properties/t/text-overflow/) property.
+
+`text-overflow` describes how text that gets cut off is signalled to users.
+
+When the one-argument version is used, it sets the end of text (right end for LTR users) that is cut off.
+
+    textOverflow ellipsis
+
+When the two-argument version is used, it specifies how the
+text cut-off is displayed at the start (left in LTR) and
+the end (right in LTR) of the text.
+
+    textOverflow2 ellipsis ellipsis
+
+-}
+textOverflow :
+    BaseValue
+        { clip : Supported
+        , ellipsis : Supported
+        }
+    -> Style
+textOverflow (Value value) =
+    AppendProperty ("text-overflow:" ++ value)
+
+
+{-| Sets the [`text-overflow`](https://css-tricks.com/almanac/properties/t/text-overflow/) property.
+
+`text-overflow` describes how text that gets cut off is signalled to users.
+
+This version specifies how the text cut-off is displayed in start
+(left in LTR) and the end (right in LTR) of the text..
+
+    textOverflow2 ellipsis ellipsis
+
+-}
+textOverflow2 :
+    Value
+        { clip : Supported
+        , ellipsis : Supported
+        }
+    ->
+        Value
+            { clip : Supported
+            , ellipsis : Supported
+            }
+    -> Style
+textOverflow2 (Value startValue) (Value endValue) =
+    AppendProperty ("text-overflow:" ++ startValue ++ " " ++ endValue)
+
+
+{-| Sets `ellipsis` value for usage with [`textOverflow`](#textOverflow).
+
+    textOverflow ellipsis
+
+-}
+ellipsis : Value { provides | ellipsis : Supported }
+ellipsis =
+    Value "ellipsis"
 
 
 {-| Sets `pixelated` value for usage with [`imageRendering`](#imageRendering).
@@ -14546,6 +14620,8 @@ scrollPaddingInlineEnd :
     -> Style
 scrollPaddingInlineEnd (Value value) =
     AppendProperty ("scroll-padding-inline-end:" ++ value)
+
+
 {-| Sets the [`overscroll-behavior`](https://css-tricks.com/almanac/properties/o/overscroll-behavior/) property.
 
 This property is a shorthand for setting both `overscroll-behavior-x` and `overscroll-behavior-y`.

--- a/src/Css.elm
+++ b/src/Css.elm
@@ -43,7 +43,7 @@ module Css exposing
     , block, flex_, flow, flowRoot, grid, contents, listItem, inline, inlineBlock, inlineFlex, inlineTable, inlineGrid, ruby, rubyBase, rubyBaseContainer, rubyText, rubyTextContainer, runIn, table, tableCaption, tableCell, tableColumn, tableColumnGroup, tableFooterGroup, tableHeaderGroup, tableRow, tableRowGroup
     , position, top, right, bottom, left, zIndex
     , absolute, fixed, relative, static, sticky
-    , padding, padding2, padding3, padding4, paddingTop, paddingRight, paddingBottom, paddingLeft
+    , padding, padding2, padding3, padding4, paddingTop, paddingRight, paddingBottom, paddingLeft, paddingBlock, paddingBlock2, paddingBlockStart, paddingBlockEnd, paddingInline, paddingInline2, paddingInlineStart, paddingInlineEnd
     , margin, margin2, margin3, margin4, marginTop, marginRight, marginBottom, marginLeft
     , boxSizing
     , alignContent, alignContent2, alignItems, alignItems2, alignSelf, alignSelf2, justifyContent, justifyContent2, justifyItems, justifyItems2, justifySelf, justifySelf2
@@ -1891,6 +1891,175 @@ paddingLeft :
     -> Style
 paddingLeft (Value value) =
     AppendProperty ("padding-left:" ++ value)
+
+
+{-| Sets [`padding-block`](https://css-tricks.com/almanac/properties/p/padding-block/) property.
+The `padding-block` property is a shorthand property for setting `padding-block-start` and
+`padding-block-end` and in a single declaration.
+
+If there is only one argument value, it applies to both sides. If there are two
+values, the block start is set to the first value and the block end is set to the second.
+
+    paddingBlock (em 4) -- set both block start and block end to 4em
+
+    paddingBlock2 (em 4) (px 2) -- block start = 4em, block end = 2px
+
+
+-}
+paddingBlock :
+    BaseValue
+        (LengthSupported
+            { pct : Supported
+            }
+        )
+    -> Style
+paddingBlock (Value value) =
+    AppendProperty ("padding-block:" ++ value)
+
+
+{-| Sets [`padding`](https://css-tricks.com/almanac/properties/p/padding/) property.
+The `padding-block` property is a shorthand property for setting `padding-block-start`,
+`padding-block-end` and in a single declaration.
+
+The block start value is set to the first value and the block end value is set to the second.
+
+    paddingBlock2 (em 4) (px 2) -- block start = 4em, block end = 2px
+
+-}
+paddingBlock2 :
+    Value
+        (LengthSupported
+            { pct : Supported
+            }
+        )
+    ->
+        Value
+            (LengthSupported
+                { pct : Supported
+                }
+            )
+    -> Style
+paddingBlock2 (Value valueStart) (Value valueEnd) =
+    AppendProperty ("padding-block:" ++ valueStart ++ " " ++ valueEnd)
+
+
+{-| Sets [`padding-block-start`](https://developer.mozilla.org/en-US/docs/Web/CSS/padding-block-start) property.
+
+    paddingBlockStart (px 4)
+
+-}
+paddingBlockStart :
+    BaseValue
+        (LengthSupported
+            { pct : Supported
+            }
+        )
+    -> Style
+paddingBlockStart (Value value) =
+    AppendProperty ("padding-block-start:" ++ value)
+
+
+{-| Sets [`padding-block-end](https://developer.mozilla.org/en-US/docs/Web/CSS/padding-block-end) property.
+
+    paddingBlockEnd (px 4)
+
+-}
+paddingBlockEnd :
+    BaseValue
+        (LengthSupported
+            { pct : Supported
+            }
+        )
+    -> Style
+paddingBlockEnd (Value value) =
+    AppendProperty ("padding-block-end:" ++ value)
+
+
+
+
+{-| Sets [`padding-inline`](https://css-tricks.com/almanac/properties/p/padding-inline/) property.
+The `padding-inline` property is a shorthand property for setting `padding-inline-start` and
+`padding-inline-end` and in a single declaration.
+
+If there is only one argument value, it applies to both sides. If there are two
+values, the inline start is set to the first value and the inline end is set to the second.
+
+    paddingInline (em 4) -- set both inline start and inline end to 4em
+
+    paddingInline2 (em 4) (px 2) -- inline start = 4em, inline end = 2px
+
+
+-}
+paddingInline :
+    BaseValue
+        (LengthSupported
+            { pct : Supported
+            }
+        )
+    -> Style
+paddingInline (Value value) =
+    AppendProperty ("padding-inline:" ++ value)
+
+
+{-| Sets [`padding`](https://css-tricks.com/almanac/properties/p/padding/) property.
+The `padding-inline` property is a shorthand property for setting `padding-inline-start`,
+`padding-inline-end` and in a single declaration.
+
+The inline start value is set to the first value and the inline end value is set to the second.
+
+    paddingInline2 (em 4) (px 2) -- inline start = 4em, inline end = 2px
+
+-}
+paddingInline2 :
+    Value
+        (LengthSupported
+            { pct : Supported
+            }
+        )
+    ->
+        Value
+            (LengthSupported
+                { pct : Supported
+                }
+            )
+    -> Style
+paddingInline2 (Value valueStart) (Value valueEnd) =
+    AppendProperty ("padding-inline:" ++ valueStart ++ " " ++ valueEnd)
+
+
+{-| Sets [`padding-inline-start`](https://developer.mozilla.org/en-US/docs/Web/CSS/padding-inline-start) property.
+
+    paddingInlineStart (px 4)
+
+-}
+paddingInlineStart :
+    BaseValue
+        (LengthSupported
+            { pct : Supported
+            }
+        )
+    -> Style
+paddingInlineStart (Value value) =
+    AppendProperty ("padding-inline-start:" ++ value)
+
+
+{-| Sets [`padding-inline-end](https://developer.mozilla.org/en-US/docs/Web/CSS/padding-inline-end) property.
+
+    paddingInlineEnd (px 4)
+
+-}
+paddingInlineEnd :
+    BaseValue
+        (LengthSupported
+            { pct : Supported
+            }
+        )
+    -> Style
+paddingInlineEnd (Value value) =
+    AppendProperty ("padding-inline-end:" ++ value)
+
+
+
 
 
 

--- a/src/Css.elm
+++ b/src/Css.elm
@@ -211,6 +211,7 @@ module Css exposing
     , boxDecorationBreak
     , isolation, isolate
     , clipPath, clipPath2
+    , maskBorderMode, maskBorderRepeat, maskBorderRepeat2, maskBorderOutset, maskBorderOutset2, maskBorderOutset3, maskBorderOutset4, maskBorderSlice, maskBorderSlice2, maskBorderSlice3, maskBorderSlice4, maskBorderWidth, maskBorderWidth2, maskBorderWidth3, maskBorderWidth4
     , maskClip, maskClipList, maskComposite, maskMode, maskModeList, maskOrigin, maskOriginList, maskPosition, maskRepeat, maskRepeat2, maskSize, maskSize2, maskType
     , noClip, add, subtract, intersect, exclude, alpha, luminance, matchSource
     , caretColor
@@ -960,6 +961,7 @@ Other values you can use for flex item alignment:
 
 # Masks
 
+@docs maskBorderMode, maskBorderRepeat, maskBorderRepeat2, maskBorderOutset, maskBorderOutset2, maskBorderOutset3, maskBorderOutset4, maskBorderSlice, maskBorderSlice2, maskBorderSlice3, maskBorderSlice4, maskBorderWidth, maskBorderWidth2, maskBorderWidth3, maskBorderWidth4
 @docs maskClip, maskClipList, maskComposite, maskMode, maskModeList, maskOrigin, maskOriginList, maskPosition, maskRepeat, maskRepeat2, maskSize, maskSize2, maskType
 @docs noClip, add, subtract, intersect, exclude, alpha, luminance, matchSource
 
@@ -2673,7 +2675,7 @@ content =
 
 
 {-| The `fill` value used in properties such as [`objectFit`](#objectFit),
-[`pointerEvents`](#pointerEvents) and [`paintOrder`](#paintOrder).
+[`pointerEvents`](#pointerEvents), [`paintOrder`](#paintOrder) and [`maskBorderSlice`](#maskBorderSlice).
 
     objectFit fill_
 
@@ -2681,6 +2683,10 @@ content =
 
     paintOrder2 fill_ markers
 
+    maskBorderSlice4 fill_ (num 20) (pct 10) (num 45)
+
+
+The value is called `fill_` instead of `fill` because [`fill`](#fill) is already a property function.
 -}
 fill_ : Value { provides | fill_ : Supported }
 fill_ =
@@ -16644,6 +16650,465 @@ bleed (Value val) =
 
 -- MASKS --
 
+{-| Sets the [`mask-border-mode`](https://developer.mozilla.org/en-US/docs/Web/CSS/mask-border-mode)
+property.
+
+    maskBorderMode inherit
+
+    maskBorderMode luminance
+-}
+maskBorderMode :
+    BaseValue
+        { luminance : Supported
+        , alpha : Supported
+        }
+    -> Style
+maskBorderMode (Value val) =
+    AppendProperty <| "mask-border-mode:" ++ val
+
+
+
+{-| Sets the 1-argument variant of the [`mask-border-repeat`](https://developer.mozilla.org/en-US/docs/Web/CSS/mask-border-repeat)
+property.
+
+    maskBorderRepeat stretch
+
+    maskBorderRepeat revert
+
+    maskBorderRepeat2 stretch repeat
+-}
+maskBorderRepeat :
+    BaseValue
+        { stretch : Supported
+        , repeat : Supported
+        , round : Supported
+        , space : Supported
+        }
+    -> Style
+maskBorderRepeat (Value val) =
+    AppendProperty <| "mask-border-repeat:" ++ val
+
+
+{-| Sets the 2-argument variant of the [`mask-border-repeat`](https://developer.mozilla.org/en-US/docs/Web/CSS/mask-border-repeat)
+property.
+
+    maskBorderRepeat2 stretch repeat
+-}
+maskBorderRepeat2 :
+    Value
+        { stretch : Supported
+        , repeat : Supported
+        , round : Supported
+        , space : Supported
+        }
+    -> Value
+        { stretch : Supported
+        , repeat : Supported
+        , round : Supported
+        , space : Supported
+        }
+    -> Style
+maskBorderRepeat2 (Value val1) (Value val2) =
+    AppendProperty <|
+        "mask-border-repeat:"
+        ++ val1
+        ++ " "
+        ++ val2
+
+
+{-| Sets the 1-argument variant of the [`mask-border-outset`](https://developer.mozilla.org/en-US/docs/Web/CSS/mask-border-outset)
+property.
+
+    maskBorderOutset revert
+
+    maskBorderOutset (num 2.5)
+
+    maskBorderOutset (px 30)
+
+    --             top+bottom | left+right
+    maskBorderOutset2 (px 30) (px 10)
+
+    --               top | left+right | bottom
+    maskBorderOutset3 (px 12) (px 16) (px 4)
+    
+    --                  top | right | bottom | left
+    maskBorderOutset4 (rem 2) (rem 1) (rem 3) (rem 4)
+-}
+maskBorderOutset :
+    BaseValue
+        ( LengthSupported
+            { num : Supported }
+        )
+    -> Style
+maskBorderOutset (Value val) =
+    AppendProperty <| "mask-border-outset:" ++ val
+
+
+{-| Sets the 2-argument variant of the [`mask-border-outset`](https://developer.mozilla.org/en-US/docs/Web/CSS/mask-border-outset)
+property.
+    
+    --             top+bottom | left+right
+    maskBorderOutset2 (px 30) (px 10)
+-}
+maskBorderOutset2 :
+    Value
+        ( LengthSupported
+            { num : Supported }
+        )
+    -> Value
+        ( LengthSupported
+            { num : Supported }
+        )
+    -> Style
+maskBorderOutset2 (Value valTB) (Value valLR) =
+    AppendProperty <|
+        "mask-border-outset:"
+        ++ valTB
+        ++ " "
+        ++ valLR
+
+
+{-| Sets the 3-argument variant of the [`mask-border-outset`](https://developer.mozilla.org/en-US/docs/Web/CSS/mask-border-outset)
+property.
+
+    --               top | left+right | bottom
+    maskBorderOutset3 (px 12) (px 16) (px 4)
+-}
+maskBorderOutset3 :
+    Value
+        ( LengthSupported
+            { num : Supported }
+        )
+    -> Value
+        ( LengthSupported
+            { num : Supported }
+        )
+    -> Value
+        ( LengthSupported
+            { num : Supported }
+        )
+    -> Style
+maskBorderOutset3 (Value valTop) (Value valLR) (Value valBottom) =
+    AppendProperty <|
+        "mask-border-outset:"
+        ++ valTop
+        ++ " "
+        ++ valLR
+        ++ " "
+        ++ valBottom
+
+
+{-| Sets the 4-argument variant of the [`mask-border-outset`](https://developer.mozilla.org/en-US/docs/Web/CSS/mask-border-outset)
+property.
+
+    --                  top | right | bottom | left
+    maskBorderOutset4 (rem 2) (rem 1) (rem 3) (rem 4)
+-}
+maskBorderOutset4 :
+    Value
+        ( LengthSupported
+            { num : Supported }
+        )
+    -> Value
+        ( LengthSupported
+            { num : Supported }
+        )
+    -> Value
+        ( LengthSupported
+            { num : Supported }
+        )
+    -> Value
+        ( LengthSupported
+            { num : Supported }
+        )
+    -> Style
+maskBorderOutset4 (Value valTop) (Value valRight) (Value valBottom) (Value valLeft) =
+    AppendProperty <|
+        "mask-border-outset:"
+        ++ valTop
+        ++ " "
+        ++ valRight
+        ++ " "
+        ++ valBottom
+        ++ " "
+        ++ valLeft
+
+
+{-| Sets the 1-argument variant of the [`mask-border-slice`](https://developer.mozilla.org/en-US/docs/Web/CSS/mask-border-slice)
+property.
+
+    maskBorderSlice initial
+
+    maskBorderSlice (num 2.5)
+
+    maskBorderSlice (rem 3)
+
+    --           top+bottom | left+right
+    maskBorderSlice2 (num 30) (pct 10)
+
+    --              top | left+right | bottom
+    maskBorderSlice3 (px 12) (num 2) fill_
+    
+    --                 top | right | bottom | left
+    maskBorderSlice4 (rem 2) (rem 1) fill_ (rem 4)
+-}
+maskBorderSlice :
+    BaseValue
+        { num : Supported
+        , pct : Supported
+        , fill_ : Supported
+        }
+    -> Style
+maskBorderSlice (Value val) =
+    AppendProperty <| "mask-border-slice:" ++ val
+
+
+{-| Sets the 2-argument variant of the [`mask-border-slice`](https://developer.mozilla.org/en-US/docs/Web/CSS/mask-border-slice)
+property.
+
+    --           top+bottom | left+right
+    maskBorderSlice2 (num 30) (pct 10)
+-}
+maskBorderSlice2 :
+    Value
+        { num : Supported
+        , pct : Supported
+        , fill_ : Supported
+        }
+    -> Value
+        { num : Supported
+        , pct : Supported
+        , fill_ : Supported
+        }
+    -> Style
+maskBorderSlice2 (Value valTB) (Value valLR) =
+    AppendProperty <|
+        "mask-border-slice:"
+        ++ valTB
+        ++ " "
+        ++ valLR
+
+
+{-| Sets the 3-argument variant of the [`mask-border-slice`](https://developer.mozilla.org/en-US/docs/Web/CSS/mask-border-slice)
+property.
+
+    --              top | left+right | bottom
+    maskBorderSlice3 (px 12) (num 2) fill_
+-}
+maskBorderSlice3 :
+    Value
+        { num : Supported
+        , pct : Supported
+        , fill_ : Supported
+        }
+    -> Value
+        { num : Supported
+        , pct : Supported
+        , fill_ : Supported
+        }
+    -> Value
+        { num : Supported
+        , pct : Supported
+        , fill_ : Supported
+        }
+    -> Style
+maskBorderSlice3 (Value valTop) (Value valLR) (Value valBottom) =
+    AppendProperty <|
+        "mask-border-slice:"
+        ++ valTop
+        ++ " "
+        ++ valLR
+        ++ " "
+        ++ valBottom
+
+
+{-| Sets the 4-argument variant of the [`mask-border-slice`](https://developer.mozilla.org/en-US/docs/Web/CSS/mask-border-slice)
+property.
+
+    --                 top | right | bottom | left
+    maskBorderSlice4 (rem 2) (rem 1) fill_ (rem 4)
+-}
+maskBorderSlice4 :
+    Value
+        { num : Supported
+        , pct : Supported
+        , fill_ : Supported
+        }
+    -> Value
+        { num : Supported
+        , pct : Supported
+        , fill_ : Supported
+        }
+    -> Value
+        { num : Supported
+        , pct : Supported
+        , fill_ : Supported
+        }
+    -> Value
+        { num : Supported
+        , pct : Supported
+        , fill_ : Supported
+        }
+    -> Style
+maskBorderSlice4 (Value valTop) (Value valRight) (Value valBottom) (Value valLeft) =
+    AppendProperty <|
+        "mask-border-slice:"
+        ++ valTop
+        ++ " "
+        ++ valRight
+        ++ " "
+        ++ valBottom
+        ++ " "
+        ++ valLeft
+
+
+{-| Sets the 1-argument variant of the [`mask-border-width`](https://developer.mozilla.org/en-US/docs/Web/CSS/mask-border-width)
+property.
+
+    maskBorderWidth initial
+
+    maskBorderWidth auto
+
+    maskBorderWidth (rem 3)
+
+    --           top+bottom | left+right
+    maskBorderWidth2 (num 30) (pct 10)
+
+    --              top | left+right | bottom
+    maskBorderWidth3 (px 12) auto (px 20)
+    
+    --                 top | right | bottom | left
+    maskBorderWidth4 (rem 2) (rem 1) auto (rem 4)
+-}
+maskBorderWidth :
+    BaseValue
+        ( LengthSupported
+            { auto : Supported
+            , pct : Supported
+            , num : Supported
+            }
+        )
+    -> Style
+maskBorderWidth (Value val) =
+    AppendProperty <| "mask-border-width:" ++ val
+
+
+{-| Sets the 2-argument variant of the [`mask-border-width`](https://developer.mozilla.org/en-US/docs/Web/CSS/mask-border-width)
+property.
+
+    --           top+bottom | left+right
+    maskBorderWidth2 (num 30) (pct 10)
+-}
+maskBorderWidth2 :
+    Value
+        ( LengthSupported
+            { auto : Supported
+            , pct : Supported
+            , num : Supported
+            }
+        )
+    -> Value
+        ( LengthSupported
+            { auto : Supported
+            , pct : Supported
+            , num : Supported
+            }
+        )
+    -> Style
+maskBorderWidth2 (Value valTB) (Value valLR) =
+    AppendProperty <|
+        "mask-border-width:"
+        ++ valTB
+        ++ " "
+        ++ valLR
+
+
+{-| Sets the 3-argument variant of the [`mask-border-width`](https://developer.mozilla.org/en-US/docs/Web/CSS/mask-border-width)
+property.
+
+    --              top | left+right | bottom
+    maskBorderWidth3 (px 12) auto (px 20)
+-}
+maskBorderWidth3 :
+    Value
+        ( LengthSupported
+            { auto : Supported
+            , pct : Supported
+            , num : Supported
+            }
+        )
+    -> Value
+        ( LengthSupported
+            { auto : Supported
+            , pct : Supported
+            , num : Supported
+            }
+        )
+    -> Value
+        ( LengthSupported
+            { auto : Supported
+            , pct : Supported
+            , num : Supported
+            }
+        )
+    -> Style
+maskBorderWidth3 (Value valTop) (Value valLR) (Value valBottom) =
+    AppendProperty <|
+        "mask-border-width:"
+        ++ valTop
+        ++ " "
+        ++ valLR
+        ++ " "
+        ++ valBottom
+
+
+{-| Sets the 4-argument variant of the [`mask-border-width`](https://developer.mozilla.org/en-US/docs/Web/CSS/mask-border-width)
+property.
+
+    --                 top | right | bottom | left
+    maskBorderWidth4 (rem 2) (rem 1) auto (rem 4)
+-}
+maskBorderWidth4 :
+    Value
+        ( LengthSupported
+            { auto : Supported
+            , pct : Supported
+            , num : Supported
+            }
+        )
+    -> Value
+        ( LengthSupported
+            { auto : Supported
+            , pct : Supported
+            , num : Supported
+            }
+        )
+    -> Value
+        ( LengthSupported
+            { auto : Supported
+            , pct : Supported
+            , num : Supported
+            }
+        )
+    -> Value
+        ( LengthSupported
+            { auto : Supported
+            , pct : Supported
+            , num : Supported
+            }
+        )
+    -> Style
+maskBorderWidth4 (Value valTop) (Value valRight) (Value valBottom) (Value valLeft) =
+    AppendProperty <|
+        "mask-border-width:"
+        ++ valTop
+        ++ " "
+        ++ valRight
+        ++ " "
+        ++ valBottom
+        ++ " "
+        ++ valLeft
+
 
 {-| The 1-argument variant of the [`mask-clip`](https://css-tricks.com/almanac/properties/m/mask-clip/)
 property.
@@ -17050,12 +17515,13 @@ exclude =
     Value "exclude"
 
 
-
-{-| Sets `alpha` value for usage with [`maskMode`](#maskMode) and [`maskType`](#maskType).
+{-| Sets `alpha` value for usage with [`maskMode`](#maskMode), [`maskType`](#maskType) and [`maskBorderMode`](#maskBorderMode).
 
     maskMode alpha
 
     maskType alpha
+
+    maskBorderMode alpha
 
 -}
 alpha : Value { provides | alpha : Supported }
@@ -17063,11 +17529,13 @@ alpha =
     Value "alpha"
 
 
-{-| Sets `luminance` value for usage with [`maskMode`](#maskMode) and [`maskType`](#maskType).
+{-| Sets `luminance` value for usage with [`maskMode`](#maskMode), [`maskType`](#maskType) and [`maskBorderMode`](#maskBorderMode).
 
     maskMode luminance
 
     maskType luminance
+
+    maskBorderMode luminance
 
 -}
 luminance : Value { provides | luminance : Supported }

--- a/src/Css.elm
+++ b/src/Css.elm
@@ -2839,7 +2839,7 @@ type alias BoxShadowConfig =
             )
     , color :
         Maybe (Value Color)
-    , inset_ : Bool
+    , inset : Bool
     }
 
 
@@ -2857,7 +2857,7 @@ defaultBoxShadow =
     , blurRadius = Nothing
     , spreadRadius = Nothing
     , color = Nothing
-    , inset_ = False
+    , inset = False
     }
 
 
@@ -2877,12 +2877,12 @@ boxShadow (Value val) =
 
 {-| Sets [`box-shadow`](https://css-tricks.com/almanac/properties/b/box-shadow/).
 
-    boxShadow [] -- "box-shadow: none"
+    boxShadows [] -- "box-shadow: none"
 
     -- "box-shadow: 3px 5px #aabbcc"
     button
         [ css
-            [ boxShadow
+            [ boxShadows
                 [ { defaultBoxShadow
                     | offsetX = px 3
                     , offsetY = px 5
@@ -2941,7 +2941,7 @@ boxShadowConfigToString config =
                     ""
 
         insetStr =
-            if config.inset_ then
+            if config.inset then
                 "inset "
 
             else
@@ -8191,6 +8191,8 @@ ridge =
 {-| The `inset` value used by properties such as [`borderStyle`](#borderStyle),
 [`columnRuleStyle`](#columnRuleStyle), and [`textDecorationStyle`](#textDecorationStyle).
 
+This is called `inset_` rather than `inset` because [`inset` is already a function](#inset).
+
     borderStyle inset_
 
     columnRuleStyle inset_
@@ -10562,6 +10564,9 @@ strokeWidth (Value val) =
 
 
 {-| Sets [`stroke-align`](https://www.w3.org/TR/fill-stroke-3/#propdef-stroke-align)
+
+**Note:** This function accepts `inset_` rather than `inset` because
+[`inset` is already a function](#inset).
 
       strokeAlign center
       strokeAlign inset_

--- a/src/Css.elm
+++ b/src/Css.elm
@@ -398,7 +398,6 @@ module Css exposing
 
     , opacity
 
-    , zoom
     
     , speak, spellOut
 
@@ -1129,11 +1128,6 @@ Other values you can use for flex item alignment:
 # Opacity
 
 @docs opacity
-
-
-# Viewport
-
-@docs zoom
 
 
 # Scroll
@@ -20668,29 +20662,6 @@ opacity :
     -> Style
 opacity (Value val) =
     AppendProperty ("opacity:" ++ val)
-
-
-{-| Sets [`zoom`](https://css-tricks.com/almanac/properties/z/zoom/)
-
-    zoom (pct 150)
-
-    zoom (num 1.5)
-
-    zoom normal
-
--}
-zoom :
-    BaseValue
-        { pct : Supported
-        , zero : Supported
-        , num : Supported
-        , normal : Supported
-        , calc : Supported
-        , auto : Supported
-        }
-    -> Style
-zoom (Value val) =
-    AppendProperty ("zoom:" ++ val)
 
 
 {-| Sets [`line-height`](https://css-tricks.com/almanac/properties/l/line-height/)

--- a/src/Css.elm
+++ b/src/Css.elm
@@ -58,7 +58,7 @@ module Css exposing
     , normal, strict, all_, both, always, scroll, column
     , content, fill_, stroke, text, style
     , clip, cover, contain_
-    , repeat, noRepeat, repeatX, repeatY, space, round
+    , repeat, noRepeat, repeatX, repeatY, space, round_
     , isolate, matchParent
 
     -- all
@@ -593,7 +593,8 @@ Sometimes these keywords mean other things too.
 @docs normal, strict, all_, both, always, scroll, column
 @docs content, fill_, stroke, text, style
 @docs clip, cover, contain_
-
+@docs repeat, noRepeat, repeatX, repeatY, space, round_
+@docs isolate, matchParent
 
 
 # Pseudo-Classes
@@ -645,9 +646,6 @@ Sometimes these keywords mean other things too.
 @docs backgroundImage, backgroundImages, backgroundPosition, backgroundPosition2, backgroundPosition3, backgroundPosition4, backgroundRepeat, backgroundRepeat2, backgroundSize, backgroundSize2
 
 @docs linearGradient, linearGradient2, stop, stop2, stop3, toBottom, toBottomLeft, toBottomRight, toLeft, toRight, toTop, toTopLeft, toTopRight
-
-@docs repeat, noRepeat, repeatX, repeatY, space, round
-
 
 # Shadows
 
@@ -4293,19 +4291,22 @@ space =
   - [`strokeRepeat`](#strokeRepeat)
   - [`strokeLinejoin`](#strokeLinejoin2)
 
+**This is called `round_` because `round` is a function
+word used in Elm Core's `Basics` module.**
+
 ```
-    backgroundRepeat round
+    backgroundRepeat round_
 
-    strokeLineCap round
+    strokeLineCap round_
 
-    strokeLinejoin2 miter round
+    strokeLinejoin2 miter round_
 
-    strokeRepeat round
+    strokeRepeat round_
 ```
 
 -}
-round : Value { provides | round : Supported }
-round =
+round_ : Value { provides | round_ : Supported }
+round_ =
     Value "round"
 
 
@@ -11174,7 +11175,7 @@ backgroundRepeat :
         , repeatX : Supported
         , repeatY : Supported
         , space : Supported
-        , round : Supported
+        , round_ : Supported
         , noRepeat : Supported
         }
     -> Style
@@ -11196,14 +11197,14 @@ backgroundRepeat2 :
     Value
         { repeat : Supported
         , space : Supported
-        , round : Supported
+        , round_ : Supported
         , noRepeat : Supported
         }
     ->
         Value
             { repeat : Supported
             , space : Supported
-            , round : Supported
+            , round_ : Supported
             , noRepeat : Supported
             }
     -> Style
@@ -19894,7 +19895,7 @@ maskBorderRepeat :
     BaseValue
         { stretch : Supported
         , repeat : Supported
-        , round : Supported
+        , round_ : Supported
         , space : Supported
         }
     -> Style
@@ -19911,13 +19912,13 @@ maskBorderRepeat2 :
     Value
         { stretch : Supported
         , repeat : Supported
-        , round : Supported
+        , round_ : Supported
         , space : Supported
         }
     -> Value
         { stretch : Supported
         , repeat : Supported
-        , round : Supported
+        , round_ : Supported
         , space : Supported
         }
     -> Style
@@ -20528,7 +20529,7 @@ maskRepeat :
     BaseValue
         { repeat : Supported
         , space : Supported
-        , round : Supported
+        , round_ : Supported
         , noRepeat : Supported
         }
     -> Style
@@ -20545,13 +20546,13 @@ maskRepeat2 :
     Value
         { repeat : Supported
         , space : Supported
-        , round : Supported
+        , round_ : Supported
         , noRepeat : Supported
         }
     -> Value
         { repeat : Supported
         , space : Supported
-        , round : Supported
+        , round_ : Supported
         , noRepeat : Supported
         }
     -> Style
@@ -20569,7 +20570,7 @@ maskRepeat2 (Value valX) (Value valY) =
 --         ( Value
 --             { repeat : Supported
 --             , space : Supported
---             , round : Supported
+--             , round_ : Supported
 --             , noRepeat : Supported
 --             }
 --         )
@@ -21227,7 +21228,7 @@ strokeRepeat :
         , repeatX : Supported
         , repeatY : Supported
         , space : Supported
-        , round : Supported
+        , round_ : Supported
         , noRepeat : Supported
         }
     -> Style
@@ -21249,14 +21250,14 @@ strokeRepeat2 :
     Value
         { repeat : Supported
         , space : Supported
-        , round : Supported
+        , round_ : Supported
         , noRepeat : Supported
         }
     ->
         Value
             { repeat : Supported
             , space : Supported
-            , round : Supported
+            , round_ : Supported
             , noRepeat : Supported
             }
     -> Style
@@ -21353,7 +21354,7 @@ strokeLinecap :
     BaseValue
         { butt : Supported
         , square : Supported
-        , round : Supported
+        , round_ : Supported
         }
     -> Style
 strokeLinecap (Value val) =
@@ -21507,7 +21508,7 @@ strokeLinejoin2 :
     ->
         Value
             { bevel : Supported
-            , round : Supported
+            , round_ : Supported
             , fallback : Supported
             }
     -> Style

--- a/src/Css.elm
+++ b/src/Css.elm
@@ -353,6 +353,7 @@ module Css exposing
 
     -- scrollbar customisation
     , scrollbarColor, scrollbarWidth
+    , scrollbarGutter, scrollbarGutter2, stable, bothEdges
 
     -- scrolling behavior
     , scrollBehavior, smooth
@@ -1233,6 +1234,7 @@ Other values you can use for flex item alignment:
 # Scrollbar customisation
 
 @docs scrollbarColor, scrollbarWidth
+@docs scrollbarGutter, scrollbarGutter2, stable, bothEdges
 
 
 ------------------------------------------------------
@@ -17034,6 +17036,66 @@ scrollbarWidth :
     -> Style
 scrollbarWidth (Value val) =
     AppendProperty ("scrollbar-width:" ++ val)
+
+
+{-| The [`scrollbar-gutter`](https://css-tricks.com/almanac/properties/s/scrollbar-gutter/)
+property.
+
+This 1-argument variant can accept global values and some keywords.
+
+    scrollbarGutter auto
+
+    scrollbarGutter inherit
+    
+    scrollbarGutter2 stable bothEdges
+-}
+scrollbarGutter :
+    BaseValue
+        { auto : Supported
+        , stable : Supported
+        }
+    -> Style
+scrollbarGutter (Value val) =
+    AppendProperty ("scrollbar-gutter:" ++ val)
+
+
+{-| The [`scrollbar-gutter`](https://css-tricks.com/almanac/properties/s/scrollbar-gutter/)
+property.
+
+This 2-argument variant can only accept the keywords `stable` and `bothEdges`.
+
+    scrollbarGutter auto
+
+    scrollbarGutter inherit
+
+    scrollbarGutter2 stable bothEdges
+-}
+scrollbarGutter2 :
+    Value { stable : Supported }
+    -> Value { bothEdges : Supported }
+    -> Style
+scrollbarGutter2 (Value val1) (Value val2) =
+    AppendProperty ("scrollbar-gutter:" ++ val1 ++ " " ++ val2)
+
+
+{-| The `stable` value used by [`scrollbarGutter`](#scrollbarGutter).
+
+    scrollbarGutter stable
+
+-}
+stable : Value { provides | stable : Supported }
+stable =
+    Value "stable"
+
+
+{-| The `both-edges` value used by [`scrollbarGutter`](#scrollbarGutter).
+
+    scrollbarGutter2 stable bothEdges
+
+-}
+bothEdges : Value { provides | bothEdges : Supported }
+bothEdges =
+    Value "both-edges"
 
 
 ------------------------------------------------------------------------

--- a/src/Css.elm
+++ b/src/Css.elm
@@ -12,24 +12,29 @@ module Css exposing
     , Time, TimeSupported, s, ms
     , deg, grad, rad, turn
     , url
-    , auto, none, normal, strict, all_, both, always
-    , hidden, visible
+    , auto, none
+    , left_, right_, top_, bottom_
+    , block, inline, start, end, blockStart, blockEnd, inlineStart, inlineEnd
+    , x, y, z
+    , stretch, center
     , contentBox, borderBox, paddingBox
-    , left_, right_, top_, bottom_, block, inline, start, end, column
-    , x, y
-    , stretch, center, content, fill_, stroke, text, style
-    , clip, cover, contain_
     , baseline, sub, super, ruby, fullWidth, under, circle
-    , pseudoClass, active, checked, disabled, empty, enabled
+    , hidden, visible
+    , normal, strict, all_, both, always, scroll, column
+    , content, fill_, stroke, text, style
+    , clip, cover, contain_
+    , pseudoClass
+    , active, checked, disabled, empty, enabled
     , firstChild, firstOfType, focus, fullscreen, hover, inRange
     , indeterminate, invalid, lastChild, lastOfType, link, onlyChild
     , onlyOfType, outOfRange, readOnly, readWrite, required
     , root, scope, target, valid, visited
-    , pseudoElement, before, after, backdrop, cue, marker, placeholder, selection
+    , pseudoElement
+    , before, after, backdrop, cue, marker, placeholder, selection
     , width, minWidth, maxWidth, height, minHeight, maxHeight
     , blockSize, minBlockSize, maxBlockSize, inlineSize, minInlineSize, maxInlineSize
     , minContent, maxContent, fitContent
-    , backgroundAttachment, backgroundAttachments, scroll, local
+    , backgroundAttachment, backgroundAttachments, local
     , backgroundBlendMode, backgroundBlendModes, multiply, screen, overlay, darken, lighten, colorDodge, colorBurn, hardLight, softLight, difference, exclusion, hue, saturation, color_, luminosity
     , backgroundClip, backgroundClips, backgroundOrigin, backgroundOrigins
     , ImageSupported, Image
@@ -148,7 +153,7 @@ module Css exposing
     , wordBreak
     , breakAll, keepAll
     , float
-    , clear, inlineStart, inlineEnd
+    , clear
     , visibility
     , fill
     , strokeDasharray, strokeDashoffset, strokeWidth, strokeAlign, strokeColor, strokeImage, strokeMiterlimit, strokeOpacity, strokePosition, strokePosition2, strokePosition4, strokeRepeat, strokeRepeat2, strokeSize, strokeSize2, strokeDashCorner
@@ -166,7 +171,7 @@ module Css exposing
     , matrix, matrix3d
     , perspective, perspectiveOrigin, perspectiveOrigin2
     , perspective_
-    , rotate, rotate2, rotate_, rotateX, rotateY, rotateZ, rotate3d, vec3, z
+    , rotate, rotate2, rotate_, rotateX, rotateY, rotateZ, rotate3d, vec3
     , scale, scale2, scale3, scale_, scale2_, scaleX, scaleY, scaleZ, scale3d
     , skew, skew2, skewX, skewY
     , translate, translate2, translateX, translateY, translateZ, translate3d
@@ -232,7 +237,7 @@ functions let you define custom properties and selectors, respectively.
 
 # General Values
 
-All CSS properties can have the values `unset`, `initial`, and `inherit`.
+All CSS properties can have the values `unset`, `initial`, `inherit` and `revert`.
 
 @docs unset, initial, inherit
 
@@ -271,22 +276,65 @@ All CSS properties can have the values `unset`, `initial`, and `inherit`.
 @docs url
 
 
-# Shared Keywords
 
-Many different kinds of CSS properties use these keyword values.
 
-@docs auto, none, normal, strict, all_, both, always
-@docs hidden, visible
+# Shared/Grouped keyword values
+
+Many different kinds of CSS properties use the same keyword values,
+so they're put in this place for easier understanding.
+
+Some of these keywords are used only in one property but they fit
+into a group of functionality (like Logical Values), so they're also grouped here.
+
+
+## Very common keywords
+
+@docs auto, none
+
+## (usually) Absolute positional values
+
+@docs left_, right_, top_, bottom_
+
+## (usually) Logical Values
+
+Logical values are those that set properties by their relation to the user's reading direction.
+
+Sometimes these keywords mean other things too.
+
+@docs block, inline, start, end, blockStart, blockEnd, inlineStart, inlineEnd
+
+## Axis values
+
+@docs x, y, z
+
+## Alignment values
+
+@docs stretch, center
+
+## Sizing, clip and origin values
+
 @docs contentBox, borderBox, paddingBox
-@docs left_, right_, top_, bottom_, block, inline, start, end, column
-@docs x, y
-@docs stretch, center, content, fill_, stroke, text, style
-@docs clip, cover, contain_
+
+## Typographic values
+
 @docs baseline, sub, super, ruby, fullWidth, under, circle
+
+## Visibility
+
+@docs hidden, visible
+
+## Miscellaneous shared
+
+@docs normal, strict, all_, both, always, scroll, column
+@docs content, fill_, stroke, text, style
+@docs clip, cover, contain_
+
+
 
 # Pseudo-Classes
 
-@docs pseudoClass, active, checked, disabled, empty, enabled
+@docs pseudoClass
+@docs active, checked, disabled, empty, enabled
 @docs firstChild, firstOfType, focus, fullscreen, hover, inRange
 @docs indeterminate, invalid, lastChild, lastOfType, link, onlyChild
 @docs onlyOfType, outOfRange, readOnly, readWrite, required
@@ -295,7 +343,8 @@ Many different kinds of CSS properties use these keyword values.
 
 # Pseudo-Elements
 
-@docs pseudoElement, before, after, backdrop, cue, marker, placeholder, selection
+@docs pseudoElement
+@docs before, after, backdrop, cue, marker, placeholder, selection
 
 
 # Sizing
@@ -310,7 +359,7 @@ Many different kinds of CSS properties use these keyword values.
 
 ## Background Attachment
 
-@docs backgroundAttachment, backgroundAttachments, scroll, local
+@docs backgroundAttachment, backgroundAttachments, local
 
 
 ## Background Blend Mode
@@ -743,7 +792,7 @@ Other values you can use for flex item alignment:
 ## Float
 
 @docs float
-@docs clear, inlineStart, inlineEnd
+@docs clear
 
 
 # Visibility
@@ -800,7 +849,7 @@ Other values you can use for flex item alignment:
 
 ## Rotation
 
-@docs rotate, rotate2, rotate_, rotateX, rotateY, rotateZ, rotate3d, vec3, z
+@docs rotate, rotate2, rotate_, rotateX, rotateY, rotateZ, rotate3d, vec3
 
 
 ## Scaling (resizing)
@@ -1305,7 +1354,7 @@ url str =
 -- SHARED VALUES --
 
 
-{-| The `auto` value used in many properties such as [`width`](#width),
+{-| The `auto` value used in many properties such as (but not limited to) [`width`](#width),
 [`zoom`](#zoom),
 [`outlineStyle`](#outlineStyle),
 and [`flexBasis`](#flexBasis).
@@ -1322,7 +1371,7 @@ auto =
     Value "auto"
 
 
-{-| The `none` value used in many properties such as [`display`](#display),
+{-| The `none` value used in many properties such as (but not limited to) [`display`](#display),
 [`borderStyle`](#borderStyle),
 [`maxWidth`](#maxWidth),
 [`clear`](#clear),
@@ -1343,128 +1392,375 @@ none =
     Value "none"
 
 
-{-| The `normal` value, which can be used with such properties as:
 
-  - [`fontVariantCaps`](#fontVariantCaps)
-  - [`fontKerning`](#fontKerning)
-  - [`fontLanguageOverride`](#fontLanguageOverride)
-  - [`whiteSpace`](#whiteSpace)
-  - [`wordBreak`](#wordBreak)
-  - [`columnGap`](#columnGap)
-  - [`zoom`](#zoom)
-  - [`animationDirection`](#animationDirection)
+{-| The `left` value, used in many properties such as:
+
+  - [`backgroundPosition`](#backgroundPosition)
+  - [`clear`](#clear)
+  - [`float`](#float)
+  - [`justifyContent`](#justifyContent)
+  - [`justifyItems`](#justifyItems)
+  - [`justifySelf`](#justifySelf)
+  - [`pageBreakAfter`](#pageBreakAfter)
+  - [`textAlign`](#textAlign)
+
+```
+backgroundPosition left_
+
+clear left_
+
+float left_
+
+justifyContent left_
+
+justifyItems left_
+
+justifySelf left_
+
+pageBreakAfter left_
+
+textAlign left_
+```
+
+The value is called `left_` instead of `left` because [`left` is already a property function](#left).
+
+-}
+left_ : Value { provides | left_ : Supported }
+left_ =
+    Value "left"
+
+
+{-| The `right` value, used in many properties such as:
+
+  - [`backgroundPosition`](#backgroundPosition)
+  - [`clear`](#clear)
+  - [`float`](#float)
+  - [`justifyContent`](#justifyContent)
+  - [`justifyItems`](#justifyItems)
+  - [`justifySelf`](#justifySelf)
+  - [`pageBreakAfter`](#pageBreakAfter)
+  - [`textAlign`](#textAlign)
+
+```
+backgroundPosition right_
+
+clear right_
+
+float right_
+
+justifyContent right_
+
+justifyItems right_
+
+justifySelf right_
+
+pageBreakAfter right_
+
+textAlign right_
+```
+
+The value is called `right_` instead of `right` because [`right` is already a property function](#right).
+
+-}
+right_ : Value { provides | right_ : Supported }
+right_ =
+    Value "right"
+
+
+{-| The `top` value, used in the following properties:
+
+  - [`backgroundPosition`](#backgroundPosition)
+  - [`captionSide`](#captionSide)
+  - [`objectPosition2`](#objectPosition2)
+  - [`perspectiveOrigin2`](#perspectiveOrigin2)
+  - [`strokePosition2`](#strokePosition2)
+  - [`transformOrigin`](#transformOrigin)
+  - [`verticalAlign`](#verticalAlign)
+
+```
+backgroundPosition top_
+
+captionSide top_
+
+objectPosition2 right_ top_
+
+perspectiveOrigin2 left_ top_
+
+transformOrigin top_
+
+verticalAlign top_
+```
+
+The value is called `top_` instead of `top` because [`top` is already a property function](#top).
+
+-}
+top_ : Value { provides | top_ : Supported }
+top_ =
+    Value "top"
+
+
+{-| The `bottom` value, used in the following properties:
+
+  - [`backgroundPosition`](#backgroundPosition)
+  - [`captionSide`](#captionSide)
+  - [`objectPosition2`](#objectPosition2)
+  - [`perspectiveOrigin2`](#perspectiveOrigin2)
+  - [`strokePosition2`](#strokePosition2)
+  - [`transformOrigin`](#transformOrigin)
+  - [`verticalAlign`](#verticalAlign)
+
+```
+backgroundPosition bottom_
+
+captionSide bottom_
+
+objectPosition2 right_ bottom_
+
+perspectiveOrigin2 left_ bottom_
+
+transformOrigin bottom_
+
+verticalAlign bottom_
+```
+
+The value is called `bottom_` instead of `bottom` because [`bottom` is already a property function](#bottom).
+
+-}
+bottom_ : Value { provides | bottom_ : Supported }
+bottom_ =
+    Value "bottom"
+
+
+{-| The `block` value.
+
+This is a [CSS Logical value](https://css-tricks.com/css-logical-properties-and-values/) used by [`display`](#display) and [`resize`](#resize).
+
+
+    display block
+
+    resize block
+
+-}
+block : Value { provides | block : Supported }
+block =
+    Value "block"
+
+
+{-| The `inline` value.
+
+This is a [CSS Logical value](https://css-tricks.com/css-logical-properties-and-values/) used by [`display`](#display) and [`resize`](#resize).
+
+    display inline
+
+    resize inline
+
+-}
+inline : Value { provides | inline : Supported }
+inline =
+    Value "inline"
+
+
+{-| The `start` value.
+
+It's used in the following properties as a [CSS Logical value](https://css-tricks.com/css-logical-properties-and-values/):
+
   - [`alignItems`](#alignItems)
-  - [`lineBreak`](#lineBreak)
+  - [`alignContent`](#alignContent)
+  - [`alignSelf`](#alignSelf)
+  - [`justifyContent`](#justifyContent)
+  - [`justifyItems`](#justifyItems)
+  - [`justifySelf`](#justifySelf)
+
 
 ```
-alignItems normal
+alignContent start
 
-columnGap normal
+justifyItems estartnd
 
-fontVariantCaps normal
+```
 
-whiteSpace normal
+It's also used as an animation keyword used in [`steps2`](#steps2).
 
-wordBreak normal
-
-zoom normal
+```
+steps2 3 start
 ```
 
 -}
-normal : Value { provides | normal : Supported }
-normal =
-    Value "normal"
+start : Value { provides | start : Supported }
+start =
+    Value "start"
 
 
-{-| Sets `strict` value for usage with [`lineBreak`](#lineBreak) and [`contain`](#contain).
+{-| The `end` value.
 
-    contain strict
+It's used in the following properties as a [CSS Logical value](https://css-tricks.com/css-logical-properties-and-values/):
 
-    lineBreak strict
-
--}
-strict : Value { provides | strict : Supported }
-strict =
-    Value "strict"
-
-
-{-| The `all` value used in properties such as [`columnSpan`](#columnSpan)
-and [`pointerEvents`](#pointerEvents).
-
-    columnSpan all_
-
-    pointerEvents all_
-
--}
-all_ : Value { provides | all_ : Supported }
-all_ =
-    Value "all"
+  - [`alignItems`](#alignItems)
+  - [`alignContent`](#alignContent)
+  - [`alignSelf`](#alignSelf)
+  - [`justifyContent`](#justifyContent)
+  - [`justifyItems`](#justifyItems)
+  - [`justifySelf`](#justifySelf)
 
 
-{-| Sets `both` value for usage with [`clear`](#clear) and [`resize`](#resize).
+```
+alignContent end
 
-      clear both
+justifyItems end
 
-      resize both
+```
+
+It's also used as an animation keyword used in [`steps2`](#steps2).
+
+```
+steps2 3 end
+```
 
 -}
-both : Value { provides | both : Supported }
-both =
-    Value "both"
+end : Value { provides | end : Supported }
+end =
+    Value "end"
 
 
-{-| Sets `always` value for usage with [`scrollSnapStop`](#scrollSnapStop), [`pageBreakBefore`](#pageBreakBefore), and [`pageBreakAfter`](#pageBreakAfter).
+{-| The `block-start` value, which is a [CSS Logical value](https://css-tricks.com/css-logical-properties-and-values/).
+It can be used with [`captionSide`](#captionSide).
 
-    scrollSnapStop always
+    captionSide blockStart
+-}
+blockStart : Value { provides | blockEnd : Supported }
+blockStart =
+    Value "block-start"
 
-    pageBreakBefore always
 
-    pageBreakAfter always
+{-| The `block-end` value, which is a [CSS Logical value](https://css-tricks.com/css-logical-properties-and-values/).
+It can be used with [`captionSide`](#captionSide).
+
+    captionSide blockEnd
+-}
+blockEnd : Value { provides | blockEnd : Supported }
+blockEnd =
+    Value "block-end"
+
+
+{-| Sets `inline-start`, which is a [CSS Logical value](https://css-tricks.com/css-logical-properties-and-values/).
+It can be used with the following properties:
+
+- [`captionSide`](#captionSide)
+- [`clear`](#clear)
+- [`float`](#float)
+
+```
+    clear inlineStart
+
+    captionSide inlineStart
+
+    float inlineStart
+```
+-}
+inlineStart : Value { provides | inlineStart : Supported }
+inlineStart =
+    Value "inline-start"
+
+
+{-| Sets `inline-end`, which is a [CSS Logical value](https://css-tricks.com/css-logical-properties-and-values/).
+It can be used with the following properties:
+
+- [`captionSide`](#captionSide)
+- [`clear`](#clear)
+- [`float`](#float)
+
+```
+    clear inlineEnd
+
+    captionSide inlineEnd
+
+    float inlineEnd
+```
+-}
+inlineEnd : Value { provides | inlineEnd : Supported }
+inlineEnd =
+    Value "inline-end"
+
+
+{-| Sets `x` value for usage with [`scrollSnapType2`](#scrollSnapType2)
+and [`rotate2`](#rotate2).
+
+    scrollSnapType2 x mandatory
+
+    rotate x (deg 10)
 
 -}
-always : Value { provides | always : Supported }
-always =
-    Value "always"
+x : Value { provides | x : Supported }
+x =
+    Value "x"
 
 
-{-| The `hidden` value used for properties such as [`visibility`](https://css-tricks.com/almanac/properties/v/visibility/), [`overflow`](https://css-tricks.com/almanac/properties/o/overflow/) and [`borderStyle`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-style).
+{-| Sets `y` value for usage with [`scrollSnapType2`](#scrollSnapType2)
+and [`rotate2`](#rotate2).
 
-    visibility hidden
+    scrollSnapType2 y mandatory
 
-    overflow hidden
-
-    borderStyle hidden
-
--}
-hidden : Value { provides | hidden : Supported }
-hidden =
-    Value "hidden"
-
-
-{-| The `visible` value used for properties such as [`visibility`](https://css-tricks.com/almanac/properties/v/visibility/), [`overflow`](https://css-tricks.com/almanac/properties/o/overflow/) and [`pointer-events`](https://developer.mozilla.org/en-US/docs/Web/CSS/pointer-events).
-
-    visibility visible
-
-    overflow visible
-
-    pointerEvents visible
+    rotate y (deg 50)
 
 -}
-visible : Value { provides | visible : Supported }
-visible =
-    Value "visible"
+y : Value { provides | y : Supported }
+y =
+    Value "y"
 
 
-{-| The `scroll` value used for properties such as [`overflow`](https://developer.mozilla.org/en-US/docs/Web/CSS/overflow#Values) and [`background-attachment`](https://developer.mozilla.org/en-US/docs/Web/CSS/background-attachment).
+{-| Sets `z` value for usage with [`rotate2`](#rotate2).
 
-    overflow scroll
-
-    backgroundAttachment scroll
+    rotate z (deg 100)
 
 -}
-scroll : Value { provides | scroll : Supported }
-scroll =
-    Value "scroll"
+z : Value { provides | z : Supported }
+z =
+    Value "z"
+
+
+{-| The `stretch` value used in the following properties:
+
+  - [`alignContent`](#alignContent)
+  - [`alignItems`](#alignItems)
+  - [`alignSelf`](#alignSelf)
+  - [`justifyContent`](#justifyContent)
+  - [`justifyItems`](#justifyItems)
+  - [`justifySelf`](#justifySelf)
+  - [`strokeDashJustify`](#strokeDashJustify)
+
+```
+alignContent stretch
+
+strokeDashJustify stretch
+```
+
+-}
+stretch : Value { provides | stretch : Supported }
+stretch =
+    Value "stretch"
+
+
+{-| The `center` value, used in many properties such as:
+
+  - [`alignContent`](#alignContent)
+  - [`alignItems`](#alignItems)
+  - [`alignSelf`](#alignSelf)
+  - [`backgroundPosition`](#backgroundPosition)
+  - [`justifyContent`](#justifyContent)
+  - [`justifyItems`](#justifyItems)
+  - [`justifySelf`](#justifySelf)
+  - [`scrollSnapAlign`](#scrollSnapAlign)
+
+```
+backgroundPosition enter
+
+justifyContent center
+```
+
+-}
+center : Value { provides | center : Supported }
+center =
+    Value "center"
 
 
 {-| The `content-box` value, used in the following properties:
@@ -1529,432 +1825,6 @@ paddingBox =
     Value "padding-box"
 
 
-{-| The `left` value, used in many properties such as:
-
-  - [`backgroundPosition`](#backgroundPosition)
-  - [`clear`](#clear)
-  - [`float`](#float)
-  - [`justifyContent`](#justifyContent)
-  - [`justifyItems`](#justifyItems)
-  - [`justifySelf`](#justifySelf)
-  - [`pageBreakAfter`](#pageBreakAfter)
-  - [`textAlign`](#textAlign)
-
-```
-backgroundPosition left_
-
-clear left_
-
-float left_
-
-justifyContent left_
-
-justifyItems left_
-
-justifySelf left_
-
-pageBreakAfter left_
-
-textAlign left_
-```
-
-The value is called `left_` instead of `left` because [`left` is already a function](#left).
-
--}
-left_ : Value { provides | left_ : Supported }
-left_ =
-    Value "left"
-
-
-{-| The `right` value, used in many properties such as:
-
-  - [`backgroundPosition`](#backgroundPosition)
-  - [`clear`](#clear)
-  - [`float`](#float)
-  - [`justifyContent`](#justifyContent)
-  - [`justifyItems`](#justifyItems)
-  - [`justifySelf`](#justifySelf)
-  - [`pageBreakAfter`](#pageBreakAfter)
-  - [`textAlign`](#textAlign)
-
-```
-backgroundPosition right_
-
-clear right_
-
-float right_
-
-justifyContent right_
-
-justifyItems right_
-
-justifySelf right_
-
-pageBreakAfter right_
-
-textAlign right_
-```
-
-The value is called `right_` instead of `right` because [`right` is already a function](#right).
-
--}
-right_ : Value { provides | right_ : Supported }
-right_ =
-    Value "right"
-
-
-{-| The `top` value, used in the following properties:
-
-  - [`backgroundPosition`](#backgroundPosition)
-  - [`captionSide`](#captionSide)
-  - [`objectPosition2`](#objectPosition2)
-  - [`perspectiveOrigin2`](#perspectiveOrigin2)
-  - [`strokePosition2`](#strokePosition2)
-  - [`transformOrigin`](#transformOrigin)
-  - [`verticalAlign`](#verticalAlign)
-
-```
-backgroundPosition top_
-
-captionSide top_
-
-objectPosition2 right_ top_
-
-perspectiveOrigin2 left_ top_
-
-transformOrigin top_
-
-verticalAlign top_
-```
-
-The value is called `top_` instead of `top` because [`top` is already a function](#top).
-
--}
-top_ : Value { provides | top_ : Supported }
-top_ =
-    Value "top"
-
-
-{-| The `bottom` value, used in the following properties:
-
-  - [`backgroundPosition`](#backgroundPosition)
-  - [`captionSide`](#captionSide)
-  - [`objectPosition2`](#objectPosition2)
-  - [`perspectiveOrigin2`](#perspectiveOrigin2)
-  - [`strokePosition2`](#strokePosition2)
-  - [`transformOrigin`](#transformOrigin)
-  - [`verticalAlign`](#verticalAlign)
-
-```
-backgroundPosition bottom_
-
-captionSide bottom_
-
-objectPosition2 right_ bottom_
-
-perspectiveOrigin2 left_ bottom_
-
-transformOrigin bottom_
-
-verticalAlign bottom_
-```
-
-The value is called `bottom_` instead of `bottom` because [`bottom` is already a function](#bottom).
-
--}
-bottom_ : Value { provides | bottom_ : Supported }
-bottom_ =
-    Value "bottom"
-
-
-{-| The `block` value used by [`display`](#display) and [`resize`](#resize).
-
-    display block
-
-    resize block
-
--}
-block : Value { provides | block : Supported }
-block =
-    Value "block"
-
-
-{-| The `inline` value used by [`display`](#display) and [`resize`](#resize).
-
-    display inline
-
-    resize inline
-
--}
-inline : Value { provides | inline : Supported }
-inline =
-    Value "inline"
-
-
-{-| The `start` value, used in the following properties:
-
-  - [`alignItems`](#alignItems)
-  - [`alignContent`](#alignContent)
-  - [`alignSelf`](#alignSelf)
-  - [`justifyContent`](#justifyContent)
-  - [`justifyItems`](#justifyItems)
-  - [`justifySelf`](#justifySelf)
-  - [`steps2`](#steps2)
-
-```
-alignContent start
-
-steps2 3 start
-```
-
--}
-start : Value { provides | start : Supported }
-start =
-    Value "start"
-
-
-{-| The `end` value, used in the following properties:
-
-  - [`alignItems`](#alignItems)
-  - [`alignContent`](#alignContent)
-  - [`alignSelf`](#alignSelf)
-  - [`justifyContent`](#justifyContent)
-  - [`justifyItems`](#justifyItems)
-  - [`justifySelf`](#justifySelf)
-  - [`steps2`](#steps2)
-
-```
-alignContent end
-
-steps2 3 end
-```
-
--}
-end : Value { provides | end : Supported }
-end =
-    Value "end"
-
-
-{-| The `column` value, used in [`flex-direction`](#flexDirection),
-[`break-before`](#breakBefore) and [`break-after`](#breakAfter) properties.
-
-    flexDirection column
-
-    breakBefore column
-
-    breakAfter column
-
--}
-column : Value { provides | column : Supported }
-column =
-    Value "column"
-
-
-{-| Sets `x` value for usage with [`scrollSnapType2`](#scrollSnapType2)
-and [`rotate2`](#rotate2).
-
-    scrollSnapType2 x mandatory
-
-    rotate x (deg 10)
-
--}
-x : Value { provides | x : Supported }
-x =
-    Value "x"
-
-
-{-| Sets `y` value for usage with [`scrollSnapType2`](#scrollSnapType2)
-and [`rotate2`](#rotate2).
-
-    scrollSnapType2 y mandatory
-
-    rotate y (deg 50)
-
--}
-y : Value { provides | y : Supported }
-y =
-    Value "y"
-
-
-{-| The `stretch` value used in the following properties:
-
-  - [`alignContent`](#alignContent)
-  - [`alignItems`](#alignItems)
-  - [`alignSelf`](#alignSelf)
-  - [`justifyContent`](#justifyContent)
-  - [`justifyItems`](#justifyItems)
-  - [`justifySelf`](#justifySelf)
-  - [`strokeDashJustify`](#strokeDashJustify)
-
-```
-alignContent stretch
-
-strokeDashJustify stretch
-```
-
--}
-stretch : Value { provides | stretch : Supported }
-stretch =
-    Value "stretch"
-
-
-{-| The `center` value, used in many properties such as:
-
-  - [`alignContent`](#alignContent)
-  - [`alignItems`](#alignItems)
-  - [`alignSelf`](#alignSelf)
-  - [`backgroundPosition`](#backgroundPosition)
-  - [`justifyContent`](#justifyContent)
-  - [`justifyItems`](#justifyItems)
-  - [`justifySelf`](#justifySelf)
-  - [`scrollSnapAlign`](#scrollSnapAlign)
-
-```
-backgroundPosition enter
-
-justifyContent center
-```
-
--}
-center : Value { provides | center : Supported }
-center =
-    Value "center"
-
-
-{-| The `content` value used in the following properties:
-
-  - [`flex`](#flex)
-  - [`flex-basis`](#flexBasis)
-  - [`contain`](#contain)
-
-```
-flexBasis content
-
-contain content
-```
-
--}
-content : Value { provides | content : Supported }
-content =
-    Value "content"
-
-
-{-| The `fill` value used in properties such as [`objectFit`](#objectFit),
-[`pointerEvents`](#pointerEvents) and [`paintOrder`](#paintOrder).
-
-    objectFit fill_
-
-    pointerEvents fill_
-
-    paintOrder2 fill_ markers
-
--}
-fill_ : Value { provides | fill_ : Supported }
-fill_ =
-    Value "fill"
-
-
-{-| The `stroke` value used by [`pointerEvents`](#pointerEvents) and [`paintOrder`](#paintOrder).
-
-    pointerEvents stroke
-
-    paintOrder2 stroke markers
-
--}
-stroke : Value { provides | stroke : Supported }
-stroke =
-    Value "stroke"
-
-
-{-| The `text` value for the [`cursor`](#cursor),
-[`backgroundClip`](#backgroundClip),
-and [`user-select`](#userSelect) properties.
-
-    backgroundClip text
-
-    cursor text
-
-    userSelect text
-
--}
-text : Value { provides | text : Supported }
-text =
-    Value "text"
-
-
-{-| Sets the `style` value for:
-
-  - [`contain`](#contain). **(This value is considered at-risk from being depreciated for this property.)**
-  - [`fontSynthesis`](#fontSynthesis)
-
-```
-    contain style
-
-    fontSynthesis style
-```
-
--}
-style : Value { provides | style : Supported }
-style =
-    Value "style"
-
-
-{-| The `clip` value used by [`overflow`](#overflow) and [`textOverflow`](#textOverflow).
-
-    overflow clip
-
-    overflowX clip
-
-    overflowY clip
-
-    textOverflow clip
-
--}
-clip : Value { provides | clip : Supported }
-clip =
-    Value "clip"
-
-
-{-| Sets `contain` for the following properties:
-
-  - [`backgroundSize`](#backgroundSize) (It always show the whole background
-    image, even if it leaves empty spaces on the sides.)
-  - [`objectFit`](#objectFit) (Replaced content is scaled to maintain proportions within the element's content box.)
-  - [`userSelect`](#userSelect) (Lets selection start within the element but that selection will be contained within that element's bounds.)
-  - [`overscrollBehavior`](#overscrollBehavior) (This means that default scroll overflow behavior
-    is observed inside the element, but scroll chaining will not happen to neighbouring elements.)
-
-```
-backgroundSize contain_
-
-overscrollBehavior contain_
-```
-
-The value is called `contain_` instead of `contain` because [`contain`](#contain) is already a function.
-
--}
-contain_ : Value { provides | contain_ : Supported }
-contain_ =
-    Value "contain"
-
-
-{-| Sets `cover` for the following properties:
-
-  - [`backgroundSize`](#backgroundSize)
-  - [`objectFit`](#objectFit)
-  - [`strokeDashCorner`](#strokeDashCorner)
-  - [`strokeSize`](#strokeSize)
-
-```
-backgroundSize cover
-
-strokeSize cover
-```
-
--}
-cover : Value { provides | cover : Supported }
-cover =
-    Value "cover"
 
 
 {-| The `baseline` value, used in the following properties:
@@ -2071,6 +1941,285 @@ under =
 circle : Value { provides | circle : Supported }
 circle =
     Value "circle"
+
+
+{-| The `hidden` value used for properties such as [`visibility`](https://css-tricks.com/almanac/properties/v/visibility/), [`overflow`](https://css-tricks.com/almanac/properties/o/overflow/) and [`borderStyle`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-style).
+
+    visibility hidden
+
+    overflow hidden
+
+    borderStyle hidden
+
+-}
+hidden : Value { provides | hidden : Supported }
+hidden =
+    Value "hidden"
+
+
+{-| The `visible` value used for properties such as [`visibility`](https://css-tricks.com/almanac/properties/v/visibility/), [`overflow`](https://css-tricks.com/almanac/properties/o/overflow/) and [`pointer-events`](https://developer.mozilla.org/en-US/docs/Web/CSS/pointer-events).
+
+    visibility visible
+
+    overflow visible
+
+    pointerEvents visible
+
+-}
+visible : Value { provides | visible : Supported }
+visible =
+    Value "visible"
+
+
+{-| The `normal` value, which can be used with such properties as:
+
+  - [`fontVariantCaps`](#fontVariantCaps)
+  - [`fontKerning`](#fontKerning)
+  - [`fontLanguageOverride`](#fontLanguageOverride)
+  - [`whiteSpace`](#whiteSpace)
+  - [`wordBreak`](#wordBreak)
+  - [`columnGap`](#columnGap)
+  - [`zoom`](#zoom)
+  - [`animationDirection`](#animationDirection)
+  - [`alignItems`](#alignItems)
+  - [`lineBreak`](#lineBreak)
+
+```
+alignItems normal
+
+columnGap normal
+
+fontVariantCaps normal
+
+whiteSpace normal
+
+wordBreak normal
+
+zoom normal
+```
+
+-}
+normal : Value { provides | normal : Supported }
+normal =
+    Value "normal"
+
+
+{-| Sets `strict` value for usage with [`lineBreak`](#lineBreak) and [`contain`](#contain).
+
+    contain strict
+
+    lineBreak strict
+
+-}
+strict : Value { provides | strict : Supported }
+strict =
+    Value "strict"
+
+
+{-| The `all` value used in properties such as [`columnSpan`](#columnSpan)
+and [`pointerEvents`](#pointerEvents).
+
+    columnSpan all_
+
+    pointerEvents all_
+
+This value function has an underscore because [`all` is already a property function](#all).
+
+-}
+all_ : Value { provides | all_ : Supported }
+all_ =
+    Value "all"
+
+
+{-| Sets `both` value for usage with [`clear`](#clear) and [`resize`](#resize).
+
+      clear both
+
+      resize both
+
+-}
+both : Value { provides | both : Supported }
+both =
+    Value "both"
+
+
+{-| Sets `always` value for usage with [`scrollSnapStop`](#scrollSnapStop), [`pageBreakBefore`](#pageBreakBefore), and [`pageBreakAfter`](#pageBreakAfter).
+
+    scrollSnapStop always
+
+    pageBreakBefore always
+
+    pageBreakAfter always
+
+-}
+always : Value { provides | always : Supported }
+always =
+    Value "always"
+
+
+{-| The `scroll` value used for properties such as [`overflow`](https://developer.mozilla.org/en-US/docs/Web/CSS/overflow#Values) and [`background-attachment`](https://developer.mozilla.org/en-US/docs/Web/CSS/background-attachment).
+
+    overflow scroll
+
+    backgroundAttachment scroll
+
+-}
+scroll : Value { provides | scroll : Supported }
+scroll =
+    Value "scroll"
+
+
+{-| The `column` value, used in [`flex-direction`](#flexDirection),
+[`break-before`](#breakBefore) and [`break-after`](#breakAfter) properties.
+
+    flexDirection column
+
+    breakBefore column
+
+    breakAfter column
+
+-}
+column : Value { provides | column : Supported }
+column =
+    Value "column"
+
+
+{-| The `content` value used in the following properties:
+
+  - [`flex`](#flex)
+  - [`flex-basis`](#flexBasis)
+  - [`contain`](#contain)
+
+```
+flexBasis content
+
+contain content
+```
+
+-}
+content : Value { provides | content : Supported }
+content =
+    Value "content"
+
+
+{-| The `fill` value used in properties such as [`objectFit`](#objectFit),
+[`pointerEvents`](#pointerEvents) and [`paintOrder`](#paintOrder).
+
+    objectFit fill_
+
+    pointerEvents fill_
+
+    paintOrder2 fill_ markers
+
+-}
+fill_ : Value { provides | fill_ : Supported }
+fill_ =
+    Value "fill"
+
+
+{-| The `stroke` value used by [`pointerEvents`](#pointerEvents) and [`paintOrder`](#paintOrder).
+
+    pointerEvents stroke
+
+    paintOrder2 stroke markers
+
+-}
+stroke : Value { provides | stroke : Supported }
+stroke =
+    Value "stroke"
+
+
+{-| The `text` value for the [`cursor`](#cursor),
+[`backgroundClip`](#backgroundClip),
+and [`user-select`](#userSelect) properties.
+
+    backgroundClip text
+
+    cursor text
+
+    userSelect text
+
+-}
+text : Value { provides | text : Supported }
+text =
+    Value "text"
+
+
+{-| Sets the `style` value for:
+
+  - [`contain`](#contain). **(This value is considered at-risk from being depreciated for this property.)**
+  - [`fontSynthesis`](#fontSynthesis)
+
+```
+    contain style
+
+    fontSynthesis style
+```
+
+-}
+style : Value { provides | style : Supported }
+style =
+    Value "style"
+
+
+{-| The `clip` value used by [`overflow`](#overflow) and [`textOverflow`](#textOverflow).
+
+    overflow clip
+
+    overflowX clip
+
+    overflowY clip
+
+    textOverflow clip
+
+-}
+clip : Value { provides | clip : Supported }
+clip =
+    Value "clip"
+
+
+{-| Sets `cover` for the following properties:
+
+  - [`backgroundSize`](#backgroundSize)
+  - [`objectFit`](#objectFit)
+  - [`strokeDashCorner`](#strokeDashCorner)
+  - [`strokeSize`](#strokeSize)
+
+```
+backgroundSize cover
+
+strokeSize cover
+```
+
+-}
+cover : Value { provides | cover : Supported }
+cover =
+    Value "cover"
+
+
+{-| Sets `contain` for the following properties:
+
+  - [`backgroundSize`](#backgroundSize) (It always show the whole background
+    image, even if it leaves empty spaces on the sides.)
+  - [`objectFit`](#objectFit) (Replaced content is scaled to maintain proportions within the element's content box.)
+  - [`userSelect`](#userSelect) (Lets selection start within the element but that selection will be contained within that element's bounds.)
+  - [`overscrollBehavior`](#overscrollBehavior) (This means that default scroll overflow behavior
+    is observed inside the element, but scroll chaining will not happen to neighbouring elements.)
+
+```
+backgroundSize contain_
+
+overscrollBehavior contain_
+```
+
+The value is called `contain_` instead of `contain` because [`contain`](#contain) is already a property function.
+
+-}
+contain_ : Value { provides | contain_ : Supported }
+contain_ =
+    Value "contain"
+
+
 
 
 -- OVERFLOW --
@@ -4832,7 +4981,7 @@ dividedBy (Value second) =
 
     display block
 
-**Note:** This function accepts `flex_` rather than `flex` because [`flex` is already a function](#flex).
+**Note:** This function accepts `flex_` rather than `flex` because [`flex` is already a property function](#flex).
 
 -}
 display :
@@ -4875,7 +5024,7 @@ display (Value val) =
 
     display2 block flex_
 
-**Note:** This function accepts `flex_` rather than `flex` because [`flex` is already a function](#flex).
+**Note:** This function accepts `flex_` rather than `flex` because [`flex` is already a property function](#flex).
 For `display: inline list-item` and similar property values that include `list-item`
 look at [`displayListItem2`](#displayListItem2) and [`displayListItem3`](#displayListItem3).
 
@@ -4947,7 +5096,7 @@ displayListItem3 (Value displayOutside) (Value displayFlow) =
 
     display flex_
 
-The value is called `flex_` instead of `flex` because [`flex` is already a function](#flex).
+The value is called `flex_` instead of `flex` because [`flex` is already a property function](#flex).
 
 -}
 flex_ : Value { provides | flex_ : Supported }
@@ -10560,7 +10709,7 @@ ridge =
 {-| The `inset` value used by properties such as [`borderStyle`](#borderStyle),
 [`columnRuleStyle`](#columnRuleStyle), and [`textDecorationStyle`](#textDecorationStyle).
 
-This is called `inset_` rather than `inset` because [`inset` is already a function](#inset).
+This is called `inset_` rather than `inset` because [`inset` is already a property function](#inset).
 
     borderStyle inset_
 
@@ -12111,11 +12260,19 @@ borderSpacing2 (Value valHorizontal) (Value valVertical) =
 
     captionSide bottom_
 
+    captionSide blockStart
+
+    captionSide inlineEnd
+
 -}
 captionSide :
     BaseValue
         { top_ : Supported
         , bottom_ : Supported
+        , blockStart : Supported
+        , blockEnd : Supported
+        , inlineStart : Supported
+        , inlineEnd : Supported
         }
     -> Style
 captionSide (Value str) =
@@ -12538,12 +12695,16 @@ keepAll =
 
     float right_
 
+    float inlineStart
+
 -}
 float :
     BaseValue
         { none : Supported
         , left_ : Supported
         , right_ : Supported
+        , inlineStart : Supported
+        , inlineEnd : Supported
         }
     -> Style
 float (Value str) =
@@ -13011,7 +13172,7 @@ strokeWidth (Value val) =
 {-| Sets [`stroke-align`](https://www.w3.org/TR/fill-stroke-3/#propdef-stroke-align)
 
 **Note:** This function accepts `inset_` rather than `inset` because
-[`inset` is already a function](#inset).
+[`inset` is already a property function](#inset).
 
       strokeAlign center
       strokeAlign inset_
@@ -14084,7 +14245,7 @@ scale3 (Value xVal) (Value yVal) (Value zVal) =
 
     transform (scale_ 0.7)
 
-This is called `scale_` instead of `scale` because [`scale` is already a function](#scale).
+This is called `scale_` instead of `scale` because [`scale` is already a property function](#scale).
 
 -}
 scale_ : Float -> Value { provides | scale_ : Supported }
@@ -14096,7 +14257,7 @@ scale_ val =
 
     transform (scale2_ 0.7 0.7)
 
-This is called `scale2_` instead of `scale2` because [`scale2` is already a function](#scale2).
+This is called `scale2_` instead of `scale2` because [`scale2` is already a property function](#scale2).
 
 -}
 scale2_ : Float -> Float -> Value { provides | scale2_ : Supported }
@@ -14261,7 +14422,7 @@ rotate2 (Value axisOrVecVal) (Value angleVal) =
 
     transform (rotate_ (deg 30))
 
-This is called `rotate_` instead of `rotate` because [`rotate` is already a function](#rotate).
+This is called `rotate_` instead of `rotate` because [`rotate` is already a property function](#rotate).
 
 -}
 rotate_ :
@@ -14348,17 +14509,6 @@ vec3 vec1Val vec2Val vec3Val =
             ++ " "
             ++ String.fromFloat vec3Val
         )
-
-
-{-| Sets `z` value for usage with [`rotate2`](#rotate2).
-
-    rotate z (deg 100)
-
--}
-z : Value { provides | z : Supported }
-z =
-    Value "z"
-
 
 
 -- PERSPECTIVE
@@ -14452,7 +14602,7 @@ perspectiveOrigin2 (Value xVal) (Value yVal) =
     transform (perspective_ (px 17))
 
 The value is called `perspective_` instead of `perspective` because
-[`perspective`](#perspective) is already a function.
+[`perspective`](#perspective) is already a property function.
 
 -}
 perspective_ :
@@ -15062,26 +15212,6 @@ clear :
     -> Style
 clear (Value val) =
     AppendProperty ("clear:" ++ val)
-
-
-{-| Sets `inline-start` value for usage with [`clear`](#clear).
-
-      clear inlineStart
-
--}
-inlineStart : Value { provides | inlineStart : Supported }
-inlineStart =
-    Value "inline-start"
-
-
-{-| Sets `inline-end` value for usage with [`clear`](#clear).
-
-      clear inlineEnd
-
--}
-inlineEnd : Value { provides | inlineEnd : Supported }
-inlineEnd =
-    Value "inline-end"
 
 
 {-| Sets [`opacity`](https://css-tricks.com/almanac/properties/o/opacity/)

--- a/src/Css.elm
+++ b/src/Css.elm
@@ -13,6 +13,7 @@ module Css exposing
     , pseudoClass, active, disabled
     , pseudoElement, before, after
     , width, minWidth, maxWidth, height, minHeight, maxHeight
+    , blockSize, minBlockSize, maxBlockSize, inlineSize, minInlineSize, maxInlineSize
     , minContent, maxContent, fitContent
     , backgroundAttachment, backgroundAttachments, scroll, local
     , backgroundBlendMode, backgroundBlendModes, multiply, screen, overlay, darken, lighten, colorDodge, colorBurn, hardLight, softLight, difference, exclusion, hue, saturation, color_, luminosity
@@ -232,6 +233,7 @@ All CSS properties can have the values `unset`, `initial`, and `inherit`
 ## Sizing
 
 @docs width, minWidth, maxWidth, height, minHeight, maxHeight
+@docs blockSize, minBlockSize, maxBlockSize, inlineSize, minInlineSize, maxInlineSize
 @docs minContent, maxContent, fitContent
 
 
@@ -11876,7 +11878,7 @@ letterSpacing (Value val) =
     AppendProperty ("letter-spacing:" ++ val)
 
 
-{-| Sets [`width`](https://css-tricks.com/almanac/properties/w/width/).
+{-| The [`width`](https://css-tricks.com/almanac/properties/w/width/) property.
 
     width (px 150)
 
@@ -11887,12 +11889,22 @@ letterSpacing (Value val) =
     width minContent
 
 -}
-width : BaseValue Width -> Style
+width :
+    BaseValue
+        (LengthSupported
+            { pct : Supported
+            , auto : Supported
+            , maxContent : Supported
+            , minContent : Supported
+            , fitContent : Supported
+            }
+        )
+    -> Style
 width (Value size) =
     AppendProperty ("width:" ++ size)
 
 
-{-| Sets [`minWidth`](https://css-tricks.com/almanac/properties/m/min-width/).
+{-| The [`min-width`](https://css-tricks.com/almanac/properties/m/min-width/) property.
 
     minWidth (px 150)
 
@@ -11916,7 +11928,7 @@ minWidth (Value size) =
     AppendProperty ("min-width:" ++ size)
 
 
-{-| Sets [`maxWidth`](https://css-tricks.com/almanac/properties/m/max-width/).
+{-| The [`max-width`](https://css-tricks.com/almanac/properties/m/max-width/) property.
 
     maxWidth (px 150)
 
@@ -11940,60 +11952,22 @@ maxWidth (Value size) =
     AppendProperty ("max-width:" ++ size)
 
 
-{-| The `min-content` value used for properties such as [`width`](#width),
-[`minWidth`](#minWidth),
-[`maxWidth`](#maxWidth),
-[`height`](#height),
-[`minHeight`](#minHeight),
-[`maxHeight`](#maxHeight)
-and [`flexBasis`](#flexBasis)
-
-    width minContent
-
--}
-minContent : Value { provides | minContent : Supported }
-minContent =
-    Value "min-content"
-
-
-{-| The `max-content` value used for properties such as [`width`](#width),
-[`minWidth`](#minWidth),
-[`maxWidth`](#maxWidth),
-[`height`](#height),
-[`minHeight`](#minHeight),
-[`maxHeight`](#maxHeight)
-and [`flexBasis`](#flexBasis)
-
-    width maxContent
-
--}
-maxContent : Value { provides | maxContent : Supported }
-maxContent =
-    Value "max-content"
-
-
-{-| The `fit-content` value used for properties such as [`width`](#width),
-[`minWidth`](#minWidth),
-[`maxWidth`](#maxWidth),
-[`height`](#height),
-[`minHeight`](#minHeight),
-[`maxHeight`](#maxHeight)
-and [`flexBasis`](#flexBasis)
-
-    width fitContent
-
--}
-fitContent : Value { provides | fitContent : Supported }
-fitContent =
-    Value "fit-content"
-
-
 {-| The [`height`](https://css-tricks.com/almanac/properties/h/height/) property.
 
     height (px 34)
 
 -}
-height : BaseValue Width -> Style
+height :
+    BaseValue
+        (LengthSupported
+            { pct : Supported
+            , auto : Supported
+            , maxContent : Supported
+            , minContent : Supported
+            , fitContent : Supported
+            }
+        )
+    -> Style
 height (Value val) =
     AppendProperty ("height:" ++ val)
 
@@ -12036,6 +12010,168 @@ maxHeight :
     -> Style
 maxHeight (Value val) =
     AppendProperty ("max-height:" ++ val)
+
+
+{-| The [`block-size`](https://css-tricks.com/almanac/properties/b/block-size/) property.
+
+    blockSize (px 20)
+
+-}
+blockSize :
+    BaseValue
+        (LengthSupported
+            { pct : Supported
+            , none : Supported
+            , maxContent : Supported
+            , minContent : Supported
+            , fitContent : Supported
+            }
+        )
+    -> Style
+blockSize (Value val) =
+    AppendProperty ("block-size:" ++ val)
+
+
+{-| The [`min-block-size`](https://developer.mozilla.org/en-US/docs/Web/CSS/min-block-size) property.
+
+    minBlockSize (px 20)
+
+-}
+minBlockSize :
+    BaseValue
+        (LengthSupported
+            { pct : Supported
+            , none : Supported
+            , maxContent : Supported
+            , minContent : Supported
+            , fitContent : Supported
+            }
+        )
+    -> Style
+minBlockSize (Value val) =
+    AppendProperty ("min-block-size:" ++ val)
+
+
+{-| The [`max-block-size`](https://developer.mozilla.org/en-US/docs/Web/CSS/max-block-size) property.
+
+    maxBlockSize (px 20)
+
+-}
+maxBlockSize :
+    BaseValue
+        (LengthSupported
+            { pct : Supported
+            , none : Supported
+            , maxContent : Supported
+            , minContent : Supported
+            , fitContent : Supported
+            }
+        )
+    -> Style
+maxBlockSize (Value val) =
+    AppendProperty ("max-block-size:" ++ val)
+
+
+{-| The [`inline-size`](https://css-tricks.com/almanac/properties/i/inline-size/) property.
+
+    inlineSize (px 20)
+
+-}
+inlineSize :
+    BaseValue
+        (LengthSupported
+            { pct : Supported
+            , none : Supported
+            , maxContent : Supported
+            , minContent : Supported
+            , fitContent : Supported
+            }
+        )
+    -> Style
+inlineSize (Value val) =
+    AppendProperty ("inline-size:" ++ val)
+
+
+{-| The [`min-inline-size`](https://developer.mozilla.org/en-US/docs/Web/CSS/min-inline-size) property.
+
+    minInlineSize (px 20)
+
+-}
+minInlineSize :
+    BaseValue
+        (LengthSupported
+            { pct : Supported
+            , none : Supported
+            , maxContent : Supported
+            , minContent : Supported
+            , fitContent : Supported
+            }
+        )
+    -> Style
+minInlineSize (Value val) =
+    AppendProperty ("min-inline-size:" ++ val)
+
+
+{-| The [`max-inline-size`](https://developer.mozilla.org/en-US/docs/Web/CSS/max-inline-size) property.
+
+    maxInlineSize (px 20)
+
+-}
+maxInlineSize :
+    BaseValue
+        (LengthSupported
+            { pct : Supported
+            , none : Supported
+            , maxContent : Supported
+            , minContent : Supported
+            , fitContent : Supported
+            }
+        )
+    -> Style
+maxInlineSize (Value val) =
+    AppendProperty ("max-inline-size:" ++ val)
+
+
+{-| The `min-content` value used for properties such as: 
+
+- sizing (eg. [`width`](#width), [`height`](#height), [`inlineSize`](#inlineSize))
+- min/max sizing (eg. [`minWidth`](#minWidth), [`maxBlockWidth`](#maxBlockWidth))
+- [`flexBasis`](#flexBasis)
+
+    width minContent
+
+-}
+minContent : Value { provides | minContent : Supported }
+minContent =
+    Value "min-content"
+
+
+{-| The `max-content` value used for properties such as:
+
+- sizing (eg. [`width`](#width), [`height`](#height), [`inlineSize`](#inlineSize))
+- min/max sizing (eg. [`minWidth`](#minWidth), [`maxBlockWidth`](#maxBlockWidth))
+- [`flexBasis`](#flexBasis)
+
+    width maxContent
+
+-}
+maxContent : Value { provides | maxContent : Supported }
+maxContent =
+    Value "max-content"
+
+
+{-| The `fit-content` value used for properties such as:
+
+- sizing (eg. [`width`](#width), [`height`](#height), [`inlineSize`](#inlineSize))
+- min/max sizing (eg. [`minWidth`](#minWidth), [`maxBlockWidth`](#maxBlockWidth))
+- [`flexBasis`](#flexBasis)
+
+    width fitContent
+
+-}
+fitContent : Value { provides | fitContent : Supported }
+fitContent =
+    Value "fit-content"
 
 
 {-| Sets [`backface-visibility`](https://css-tricks.com/almanac/properties/b/backface-visibility/)

--- a/src/Css.elm
+++ b/src/Css.elm
@@ -35,7 +35,7 @@ module Css exposing
     , borderWidth, borderWidth2, borderWidth3, borderWidth4, borderTopWidth, borderRightWidth, borderBottomWidth, borderLeftWidth
     , thin, thick
     , borderStyle, borderStyle2, borderStyle3, borderStyle4, borderTopStyle, borderRightStyle, borderBottomStyle, borderLeftStyle
-    , borderBlockStyle, borderInlineStyle
+    , borderBlockStyle, borderBlockStartStyle, borderBlockEndStyle, borderInlineStyle, borderInlineStartStyle, borderInlineEndStyle
     , dotted, dashed, solid, double, groove, ridge, inset, outset
     , borderColor, borderColor2, borderColor3, borderColor4, borderTopColor, borderRightColor, borderBottomColor, borderLeftColor
     , borderBlockColor, borderBlockStartColor, borderBlockEndColor, borderInlineColor, borderInlineStartColor, borderInlineEndColor
@@ -309,7 +309,7 @@ All CSS properties can have the values `unset`, `initial`, and `inherit`
 
 @docs borderStyle, borderStyle2, borderStyle3, borderStyle4, borderTopStyle, borderRightStyle, borderBottomStyle, borderLeftStyle
 
-@docs borderBlockStyle, borderInlineStyle
+@docs borderBlockStyle, borderBlockStartStyle, borderBlockEndStyle, borderInlineStyle, borderInlineStartStyle, borderInlineEndStyle
 
 @docs dotted, dashed, solid, double, groove, ridge, inset, outset
 
@@ -7699,6 +7699,26 @@ borderBlockStyle (Value style) =
     AppendProperty ("border-block-style:" ++ style)
 
 
+{-| Sets [`border-block-start-style`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-block-start-style) property.
+
+    borderBlockStartStyle solid
+
+-}
+borderBlockStartStyle : BaseValue LineStyle -> Style
+borderBlockStartStyle (Value style) =
+    AppendProperty ("border-block-start-style:" ++ style)
+
+
+{-| Sets [`border-block-end-style`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-block-end-style) property.
+
+    borderBlockEndStyle solid
+
+-}
+borderBlockEndStyle : BaseValue LineStyle -> Style
+borderBlockEndStyle (Value style) =
+    AppendProperty ("border-block-end-style:" ++ style)
+
+
 {-| Sets [`border-inline-style`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-inline-style) property.
 
     borderInlineStyle solid
@@ -7707,6 +7727,26 @@ borderBlockStyle (Value style) =
 borderInlineStyle : BaseValue LineStyle -> Style
 borderInlineStyle (Value style) =
     AppendProperty ("border-inline-style:" ++ style)
+
+
+{-| Sets [`border-inline-start-style`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-inline-start-style) property.
+
+    borderInlineStartStyle solid
+
+-}
+borderInlineStartStyle : BaseValue LineStyle -> Style
+borderInlineStartStyle (Value style) =
+    AppendProperty ("border-inline-start-style:" ++ style)
+
+
+{-| Sets [`border-inline-end-style`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-inline-end-style) property.
+
+    borderInlineEndStyle solid
+
+-}
+borderInlineEndStyle : BaseValue LineStyle -> Style
+borderInlineEndStyle (Value style) =
+    AppendProperty ("border-inline-end-style:" ++ style)
 
 
 {-| Sets [`border-color`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-color) property.

--- a/src/Css.elm
+++ b/src/Css.elm
@@ -131,7 +131,7 @@ module Css exposing
     , transform, transforms, transformOrigin, transformOrigin2
     , TransformFunction, TransformFunctionSupported
     , matrix, matrix3d
-    , perspective
+    , perspective, perspective_
     , rotate, rotateX, rotateY, rotateZ, rotate3d
     , scale, scale2, scaleX, scaleY, scaleZ, scale3d
     , skew, skew2, skewX, skewY
@@ -641,7 +641,6 @@ Multiple CSS properties use these values.
 @docs transform, transforms, transformOrigin, transformOrigin2
 @docs TransformFunction, TransformFunctionSupported
 
-
 ## Matrix transformation
 
 @docs matrix, matrix3d
@@ -650,6 +649,7 @@ Multiple CSS properties use these values.
 ## Perspective
 
 @docs perspective
+@docs perspective_
 
 
 ## Rotation
@@ -10813,7 +10813,7 @@ type alias TransformFunctionSupported supported =
         , rotateY : Supported
         , rotateZ : Supported
         , rotate3d : Supported
-        , perspective : Supported
+        , perspective_ : Supported
     }
 
 
@@ -10849,7 +10849,7 @@ type alias TransformFunction =
     transform (rotateY (deg 10))
     transform (rotateZ (deg 10))
     transform (rotate3d 1 2.0 3.0 (deg 10))
-    transform (perspective (px 17))
+    transform (perspective_ (px 17))
 
 -}
 transform : BaseValue (TransformFunctionSupported { none : Supported }) -> Style
@@ -10871,14 +10871,13 @@ transforms head rest =
     AppendProperty ("transform:" ++ plusListToString head rest)
 
 
-{-| Named afte the plus symbol in the CSS specification [CSS-VALUES-3].
+{-| Named after the plus symbol in the CSS specification [CSS-VALUES-3].
 -}
 plusListToString : Value a -> List (Value a) -> String
 plusListToString head rest =
     (head :: rest)
         |> List.map unpackValue
         |> String.join " "
-
 
 
 -- MATRIX TRANSFORMATION
@@ -11270,15 +11269,38 @@ rotate3d valX valY z (Value angle) =
 -- PERSPECTIVE
 
 
-{-| Sets `perspective` value for usage with [`transform`](#transform).
+{-| The [`perspective`](https://css-tricks.com/almanac/properties/p/perspective/) property.
 
-    transform (perspective (px 17))
+Negative values are not supported and any value smaller than 1px is clamped to 1px.
 
+    perspective none
+
+    perspective (px 100)
+
+    perspective (rem 50)
 -}
 perspective :
+    BaseValue
+        ( LengthSupported
+            { none : Supported
+            }
+        )
+    -> Style
+perspective (Value val) =
+    AppendProperty ("perspective:" ++ val)
+
+
+{-| Sets `perspective` value for usage with [`transform`](#transform).
+
+    transform (perspective_ (px 17))
+
+The value is called `perspective_` instead of `perspective` because
+[`perspective`](#perspective) is already a function.
+-}
+perspective_ :
     Value Length
-    -> Value { provides | perspective : Supported }
-perspective (Value length) =
+    -> Value { provides | perspective_ : Supported }
+perspective_ (Value length) =
     Value ("perspective(" ++ length ++ ")")
 
 

--- a/src/Css.elm
+++ b/src/Css.elm
@@ -33,6 +33,7 @@ module Css exposing
     , borderBlock, borderBlock2, borderBlock3
     , borderInline, borderInline2, borderInline3
     , borderWidth, borderWidth2, borderWidth3, borderWidth4, borderTopWidth, borderRightWidth, borderBottomWidth, borderLeftWidth
+    , borderBlockWidth, borderInlineWidth
     , thin, thick
     , borderStyle, borderStyle2, borderStyle3, borderStyle4, borderTopStyle, borderRightStyle, borderBottomStyle, borderLeftStyle
     , borderBlockStyle, borderBlockStartStyle, borderBlockEndStyle, borderInlineStyle, borderInlineStartStyle, borderInlineEndStyle
@@ -290,9 +291,6 @@ All CSS properties can have the values `unset`, `initial`, and `inherit`
 
 @docs borderLeft, borderLeft2, borderLeft3
 
-
-## Logical Borders
-
 @docs borderBlock, borderBlock2, borderBlock3
 
 @docs borderInline, borderInline2, borderInline3
@@ -301,6 +299,8 @@ All CSS properties can have the values `unset`, `initial`, and `inherit`
 ## Border Width
 
 @docs borderWidth, borderWidth2, borderWidth3, borderWidth4, borderTopWidth, borderRightWidth, borderBottomWidth, borderLeftWidth
+
+@docs borderBlockWidth, borderInlineWidth
 
 @docs thin, thick
 
@@ -7601,6 +7601,26 @@ borderBottomWidth (Value widthVal) =
 borderLeftWidth : BaseValue LineWidth -> Style
 borderLeftWidth (Value widthVal) =
     AppendProperty ("border-left-width:" ++ widthVal)
+
+
+{-| Sets [`border-block-width`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-block-width) property.
+
+    borderBlockWidth (px 1)
+
+-}
+borderBlockWidth : BaseValue LineWidth -> Style
+borderBlockWidth (Value widthVal) =
+    AppendProperty ("border-block-width:" ++ widthVal)
+
+
+{-| Sets [`border-inline-width`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-inline-width) property.
+
+    borderTopWidth (px 1)
+
+-}
+borderInlineWidth : BaseValue LineWidth -> Style
+borderInlineWidth (Value widthVal) =
+    AppendProperty ("border-inline-width:" ++ widthVal)
 
 
 {-| Sets [`border-style`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-style) property.

--- a/src/Css.elm
+++ b/src/Css.elm
@@ -44,7 +44,7 @@ module Css exposing
     , position, zIndex
     , absolute, fixed, relative, static, sticky
     , inset, inset2, inset3, inset4, top, right, bottom, left
-    , insetBlock, insetBlock2, insetInline, insetInline2
+    , insetBlock, insetBlock2, insetInline, insetInline2, insetBlockStart, insetBlockEnd, insetInlineStart, insetInlineEnd
     , padding, padding2, padding3, padding4, paddingTop, paddingRight, paddingBottom, paddingLeft
     , margin, margin2, margin3, margin4, marginTop, marginRight, marginBottom, marginLeft
     , boxSizing
@@ -343,7 +343,7 @@ All CSS properties can have the values `unset`, `initial`, and `inherit`
 
 @docs inset, inset2, inset3, inset4, top, right, bottom, left
 
-@docs insetBlock, insetBlock2, insetInline, insetInline2
+@docs insetBlock, insetBlock2, insetInline, insetInline2, insetBlockStart, insetBlockEnd, insetInlineStart, insetInlineEnd
 
 
 ## Paddings
@@ -1658,7 +1658,7 @@ inset4 (Value valTop) (Value valRight) (Value valBottom) (Value valLeft) =
     AppendProperty ("inset:" ++ valTop ++ " " ++ valRight ++ " " ++ valBottom ++ " " ++ valLeft)
 
 
-{-| Sets the [`top` property](https://css-tricks.com/almanac/properties/t/top/).
+{-| Sets the [`top`](https://css-tricks.com/almanac/properties/t/top/) property.
 
     top (px 10)
 
@@ -1684,7 +1684,7 @@ top (Value val) =
     AppendProperty ("top:" ++ val)
 
 
-{-| Sets the [`bottom` property](https://css-tricks.com/almanac/properties/b/bottom/).
+{-| Sets the [`bottom`](https://css-tricks.com/almanac/properties/b/bottom/) property.
 
     bottom (px 10)
 
@@ -1710,7 +1710,7 @@ bottom (Value val) =
     AppendProperty ("bottom:" ++ val)
 
 
-{-| Sets the [`left` property](https://css-tricks.com/almanac/properties/l/left/).
+{-| Sets the [`left`](https://css-tricks.com/almanac/properties/l/left/) property.
 
     left (px 10)
 
@@ -1736,7 +1736,7 @@ left (Value val) =
     AppendProperty ("left:" ++ val)
 
 
-{-| Sets the [`right` property](https://css-tricks.com/almanac/properties/r/right).
+{-| Sets the [`right`](https://css-tricks.com/almanac/properties/r/right) property.
 
     right (px 10)
 
@@ -1762,7 +1762,7 @@ right (Value val) =
     AppendProperty ("right:" ++ val)
 
 
-{-| Sets the [`inset-block`](https://developer.mozilla.org/en-US/docs/Web/CSS/inset-block) property.
+{-| Sets the [`inset-block`](https://css-tricks.com/almanac/properties/i/inset-block/) property.
 
 `inset-block` sets the `inset-block-start` and `inset-block-end` properties.
 
@@ -1783,7 +1783,7 @@ insetBlock (Value val) =
     AppendProperty ("inset-block:" ++ val)
 
 
-{-| Sets the [`inset-block`](https://developer.mozilla.org/en-US/docs/Web/CSS/inset-block) property.
+{-| Sets the [`inset-block`](https://css-tricks.com/almanac/properties/i/inset-block/) property.
 
 `inset-block` sets the `inset-block-start` and `inset-block-end` properties.
 
@@ -1811,7 +1811,7 @@ insetBlock2 (Value valStart) (Value valEnd) =
     AppendProperty ("inset-block:" ++ valStart ++ " " ++ valEnd)
 
 
-{-| Sets the [`inset-inline`](https://developer.mozilla.org/en-US/docs/Web/CSS/inset-inline) property.
+{-| Sets the [`inset-inline`](https://css-tricks.com/almanac/properties/i/inset-inline) property.
 
 `inset-inline` sets the `inset-inline-start` and `inset-inline-end` properties.
 
@@ -1832,7 +1832,7 @@ insetInline (Value val) =
     AppendProperty ("inset-inline:" ++ val)
 
 
-{-| Sets the [`inset-inline`](https://developer.mozilla.org/en-US/docs/Web/CSS/inset-inline) property.
+{-| Sets the [`inset-inline`](https://css-tricks.com/almanac/properties/i/inset-inline) property.
 
 `inset-inline` sets the `inset-inline-start` and `inset-inline-end` properties.
 
@@ -1858,6 +1858,98 @@ insetInline2 :
     -> Style
 insetInline2 (Value valStart) (Value valEnd) =
     AppendProperty ("inset-inline:" ++ valStart ++ " " ++ valEnd)
+
+
+{-| Sets the [`inset-block-start`](https://developer.mozilla.org/en-US/docs/Web/CSS/inset-block-start) property.
+
+    insetBlockStart (px 10)
+
+    insetBlockStart (pct 50)
+
+    insetBlockStart auto
+
+    insetBlockStart zero
+
+-}
+insetBlockStart :
+    BaseValue
+        (LengthSupported
+            { pct : Supported
+            , auto : Supported
+            }
+        )
+    -> Style
+insetBlockStart (Value val) =
+    AppendProperty ("inset-block-start:" ++ val)
+
+
+{-| Sets the [`inset-block-end`](https://developer.mozilla.org/en-US/docs/Web/CSS/inset-block-end) property.
+
+    insetBlockEnd (px 10)
+
+    insetBlockEnd (pct 50)
+
+    insetBlockEnd auto
+
+    insetBlockEnd zero
+
+-}
+insetBlockEnd :
+    BaseValue
+        (LengthSupported
+            { pct : Supported
+            , auto : Supported
+            }
+        )
+    -> Style
+insetBlockEnd (Value val) =
+    AppendProperty ("inset-block-end:" ++ val)
+
+
+{-| Sets the [`inset-inline-start`](https://developer.mozilla.org/en-US/docs/Web/CSS/inset-inline-start) property.
+
+    insetInlineStart (px 10)
+
+    insetInlineStart (pct 50)
+
+    insetInlineStart auto
+
+    insetInlineStart zero
+
+-}
+insetInlineStart :
+    BaseValue
+        (LengthSupported
+            { pct : Supported
+            , auto : Supported
+            }
+        )
+    -> Style
+insetInlineStart (Value val) =
+    AppendProperty ("inset-inline-start:" ++ val)
+
+
+{-| Sets the [`inset-inline-end`](https://developer.mozilla.org/en-US/docs/Web/CSS/inset-inline-end) property.
+
+    insetInlineEnd (px 10)
+
+    insetInlineEnd (pct 50)
+
+    insetInlineEnd auto
+
+    insetInlineEnd zero
+
+-}
+insetInlineEnd :
+    BaseValue
+        (LengthSupported
+            { pct : Supported
+            , auto : Supported
+            }
+        )
+    -> Style
+insetInlineEnd (Value val) =
+    AppendProperty ("inset-inline-end:" ++ val)
 
 
 {-| An [`absolute` `position`](https://developer.mozilla.org/en-US/docs/Web/CSS/position#relative).

--- a/src/Css.elm
+++ b/src/Css.elm
@@ -1958,7 +1958,7 @@ It's used in the following properties as a [CSS Logical value](https://css-trick
 ```
 alignContent start
 
-justifyItems estartnd
+justifyItems start
 
 ```
 

--- a/src/Css.elm
+++ b/src/Css.elm
@@ -160,6 +160,7 @@ module Css exposing
     , caretColor
     , pointerEvents
     , visiblePainted, visibleFill, visibleStroke, painted, stroke
+    , resize, horizontal, vertical
     )
 
 {-| If you need something that `elm-css` does not support right now, the
@@ -722,7 +723,7 @@ Multiple CSS properties use these values.
 @docs caretColor
 @docs pointerEvents
 @docs visiblePainted, visibleFill, visibleStroke, painted, stroke
-
+@docs resize, horizontal, vertical
 -}
 
 import Css.Preprocess as Preprocess exposing (Style(..))
@@ -2963,9 +2964,11 @@ displayListItem3 (Value displayOutside) (Value displayFlow) =
     AppendProperty ("display:list-item " ++ displayOutside ++ " " ++ displayFlow)
 
 
-{-| The `block` value used by [`display`](#display)
+{-| The `block` value used by [`display`](#display) and [`resize`].
 
     display block
+
+    resize block
 
 -}
 block : Value { provides | block : Supported }
@@ -3025,9 +3028,11 @@ contents =
     Value "contents"
 
 
-{-| The `inline` value used by [`display`](#display)
+{-| The `inline` value used by [`display`](#display) and [`resize`].
 
     display inline
+
+    resize inline
 
 -}
 inline : Value { provides | inline : Supported }
@@ -8040,8 +8045,8 @@ borderTopLeftRadius2 :
                 }
             )
     -> Style
-borderTopLeftRadius2 (Value horizontal) (Value vertical) =
-    AppendProperty ("border-top-left-radius:" ++ horizontal ++ " " ++ vertical)
+borderTopLeftRadius2 (Value valHorizontal) (Value valVertical) =
+    AppendProperty ("border-top-left-radius:" ++ valHorizontal ++ " " ++ valVertical)
 
 
 {-| Sets [`border-top-right-radius`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-top-right-radius) property.
@@ -8082,8 +8087,8 @@ borderTopRightRadius2 :
                 }
             )
     -> Style
-borderTopRightRadius2 (Value horizontal) (Value vertical) =
-    AppendProperty ("border-top-right-radius:" ++ horizontal ++ " " ++ vertical)
+borderTopRightRadius2 (Value valHorizontal) (Value valVertical) =
+    AppendProperty ("border-top-right-radius:" ++ valHorizontal ++ " " ++ valVertical)
 
 
 {-| Sets [`border-bottom-right-radius`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-bottom-right-radius) property.
@@ -8124,8 +8129,8 @@ borderBottomRightRadius2 :
                 }
             )
     -> Style
-borderBottomRightRadius2 (Value horizontal) (Value vertical) =
-    AppendProperty ("border-bottom-right-radius:" ++ horizontal ++ " " ++ vertical)
+borderBottomRightRadius2 (Value valHorizontal) (Value valVertical) =
+    AppendProperty ("border-bottom-right-radius:" ++ valHorizontal ++ " " ++ valVertical)
 
 
 {-| Sets [`border-bottom-left-radius`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-bottom-left-radius) property.
@@ -8166,8 +8171,8 @@ borderBottomLeftRadius2 :
                 }
             )
     -> Style
-borderBottomLeftRadius2 (Value horizontal) (Value vertical) =
-    AppendProperty ("border-bottom-left-radius:" ++ horizontal ++ " " ++ vertical)
+borderBottomLeftRadius2 (Value valHorizontal) (Value valVertical) =
+    AppendProperty ("border-bottom-left-radius:" ++ valHorizontal ++ " " ++ valVertical)
 
 
 {-| Sets [`border-image-outset`](https://css-tricks.com/almanac/properties/b/border-image/) property.
@@ -9165,8 +9170,8 @@ borderSpacing (Value str) =
 
 -}
 borderSpacing2 : Value Length -> Value Length -> Style
-borderSpacing2 (Value horizontal) (Value vertical) =
-    AppendProperty ("border-spacing:" ++ horizontal ++ " " ++ vertical)
+borderSpacing2 (Value valHorizontal) (Value valVertical) =
+    AppendProperty ("border-spacing:" ++ valHorizontal ++ " " ++ valVertical)
 
 
 
@@ -11756,9 +11761,11 @@ clear (Value val) =
     AppendProperty ("clear:" ++ val)
 
 
-{-| Sets `both` value for usage with [`clear`](#clear).
+{-| Sets `both` value for usage with [`clear`](#clear) and [`resize`](#resize).
 
       clear both
+
+      resize both
 
 -}
 both : Value { provides | both : Supported }
@@ -13938,3 +13945,44 @@ writingMode :
     -> Style
 writingMode (Value str) =
     AppendProperty ("writing-mode:" ++ str)
+
+
+{-| The [`resize`](https://css-tricks.com/almanac/properties/r/resize/) property.
+
+    resize none
+
+    resize both
+
+    resize inline
+
+-}
+resize : 
+    BaseValue
+        { none : Supported
+        , both : Supported
+        , horizontal : Supported
+        , vertical : Supported
+        , block : Supported
+        , inline : Supported
+        }
+    -> Style
+resize (Value value) =
+    AppendProperty ("resize:" ++ value)
+
+
+{-| The `horizontal` value used by [`resize`](#resize).
+
+    resize horizontal
+-}
+horizontal : Value { provides | horizontal : Supported }
+horizontal =
+    Value "horizontal"
+
+
+{-| The `vertical` value used by [`resize`](#resize).
+
+    resize vertical
+-}
+vertical : Value { provides | vertical : Supported }
+vertical =
+    Value "vertical"

--- a/src/Css.elm
+++ b/src/Css.elm
@@ -346,6 +346,11 @@ module Css exposing
     , pointerEvents
     , visiblePainted, visibleFill, visibleStroke, painted
 
+    -- touch action
+    , touchAction
+    , panX, panY
+    , pinchZoom, manipulation
+
     -- scrollbar customisation
     , scrollbarColor, scrollbarWidth
 
@@ -1210,6 +1215,16 @@ Other values you can use for flex item alignment:
 
 @docs pointerEvents
 @docs visiblePainted, visibleFill, visibleStroke, painted
+
+
+------------------------------------------------------
+
+
+# Touch action
+
+@docs touchAction
+@docs panX, panY
+@docs pinchZoom, manipulation
 
 
 ------------------------------------------------------
@@ -16853,7 +16868,7 @@ pointerEvents (Value val) =
     AppendProperty ("pointer-events:" ++ val)
 
 
-{-| The `visiblePainted` value used by [`pointerEvents`](#pointerEvents)
+{-| The `visiblePainted` value used by [`pointerEvents`](#pointerEvents).
 
     pointerEvents visiblePainted
 
@@ -16863,7 +16878,7 @@ visiblePainted =
     Value "visiblePainted"
 
 
-{-| The `visibleFill` value used by [`pointerEvents`](#pointerEvents)
+{-| The `visibleFill` value used by [`pointerEvents`](#pointerEvents).
 
     pointerEvents visibleFill
 
@@ -16873,7 +16888,7 @@ visibleFill =
     Value "visibleFill"
 
 
-{-| The `visibleStroke` value used by [`pointerEvents`](#pointerEvents)
+{-| The `visibleStroke` value used by [`pointerEvents`](#pointerEvents).
 
     pointerEvents visibleStroke
 
@@ -16883,7 +16898,7 @@ visibleStroke =
     Value "visibleStroke"
 
 
-{-| The `painted` value used by [`pointerEvents`](#pointerEvents)
+{-| The `painted` value used by [`pointerEvents`](#pointerEvents).
 
     pointerEvents painted
 
@@ -16891,6 +16906,83 @@ visibleStroke =
 painted : Value { provides | painted : Supported }
 painted =
     Value "painted"
+
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+---------------------------- POINTER-EVENTS-----------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+
+
+{-| The [`touch-action`](https://css-tricks.com/almanac/properties/t/touch-action/)
+property.
+
+    touchAction auto
+
+    touchAction panY
+
+    touchAction pinchZoom
+-}
+touchAction :
+    BaseValue
+        { auto : Supported
+        , none : Supported
+        , panX : Supported
+        , panY : Supported
+        , pinchZoom : Supported
+        , manipulation : Supported
+        }
+    -> Style
+touchAction (Value val) =
+    AppendProperty <| "touch-action:" ++ val
+
+
+{-| The `pan-x` value used by [`touch-action`](#touchAction).
+
+    touchAction panX
+
+-}
+panX : Value { provides | panX : Supported }
+panX =
+    Value "pan-x"
+
+
+{-| The `pan-y` value used by [`touch-action`](#touchAction).
+
+    touchAction panY
+
+-}
+panY : Value { provides | panY : Supported }
+panY =
+    Value "pan-y"
+
+
+{-| The `pinch-zoom` value used by [`touch-action`](#touchAction).
+
+    touchAction pinchZoom
+
+-}
+pinchZoom : Value { provides | pinchZoom : Supported }
+pinchZoom =
+    Value "pinch-zoom"
+
+
+{-| The `manipulation` value used by [`touch-action`](#touchAction).
+
+    touchAction manipulation
+
+-}
+manipulation : Value { provides | manipulation : Supported }
+manipulation =
+    Value "manipulation"
 
 
 ------------------------------------------------------------------------

--- a/src/Css.elm
+++ b/src/Css.elm
@@ -1541,7 +1541,7 @@ position (Value val) =
 
 -}
 inset :
-    Value
+    BaseValue
         (LengthSupported
             { pct : Supported
             , auto : Supported
@@ -1783,7 +1783,7 @@ right (Value val) =
 
 -}
 insetBlock :
-    Value
+    BaseValue
         (LengthSupported
             { pct : Supported
             , auto : Supported
@@ -1832,7 +1832,7 @@ insetBlock2 (Value valStart) (Value valEnd) =
 
 -}
 insetInline :
-    Value
+    BaseValue
         (LengthSupported
             { pct : Supported
             , auto : Supported

--- a/src/Css.elm
+++ b/src/Css.elm
@@ -6,7 +6,7 @@ module Css exposing
     , unset, initial, inherit
     , all, revert
     , Angle, AngleSupported, Width, WidthSupported
-    , BasicShapeSupported, circle, circleAt, circleAt2, ellipse, ellipseAt, ellipseAt2, closestSide, farthestSide
+    , BasicShapeSupported, circle, circleAt, circleAt2, ellipse, ellipseAt, ellipseAt2, closestSide, farthestSide, polygon, path
     , Length, LengthSupported, zero, px, em, ex, ch, rem, vh, vw, vmin, vmax, mm, cm, q, inches, pt, pc, pct, num, int
     , calc, CalcOperation, minus, plus, times, dividedBy
     , Color, ColorSupported, color, backgroundColor, hex, rgb, rgba, hsl, hsla, currentcolor
@@ -275,7 +275,7 @@ All CSS properties can have the values `unset`, `initial`, `inherit` and `revert
 
 ## Shapes
 
-@docs BasicShapeSupported, circle, circleAt, circleAt2, ellipse, ellipseAt, ellipseAt2, closestSide, farthestSide
+@docs BasicShapeSupported, circle, circleAt, circleAt2, ellipse, ellipseAt, ellipseAt2, closestSide, farthestSide, polygon, path
 
 ## URLs
 
@@ -1179,6 +1179,7 @@ type alias BasicShapeSupported supported =
         , path : Supported
     }
 
+
 {-| A type alias used to accept an [image](https://developer.mozilla.org/en-US/docs/Web/CSS/image).
 -}
 type alias Image =
@@ -1542,6 +1543,43 @@ closestSide =
 farthestSide : Value { provides | farthestSide : Supported }
 farthestSide =
     Value "farthest-side"
+
+
+{-| Creates a `polygon()` value for CSS
+properties that accept a `<basic-shape>` value.
+
+Each numerical argument is a Float that represents a
+percentage.
+
+    clipPath <| polygon [ (20, 30), (40, 80.3), (14, 50) ]
+-}
+polygon : List (Float, Float) -> Value { provides | polygon : Supported }
+polygon list = 
+
+    let
+        stringed = List.map (\l ->
+                ( (String.fromFloat <| Tuple.first l )++ "% " )
+                ++ ( (String.fromFloat <| Tuple.second l) ++ "%")
+            ) list
+
+        split = String.join ", " stringed
+
+    in
+    Value <| "polygon("
+        ++ split
+        ++ ")"
+
+
+{-| Creates a `path()` value for CSS properties that accept a
+`<basic-shape>` value.
+
+The input string needs to be a valid SVG path string.
+
+    clipPath <| path "M161.693,39.249C94.047,39.249 39.127,94.169 39.127,161.816C39.127,229.462 94.047,284.382 161.693,284.382C229.34,284.382 284.26,229.462 284.26,161.816C284.26,94.169 229.34,39.249 161.693,39.249ZM161.693,71.382C211.605,71.382 211.605,252.249 161.693,252.249C111.782,252.249 71.26,211.727 71.26,161.816C71.26,111.904 111.782,71.382 161.693,71.382Z"
+-}
+path : String -> Value { provides | path : Supported }
+path svgPathDef =
+    Value <| "path('" ++ svgPathDef ++ "')"
 
 
 -- GLOBAL VALUES --

--- a/src/Css.elm
+++ b/src/Css.elm
@@ -6,7 +6,8 @@ module Css exposing
     , unset, initial, inherit
     , all, revert
     , Angle, AngleSupported, Width, WidthSupported
-    , BasicShape, BasicShapeSupported, circle, circleAt, circleAt2, ellipse, ellipseAt, ellipseAt2, closestSide, farthestSide, polygon, path
+    , BasicShape, BasicShapeSupported
+    , circle, circleAt, circleAt2, ellipse, ellipseAt, ellipseAt2, closestSide, farthestSide, polygon, path
     , Length, LengthSupported, zero, px, em, ex, ch, rem, vh, vw, vmin, vmax, mm, cm, q, inches, pt, pc, pct, num, int
     , calc, CalcOperation, minus, plus, times, dividedBy
     , Color, ColorSupported, color, backgroundColor, hex, rgb, rgba, hsl, hsla, currentcolor
@@ -112,6 +113,7 @@ module Css exposing
     , fontWeight, bold, lighter, bolder
     , fontStretch, ultraCondensed, extraCondensed, condensed, semiCondensed, semiExpanded, expanded, extraExpanded, ultraExpanded
     , fontFeatureSettings, fontFeatureSettingsList, featureTag, featureTag2
+    , fontVariationSettings, fontVariationSettingsList
     , fontVariantCaps, smallCaps, allSmallCaps, petiteCaps, allPetiteCaps, unicase, titlingCaps
     , fontVariantEastAsian, fontVariantEastAsian2, fontVariantEastAsian3, jis78, jis83, jis90, jis04, simplified, traditional, proportionalWidth
     , fontVariantLigatures, commonLigatures, noCommonLigatures, discretionaryLigatures, noDiscretionaryLigatures, historicalLigatures, noHistoricalLigatures, contextual, noContextual
@@ -284,7 +286,8 @@ All CSS properties can have the values `unset`, `initial`, `inherit` and `revert
 
 ## Shapes
 
-@docs BasicShape, BasicShapeSupported, circle, circleAt, circleAt2, ellipse, ellipseAt, ellipseAt2, closestSide, farthestSide, polygon, path
+@docs BasicShape, BasicShapeSupported
+@docs circle, circleAt, circleAt2, ellipse, ellipseAt, ellipseAt2, closestSide, farthestSide, polygon, path
 
 ## Resolution
 
@@ -672,6 +675,10 @@ Other values you can use for flex item alignment:
 
 [`normal`](#normal) is also a supported font feature settings.
 
+
+## Font Variation Settings
+
+@docs fontVariationSettings, fontVariationSettingsList
 
 ## Font Variant Caps
 
@@ -7796,6 +7803,51 @@ bolder : Value { provides | bolder : Supported }
 bolder =
     Value "bolder"
 
+
+{-| The 1-argument variant of the [`font-variation-settings`](https://developer.mozilla.org/en-US/docs/Web/CSS/font-variation-settings)
+property.
+
+For controlling aspects of variable fonts.
+Use [`fontVariationSettingsList`](#fontVariationSettingsList) to work with variable font tags.
+
+    fontVariationSettings normal
+
+    fontVariationSettings inherit
+
+    fontVariationSettingsList [ ("XHGT", 0.7) ]
+-}
+fontVariationSettings :
+    BaseValue
+        { normal : Supported
+        }
+    -> Style
+fontVariationSettings (Value val) =
+    AppendProperty ("font-variation-settings:" ++ val)
+
+
+{-| The multi-argument variant of the [`font-variation-settings`](https://developer.mozilla.org/en-US/docs/Web/CSS/font-variation-settings)
+property.
+
+For using single keywords with this property, use [`fontVariationSettings`](#fontVariationSettings).
+
+    fontVariationSettingsList [ ("XHGT", 0.7) ]
+-}
+fontVariationSettingsList :
+    List
+        ( String
+        , Float
+        )
+    -> Style
+fontVariationSettingsList list =
+    AppendProperty <|
+        "font-variation-settings:"
+        ++
+        ( list
+        |> List.map
+            (\(tagVal, numberVal) -> (enquoteString tagVal) ++ " " ++ (String.fromFloat numberVal)
+            )
+        |> String.join ", "
+        )
 
 
 -- FONT VARIANT CAPS --

--- a/src/Css.elm
+++ b/src/Css.elm
@@ -31,7 +31,11 @@ module Css exposing
     , borderBottom, borderBottom2, borderBottom3
     , borderLeft, borderLeft2, borderLeft3
     , borderBlock, borderBlock2, borderBlock3
+    , borderBlockStart, borderBlockStart2, borderBlockStart3
+    , borderBlockEnd, borderBlockEnd2, borderBlockEnd3
     , borderInline, borderInline2, borderInline3
+    , borderInlineStart, borderInlineStart2, borderInlineStart3
+    , borderInlineEnd, borderInlineEnd2, borderInlineEnd3
     , borderWidth, borderWidth2, borderWidth3, borderWidth4, borderTopWidth, borderRightWidth, borderBottomWidth, borderLeftWidth
     , borderBlockWidth, borderBlockStartWidth, borderBlockEndWidth, borderInlineWidth, borderInlineStartWidth, borderInlineEndWidth
     , thin, thick
@@ -293,7 +297,15 @@ All CSS properties can have the values `unset`, `initial`, and `inherit`
 
 @docs borderBlock, borderBlock2, borderBlock3
 
+@docs borderBlockStart, borderBlockStart2, borderBlockStart3
+
+@docs borderBlockEnd, borderBlockEnd2, borderBlockEnd3
+
 @docs borderInline, borderInline2, borderInline3
+
+@docs borderInlineStart, borderInlineStart2, borderInlineStart3
+
+@docs borderInlineEnd, borderInlineEnd2, borderInlineEnd3
 
 
 ## Border Width
@@ -7457,6 +7469,90 @@ borderBlock3 (Value widthVal) (Value style) (Value colorVal) =
     AppendProperty ("border-block:" ++ widthVal ++ " " ++ style ++ " " ++ colorVal)
 
 
+{-| Sets [`border-block-start`](https://css-tricks.com/almanac/properties/b/border-block-start/) property.
+
+    borderBlockStart (px 1)
+
+    borderBlockStart2 (px 1) solid
+
+    borderBlockStart3 (px 1) solid (hex "#f00")
+
+-}
+borderBlockStart : BaseValue LineWidth -> Style
+borderBlockStart (Value widthVal) =
+    AppendProperty ("border-block-start:" ++ widthVal)
+
+
+{-| Sets [`border-block-start`](https://css-tricks.com/almanac/properties/b/border-block-start/) property.
+
+    borderBlockStart (px 1)
+
+    borderBlockStart2 (px 1) solid
+
+    borderBlockStart3 (px 1) solid (hex "#f00")
+
+-}
+borderBlockStart2 : Value LineWidth -> Value LineStyle -> Style
+borderBlockStart2 (Value widthVal) (Value style) =
+    AppendProperty ("border-block-start:" ++ widthVal ++ " " ++ style)
+
+
+{-| Sets [`border-block-start`](https://css-tricks.com/almanac/properties/b/border-block-start/) property.
+
+    borderBlockStart (px 1)
+
+    borderBlockStart2 (px 1) solid
+
+    borderBlockStart3 (px 1) solid (hex "#f00")
+
+-}
+borderBlockStart3 : Value LineWidth -> Value LineStyle -> Value Color -> Style
+borderBlockStart3 (Value widthVal) (Value style) (Value colorVal) =
+    AppendProperty ("border-block-start:" ++ widthVal ++ " " ++ style ++ " " ++ colorVal)
+
+
+{-| Sets [`border-block-end`](https://css-tricks.com/almanac/properties/b/border-block-end/) property.
+
+    borderBlockEnd (px 1)
+
+    borderBlockEnd2 (px 1) solid
+
+    borderBlockEnd3 (px 1) solid (hex "#f00")
+
+-}
+borderBlockEnd : BaseValue LineWidth -> Style
+borderBlockEnd (Value widthVal) =
+    AppendProperty ("border-block-end:" ++ widthVal)
+
+
+{-| Sets [`border-block-end`](https://css-tricks.com/almanac/properties/b/border-block-end/) property.
+
+    borderBlockEnd (px 1)
+
+    borderBlockEnd2 (px 1) solid
+
+    borderBlockEnd3 (px 1) solid (hex "#f00")
+
+-}
+borderBlockEnd2 : Value LineWidth -> Value LineStyle -> Style
+borderBlockEnd2 (Value widthVal) (Value style) =
+    AppendProperty ("border-block-end:" ++ widthVal ++ " " ++ style)
+
+
+{-| Sets [`border-block-end`](https://css-tricks.com/almanac/properties/b/border-block-end/) property.
+
+    borderBlockEnd (px 1)
+
+    borderBlockEnd2 (px 1) solid
+
+    borderBlockEnd3 (px 1) solid (hex "#f00")
+
+-}
+borderBlockEnd3 : Value LineWidth -> Value LineStyle -> Value Color -> Style
+borderBlockEnd3 (Value widthVal) (Value style) (Value colorVal) =
+    AppendProperty ("border-block-end:" ++ widthVal ++ " " ++ style ++ " " ++ colorVal)
+
+
 {-| Sets [`border-inline`](https://css-tricks.com/almanac/properties/b/border-inline/) property.
 
     borderInline (px 1)
@@ -7497,6 +7593,90 @@ borderInline2 (Value widthVal) (Value style) =
 borderInline3 : Value LineWidth -> Value LineStyle -> Value Color -> Style
 borderInline3 (Value widthVal) (Value style) (Value colorVal) =
     AppendProperty ("border-inline:" ++ widthVal ++ " " ++ style ++ " " ++ colorVal)
+
+
+{-| Sets [`border-inline-start`](https://css-tricks.com/almanac/properties/b/border-inline-start/) property.
+
+    borderInlineStart (px 1)
+
+    borderInlineStart2 (px 1) solid
+
+    borderInlineStart3 (px 1) solid (hex "#f00")
+
+-}
+borderInlineStart : BaseValue LineWidth -> Style
+borderInlineStart (Value widthVal) =
+    AppendProperty ("border-inline-start:" ++ widthVal)
+
+
+{-| Sets [`border-inline-start`](https://css-tricks.com/almanac/properties/b/border-inline-start/) property.
+
+    borderInlineStart (px 1)
+
+    borderInlineStart2 (px 1) solid
+
+    borderInlineStart3 (px 1) solid (hex "#f00")
+
+-}
+borderInlineStart2 : Value LineWidth -> Value LineStyle -> Style
+borderInlineStart2 (Value widthVal) (Value style) =
+    AppendProperty ("border-inline-start:" ++ widthVal ++ " " ++ style)
+
+
+{-| Sets [`border-inline-start`](https://css-tricks.com/almanac/properties/b/border-inline-start/) property.
+
+    borderInlineStart (px 1)
+
+    borderInlineStart2 (px 1) solid
+
+    borderInlineStart3 (px 1) solid (hex "#f00")
+
+-}
+borderInlineStart3 : Value LineWidth -> Value LineStyle -> Value Color -> Style
+borderInlineStart3 (Value widthVal) (Value style) (Value colorVal) =
+    AppendProperty ("border-inline-start:" ++ widthVal ++ " " ++ style ++ " " ++ colorVal)
+
+
+{-| Sets [`border-inline-end`](https://css-tricks.com/almanac/properties/b/border-inline-end/) property.
+
+    borderInlineEnd (px 1)
+
+    borderInlineEnd2 (px 1) solid
+
+    borderInlineEnd3 (px 1) solid (hex "#f00")
+
+-}
+borderInlineEnd : BaseValue LineWidth -> Style
+borderInlineEnd (Value widthVal) =
+    AppendProperty ("border-inline-end:" ++ widthVal)
+
+
+{-| Sets [`border-inline-end`](https://css-tricks.com/almanac/properties/b/border-inline-end/) property.
+
+    borderInlineEnd (px 1)
+
+    borderInlineEnd2 (px 1) solid
+
+    borderInlineEnd3 (px 1) solid (hex "#f00")
+
+-}
+borderInlineEnd2 : Value LineWidth -> Value LineStyle -> Style
+borderInlineEnd2 (Value widthVal) (Value style) =
+    AppendProperty ("border-inline-end:" ++ widthVal ++ " " ++ style)
+
+
+{-| Sets [`border-inline-end`](https://css-tricks.com/almanac/properties/b/border-inline-end/) property.
+
+    borderInlineEnd (px 1)
+
+    borderInlineEnd2 (px 1) solid
+
+    borderInlineEnd3 (px 1) solid (hex "#f00")
+
+-}
+borderInlineEnd3 : Value LineWidth -> Value LineStyle -> Value Color -> Style
+borderInlineEnd3 (Value widthVal) (Value style) (Value colorVal) =
+    AppendProperty ("border-inline-end:" ++ widthVal ++ " " ++ style ++ " " ++ colorVal)
 
 
 {-| Sets [`border-width`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-width) property.

--- a/src/Css.elm
+++ b/src/Css.elm
@@ -35,8 +35,10 @@ module Css exposing
     , borderWidth, borderWidth2, borderWidth3, borderWidth4, borderTopWidth, borderRightWidth, borderBottomWidth, borderLeftWidth
     , thin, thick
     , borderStyle, borderStyle2, borderStyle3, borderStyle4, borderTopStyle, borderRightStyle, borderBottomStyle, borderLeftStyle
+    , borderBlockStyle, borderInlineStyle
     , dotted, dashed, solid, double, groove, ridge, inset, outset
-    , borderColor, borderColor2, borderColor3, borderColor4, borderTopColor, borderRightColor, borderBottomColor, borderLeftColor, borderBlockColor, borderBlockStartColor, borderBlockEndColor, borderInlineColor, borderInlineStartColor, borderInlineEndColor
+    , borderColor, borderColor2, borderColor3, borderColor4, borderTopColor, borderRightColor, borderBottomColor, borderLeftColor
+    , borderBlockColor, borderBlockStartColor, borderBlockEndColor, borderInlineColor, borderInlineStartColor, borderInlineEndColor
     , borderRadius, borderRadius2, borderRadius3, borderRadius4, borderTopLeftRadius, borderTopLeftRadius2, borderTopRightRadius, borderTopRightRadius2, borderBottomRightRadius, borderBottomRightRadius2, borderBottomLeftRadius, borderBottomLeftRadius2
     , borderImageOutset, borderImageOutset2, borderImageOutset3, borderImageOutset4
     , borderImageWidth, borderImageWidth2, borderImageWidth3, borderImageWidth4
@@ -306,6 +308,8 @@ All CSS properties can have the values `unset`, `initial`, and `inherit`
 ## Border Style
 
 @docs borderStyle, borderStyle2, borderStyle3, borderStyle4, borderTopStyle, borderRightStyle, borderBottomStyle, borderLeftStyle
+
+@docs borderBlockStyle, borderInlineStyle
 
 @docs dotted, dashed, solid, double, groove, ridge, inset, outset
 
@@ -7411,7 +7415,6 @@ borderLeft3 (Value widthVal) (Value style) (Value colorVal) =
     AppendProperty ("border-left:" ++ widthVal ++ " " ++ style ++ " " ++ colorVal)
 
 
-
 {-| Sets [`border-block`](https://css-tricks.com/almanac/properties/b/border-block/) property.
 
     borderBlock (px 1)
@@ -7494,10 +7497,6 @@ borderInline2 (Value widthVal) (Value style) =
 borderInline3 : Value LineWidth -> Value LineStyle -> Value Color -> Style
 borderInline3 (Value widthVal) (Value style) (Value colorVal) =
     AppendProperty ("border-inline:" ++ widthVal ++ " " ++ style ++ " " ++ colorVal)
-
-
-
-
 
 
 {-| Sets [`border-width`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-width) property.
@@ -7690,6 +7689,26 @@ borderLeftStyle (Value style) =
     AppendProperty ("border-left-style:" ++ style)
 
 
+{-| Sets [`border-block-style`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-block-style) property.
+
+    borderBlockStyle solid
+
+-}
+borderBlockStyle : BaseValue LineStyle -> Style
+borderBlockStyle (Value style) =
+    AppendProperty ("border-block-style:" ++ style)
+
+
+{-| Sets [`border-inline-style`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-inline-style) property.
+
+    borderInlineStyle solid
+
+-}
+borderInlineStyle : BaseValue LineStyle -> Style
+borderInlineStyle (Value style) =
+    AppendProperty ("border-inline-style:" ++ style)
+
+
 {-| Sets [`border-color`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-color) property.
 
     borderColor (rgb 0 0 0)
@@ -7852,6 +7871,7 @@ borderInlineStartColor (Value colorVal) =
 borderInlineEndColor : BaseValue Color -> Style
 borderInlineEndColor (Value colorVal) =
     AppendProperty ("border-inline-end-color:" ++ colorVal)
+
 
 
 -- BORDER WIDTH --

--- a/src/Css.elm
+++ b/src/Css.elm
@@ -143,6 +143,7 @@ module Css exposing
     , scrollSnapType, scrollSnapType2, x, y, mandatory, proximity
     , scrollMargin, scrollMargin2, scrollMargin3, scrollMargin4, scrollMarginTop, scrollMarginLeft, scrollMarginRight, scrollMarginBottom
     , scrollMarginBlock, scrollMarginBlock2, scrollMarginInline, scrollMarginInline2
+    , scrollMarginBlockStart, scrollMarginBlockEnd, scrollMarginInlineStart, scrollMarginInlineEnd
     , scrollPadding, scrollPadding2, scrollPadding3, scrollPadding4, scrollPaddingTop, scrollPaddingLeft, scrollPaddingRight, scrollPaddingBottom
     , speak, spellOut
     , userSelect
@@ -690,6 +691,7 @@ Multiple CSS properties use these values.
 @docs scrollSnapType, scrollSnapType2, x, y, mandatory, proximity
 @docs scrollMargin, scrollMargin2, scrollMargin3, scrollMargin4, scrollMarginTop, scrollMarginLeft, scrollMarginRight, scrollMarginBottom
 @docs scrollMarginBlock, scrollMarginBlock2, scrollMarginInline, scrollMarginInline2
+@docs scrollMarginBlockStart, scrollMarginBlockEnd, scrollMarginInlineStart, scrollMarginInlineEnd
 @docs scrollPadding, scrollPadding2, scrollPadding3, scrollPadding4, scrollPaddingTop, scrollPaddingLeft, scrollPaddingRight, scrollPaddingBottom
 
 
@@ -13209,6 +13211,58 @@ scrollMarginInline2 :
     -> Style
 scrollMarginInline2 (Value valueTopBottom) (Value valueRightLeft) =
     AppendProperty ("scroll-margin-inline:" ++ valueTopBottom ++ " " ++ valueRightLeft)
+
+
+{-| Sets [`scroll-margin-block-start`](https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-margin-block-start) property.
+
+    scrollMarginBlockStart (px 4)
+
+-}
+scrollMarginBlockStart :
+    BaseValue
+        Length
+    -> Style
+scrollMarginBlockStart (Value value) =
+    AppendProperty ("scroll-margin-block-start:" ++ value)
+
+
+{-| Sets [`scroll-margin-block-end`](https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-margin-block-end) property.
+
+    scrollMarginBlockEnd (px 4)
+
+-}
+scrollMarginBlockEnd :
+    BaseValue
+        Length
+    -> Style
+scrollMarginBlockEnd (Value value) =
+    AppendProperty ("scroll-margin-block-end:" ++ value)
+
+
+{-| Sets [`scroll-margin-inline-start`](https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-margin-inline-start) property.
+
+    scrollMarginInlineStart (px 4)
+
+-}
+scrollMarginInlineStart :
+    BaseValue
+        Length
+    -> Style
+scrollMarginInlineStart (Value value) =
+    AppendProperty ("scroll-margin-inline-start:" ++ value)
+
+
+{-| Sets [`scroll-margin-inline-end`](https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-margin-inline-end) property.
+
+    scrollMarginInlineEnd (px 4)
+
+-}
+scrollMarginInlineEnd :
+    BaseValue
+        Length
+    -> Style
+scrollMarginInlineEnd (Value value) =
+    AppendProperty ("scroll-margin-inline-end:" ++ value)
 
 
 {-| Sets [`scroll-padding`](https://css-tricks.com/almanac/properties/s/scroll-padding/) property.

--- a/src/Css.elm
+++ b/src/Css.elm
@@ -57,6 +57,7 @@ module Css exposing
     , content, fill_, stroke, text, style
     , clip, cover, contain_
     , repeat, noRepeat, repeatX, repeatY, space, round
+    , isolate, matchParent
 
     -- all
     , all
@@ -73,8 +74,8 @@ module Css exposing
     , position
     , absolute, fixed, relative, static, sticky
 
-    -- z-index + box-sizing
-    , zIndex, boxSizing
+    -- stacking contexts + box-sizing
+    , zIndex, isolation, boxSizing
 
     -- sizing
     , width, minWidth, maxWidth, height, minHeight, maxHeight
@@ -169,9 +170,13 @@ module Css exposing
     -- backgrounds
     , backgroundColor
     , backgroundAttachment, backgroundAttachments, local
-    , backgroundBlendMode, backgroundBlendModes, multiply, screen, overlay, darken, lighten, colorDodge, colorBurn, hardLight, softLight, difference, exclusion, hue, saturation, color_, luminosity
+    , backgroundBlendMode, backgroundBlendModes
+    , multiply, screen, overlay, darken, lighten, colorDodge, colorBurn, hardLight, softLight, difference, exclusion, hue, saturation, color_, luminosity
     , backgroundClip, backgroundClips, backgroundOrigin, backgroundOrigins
-    , backgroundImage, backgroundImages, backgroundPosition, backgroundPosition2, backgroundPosition3, backgroundPosition4, backgroundRepeat, backgroundRepeat2, backgroundSize, backgroundSize2
+    , backgroundImage, backgroundImages
+    , backgroundPosition, backgroundPosition2, backgroundPosition3, backgroundPosition4
+    , backgroundRepeat, backgroundRepeat2
+    , backgroundSize, backgroundSize2
 
     -- font size
     , fontSize
@@ -200,7 +205,7 @@ module Css exposing
 
     -- variable fonts (not to be confused with variants)
     , fontVariationSettings, fontVariationSettingsList
-
+    
     -- list styles
     , ListStyleType, ListStyleTypeSupported
     , listStyle, listStyle2, listStyle3, listStylePosition, inside, outside, listStyleType, listStyleImage
@@ -212,6 +217,30 @@ module Css exposing
     , textDecoration, textDecoration2, textDecoration3, textDecorationLine, textDecorationLine2, textDecorationLine3, textDecorationStyle, textDecorationColor, textDecorationThickness, fromFont
     , textDecorationSkip, textDecorationSkipInk, objects, spaces, ink, edges, boxDecoration
     , wavy, underline, overline, lineThrough
+
+    -- text decoration (other)
+    , textIndent, textIndent2, textIndent3, hanging, eachLine
+    , textUnderlineOffset
+    , textEmphasis, textEmphasis2
+    , textEmphasisStyle, textEmphasisStyle2
+    , textEmphasisColor, textEmphasisPosition, textEmphasisPosition2
+    , filled, open, dot, doubleCircle, triangle, sesame, over
+
+    -- more text stuff to rearrange
+    , textAlign, justify 
+    , textJustify, interWord, interCharacter
+    , textUnderlinePosition, textUnderlinePosition2
+    , textOrientation
+    , mixed, sideways, sidewaysRight, upright, useGlyphOrientation
+
+    -- script handling
+    , direction, ltr, rtl
+    , writingMode, verticalLr, verticalRl, horizontalTb
+    , unicodeBidi, embed, plaintext, bidiOverride, isolateOverride
+
+    -- text rendering
+    , textRendering
+    , geometricPrecision, optimizeLegibility, optimizeSpeed
 
     -- cursors
     , CursorKeyword
@@ -227,25 +256,11 @@ module Css exposing
     , TextShadowConfig, textShadow, defaultTextShadow
     , linearGradient, linearGradient2, stop, stop2, stop3, toBottom, toBottomLeft, toBottomRight, toLeft, toRight, toTop, toTopLeft, toTopRight
 
-    -- ??
-    , textStroke, textStroke2, textStrokeColor, textStrokeWidth
-    , textIndent, textIndent2, textIndent3, hanging, eachLine
-    , textUnderlineOffset
-    , textEmphasis, textEmphasis2, textEmphasisStyle, textEmphasisStyle2, textEmphasisColor, textEmphasisPosition, textEmphasisPosition2, filled, open, dot, doubleCircle, triangle, sesame, over
-    
-    -- ??
-    , direction, ltr, rtl
-    , justify, matchParent, textAlign, textJustify, interWord, interCharacter, textUnderlinePosition, textUnderlinePosition2
-    , textOrientation
-    , mixed, sideways, sidewaysRight, upright, useGlyphOrientation
-    , textRendering
-    , geometricPrecision, optimizeLegibility, optimizeSpeed
 
     -- ??
     , wordSpacing
     , tabSize
     , fontDisplay, fallback, swap, optional
-    , writingMode, verticalLr, verticalRl, horizontalTb
     , hyphens, quotes, quotes2, quotes4, textOverflow, textOverflow2, lineBreak, manual, ellipsis, loose
     , hangingPunctuation, hangingPunctuation2, hangingPunctuation3, first, last, forceEnd, allowEnd
     , lineClamp
@@ -269,13 +284,19 @@ module Css exposing
     , clear
     , visibility
     , fill
+
+    -- ??
     , strokeDasharray, strokeDashoffset, strokeWidth, strokeAlign, strokeColor, strokeImage, strokeMiterlimit, strokeOpacity, strokePosition, strokePosition2, strokePosition4, strokeRepeat, strokeRepeat2, strokeSize, strokeSize2, strokeDashCorner
     , strokeLinecap, butt, square
     , strokeBreak, boundingBox, slice, clone
     , strokeOrigin
     , strokeLinejoin, strokeLinejoin2, crop, arcs, miter, bevel
     , strokeDashJustify, compress, dashes, gaps
+
+    -- ??
     , paintOrder, paintOrder2, paintOrder3, markers
+
+    -- ??
     , columns, columns2, columnWidth, columnCount, columnRuleWidth, columnRuleStyle, columnRuleColor, columnRule, columnRule2, columnRule3
     , columnFill, balance, balanceAll
     , columnSpan
@@ -326,7 +347,6 @@ module Css exposing
     -- ??
     , speak, spellOut
     , userSelect
-    , unicodeBidi, embed, bidiOverride, isolateOverride, plaintext
     , bleed
     , orphans, widows
     , mixBlendMode
@@ -335,7 +355,6 @@ module Css exposing
     , objectFit, scaleDown
     , objectPosition, objectPosition2, objectPosition4
     , boxDecorationBreak
-    , isolation, isolate
     , clipPath, clipPath2
     , maskBorderMode, maskBorderRepeat, maskBorderRepeat2, maskBorderOutset, maskBorderOutset2, maskBorderOutset3, maskBorderOutset4, maskBorderSlice, maskBorderSlice2, maskBorderSlice3, maskBorderSlice4, maskBorderWidth, maskBorderWidth2, maskBorderWidth3, maskBorderWidth4
     , maskClip, maskClipList, maskComposite, maskMode, maskModeList, maskOrigin, maskOriginList, maskPosition, maskRepeat, maskRepeat2, maskSize, maskSize2, maskType
@@ -902,8 +921,6 @@ Other values you can use for flex item alignment:
 @docs textDecorationSkip, textDecorationSkipInk, objects, spaces, ink, edges, boxDecoration
 
 @docs wavy, underline, overline, lineThrough
-
-@docs textStroke, textStroke2, textStrokeColor, textStrokeWidth
 
 @docs textIndent, textIndent2, textIndent3, hanging, eachLine
 
@@ -4213,6 +4230,32 @@ round =
 
 
 
+{-| Sets `isolate` value for usage with [`isolation`](#isolation), and
+[`unicodeBidi`](#unicodeBidi).
+
+    isolation isolate
+
+    unicodeBidi isolate
+
+-}
+isolate : Value { provides | isolate : Supported }
+isolate =
+    Value "isolate"
+
+    
+{-| A `match-parent` value for the [`text-align`](https://css-tricks.com/almanac/properties/t/text-align/),
+and [`strokeOrigin`](#strokeOrigin) properties.
+
+    textAlign matchParent
+
+    strokeOrigin matchParent
+
+-}
+matchParent : Value { provides | matchParent : Supported }
+matchParent =
+    Value "match-parent"
+
+
 ------------------------------------------------------------------------
 ------------------------------------------------------------------------
 ------------------------------------------------------------------------
@@ -4717,7 +4760,7 @@ sticky =
 ------------------------------------------------------------------------
 ------------------------------------------------------------------------
 ------------------------------------------------------------------------
------------------------- Z-INDEX, BOX-SIZING ---------------------------
+--------------------- STACKING CONTEXTS, BOX-SIZING --------------------
 ------------------------------------------------------------------------
 ------------------------------------------------------------------------
 ------------------------------------------------------------------------
@@ -4747,8 +4790,21 @@ zIndex (Value val) =
     AppendProperty ("z-index:" ++ val)
 
 
+{-| Sets [`isolation`](https://css-tricks.com/almanac/properties/i/isolation/)
 
--- BOX SIZING --
+    isolation auto
+
+    isolation isolate
+
+-}
+isolation :
+    BaseValue
+        { auto : Supported
+        , isolate : Supported
+        }
+    -> Style
+isolation (Value val) =
+    AppendProperty ("isolation:" ++ val)
 
 
 {-| Sets [`box-sizing`](https://css-tricks.com/almanac/properties/b/box-sizing/) property.
@@ -13100,7 +13156,6 @@ upperRoman =
     Value "upper-roman"
 
 
-
 ------------------------------------------------------------------------
 ------------------------------------------------------------------------
 ------------------------------------------------------------------------
@@ -13525,6 +13580,802 @@ overline =
 lineThrough : Value { provides | lineThrough : Supported }
 lineThrough =
     Value "line-through"
+
+
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+-------------------------- OTHER TEXT DECORATION -----------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+
+
+{-| The [`text-indent`](https://css-tricks.com/almanac/properties/t/text-indent/) property.
+
+    textIndent (em 1.5)
+
+-}
+textIndent : BaseValue (LengthSupported { pct : Supported }) -> Style
+textIndent (Value val) =
+    AppendProperty ("text-indent:" ++ val)
+
+
+{-| The [`text-indent`](https://css-tricks.com/almanac/properties/t/text-indent/) property.
+
+    textIndent2 (em 1.5) hanging
+
+-}
+textIndent2 :
+    Value (LengthSupported { pct : Supported })
+    ->
+        Value
+            { hanging : Supported
+            , eachLine : Supported
+            }
+    -> Style
+textIndent2 (Value lengthVal) (Value optionVal) =
+    AppendProperty ("text-indent:" ++ lengthVal ++ " " ++ optionVal)
+
+
+{-| The [`text-indent`](https://css-tricks.com/almanac/properties/t/text-indent/) property.
+
+    textIndent3 (em 1.5) hanging eachLine
+
+-}
+textIndent3 :
+    Value (LengthSupported { pct : Supported })
+    -> Value { hanging : Supported }
+    -> Value { eachLine : Supported }
+    -> Style
+textIndent3 (Value lengthVal) (Value hangingVal) (Value eachLineVal) =
+    AppendProperty
+        ("text-indent:"
+            ++ lengthVal
+            ++ " "
+            ++ hangingVal
+            ++ " "
+            ++ eachLineVal
+        )
+
+
+{-| The `hanging` value used for properties such as [`textIdent2`](#textIdent2).
+
+    textIdent2 (px 20) hanging
+
+-}
+hanging : Value { provides | hanging : Supported }
+hanging =
+    Value "hanging"
+
+
+{-| The `each-line` value used for properties such as [`textIdent2`](#textIdent2).
+
+    textIdent2 (px 20) eachLine
+
+-}
+eachLine : Value { provides | eachLine : Supported }
+eachLine =
+    Value "each-line"
+
+
+{-| Sets the [text-underline-offset](https://css-tricks.com/almanac/properties/t/text-underline-offset/) property.
+
+    textUnderlineOffset (pct 5)
+-}
+textUnderlineOffset :
+    BaseValue
+        ( LengthSupported
+            { pct : Supported
+            , auto : Supported
+            }
+        )
+    -> Style
+textUnderlineOffset (Value value) =
+    AppendProperty ("text-underline-offset:" ++ value)
+
+
+{-| Sets the [`text-emphasis`](https://css-tricks.com/almanac/properties/t/text-emphasis/) property.
+
+This is for drawing attention towards textual elements in a way that is commonly
+used in East Asian languages.
+
+    textEmphasis (hex "ff0000")
+
+    textEmphasis sesame
+
+    textEmphasis2 triangle (hex "00ff00")
+
+-}
+textEmphasis :
+    BaseValue
+        (ColorSupported
+            { none : Supported
+            , filled : Supported
+            , open : Supported
+            , dot : Supported
+            , circle_ : Supported
+            , doubleCircle : Supported
+            , triangle : Supported
+            , sesame : Supported
+            , string : Supported
+            }
+        )
+    -> Style
+textEmphasis (Value value) =
+    AppendProperty ("text-emphasis:" ++ value)
+
+
+{-| Sets the [`text-emphasis`](https://css-tricks.com/almanac/properties/t/text-emphasis/) property.
+
+This 2-argument form sets [`text-emphasis-style`](#textEmphasisStyle) and [`textEmphasisColor`](#textEmphasisColor) in a single declaration.
+
+    textEmphasis2 filled (hex "ff0000")
+-}
+textEmphasis2 :
+    BaseValue
+        { none : Supported
+        , filled : Supported
+        , open : Supported
+        , dot : Supported
+        , circle_ : Supported
+        , doubleCircle : Supported
+        , triangle : Supported
+        , sesame : Supported
+        , string : Supported
+        }
+    ->
+        BaseValue
+            (Color)
+    -> Style
+textEmphasis2 (Value value1) (Value value2) =
+    AppendProperty
+        ("text-emphasis:"
+            ++ value1
+            ++ " "
+            ++ value2
+        )
+
+
+{-| Sets the [`text-emphasis-style`](https://developer.mozilla.org/en-US/docs/Web/CSS/text-emphasis-style) property.
+
+    textEmphasisStyle none
+
+    textEmphasisStyle open
+
+    textEmphasisStyle (string "🐯")
+-}
+textEmphasisStyle :
+    BaseValue
+        { none : Supported
+        , filled : Supported
+        , open : Supported
+        , dot : Supported
+        , circle_ : Supported
+        , doubleCircle : Supported
+        , triangle : Supported
+        , sesame : Supported
+        , string : Supported
+        }
+    -> Style
+textEmphasisStyle (Value value) =
+    AppendProperty ("text-emphasis-style:" ++ value)
+
+
+{-| Sets the [`text-emphasis-style`](https://developer.mozilla.org/en-US/docs/Web/CSS/text-emphasis-style) property when you want to use two arguments - one for `filled` or `open`, and one for the shape style.
+
+    textEmphasisStyle filled sesame
+
+    textEmphasisStyle open dot
+-}
+textEmphasisStyle2 :
+    BaseValue
+        { filled : Supported
+        , open : Supported
+        }
+    -> BaseValue
+        { dot : Supported
+        , circle_ : Supported
+        , doubleCircle : Supported
+        , triangle : Supported
+        , sesame : Supported
+        }
+    -> Style
+textEmphasisStyle2 (Value val1) (Value val2) =
+    AppendProperty
+        ("text-emphasis-style:"
+        ++ val1
+        ++ " "
+        ++ val2
+        )
+
+
+{-| Sets the [`text-emphasis-color`](https://developer.mozilla.org/en-US/docs/Web/CSS/text-emphasis-color) property.
+
+    textEmphasisColor currentcolor
+
+    textemphasisColor (hex "0000ff")
+-}
+textEmphasisColor :
+    BaseValue (Color)
+    -> Style
+textEmphasisColor (Value value) =
+    AppendProperty ("text-emphasis-color:" ++ value)
+
+
+{-| Sets the [`text-emphasis-position`](https://developer.mozilla.org/en-US/docs/Web/CSS/text-emphasis-position) property.
+
+This is the one argument version, which is limited to setting global values.
+
+If you want to specify the positions of the text-emphasis, you must use the [2-argument form](#textEmphasisPosition2).
+
+    textEmphasisPosition inherit
+
+    textEmphasisPosition revert
+
+    textEmphasisPosition2 over left_
+
+    textEmphasisPosition2 under right_
+
+-}
+textEmphasisPosition :
+    BaseValue a
+    -> Style
+textEmphasisPosition (Value value) =
+    AppendProperty ("text-emphasis-position:" ++ value)
+
+
+{-| Sets the the [`text-emphasis-position`](https://developer.mozilla.org/en-US/docs/Web/CSS/text-emphasis-position) property.
+
+This is the 2-argument form that lets you specify the positions of the emphasis.
+
+if you want to apply global values, you must use the [1-argument form](#textEmphasisPosition).
+
+    textEmphasisPosition inherit
+
+    textEmphasisPosition revert
+
+    textEmphasisPosition2 over left_
+
+    textEmphasisPosition2 under right_
+
+-}
+textEmphasisPosition2 :
+    BaseValue
+        { over : Supported
+        , under : Supported
+        }
+    -> BaseValue
+        { left_ : Supported
+        , right_ : Supported
+        }
+    -> Style
+textEmphasisPosition2 (Value val1) (Value val2) =
+    AppendProperty
+        ("text-emphasis-position:"
+        ++ val1
+        ++ " "
+        ++ val2
+        )
+
+
+{-| The `filled` value used in [`textEmphasis`](#textEmphasis).
+
+    textEmphasis filled
+
+-}
+filled : Value { provides | filled : Supported }
+filled =
+    Value "filled"
+
+
+{-| The `open` value used in [`textEmphasis`](#textEmphasis).
+
+    textEmphasis open
+
+-}
+open : Value { provides | open : Supported }
+open =
+    Value "open"
+
+
+{-| The `dot` value used in [`textEmphasis`](#textEmphasis).
+
+    textEmphasis dot
+
+-}
+dot : Value { provides | dot : Supported }
+dot =
+    Value "dot"
+
+
+{-| The `doubleCircle` value used in [`textEmphasis`](#textEmphasis).
+
+    textEmphasis doubleCircle
+
+-}
+doubleCircle : Value { provides | doubleCircle : Supported }
+doubleCircle =
+    Value "double-circle"
+
+
+{-| The `triangle` value used in [`textEmphasis`](#textEmphasis).
+
+    textEmphasis triangle
+
+-}
+triangle : Value { provides | triangle : Supported }
+triangle =
+    Value "triangle"
+
+
+{-| The `sesame` value used in [`textEmphasis`](#textEmphasis).
+
+    textEmphasis sesame
+
+-}
+sesame : Value { provides | sesame : Supported }
+sesame =
+    Value "sesame"
+
+
+{-| The `over` value used in [`textEmphasisPosition2`](#textEmphasisPosition2).
+
+    textEmphasisPosition2 over left_
+
+-}
+over : Value { provides | over : Supported }
+over =
+    Value "over"
+
+
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+--------------------- MORE TEXT STUFF TO REARRANGE ---------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+
+
+{-| Sets [`text-align`](https://css-tricks.com/almanac/properties/t/text-align/)
+
+    textAlign left_
+
+    textAlign justfy
+
+-}
+textAlign :
+    BaseValue
+        { left_ : Supported
+        , right_ : Supported
+        , center : Supported
+        , justify : Supported
+        , start : Supported
+        , end : Supported
+        , matchParent : Supported
+        }
+    -> Style
+textAlign (Value str) =
+    AppendProperty ("text-align:" ++ str)
+
+
+{-| A `justify` value for the [`text-align`](https://css-tricks.com/almanac/properties/t/text-align/)
+
+    textAlign justify
+
+-}
+justify : Value { provides | justify : Supported }
+justify =
+    Value "justify"
+
+
+{-| Sets [`text-justify`](https://css-tricks.com/almanac/properties/t/text-justify/)
+
+    textJustify interWord
+
+    textJustify interCharacter
+
+    textJustify auto
+
+    textJustify none
+
+-}
+textJustify :
+    BaseValue
+        { interWord : Supported
+        , interCharacter : Supported
+        , auto : Supported
+        , none : Supported
+        }
+    -> Style
+textJustify (Value val) =
+    AppendProperty ("text-justify:" ++ val)
+
+
+{-| A `inter-word` value for the [`textJustify`](#textJustify) property.
+
+    textJustify interWord
+
+-}
+interWord : Value { provides | interWord : Supported }
+interWord =
+    Value "inter-word"
+
+
+{-| A `inter-character` value for the [`textJustify`](#textJustify) property.
+
+    textJustify interCharacter
+
+-}
+interCharacter : Value { provides | interCharacter : Supported }
+interCharacter =
+    Value "inter-character"
+
+
+{-| Sets [`text-underline-position`](https://css-tricks.com/almanac/properties/t/text-underline-position/)
+
+    textUnderlinePosition auto
+
+    textUnderlinePosition under
+
+    textUnderlinePosition left_
+
+    textUnderlinePosition right_
+
+-}
+textUnderlinePosition :
+    BaseValue
+        { auto : Supported
+        , under : Supported
+        , left_ : Supported
+        , right_ : Supported
+        }
+    -> Style
+textUnderlinePosition (Value val) =
+    AppendProperty ("text-underline-position:" ++ val)
+
+
+{-| Sets [`text-underline-position`](https://css-tricks.com/almanac/properties/t/text-underline-position/)
+
+    textUnderlinePosition2 under left_
+
+    textUnderlinePosition2 under right_
+
+-}
+textUnderlinePosition2 :
+    Value { under : Supported }
+    ->
+        Value
+            { left_ : Supported
+            , right_ : Supported
+            }
+    -> Style
+textUnderlinePosition2 (Value underVal) (Value val) =
+    AppendProperty ("text-underline-position:" ++ underVal ++ " " ++ val)
+
+
+
+{-| Sets [`text-orientation`](https://developer.mozilla.org/en-US/docs/Web/CSS/text-orientation).
+
+    textOrientation sideways
+
+    textOrientation upright
+
+-}
+textOrientation :
+    BaseValue
+        { mixed : Supported
+        , sideways : Supported
+        , sidewaysRight : Supported
+        , upright : Supported
+        , useGlyphOrientation : Supported
+        }
+    -> Style
+textOrientation (Value str) =
+    AppendProperty ("text-orientation:" ++ str)
+
+
+{-| A `mixed` value for the
+[`textOrientation`](#textOrientation) property.
+
+    textOrientation mixed
+
+-}
+mixed : Value { provides | mixed : Supported }
+mixed =
+    Value "mixed"
+
+
+{-| A `sideways` value for the
+[`textOrientation`](#textOrientation) property.
+
+    textOrientation sideways
+
+-}
+sideways : Value { provides | sideways : Supported }
+sideways =
+    Value "sideways"
+
+
+{-| A `sideways-right` value for the
+[`textOrientation`](#textOrientation) property.
+
+    textOrientation sidewaysRight
+
+-}
+sidewaysRight : Value { provides | sidewaysRight : Supported }
+sidewaysRight =
+    Value "sideways-right"
+
+
+{-| A `upright` value for the
+[`textOrientation`](#textOrientation) property.
+
+    textOrientation upright
+
+-}
+upright : Value { provides | upright : Supported }
+upright =
+    Value "upright"
+
+
+{-| A `use-glyph-orientation` value for the
+[`textOrientation`](#textOrientation) property.
+
+    textOrientation useGlyphOrientation
+
+-}
+useGlyphOrientation : Value { provides | useGlyphOrientation : Supported }
+useGlyphOrientation =
+    Value "use-glyph-orientation"
+
+
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+---------------------------- SCRIPT HANDLING ---------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+
+
+{-| Sets [`direction`](https://css-tricks.com/almanac/properties/d/direction/)
+
+    direction ltr
+
+    direction rtl
+
+-}
+direction :
+    BaseValue
+        { rtl : Supported
+        , ltr : Supported
+        }
+    -> Style
+direction (Value str) =
+    AppendProperty ("direction:" ++ str)
+
+
+{-| A `ltr` value for the [`direction`](https://css-tricks.com/almanac/properties/d/direction/) property.
+
+    direction ltr
+
+-}
+ltr : Value { provides | ltr : Supported }
+ltr =
+    Value "ltr"
+
+
+{-| A `rtl` value for the [`direction`](https://css-tricks.com/almanac/properties/d/direction/) property.
+
+    direction rtl
+
+-}
+rtl : Value { provides | rtl : Supported }
+rtl =
+    Value "rtl"
+
+
+{-| Sets [`writing-mode`](https://css-tricks.com/almanac/properties/w/writing-mode/).
+
+    writingMode horizontalTb
+
+    writingMode verticalRl
+
+    writingMode verticalLr
+
+-}
+writingMode :
+    BaseValue
+        { horizontalTb : Supported
+        , verticalRl : Supported
+        , verticalLr : Supported
+        }
+    -> Style
+writingMode (Value str) =
+    AppendProperty ("writing-mode:" ++ str)
+
+
+{-| Sets `horizontal-tb` value for usage with [`writingMode`](#writingMode).
+
+    writingMode horizontalTb
+
+-}
+horizontalTb : Value { provides | horizontalTb : Supported }
+horizontalTb =
+    Value "horizontal-tb"
+
+
+{-| Sets `vertical-lr` value for usage with [`writingMode`](#writingMode).
+
+    writingMode verticalLr
+
+-}
+verticalLr : Value { provides | verticalLr : Supported }
+verticalLr =
+    Value "vertical-lr"
+
+
+{-| Sets `vertical-rl` value for usage with [`writingMode`](#writingMode).
+
+    writingMode verticalRl
+
+-}
+verticalRl : Value { provides | verticalRl : Supported }
+verticalRl =
+    Value "vertical-rl"
+
+
+{-| Sets [`unicode-bidi`](https://css-tricks.com/almanac/properties/u/unicode-bidi/)
+
+    unicodeBidi normal
+
+    unicodeBidi embed
+
+    unicodeBidi isolate
+
+    unicodeBidi bidiOverride
+
+    unicodeBidi isolateOverride
+
+    unicodeBidi plaintext
+
+-}
+unicodeBidi :
+    BaseValue
+        { normal : Supported
+        , embed : Supported
+        , isolate : Supported
+        , bidiOverride : Supported
+        , isolateOverride : Supported
+        , plaintext : Supported
+        }
+    -> Style
+unicodeBidi (Value val) =
+    AppendProperty ("unicode-bidi:" ++ val)
+
+
+{-| Sets `embed` value for usage with [`unicodeBidi`](#unicodeBidi).
+
+    unicodeBidi embed
+
+-}
+embed : Value { provides | embed : Supported }
+embed =
+    Value "embed"
+
+
+{-| Sets `plaintext` value for usage with [`unicodeBidi`](#unicodeBidi).
+
+    unicodeBidi plaintext
+
+-}
+plaintext : Value { provides | plaintext : Supported }
+plaintext =
+    Value "plaintext"
+
+
+{-| Sets `bidi-override` value for usage with [`unicodeBidi`](#unicodeBidi).
+
+    unicodeBidi bidiOverride
+
+-}
+bidiOverride : Value { provides | bidiOverride : Supported }
+bidiOverride =
+    Value "bidi-override"
+
+
+{-| Sets `isolate-override` value for usage with [`unicodeBidi`](#unicodeBidi).
+
+    unicodeBidi isolateOverride
+
+-}
+isolateOverride : Value { provides | isolateOverride : Supported }
+isolateOverride =
+    Value "isolate-override"
+
+
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+--------------------------- TEXT RENDERING -----------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+
+
+{-| Sets [`text-rendering`](https://css-tricks.com/almanac/properties/t/text-rendering/).
+
+    textRendering geometricPrecision
+
+    textRendering optimizeSpeed
+
+-}
+textRendering :
+    BaseValue
+        { auto : Supported
+        , geometricPrecision : Supported
+        , optimizeLegibility : Supported
+        , optimizeSpeed : Supported
+        }
+    -> Style
+textRendering (Value str) =
+    AppendProperty ("text-rendering:" ++ str)
+
+
+{-| A `geometricPrecision` value for the [`text-rendering`](https://css-tricks.com/almanac/properties/t/text-rendering/) property.
+
+    textRendering geometricPrecision
+
+-}
+geometricPrecision : Value { provides | geometricPrecision : Supported }
+geometricPrecision =
+    Value "geometricPrecision"
+
+
+{-| An `optimizeLegibility` value for the [`text-rendering`](https://css-tricks.com/almanac/properties/t/text-rendering/) property.
+
+    textRendering optimizeLegibility
+
+-}
+optimizeLegibility : Value { provides | optimizeLegibility : Supported }
+optimizeLegibility =
+    Value "optimizeLegibility"
+
+
+{-| An `optimizeSpeed` value for the [`text-rendering`](https://css-tricks.com/almanac/properties/t/text-rendering/) property.
+
+    textRendering optimizeSpeed
+
+-}
+optimizeSpeed : Value { provides | optimizeSpeed : Supported }
+optimizeSpeed =
+    Value "optimizeSpeed"
 
 
 ------------------------------------------------------------------------
@@ -14396,154 +15247,6 @@ toTopRight =
     Value "to top right"
 
 
--- TEXT ORIENTATION --
-
-
-{-| Sets [`text-orientation`](https://developer.mozilla.org/en-US/docs/Web/CSS/text-orientation).
-
-    textOrientation sideways
-
-    textOrientation upright
-
--}
-textOrientation :
-    BaseValue
-        { mixed : Supported
-        , sideways : Supported
-        , sidewaysRight : Supported
-        , upright : Supported
-        , useGlyphOrientation : Supported
-        }
-    -> Style
-textOrientation (Value str) =
-    AppendProperty ("text-orientation:" ++ str)
-
-
-{-| A `mixed` value for the
-[`textOrientation`](#textOrientation) property.
-
-    textOrientation mixed
-
--}
-mixed : Value { provides | mixed : Supported }
-mixed =
-    Value "mixed"
-
-
-{-| A `sideways` value for the
-[`textOrientation`](#textOrientation) property.
-
-    textOrientation sideways
-
--}
-sideways : Value { provides | sideways : Supported }
-sideways =
-    Value "sideways"
-
-
-{-| A `sideways-right` value for the
-[`textOrientation`](#textOrientation) property.
-
-    textOrientation sidewaysRight
-
--}
-sidewaysRight : Value { provides | sidewaysRight : Supported }
-sidewaysRight =
-    Value "sideways-right"
-
-
-{-| A `upright` value for the
-[`textOrientation`](#textOrientation) property.
-
-    textOrientation upright
-
--}
-upright : Value { provides | upright : Supported }
-upright =
-    Value "upright"
-
-
-{-| A `use-glyph-orientation` value for the
-[`textOrientation`](#textOrientation) property.
-
-    textOrientation useGlyphOrientation
-
--}
-useGlyphOrientation : Value { provides | useGlyphOrientation : Supported }
-useGlyphOrientation =
-    Value "use-glyph-orientation"
-
-
-
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
---------------------------- TEXT RENDERING -----------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-
-
-{-| Sets [`text-rendering`](https://css-tricks.com/almanac/properties/t/text-rendering/).
-
-    textRendering geometricPrecision
-
-    textRendering optimizeSpeed
-
--}
-textRendering :
-    BaseValue
-        { auto : Supported
-        , geometricPrecision : Supported
-        , optimizeLegibility : Supported
-        , optimizeSpeed : Supported
-        }
-    -> Style
-textRendering (Value str) =
-    AppendProperty ("text-rendering:" ++ str)
-
-
-{-| A `geometricPrecision` value for the [`text-rendering`](https://css-tricks.com/almanac/properties/t/text-rendering/) property.
-
-    textRendering geometricPrecision
-
--}
-geometricPrecision : Value { provides | geometricPrecision : Supported }
-geometricPrecision =
-    Value "geometricPrecision"
-
-
-{-| An `optimizeLegibility` value for the [`text-rendering`](https://css-tricks.com/almanac/properties/t/text-rendering/) property.
-
-    textRendering optimizeLegibility
-
--}
-optimizeLegibility : Value { provides | optimizeLegibility : Supported }
-optimizeLegibility =
-    Value "optimizeLegibility"
-
-
-{-| An `optimizeSpeed` value for the [`text-rendering`](https://css-tricks.com/almanac/properties/t/text-rendering/) property.
-
-    textRendering optimizeSpeed
-
--}
-optimizeSpeed : Value { provides | optimizeSpeed : Supported }
-optimizeSpeed =
-    Value "optimizeSpeed"
-
-
-
-
-
-
-
 
 
 
@@ -14773,174 +15476,6 @@ textBottom =
 middle : Value { provides | middle : Supported }
 middle =
     Value "middle"
-
-
-{-| Sets [`direction`](https://css-tricks.com/almanac/properties/d/direction/)
-
-    direction ltr
-
-    direction rtl
-
--}
-direction :
-    BaseValue
-        { rtl : Supported
-        , ltr : Supported
-        }
-    -> Style
-direction (Value str) =
-    AppendProperty ("direction:" ++ str)
-
-
-{-| A `ltr` value for the [`direction`](https://css-tricks.com/almanac/properties/d/direction/) property.
-
-    direction ltr
-
--}
-ltr : Value { provides | ltr : Supported }
-ltr =
-    Value "ltr"
-
-
-{-| A `rtl` value for the [`direction`](https://css-tricks.com/almanac/properties/d/direction/) property.
-
-    direction rtl
-
--}
-rtl : Value { provides | rtl : Supported }
-rtl =
-    Value "rtl"
-
-
-{-| Sets [`text-align`](https://css-tricks.com/almanac/properties/t/text-align/)
-
-    textAlign left_
-
-    textAlign justfy
-
--}
-textAlign :
-    BaseValue
-        { left_ : Supported
-        , right_ : Supported
-        , center : Supported
-        , justify : Supported
-        , start : Supported
-        , end : Supported
-        , matchParent : Supported
-        }
-    -> Style
-textAlign (Value str) =
-    AppendProperty ("text-align:" ++ str)
-
-
-{-| A `justify` value for the [`text-align`](https://css-tricks.com/almanac/properties/t/text-align/)
-
-    textAlign justify
-
--}
-justify : Value { provides | justify : Supported }
-justify =
-    Value "justify"
-
-
-{-| A `match-parent` value for the [`text-align`](https://css-tricks.com/almanac/properties/t/text-align/),
-and [`strokeOrigin`](#strokeOrigin) properties.
-
-    textAlign matchParent
-
-    strokeOrigin matchParent
-
--}
-matchParent : Value { provides | matchParent : Supported }
-matchParent =
-    Value "match-parent"
-
-
-{-| Sets [`text-justify`](https://css-tricks.com/almanac/properties/t/text-justify/)
-
-    textJustify interWord
-
-    textJustify interCharacter
-
-    textJustify auto
-
-    textJustify none
-
--}
-textJustify :
-    BaseValue
-        { interWord : Supported
-        , interCharacter : Supported
-        , auto : Supported
-        , none : Supported
-        }
-    -> Style
-textJustify (Value val) =
-    AppendProperty ("text-justify:" ++ val)
-
-
-{-| A `inter-word` value for the [`textJustify`](#textJustify) property.
-
-    textJustify interWord
-
--}
-interWord : Value { provides | interWord : Supported }
-interWord =
-    Value "inter-word"
-
-
-{-| A `inter-character` value for the [`textJustify`](#textJustify) property.
-
-    textJustify interCharacter
-
--}
-interCharacter : Value { provides | interCharacter : Supported }
-interCharacter =
-    Value "inter-character"
-
-
-{-| Sets [`text-underline-position`](https://css-tricks.com/almanac/properties/t/text-underline-position/)
-
-    textUnderlinePosition auto
-
-    textUnderlinePosition under
-
-    textUnderlinePosition left_
-
-    textUnderlinePosition right_
-
--}
-textUnderlinePosition :
-    BaseValue
-        { auto : Supported
-        , under : Supported
-        , left_ : Supported
-        , right_ : Supported
-        }
-    -> Style
-textUnderlinePosition (Value val) =
-    AppendProperty ("text-underline-position:" ++ val)
-
-
-{-| Sets [`text-underline-position`](https://css-tricks.com/almanac/properties/t/text-underline-position/)
-
-    textUnderlinePosition2 under left_
-
-    textUnderlinePosition2 under right_
-
--}
-textUnderlinePosition2 :
-    Value { under : Supported }
-    ->
-        Value
-            { left_ : Supported
-            , right_ : Supported
-            }
-    -> Style
-textUnderlinePosition2 (Value underVal) (Value val) =
-    AppendProperty ("text-underline-position:" ++ underVal ++ " " ++ val)
-
 
 
 -- WHITE-SPACE --
@@ -20374,411 +20909,6 @@ tabSize (Value val) =
     AppendProperty ("tab-size:" ++ val)
 
 
-
---- Text stroke ---
-
-
-{-| Sets [`text-stroke`](https://css-tricks.com/almanac/properties/t/text-stroke/)
-This is a shorthand for [`text-stroke-width`](#textStrokeWidth) and [`text-stroke-color`](#textStrokeColor).
-
-    tabStroke (px 2)
-
--}
-textStroke :
-    BaseValue
-        (LengthSupported
-            { auto : Supported
-            , pct : Supported
-            }
-        )
-    -> Style
-textStroke (Value val) =
-    AppendProperty ("text-stroke:" ++ val)
-
-
-{-| Sets [`text-stroke`](https://css-tricks.com/almanac/properties/t/text-stroke/)
-
-    tabStroke2 (px 2) (hex "#60b5cc")
-
--}
-textStroke2 :
-    Value
-        (LengthSupported
-            { auto : Supported
-            , pct : Supported
-            }
-        )
-    -> Value Color
-    -> Style
-textStroke2 (Value val1) (Value val2) =
-    AppendProperty ("text-stroke:" ++ val1 ++ " " ++ val2)
-
-
-{-| Sets [`text-stroke-width`](https://css-tricks.com/almanac/properties/t/text-stroke/)
-
-    tabStrokeWidth (px 2)
-
--}
-textStrokeWidth :
-    BaseValue
-        (LengthSupported
-            { auto : Supported
-            , pct : Supported
-            }
-        )
-    -> Style
-textStrokeWidth (Value val) =
-    AppendProperty ("text-stroke-width:" ++ val)
-
-
-{-| Sets [`text-stroke-color`](https://css-tricks.com/almanac/properties/t/text-stroke/)
-
-    tabStrokeColor (hex "#60b5cc")
-
--}
-textStrokeColor : BaseValue Color -> Style
-textStrokeColor (Value val) =
-    AppendProperty ("text-stroke-color:" ++ val)
-
-
-{-| The [`text-indent`](https://css-tricks.com/almanac/properties/t/text-indent/) property.
-
-    textIndent (em 1.5)
-
--}
-textIndent : BaseValue (LengthSupported { pct : Supported }) -> Style
-textIndent (Value val) =
-    AppendProperty ("text-indent:" ++ val)
-
-
-{-| The [`text-indent`](https://css-tricks.com/almanac/properties/t/text-indent/) property.
-
-    textIndent2 (em 1.5) hanging
-
--}
-textIndent2 :
-    Value (LengthSupported { pct : Supported })
-    ->
-        Value
-            { hanging : Supported
-            , eachLine : Supported
-            }
-    -> Style
-textIndent2 (Value lengthVal) (Value optionVal) =
-    AppendProperty ("text-indent:" ++ lengthVal ++ " " ++ optionVal)
-
-
-{-| The [`text-indent`](https://css-tricks.com/almanac/properties/t/text-indent/) property.
-
-    textIndent3 (em 1.5) hanging eachLine
-
--}
-textIndent3 :
-    Value (LengthSupported { pct : Supported })
-    -> Value { hanging : Supported }
-    -> Value { eachLine : Supported }
-    -> Style
-textIndent3 (Value lengthVal) (Value hangingVal) (Value eachLineVal) =
-    AppendProperty
-        ("text-indent:"
-            ++ lengthVal
-            ++ " "
-            ++ hangingVal
-            ++ " "
-            ++ eachLineVal
-        )
-
-
-{-| The `hanging` value used for properties such as [`textIdent2`](#textIdent2).
-
-    textIdent2 (px 20) hanging
-
--}
-hanging : Value { provides | hanging : Supported }
-hanging =
-    Value "hanging"
-
-
-{-| The `each-line` value used for properties such as [`textIdent2`](#textIdent2).
-
-    textIdent2 (px 20) eachLine
-
--}
-eachLine : Value { provides | eachLine : Supported }
-eachLine =
-    Value "each-line"
-
-
-{-| Sets the [text-underline-offset](https://css-tricks.com/almanac/properties/t/text-underline-offset/) property.
-
-    textUnderlineOffset (pct 5)
--}
-textUnderlineOffset :
-    BaseValue
-        ( LengthSupported
-            { pct : Supported
-            , auto : Supported
-            }
-        )
-    -> Style
-textUnderlineOffset (Value value) =
-    AppendProperty ("text-underline-offset:" ++ value)
-
-
-{-| Sets the [`text-emphasis`](https://css-tricks.com/almanac/properties/t/text-emphasis/) property.
-
-This is for drawing attention towards textual elements in a way that is commonly
-used in East Asian languages.
-
-    textEmphasis (hex "ff0000")
-
-    textEmphasis sesame
-
-    textEmphasis2 triangle (hex "00ff00")
-
--}
-textEmphasis :
-    BaseValue
-        (ColorSupported
-            { none : Supported
-            , filled : Supported
-            , open : Supported
-            , dot : Supported
-            , circle_ : Supported
-            , doubleCircle : Supported
-            , triangle : Supported
-            , sesame : Supported
-            , string : Supported
-            }
-        )
-    -> Style
-textEmphasis (Value value) =
-    AppendProperty ("text-emphasis:" ++ value)
-
-
-{-| Sets the [`text-emphasis`](https://css-tricks.com/almanac/properties/t/text-emphasis/) property.
-
-This 2-argument form sets [`text-emphasis-style`](#textEmphasisStyle) and [`textEmphasisColor`](#textEmphasisColor) in a single declaration.
-
-    textEmphasis2 filled (hex "ff0000")
--}
-textEmphasis2 :
-    BaseValue
-        { none : Supported
-        , filled : Supported
-        , open : Supported
-        , dot : Supported
-        , circle_ : Supported
-        , doubleCircle : Supported
-        , triangle : Supported
-        , sesame : Supported
-        , string : Supported
-        }
-    ->
-        BaseValue
-            (Color)
-    -> Style
-textEmphasis2 (Value value1) (Value value2) =
-    AppendProperty
-        ("text-emphasis:"
-            ++ value1
-            ++ " "
-            ++ value2
-        )
-
-
-{-| Sets the [`text-emphasis-style`](https://developer.mozilla.org/en-US/docs/Web/CSS/text-emphasis-style) property.
-
-    textEmphasisStyle none
-
-    textEmphasisStyle open
-
-    textEmphasisStyle (string "🐯")
--}
-textEmphasisStyle :
-    BaseValue
-        { none : Supported
-        , filled : Supported
-        , open : Supported
-        , dot : Supported
-        , circle_ : Supported
-        , doubleCircle : Supported
-        , triangle : Supported
-        , sesame : Supported
-        , string : Supported
-        }
-    -> Style
-textEmphasisStyle (Value value) =
-    AppendProperty ("text-emphasis-style:" ++ value)
-
-
-{-| Sets the [`text-emphasis-style`](https://developer.mozilla.org/en-US/docs/Web/CSS/text-emphasis-style) property when you want to use two arguments - one for `filled` or `open`, and one for the shape style.
-
-    textEmphasisStyle filled sesame
-
-    textEmphasisStyle open dot
--}
-textEmphasisStyle2 :
-    BaseValue
-        { filled : Supported
-        , open : Supported
-        }
-    -> BaseValue
-        { dot : Supported
-        , circle_ : Supported
-        , doubleCircle : Supported
-        , triangle : Supported
-        , sesame : Supported
-        }
-    -> Style
-textEmphasisStyle2 (Value val1) (Value val2) =
-    AppendProperty
-        ("text-emphasis-style:"
-        ++ val1
-        ++ " "
-        ++ val2
-        )
-
-
-{-| Sets the [`text-emphasis-color`](https://developer.mozilla.org/en-US/docs/Web/CSS/text-emphasis-color) property.
-
-    textEmphasisColor currentcolor
-
-    textemphasisColor (hex "0000ff")
--}
-textEmphasisColor :
-    BaseValue (Color)
-    -> Style
-textEmphasisColor (Value value) =
-    AppendProperty ("text-emphasis-color:" ++ value)
-
-
-{-| Sets the [`text-emphasis-position`](https://developer.mozilla.org/en-US/docs/Web/CSS/text-emphasis-position) property.
-
-This is the one argument version, which is limited to setting global values.
-
-If you want to specify the positions of the text-emphasis, you must use the [2-argument form](#textEmphasisPosition2).
-
-    textEmphasisPosition inherit
-
-    textEmphasisPosition revert
-
-    textEmphasisPosition2 over left_
-
-    textEmphasisPosition2 under right_
-
--}
-textEmphasisPosition :
-    BaseValue a
-    -> Style
-textEmphasisPosition (Value value) =
-    AppendProperty ("text-emphasis-position:" ++ value)
-
-
-{-| Sets the the [`text-emphasis-position`](https://developer.mozilla.org/en-US/docs/Web/CSS/text-emphasis-position) property.
-
-This is the 2-argument form that lets you specify the positions of the emphasis.
-
-if you want to apply global values, you must use the [1-argument form](#textEmphasisPosition).
-
-    textEmphasisPosition inherit
-
-    textEmphasisPosition revert
-
-    textEmphasisPosition2 over left_
-
-    textEmphasisPosition2 under right_
-
--}
-textEmphasisPosition2 :
-    BaseValue
-        { over : Supported
-        , under : Supported
-        }
-    -> BaseValue
-        { left_ : Supported
-        , right_ : Supported
-        }
-    -> Style
-textEmphasisPosition2 (Value val1) (Value val2) =
-    AppendProperty
-        ("text-emphasis-position:"
-        ++ val1
-        ++ " "
-        ++ val2
-        )
-
-
-{-| The `filled` value used in [`textEmphasis`](#textEmphasis).
-
-    textEmphasis filled
-
--}
-filled : Value { provides | filled : Supported }
-filled =
-    Value "filled"
-
-
-{-| The `open` value used in [`textEmphasis`](#textEmphasis).
-
-    textEmphasis open
-
--}
-open : Value { provides | open : Supported }
-open =
-    Value "open"
-
-
-{-| The `dot` value used in [`textEmphasis`](#textEmphasis).
-
-    textEmphasis dot
-
--}
-dot : Value { provides | dot : Supported }
-dot =
-    Value "dot"
-
-
-{-| The `doubleCircle` value used in [`textEmphasis`](#textEmphasis).
-
-    textEmphasis doubleCircle
-
--}
-doubleCircle : Value { provides | doubleCircle : Supported }
-doubleCircle =
-    Value "double-circle"
-
-
-{-| The `triangle` value used in [`textEmphasis`](#textEmphasis).
-
-    textEmphasis triangle
-
--}
-triangle : Value { provides | triangle : Supported }
-triangle =
-    Value "triangle"
-
-
-{-| The `sesame` value used in [`textEmphasis`](#textEmphasis).
-
-    textEmphasis sesame
-
--}
-sesame : Value { provides | sesame : Supported }
-sesame =
-    Value "sesame"
-
-
-{-| The `over` value used in [`textEmphasisPosition2`](#textEmphasisPosition2).
-
-    textEmphasisPosition2 over left_
-
--}
-over : Value { provides | over : Supported }
-over =
-    Value "over"
-
-
 {-| Sets [`transform-origin`](https://css-tricks.com/almanac/properties/t/transform-origin/).
 
     transformOrigin top_
@@ -20859,74 +20989,6 @@ transformBox (Value val) =
 --- unicode-bidi ---
 
 
-{-| Sets `embed` value for usage with [`unicodeBidi`](#unicodeBidi).
-
-    unicodeBidi embed
-
--}
-embed : Value { provides | embed : Supported }
-embed =
-    Value "embed"
-
-
-{-| Sets `plaintext` value for usage with [`unicodeBidi`](#unicodeBidi).
-
-    unicodeBidi plaintext
-
--}
-plaintext : Value { provides | plaintext : Supported }
-plaintext =
-    Value "plaintext"
-
-
-{-| Sets `bidi-override` value for usage with [`unicodeBidi`](#unicodeBidi).
-
-    unicodeBidi bidiOverride
-
--}
-bidiOverride : Value { provides | bidiOverride : Supported }
-bidiOverride =
-    Value "bidi-override"
-
-
-{-| Sets `isolate-override` value for usage with [`unicodeBidi`](#unicodeBidi).
-
-    unicodeBidi isolateOverride
-
--}
-isolateOverride : Value { provides | isolateOverride : Supported }
-isolateOverride =
-    Value "isolate-override"
-
-
-{-| Sets [`unicode-bidi`](https://css-tricks.com/almanac/properties/u/unicode-bidi/)
-
-    unicodeBidi normal
-
-    unicodeBidi embed
-
-    unicodeBidi isolate
-
-    unicodeBidi bidiOverride
-
-    unicodeBidi isolateOverride
-
-    unicodeBidi plaintext
-
--}
-unicodeBidi :
-    BaseValue
-        { normal : Supported
-        , embed : Supported
-        , isolate : Supported
-        , bidiOverride : Supported
-        , isolateOverride : Supported
-        , plaintext : Supported
-        }
-    -> Style
-unicodeBidi (Value val) =
-    AppendProperty ("unicode-bidi:" ++ val)
-
 
 {-| Sets [`user-select`](https://css-tricks.com/almanac/properties/u/user-select/)
 
@@ -20990,54 +21052,6 @@ wordSpacing (Value str) =
     AppendProperty ("word-spacing:" ++ str)
 
 
-{-| Sets `horizontal-tb` value for usage with [`writingMode`](#writingMode).
-
-    writingMode horizontalTb
-
--}
-horizontalTb : Value { provides | horizontalTb : Supported }
-horizontalTb =
-    Value "horizontal-tb"
-
-
-{-| Sets `vertical-lr` value for usage with [`writingMode`](#writingMode).
-
-    writingMode verticalLr
-
--}
-verticalLr : Value { provides | verticalLr : Supported }
-verticalLr =
-    Value "vertical-lr"
-
-
-{-| Sets `vertical-rl` value for usage with [`writingMode`](#writingMode).
-
-    writingMode verticalRl
-
--}
-verticalRl : Value { provides | verticalRl : Supported }
-verticalRl =
-    Value "vertical-rl"
-
-
-{-| Sets [`writing-mode`](https://css-tricks.com/almanac/properties/w/writing-mode/).
-
-    writingMode horizontalTb
-
-    writingMode verticalRl
-
-    writingMode verticalLr
-
--}
-writingMode :
-    BaseValue
-        { horizontalTb : Supported
-        , verticalRl : Supported
-        , verticalLr : Supported
-        }
-    -> Style
-writingMode (Value str) =
-    AppendProperty ("writing-mode:" ++ str)
 
 
 {-| The [`resize`](https://css-tricks.com/almanac/properties/r/resize/) property.
@@ -21309,36 +21323,6 @@ pixelated =
 crispEdges : Value { provides | crispEdges : Supported }
 crispEdges =
     Value "crisp-edges"
-
-
-{-| Sets `isolate` value for usage with [`isolation`](#isolation), and
-[`unicodeBidi`](#unicodeBidi).
-
-    isolation isolate
-
-    unicodeBidi isolate
-
--}
-isolate : Value { provides | isolate : Supported }
-isolate =
-    Value "isolate"
-
-
-{-| Sets [`isolation`](https://css-tricks.com/almanac/properties/i/isolation/)
-
-    isolation auto
-
-    isolation isolate
-
--}
-isolation :
-    BaseValue
-        { auto : Supported
-        , isolate : Supported
-        }
-    -> Style
-isolation (Value val) =
-    AppendProperty ("isolation:" ++ val)
 
 
 {-| Sets [`lineClamp`](https://css-tricks.com/almanac/properties/l/line-clamp/)

--- a/src/Css.elm
+++ b/src/Css.elm
@@ -127,7 +127,7 @@ module Css exposing
     , direction, ltr, rtl
     , justify, matchParent, textAlign, textJustify, interWord, interCharacter, textUnderlinePosition, textUnderlinePosition2
     , textOrientation
-    , mixed, sideways, upright
+    , mixed, sideways, sidewaysRight, upright, useGlyphOrientation
     , textRendering
     , geometricPrecision, optimizeLegibility, optimizeSpeed
     , textTransform
@@ -710,7 +710,7 @@ Other values you can use for flex item alignment:
 # Text Orientation
 
 @docs textOrientation
-@docs mixed, sideways, upright
+@docs mixed, sideways, sidewaysRight, upright, useGlyphOrientation
 
 
 # Text Rendering
@@ -11646,14 +11646,17 @@ textOrientation :
     BaseValue
         { mixed : Supported
         , sideways : Supported
+        , sidewaysRight : Supported
         , upright : Supported
+        , useGlyphOrientation : Supported
         }
     -> Style
 textOrientation (Value str) =
     AppendProperty ("text-orientation:" ++ str)
 
 
-{-| A `mixed` value for the [`text-orientation`](https://developer.mozilla.org/en-US/docs/Web/CSS/text-orientation) property.
+{-| A `mixed` value for the
+[`textOrientation`](#textOrientation) property.
 
     textOrientation mixed
 
@@ -11663,7 +11666,8 @@ mixed =
     Value "mixed"
 
 
-{-| A `sideways` value for the [`text-orientation`](https://developer.mozilla.org/en-US/docs/Web/CSS/text-orientation) property.
+{-| A `sideways` value for the
+[`textOrientation`](#textOrientation) property.
 
     textOrientation sideways
 
@@ -11673,7 +11677,19 @@ sideways =
     Value "sideways"
 
 
-{-| A `upright` value for the [`text-orientation`](https://developer.mozilla.org/en-US/docs/Web/CSS/text-orientation) property.
+{-| A `sideways-right` value for the
+[`textOrientation`](#textOrientation) property.
+
+    textOrientation sidewaysRight
+
+-}
+sidewaysRight : Value { provides | sidewaysRight : Supported }
+sidewaysRight =
+    Value "sideways-right"
+
+
+{-| A `upright` value for the
+[`textOrientation`](#textOrientation) property.
 
     textOrientation upright
 
@@ -11682,6 +11698,16 @@ upright : Value { provides | upright : Supported }
 upright =
     Value "upright"
 
+
+{-| A `use-glyph-orientation` value for the
+[`textOrientation`](#textOrientation) property.
+
+    textOrientation useGlyphOrientation
+
+-}
+useGlyphOrientation : Value { provides | useGlyphOrientation : Supported }
+useGlyphOrientation =
+    Value "use-glyph-orientation"
 
 
 -- TEXT RENDERING --

--- a/src/Css.elm
+++ b/src/Css.elm
@@ -57,7 +57,7 @@ module Css exposing
     , fontDisplay, fallback, swap, optional
     , writingMode, verticalLr, verticalRl, horizontalTb
     , hyphens, manual
-    , hangingPunctuation, first, last, forceEnd, allowEnd
+    , hangingPunctuation, hangingPunctuation2, hangingPunctuation3, first, last, forceEnd, allowEnd
     , lineClamp
     , fontSize, xxSmall, xSmall, small, medium, large, xLarge, xxLarge, smaller, larger, lineHeight, letterSpacing
     , fontSizeAdjust
@@ -402,7 +402,7 @@ See this [complete guide](https://css-tricks.com/snippets/css/a-guide-to-flexbox
 @docs fontDisplay, fallback, swap, optional
 @docs writingMode, verticalLr, verticalRl, horizontalTb
 @docs hyphens, manual
-@docs hangingPunctuation, first, last, forceEnd, allowEnd
+@docs hangingPunctuation, hangingPunctuation2, hangingPunctuation3, first, last, forceEnd, allowEnd
 @docs lineClamp
 
 
@@ -12418,11 +12418,9 @@ allowEnd =
 
     hangingPunctuation first
 
-    hangingPunctuation forceEnd
+    hangingPunctuation2 first forceEnd
 
-    hangingPunctuation allowEnd
-
-    hangingPunctuation last
+    hangingPunctuation3 first allowEnd last
 
 -}
 hangingPunctuation :
@@ -12436,6 +12434,53 @@ hangingPunctuation :
     -> Style
 hangingPunctuation (Value val) =
     AppendProperty ("hanging-punctuation:" ++ val)
+
+
+{-| Sets [`hanging-punctuation`](https://css-tricks.com/almanac/properties/h/hanging-punctuation/)
+
+    hangingPunctuation2 first forceEnd
+
+-}
+hangingPunctuation2 :
+    Value
+        { first : Supported
+        , last : Supported
+        }
+    ->
+        Value
+            { first : Supported
+            , forceEnd : Supported
+            , allowEnd : Supported
+            , last : Supported
+            }
+    -> Style
+hangingPunctuation2 (Value val1) (Value val2) =
+    AppendProperty ("hanging-punctuation:" ++ val1 ++ " " ++ val2)
+
+
+{-| Sets [`hanging-punctuation`](https://css-tricks.com/almanac/properties/h/hanging-punctuation/)
+
+    hangingPunctuation3 first allowEnd last
+
+-}
+hangingPunctuation3 :
+    Value
+        { first : Supported
+        , last : Supported
+        }
+    ->
+        Value
+            { forceEnd : Supported
+            , allowEnd : Supported
+            }
+    ->
+        Value
+            { first : Supported
+            , last : Supported
+            }
+    -> Style
+hangingPunctuation3 (Value val1) (Value val2) (Value val3) =
+    AppendProperty ("hanging-punctuation:" ++ val1 ++ " " ++ val2 ++ " " ++ val3)
 
 
 {-| Sets `manual` value for usage with [`hyphens`](#hyphens).

--- a/src/Css.elm
+++ b/src/Css.elm
@@ -234,6 +234,7 @@ module Css exposing
     , commonLigatures, noCommonLigatures, discretionaryLigatures, noDiscretionaryLigatures, historicalLigatures, noHistoricalLigatures, contextual, noContextual
     , fontVariantNumeric, fontVariantNumeric4
     , ordinal, slashedZero, liningNums, oldstyleNums, proportionalNums, tabularNums, diagonalFractions, stackedFractions
+    , fontVariantEmoji, emoji, unicode
     , fontKerning
     , fontLanguageOverride
     , fontOpticalSizing
@@ -1019,6 +1020,10 @@ Other values you can use for flex item alignment:
 @docs fontVariantNumeric, fontVariantNumeric4
 @docs ordinal, slashedZero, liningNums, oldstyleNums, proportionalNums, tabularNums, diagonalFractions, stackedFractions
     
+## Emoji variants
+
+@docs fontVariantEmoji, emoji, unicode
+
 ## Kerning
 
 @docs fontKerning
@@ -13247,8 +13252,43 @@ stackedFractions =
     Value "stacked-fractions"
 
 
+{-| The [`font-variant-emoji`](https://developer.mozilla.org/en-US/docs/Web/CSS/font-variant-emoji)
+property.
 
--- FONT OPTICAL SIZING --
+    fontVariantEmoji unset
+
+    fontVariantemoji emoji
+
+    fontVariantemoji normal
+-}
+fontVariantEmoji :
+    BaseValue
+        { normal : Supported
+        , text : Supported
+        , emoji : Supported
+        , unicode : Supported
+        }
+    -> Style
+fontVariantEmoji (Value val) =
+    AppendProperty <| "font-variant-emoji:" ++ val
+
+
+{-| The `emoji` value used with [`fontVariantEmoji`](#fontVariantEmoji).
+
+    fontVariantemoji emoji
+-}
+emoji : Value { provides | emoji : Supported }
+emoji =
+    Value "emoji"
+
+
+{-| The `unicode` value used with [`fontVariantEmoji`](#fontVariantEmoji).
+
+    fontVariantemoji unicode
+-}
+unicode : Value { provides | unicode : Supported }
+unicode =
+    Value "unicode"
 
 
 {-| The [`font-kerning`](https://developer.mozilla.org/en-US/docs/Web/CSS/font-kerning) property.

--- a/src/Css.elm
+++ b/src/Css.elm
@@ -10,6 +10,7 @@ module Css exposing
     , calc, CalcOperation, minus, plus, times, dividedBy
     , Color, ColorSupported, color, backgroundColor, hex, rgb, rgba, hsl, hsla, currentcolor
     , Time, TimeSupported, s, ms
+    , string
     , pseudoClass, active, disabled
     , pseudoElement, before, after
     , width, minWidth, maxWidth, height, minHeight, maxHeight
@@ -61,7 +62,7 @@ module Css exposing
     , tabSize
     , fontDisplay, fallback, swap, optional
     , writingMode, verticalLr, verticalRl, horizontalTb
-    , hyphens, manual
+    , hyphens, quotes, quotes2, quotes4, manual
     , hangingPunctuation, first, last, forceEnd, allowEnd
     , lineClamp
     , fontSize, xxSmall, xSmall, small, medium, large, xLarge, xxLarge, smaller, larger, lineHeight, letterSpacing
@@ -83,7 +84,7 @@ module Css exposing
     , wResize, neResize, nwResize, seResize, swResize, ewResize, nsResize
     , neswResize, nwseResize, zoomIn, zoomOut, grab, grabbing
     , ListStyleType, ListStyleTypeSupported
-    , listStyle, listStyle2, listStyle3, listStylePosition, inside, outside, listStyleType, string, customIdent, listStyleImage
+    , listStyle, listStyle2, listStyle3, listStylePosition, inside, outside, listStyleType, customIdent, listStyleImage
     , arabicIndic, armenian, bengali, cambodian, circle, cjkDecimal, cjkEarthlyBranch, cjkHeavenlyStem, cjkIdeographic, decimal, decimalLeadingZero, devanagari, disclosureClosed, disclosureOpen, disc, ethiopicNumeric, georgian, gujarati, gurmukhi, hebrew, hiragana, hiraganaIroha, japaneseFormal, japaneseInformal, kannada, katakana, katakanaIroha, khmer, koreanHangulFormal, koreanHanjaFormal, koreanHanjaInformal, lao, lowerAlpha, lowerArmenian, lowerGreek, lowerLatin, lowerRoman, malayalam, monogolian, myanmar, oriya, persian, simpChineseFormal, simpChineseInformal, tamil, telugu, thai, tibetan, tradChineseFormal, tradChineseInformal, upperAlpha, upperArmenian, upperLatin, upperRoman
     , auto, none
     , hidden, visible
@@ -426,7 +427,7 @@ See this [complete guide](https://css-tricks.com/snippets/css/a-guide-to-flexbox
 
 @docs fontDisplay, fallback, swap, optional
 @docs writingMode, verticalLr, verticalRl, horizontalTb
-@docs hyphens, manual
+@docs hyphens, quotes, quotes2, quotes4, manual
 @docs hangingPunctuation, first, last, forceEnd, allowEnd
 @docs lineClamp
 
@@ -999,6 +1000,21 @@ type alias TimeSupported supported =
 type alias Time =
     TimeSupported {}
 
+
+{-| Produces an [`string`](https://developer.mozilla.org/en-US/docs/Web/CSS/string)
+value used by properties such as:
+- [`listStyle`](#listStyle),
+- [`listStyleType`](#listStyleType)
+- [`quotes2`](#quotes2)
+
+    listStyleType (string "> ")
+
+    quotes2 (string "«") (string "»")
+
+-}
+string : String -> Value { provides | string : Supported }
+string =
+    Value << enquoteString
 
 
 -- CUSTOM PROPERTIES --
@@ -6964,18 +6980,6 @@ outside =
 listStyleType : BaseValue ListStyleType -> Style
 listStyleType (Value val) =
     AppendProperty ("list-style-type:" ++ val)
-
-
-{-| Produces an [`string`](https://developer.mozilla.org/en-US/docs/Web/CSS/string)
-value used by properties such as [`listStyle`](#listStyle),
-and [`listStyleType`](#listStyleType)
-
-    listStyleType (string "> ")
-
--}
-string : String -> Value { provides | string : Supported }
-string =
-    Value << enquoteString
 
 
 {-| Produces an [`custom-ident`](https://developer.mozilla.org/en-US/docs/Web/CSS/custom-ident)
@@ -13267,6 +13271,101 @@ hyphens :
     -> Style
 hyphens (Value val) =
     AppendProperty ("hyphens:" ++ val)
+
+
+{-| Sets the [`quotes`](https://css-tricks.com/almanac/properties/q/quotes/) property.
+
+This one-argument version can only use keyword or global values.
+
+    quotes none
+
+    quotes inherit
+
+    quotes2 (string "\"") (string "\"")
+
+    quotes4 (string "\"") (string "\"") (string "\'") (string "\'")
+
+-}
+quotes :
+    BaseValue
+        { none : Supported 
+        , auto : Supported
+        }
+    -> Style
+quotes (Value val) =
+    AppendProperty ("quotes:" ++ val)
+
+
+{-| Sets the [`quotes`](https://css-tricks.com/almanac/properties/q/quotes/) property.
+
+This 2-argument version sets the starting and closing quotation marks for
+a top-level quote (a quote that is not nested within another quote). It only accepts 
+string values.
+
+    quotes auto
+
+    quotes2 (string "\"") (string "\"") -- "Hey, this is a first-level quote."
+
+    quotes2 (string "\'") (string "\'") -- 'Hey, this is a first-level quote.'
+
+    quotes2 (string "«") (string "»") -- «Hey, this is a first-level quote.»
+-}
+quotes2 :
+    Value
+        { string : Supported
+        }
+    -> Value
+        { string : Supported
+        }
+    -> Style
+quotes2 (Value lv1StartQuote) (Value lv1EndQuote) =
+    AppendProperty ("quotes:" ++ lv1StartQuote ++ " " ++ lv1EndQuote)
+
+
+{-| Sets the [`quotes`](https://css-tricks.com/almanac/properties/q/quotes/) property.
+
+This 4-argument version sets the starting and closing quotation marks for both
+a top-level quote and a nested quote. It only accepts 
+string values.
+
+    quotes auto
+
+    quotes2 (string "\"") (string "\"")
+    
+    -- "Hey, this is a first-level quote."
+
+
+    quotes4 (string "\"") (string "\"") (string "\'") (string "\'")
+
+    {- "Hey, this is a first-level quote.
+    'And this is someone else I made up for
+    a second-level quote!' Yeah, I did that!"
+    -}
+
+    quotes4 (string "«") (string "»") (string "👏") (string "🤔")
+
+    {- «Hey, this is a first-level quote.
+    👏And this is someone else I made up for
+    a second-level quote!🤔 Yeah, I did that!»
+    -}
+
+-}
+quotes4 :
+    Value
+        { string : Supported
+        }
+    -> Value
+        { string : Supported
+        }
+    -> Value
+        { string : Supported
+        }
+    -> Value
+        { string : Supported
+        }
+    -> Style
+quotes4 (Value lv1StartQuote) (Value lv1EndQuote) (Value lv2StartQuote) (Value lv2EndQuote) =
+    AppendProperty ("quotes:" ++ lv1StartQuote ++ " " ++ lv1EndQuote ++ " " ++ lv2StartQuote ++ " " ++ lv2EndQuote)
 
 
 {-| Sets `pixelated` value for usage with [`imageRendering`](#imageRendering).

--- a/src/Css.elm
+++ b/src/Css.elm
@@ -177,7 +177,7 @@ module Css exposing
     , pointerEvents
     , visiblePainted, visibleFill, visibleStroke, painted, stroke
     , resize, horizontal, vertical
-    , contain, contain2, contain3, contain4, strict, size, layout, style, paint
+    , contain, contain2, contain3, contain4, size, layout, style, paint
     )
 
 {-| If you need something that `elm-css` does not support right now, the
@@ -771,7 +771,7 @@ Multiple CSS properties use these values.
 @docs pointerEvents
 @docs visiblePainted, visibleFill, visibleStroke, painted, stroke
 @docs resize, horizontal, vertical
-@docs contain, contain2, contain3, contain4, strict, size, layout, style, paint
+@docs contain, contain2, contain3, contain4, size, layout, style, paint
 
 -}
 
@@ -1385,8 +1385,8 @@ overflowY (Value val) =
 clip : Value { provides | clip : Supported }
 clip =
     Value "clip"
-    
-    
+
+
 {-| Sets [`overflow-block`](https://developer.mozilla.org/en-US/docs/Web/CSS/overflow-block).
 
     overflowBlock visible
@@ -3104,7 +3104,6 @@ placeholder =
     selection
         [ backgroundColor (rgb 200 140 15)
         ]
-
 
 -}
 selection : List Style -> Style
@@ -5498,27 +5497,28 @@ fontVariantCaps (Value str) =
 
 {-| The `normal` value, which can be used with such properties as:
 
-- [`fontVariantCaps`](#fontVariantCaps)
-- [`whiteSpace`](#whiteSpace)
-- [`wordBreak`](#wordBreak)
-- [`columnGap`](#columnGap)
-- [`zoom`](#zoom)
-- [`animationDirection`](#animationDirection)
-- [`alignItems`](#alignItems)
-- [`lineBreak`](#lineBreak)
+  - [`fontVariantCaps`](#fontVariantCaps)
+  - [`whiteSpace`](#whiteSpace)
+  - [`wordBreak`](#wordBreak)
+  - [`columnGap`](#columnGap)
+  - [`zoom`](#zoom)
+  - [`animationDirection`](#animationDirection)
+  - [`alignItems`](#alignItems)
+  - [`lineBreak`](#lineBreak)
 
+```
+alignItems normal
 
-    alignItems normal
+columnGap normal
 
-    columnGap normal
+fontVariantCaps normal
 
-    fontVariantCaps normal
+whiteSpace normal
 
-    whiteSpace normal
+wordBreak normal
 
-    wordBreak normal
-
-    zoom normal
+zoom normal
+```
 
 -}
 normal : Value { provides | normal : Supported }
@@ -7000,15 +7000,15 @@ for the following properties:
   - [`objectFit`](#objectFit) (Replaced content is scaled to maintain proportions within the element's content box.)
   - [`userSelect`](#userSelect) (Lets selection start within the element but that selection will be contained within that element's bounds.)
   - [`overscrollBehavior`](#overscrollBehavior) (This means that default scroll overflow behavior
-is observed inside the element, but scroll chaining will not happen to neighbouring elements.)
+    is observed inside the element, but scroll chaining will not happen to neighbouring elements.)
 
+```
+backgroundSize contain_
 
-	backgroundSize contain_
-	
-	overscrollBehavior contain
+overscrollBehavior contain
+```
 
 The value is called `contain_` instead of `contain` because [`contain`](#contain) is already a function.
-
 
 -}
 contain_ : Value { provides | contain_ : Supported }
@@ -9095,8 +9095,8 @@ borderStartStartRadius2 :
                 }
             )
     -> Style
-borderStartStartRadius2 (Value horizontal) (Value vertical) =
-    AppendProperty ("border-start-start-radius:" ++ horizontal ++ " " ++ vertical)
+borderStartStartRadius2 (Value horizontalValue) (Value verticalValue) =
+    AppendProperty ("border-start-start-radius:" ++ horizontalValue ++ " " ++ verticalValue)
 
 
 {-| Sets [`border-start-end-radius`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-start-end-radius) property.
@@ -9137,8 +9137,8 @@ borderStartEndRadius2 :
                 }
             )
     -> Style
-borderStartEndRadius2 (Value horizontal) (Value vertical) =
-    AppendProperty ("border-start-end-radius:" ++ horizontal ++ " " ++ vertical)
+borderStartEndRadius2 (Value horizontalValue) (Value verticalValue) =
+    AppendProperty ("border-start-end-radius:" ++ horizontalValue ++ " " ++ verticalValue)
 
 
 {-| Sets [`border-end-start-radius`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-end-start-radius) property.
@@ -9179,8 +9179,8 @@ borderEndStartRadius2 :
                 }
             )
     -> Style
-borderEndStartRadius2 (Value horizontal) (Value vertical) =
-    AppendProperty ("border-end-start-radius:" ++ horizontal ++ " " ++ vertical)
+borderEndStartRadius2 (Value horizontalValue) (Value verticalValue) =
+    AppendProperty ("border-end-start-radius:" ++ horizontalValue ++ " " ++ verticalValue)
 
 
 {-| Sets [`border-end-end-radius`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-end-end-radius) property.
@@ -9221,8 +9221,8 @@ borderEndEndRadius2 :
                 }
             )
     -> Style
-borderEndEndRadius2 (Value horizontal) (Value vertical) =
-    AppendProperty ("border-end-end-radius:" ++ horizontal ++ " " ++ vertical)
+borderEndEndRadius2 (Value horizontalValue) (Value verticalValue) =
+    AppendProperty ("border-end-end-radius:" ++ horizontalValue ++ " " ++ verticalValue)
 
 
 {-| Sets [`border-image-outset`](https://css-tricks.com/almanac/properties/b/border-image/) property.
@@ -14095,16 +14095,6 @@ hangingPunctuation3 (Value val1) (Value val2) (Value val3) =
     AppendProperty ("hanging-punctuation:" ++ val1 ++ " " ++ val2 ++ " " ++ val3)
 
 
-{-| Sets `manual` value for usage with [`hyphens`](#hyphens).
-
-    hyphens manual
-
--}
-manual : Value { provides | manual : Supported }
-manual =
-    Value "manual"
-
-
 {-| Sets [`hyphens`](https://css-tricks.com/almanac/properties/h/hyphens/)
 
     hyphens none
@@ -14280,6 +14270,7 @@ textOverflow2 (Value startValue) (Value endValue) =
     lineBreak auto
 
     lineBreak strict
+
 -}
 lineBreak :
     BaseValue
@@ -14314,9 +14305,12 @@ ellipsis =
     Value "ellipsis"
 
 
-{-| Sets `strict` value for usage with [`lineBreak`](#lineBreak).
+{-| Sets `strict` value for usage with [`lineBreak`](#lineBreak) and [`contain`](#contain).
+
+    contain strict
 
     lineBreak strict
+
 -}
 strict : Value { provides | strict : Supported }
 strict =
@@ -14326,10 +14320,12 @@ strict =
 {-| Sets `loose` value for usage with [`lineBreak`](#lineBreak).
 
     lineBreak loose
+
 -}
 loose : Value { provides | loose : Supported }
 loose =
     Value "loose"
+
 
 {-| Sets `pixelated` value for usage with [`imageRendering`](#imageRendering).
 
@@ -16346,20 +16342,6 @@ Equivalent to `contain: size layout style paint;`.
 contain4 : Style
 contain4 =
     AppendProperty "contain:size layout style paint"
-
-
-{-| Sets the `strict` value for [`contain`](#contain).
-
-This indicates that all containment rules apart from `style` are applied.
-
-This is equivalent to `contain3 size layout paint`.
-
-    contain strict
-
--}
-strict : Value { provides | strict : Supported }
-strict =
-    Value "strict"
 
 
 {-| Sets the `size` value for [`contain`](#contain).

--- a/src/Css.elm
+++ b/src/Css.elm
@@ -144,6 +144,7 @@ module Css exposing
     , scrollSnapType, scrollSnapType2, x, y, mandatory, proximity
     , scrollMargin, scrollMargin2, scrollMargin3, scrollMargin4, scrollMarginTop, scrollMarginLeft, scrollMarginRight, scrollMarginBottom
     , scrollPadding, scrollPadding2, scrollPadding3, scrollPadding4, scrollPaddingTop, scrollPaddingLeft, scrollPaddingRight, scrollPaddingBottom
+    , overscrollBehavior, overscrollBehavior2, overscrollBehaviorX, overscrollBehaviorY, overscrollBehaviorBlock, overscrollBehaviorInline
     , speak, spellOut
     , userSelect
     , unicodeBidi, embed, bidiOverride, isolateOverride, plaintext
@@ -695,6 +696,7 @@ Multiple CSS properties use these values.
 @docs scrollSnapType, scrollSnapType2, x, y, mandatory, proximity
 @docs scrollMargin, scrollMargin2, scrollMargin3, scrollMargin4, scrollMarginTop, scrollMarginLeft, scrollMarginRight, scrollMarginBottom
 @docs scrollPadding, scrollPadding2, scrollPadding3, scrollPadding4, scrollPaddingTop, scrollPaddingLeft, scrollPaddingRight, scrollPaddingBottom
+@docs overscrollBehavior, overscrollBehavior2, overscrollBehaviorX, overscrollBehaviorY, overscrollBehaviorBlock, overscrollBehaviorInline
 
 
 # Accessibility
@@ -13508,6 +13510,122 @@ scrollPaddingLeft :
     -> Style
 scrollPaddingLeft (Value value) =
     AppendProperty ("scroll-padding-left:" ++ value)
+
+
+{-| Sets the [`overscroll-behavior`](https://css-tricks.com/almanac/properties/o/overscroll-behavior/) property.
+
+This property is a shorthand for setting both `overscroll-behavior-x` and `overscroll-behavior-y`.
+
+    overscrollBehavior auto -- sets both X and Y to auto
+
+    overscrollBehavior2 auto contain -- X = auto, Y = contain.
+
+-}
+overscrollBehavior :
+    BaseValue
+        { auto : Supported
+        , contain : Supported
+        , none : Supported
+        }
+    -> Style
+overscrollBehavior (Value value) =
+    AppendProperty ("overscroll-behavior:" ++ value)
+
+
+{-| Sets the [`overscroll-behavior`](https://css-tricks.com/almanac/properties/o/overscroll-behavior/) property.
+
+This property is a shorthand for setting both `overscroll-behavior-x` and `overscroll-behavior-y`.
+
+    overscrollBehavior2 auto contain -- X = auto, Y = contain.
+
+-}
+overscrollBehavior2 :
+    Value
+        { auto : Supported
+        , contain : Supported
+        , none : Supported
+        }
+    ->
+        Value
+            { auto : Supported
+            , contain : Supported
+            , none : Supported
+            }
+    -> Style
+overscrollBehavior2 (Value xValue) (Value yValue) =
+    AppendProperty ("overscroll-behavior:" ++ xValue ++ " " ++ yValue)
+
+
+{-| Sets the [`overscroll-behavior-x`](https://css-tricks.com/almanac/properties/o/overscroll-behavior/) property.
+
+    overscrollBehaviorX auto
+
+    overscrollBehaviorX contain
+
+-}
+overscrollBehaviorX :
+    BaseValue
+        { auto : Supported
+        , contain : Supported
+        , none : Supported
+        }
+    -> Style
+overscrollBehaviorX (Value value) =
+    AppendProperty ("overscroll-behavior-x:" ++ value)
+
+
+{-| Sets the [`overscroll-behavior-y`](https://css-tricks.com/almanac/properties/o/overscroll-behavior/) property.
+
+    overscrollBehaviorY auto
+
+    overscrollBehaviorY contain
+
+-}
+overscrollBehaviorY :
+    BaseValue
+        { auto : Supported
+        , contain : Supported
+        , none : Supported
+        }
+    -> Style
+overscrollBehaviorY (Value value) =
+    AppendProperty ("overscroll-behavior-y:" ++ value)
+
+
+{-| Sets the [`overscroll-behavior-block`](https://developer.mozilla.org/en-US/docs/Web/CSS/overscroll-behavior-block) property.
+
+    overscrollBehaviorBlock auto
+
+    overscrollBehaviorBlock contain
+
+-}
+overscrollBehaviorBlock :
+    BaseValue
+        { auto : Supported
+        , contain : Supported
+        , none : Supported
+        }
+    -> Style
+overscrollBehaviorBlock (Value value) =
+    AppendProperty ("overscroll-behavior-block:" ++ value)
+
+
+{-| Sets the [`overscroll-behavior-inline`](https://developer.mozilla.org/en-US/docs/Web/CSS/overscroll-behavior-inline) property.
+
+    overscrollBehaviorInline auto
+
+    overscrollBehaviorInline contain
+
+-}
+overscrollBehaviorInline :
+    BaseValue
+        { auto : Supported
+        , contain : Supported
+        , none : Supported
+        }
+    -> Style
+overscrollBehaviorInline (Value value) =
+    AppendProperty ("overscroll-behavior-inline:" ++ value)
 
 
 {-| Sets [`scroll-snap-align`](https://css-tricks.com/almanac/properties/s/scroll-snap-align/)

--- a/src/Css.elm
+++ b/src/Css.elm
@@ -45,6 +45,7 @@ module Css exposing
     , absolute, fixed, relative, static, sticky
     , padding, padding2, padding3, padding4, paddingTop, paddingRight, paddingBottom, paddingLeft
     , margin, margin2, margin3, margin4, marginTop, marginRight, marginBottom, marginLeft
+    , gap, gap2, rowGap, columnGap
     , boxSizing
     , alignContent, alignContent2, alignItems, alignItems2, alignSelf, alignSelf2, justifyContent, justifyContent2, justifyItems, justifyItems2, justifySelf, justifySelf2
     , flexDirection, row, rowReverse, column, columnReverse
@@ -124,7 +125,7 @@ module Css exposing
     , strokeOrigin, fillBox, strokeBox
     , strokeLinejoin, strokeLinejoin2, crop, arcs, miter, bevel
     , strokeDashJustify, compress, dashes, gaps
-    , columns, columns2, columnWidth, columnCount, columnGap, columnRuleWidth, columnRuleStyle, columnRuleColor, columnRule, columnRule2, columnRule3
+    , columns, columns2, columnWidth, columnCount, columnRuleWidth, columnRuleStyle, columnRuleColor, columnRule, columnRule2, columnRule3
     , columnFill, balance, balanceAll
     , columnSpan, all_
     , transform, transforms, transformOrigin, transformOrigin2
@@ -345,6 +346,11 @@ All CSS properties can have the values `unset`, `initial`, and `inherit`
 ## Margins
 
 @docs margin, margin2, margin3, margin4, marginTop, marginRight, marginBottom, marginLeft
+
+
+## Gap
+
+@docs gap, gap2, rowGap, columnGap
 
 
 ## Box Sizing
@@ -626,7 +632,7 @@ Multiple CSS properties use these values.
 
 # Columns
 
-@docs columns, columns2, columnWidth, columnCount, columnGap, columnRuleWidth, columnRuleStyle, columnRuleColor, columnRule, columnRule2, columnRule3
+@docs columns, columns2, columnWidth, columnCount, columnRuleWidth, columnRuleStyle, columnRuleColor, columnRule, columnRule2, columnRule3
 @docs columnFill, balance, balanceAll
 @docs columnSpan, all_
 
@@ -9864,24 +9870,6 @@ all_ =
     Value "all"
 
 
-{-| Sets [`column-gap`](https://css-tricks.com/almanac/properties/c/column-gap/)
-
-    columnGap normal
-
-    columnGap (px 20)
-
--}
-columnGap :
-    BaseValue
-        (LengthSupported
-            { normal : Supported
-            }
-        )
-    -> Style
-columnGap (Value widthVal) =
-    AppendProperty ("column-gap:" ++ widthVal)
-
-
 {-| Sets [`column-rule-width`](https://www.w3.org/TR/css-multicol-1/#propdef-column-rule-width)
 
     columnRuleWidth thin
@@ -9918,6 +9906,104 @@ columnRuleStyle (Value style) =
 columnRuleColor : BaseValue Color -> Style
 columnRuleColor (Value colorVal) =
     AppendProperty ("column-rule-color:" ++ colorVal)
+
+
+{-| Sets the [`gap`](https://css-tricks.com/almanac/properties/g/gap/) property.
+
+The `gap` property is a shorthand for setting `row-gap` and `column-gap`
+in a single declaration.
+
+`gap` specifies the size of spacing between items within grid, flex
+and multi-column layouts.
+
+    gap initial
+
+    gap (px 20) -- 20px gap between all items.
+
+    gap2 (px 20) (px 40) -- 20px row gap, 40px column gap.
+
+-}
+gap :
+    BaseValue
+        (LengthSupported
+            { pct : Supported
+            }
+        )
+    -> Style
+gap (Value val) =
+    AppendProperty ("gap:" ++ val)
+
+
+{-| Sets the [`gap`](https://css-tricks.com/almanac/properties/g/gap/) property.
+
+The `gap` property is a shorthand for setting `row-gap` and `column-gap`
+in a single declaration.
+
+`gap` specifies the size of spacing between items within grid, flex
+and multi-column layouts.
+
+    gap2 (px 20) (px 40) -- 20px row gap, 40px column gap.
+
+-}
+gap2 :
+    Value
+        (LengthSupported
+            { pct : Supported
+            }
+        )
+    ->
+        Value
+            (LengthSupported
+                { pct : Supported
+                }
+            )
+    -> Style
+gap2 (Value rowVal) (Value columnVal) =
+    AppendProperty ("gap:" ++ rowVal ++ " " ++ columnVal)
+
+
+{-| Sets the [`row-gap`](https://developer.mozilla.org/en-US/docs/Web/CSS/row-gap) property.
+
+`row-gap` specifies the size of spacing between rows of items within grid, flex
+and multi-column layouts.
+
+    rowGap normal
+
+    rowGap (px 20)
+
+-}
+rowGap :
+    BaseValue
+        (LengthSupported
+            { normal : Supported
+            , pct : Supported
+            }
+        )
+    -> Style
+rowGap (Value widthVal) =
+    AppendProperty ("row-gap:" ++ widthVal)
+
+
+{-| Sets the [`column-gap`](https://developer.mozilla.org/en-US/docs/Web/CSS/column-gap) property.
+
+`column-gap` specifies the size of spacing between column of items within grid, flex
+and multi-column layouts.
+
+    columnGap normal
+
+    columnGap (px 20)
+
+-}
+columnGap :
+    BaseValue
+        (LengthSupported
+            { normal : Supported
+            , pct : Supported
+            }
+        )
+    -> Style
+columnGap (Value widthVal) =
+    AppendProperty ("column-gap:" ++ widthVal)
 
 
 

--- a/src/Css.elm
+++ b/src/Css.elm
@@ -44,7 +44,7 @@ module Css exposing
     , position, top, right, bottom, left, zIndex
     , absolute, fixed, relative, static, sticky
     , padding, padding2, padding3, padding4, paddingTop, paddingRight, paddingBottom, paddingLeft, paddingBlock, paddingBlock2, paddingBlockStart, paddingBlockEnd, paddingInline, paddingInline2, paddingInlineStart, paddingInlineEnd
-    , margin, margin2, margin3, margin4, marginTop, marginRight, marginBottom, marginLeft
+    , margin, margin2, margin3, margin4, marginTop, marginRight, marginBottom, marginLeft, marginBlock, marginBlock2, marginBlockStart, marginBlockEnd, marginInline, marginInline2, marginInlineStart, marginInlineEnd
     , boxSizing
     , alignContent, alignContent2, alignItems, alignItems2, alignSelf, alignSelf2, justifyContent, justifyContent2, justifyItems, justifyItems2, justifySelf, justifySelf2
     , flexDirection, row, rowReverse, column, columnReverse
@@ -2285,6 +2285,185 @@ marginLeft (Value value) =
     AppendProperty ("margin-left:" ++ value)
 
 
+{-| Sets [`margin-block`](https://css-tricks.com/almanac/properties/m/margin-block/) property.
+The `margin-block` property is a shorthand property for setting `margin-block-start` and
+`margin-block-end` in a single declaration.
+
+If there is only one argument value, it applies to all sides. If there are two
+values, the block start margins are set to the first value and the block end margins
+are set to the second. 
+
+    marginBlock (em 4) -- set block start and end margins to 4em
+
+    marginBlock2 (em 4) (px 2) -- block start = 4em, block end = 2px
+
+You may want to check out [this article on collapsing margins](https://css-tricks.com/good-ol-margin-collapsing/)!
+-}
+marginBlock :
+    BaseValue
+        (LengthSupported
+            { pct : Supported
+            , auto : Supported
+            }
+        )
+    -> Style
+marginBlock (Value value) =
+    AppendProperty ("margin-block:" ++ value)
+
+
+{-| Sets [`margin-block`](https://css-tricks.com/almanac/properties/m/margin-block/) property.
+The `margin-block` property is a shorthand property for setting `margin-block-start` and
+`margin-block-end` in a single declaration.
+
+The block start margins are set to the first value and the block end margins
+are set to the second.
+
+    marginBlock2 (em 4) (px 2) -- block start = 4em, block end = 2px
+
+You may want to check out [this article on collapsing margins](https://css-tricks.com/good-ol-margin-collapsing/)!
+-}
+marginBlock2 :
+    Value
+        (LengthSupported
+            { pct : Supported
+            , auto : Supported
+            }
+        )
+    ->
+        Value
+            (LengthSupported
+                { pct : Supported
+                , auto : Supported
+                }
+            )
+    -> Style
+marginBlock2 (Value valueStart) (Value valueEnd) =
+    AppendProperty ("margin-block:" ++ valueStart ++ " " ++ valueEnd)
+
+
+{-| Sets [`margin-block-start`](https://developer.mozilla.org/en-US/docs/Web/CSS/margin-block-start) property.
+
+    marginBlockStart (px 4)
+
+-}
+marginBlockStart :
+    BaseValue
+        (LengthSupported
+            { pct : Supported
+            , auto : Supported
+            }
+        )
+    -> Style
+marginBlockStart (Value value) =
+    AppendProperty ("margin-block-start:" ++ value)
+
+
+{-| Sets [`margin-block-end`](https://developer.mozilla.org/en-US/docs/Web/CSS/margin-block-end) property.
+
+    marginBlockEnd (px 4)
+
+-}
+marginBlockEnd :
+    BaseValue
+        (LengthSupported
+            { pct : Supported
+            , auto : Supported
+            }
+        )
+    -> Style
+marginBlockEnd (Value value) =
+    AppendProperty ("margin-block-end:" ++ value)
+
+
+{-| Sets [`margin-inline`](https://css-tricks.com/almanac/properties/m/margin-inline/) property.
+The `margin-inline` property is a shorthand property for setting `margin-inline-start` and
+`margin-inline-end` in a single declaration.
+
+If there is only one argument value, it applies to all sides. If there are two
+values, the inline start margins are set to the first value and the inline end margins
+are set to the second. 
+
+    marginInline (em 4) -- set inline start and end margins to 4em
+
+    marginInline2 (em 4) (px 2) -- inline start = 4em, inline end = 2px
+
+You may want to check out [this article on collapsing margins](https://css-tricks.com/good-ol-margin-collapsing/)!
+-}
+marginInline :
+    BaseValue
+        (LengthSupported
+            { pct : Supported
+            , auto : Supported
+            }
+        )
+    -> Style
+marginInline (Value value) =
+    AppendProperty ("margin-inline:" ++ value)
+
+
+{-| Sets [`margin-inline`](https://css-tricks.com/almanac/properties/m/margin-inline/) property.
+The `margin-inline` property is a shorthand property for setting `margin-inline-start` and
+`margin-inline-end` in a single declaration.
+
+The inline start margins are set to the first value and the inline end margins
+are set to the second.
+
+    marginInline2 (em 4) (px 2) -- inline start = 4em, inline end = 2px
+
+You may want to check out [this article on collapsing margins](https://css-tricks.com/good-ol-margin-collapsing/)!
+-}
+marginInline2 :
+    Value
+        (LengthSupported
+            { pct : Supported
+            , auto : Supported
+            }
+        )
+    ->
+        Value
+            (LengthSupported
+                { pct : Supported
+                , auto : Supported
+                }
+            )
+    -> Style
+marginInline2 (Value valueStart) (Value valueEnd) =
+    AppendProperty ("margin-inline:" ++ valueStart ++ " " ++ valueEnd)
+
+
+
+{-| Sets [`margin-inline-start`](https://developer.mozilla.org/en-US/docs/Web/CSS/margin-inline-start) property.
+
+    marginInlineStart (px 4)
+
+-}
+marginInlineStart :
+    BaseValue
+        (LengthSupported
+            { pct : Supported
+            , auto : Supported
+            }
+        )
+    -> Style
+marginInlineStart (Value value) =
+    AppendProperty ("margin-inline-start:" ++ value)
+
+
+{-| Sets [`margin-inline-end`](https://developer.mozilla.org/en-US/docs/Web/CSS/margin-inline-end) property.
+
+    marginInlineEnd (px 4)
+
+-}
+marginInlineEnd :
+    BaseValue
+        (LengthSupported
+            { pct : Supported
+            , auto : Supported
+            }
+        )
+    -> Style
+marginInlineEnd (Value value) =
+    AppendProperty ("margin-inline-end:" ++ value)
 
 -- BOX SIZING --
 

--- a/src/Css.elm
+++ b/src/Css.elm
@@ -62,7 +62,11 @@ module Css exposing
 
     -- display
     , display, display2, displayListItem2, displayListItem3
-    , flex_, flow, flowRoot, grid, contents, listItem, inlineBlock, inlineFlex, inlineTable, inlineGrid, rubyBase, rubyBaseContainer, rubyText, rubyTextContainer, runIn, table, tableCaption, tableCell, tableColumn, tableColumnGroup, tableFooterGroup, tableHeaderGroup, tableRow, tableRowGroup
+    , flex_, flow, flowRoot, grid, contents, listItem
+    , inlineBlock, inlineFlex, inlineTable, inlineGrid
+    , rubyBase, rubyBaseContainer, rubyText, rubyTextContainer
+    , runIn, table
+    , tableCaption, tableCell, tableColumn, tableColumnGroup, tableFooterGroup, tableHeaderGroup, tableRow, tableRowGroup
     
     -- position
     , position
@@ -78,7 +82,8 @@ module Css exposing
 
     -- insets
     , inset, inset2, inset3, inset4, top, right, bottom, left
-    , insetBlock, insetBlock2, insetInline, insetInline2, insetBlockStart, insetBlockEnd, insetInlineStart, insetInlineEnd
+    , insetBlock, insetBlock2, insetInline, insetInline2
+    , insetBlockStart, insetBlockEnd, insetInlineStart, insetInlineEnd
 
     -- margins
     , margin, margin2, margin3, margin4
@@ -106,17 +111,22 @@ module Css exposing
     , borderInlineEnd, borderInlineEnd2, borderInlineEnd3
     , borderWidth, borderWidth2, borderWidth3, borderWidth4
     , borderTopWidth, borderRightWidth, borderBottomWidth, borderLeftWidth
-    , borderBlockWidth, borderBlockStartWidth, borderBlockEndWidth, borderInlineWidth, borderInlineStartWidth, borderInlineEndWidth
+    , borderBlockWidth, borderBlockStartWidth, borderBlockEndWidth
+    , borderInlineWidth, borderInlineStartWidth, borderInlineEndWidth
     , borderStyle, borderStyle2, borderStyle3, borderStyle4
     , borderTopStyle, borderRightStyle, borderBottomStyle, borderLeftStyle
-    , borderBlockStyle, borderBlockStartStyle, borderBlockEndStyle, borderInlineStyle, borderInlineStartStyle, borderInlineEndStyle
+    , borderBlockStyle, borderBlockStartStyle, borderBlockEndStyle
+    , borderInlineStyle, borderInlineStartStyle, borderInlineEndStyle
     , dotted, dashed, solid, double, groove, ridge, inset_, outset
     , borderColor, borderColor2, borderColor3, borderColor4
     , borderTopColor, borderRightColor, borderBottomColor, borderLeftColor
-    , borderBlockColor, borderBlockStartColor, borderBlockEndColor, borderInlineColor, borderInlineStartColor, borderInlineEndColor
+    , borderBlockColor, borderBlockStartColor, borderBlockEndColor
+    , borderInlineColor, borderInlineStartColor, borderInlineEndColor
     , borderRadius, borderRadius2, borderRadius3, borderRadius4
-    , borderTopLeftRadius, borderTopLeftRadius2, borderTopRightRadius, borderTopRightRadius2, borderBottomRightRadius, borderBottomRightRadius2, borderBottomLeftRadius, borderBottomLeftRadius2
-    , borderStartStartRadius, borderStartStartRadius2, borderStartEndRadius, borderStartEndRadius2, borderEndStartRadius, borderEndStartRadius2, borderEndEndRadius, borderEndEndRadius2
+    , borderTopLeftRadius, borderTopLeftRadius2, borderTopRightRadius, borderTopRightRadius2
+    , borderBottomRightRadius, borderBottomRightRadius2, borderBottomLeftRadius, borderBottomLeftRadius2
+    , borderStartStartRadius, borderStartStartRadius2, borderStartEndRadius, borderStartEndRadius2
+    , borderEndStartRadius, borderEndStartRadius2, borderEndEndRadius, borderEndEndRadius2
     , borderImageOutset, borderImageOutset2, borderImageOutset3, borderImageOutset4
     , borderImageWidth, borderImageWidth2, borderImageWidth3, borderImageWidth4
 
@@ -126,8 +136,7 @@ module Css exposing
 
     -- overflow
     , overflow, overflowX, overflowY, overflowBlock, overflowInline
-    , overflowAnchor
-    , overflowWrap
+    , overflowWrap, overflowAnchor
     , breakWord, anywhere
 
     -- flex
@@ -145,7 +154,9 @@ module Css exposing
     
     -- grid
     , gridAutoRows, gridAutoColumns, gridAutoFlow, gridAutoFlow2, dense
-    , gridRowStart, gridRowStart2, gridRowStart3, gridRowEnd, gridRowEnd2, gridRowEnd3, gridColumnStart, gridColumnStart2, gridColumnStart3, gridColumnEnd, gridColumnEnd2, gridColumnEnd3, span
+    , gridRowStart, gridRowStart2, gridRowStart3, gridRowEnd, gridRowEnd2, gridRowEnd3
+    , gridColumnStart, gridColumnStart2, gridColumnStart3, gridColumnEnd, gridColumnEnd2, gridColumnEnd3
+    , span
     , gridTemplateAreas, gridTemplateAreasList
 
     -- gaps
@@ -166,30 +177,33 @@ module Css exposing
     , TextShadowConfig, textShadow, defaultTextShadow
     , LineWidth, LineWidthSupported, LineStyle, LineStyleSupported
 
-    -- fonts
+    -- font size
     , fontSize
     , xxSmall, xSmall, small, medium, large, xLarge, xxLarge, smaller, larger, lineHeight, letterSpacing
     , fontSizeAdjust
+
+    -- font family
     , fontFamily, fontFamilies, serif, sansSerif, monospace, cursive, fantasy, systemUi
+
+    -- font style, weight + stretch
     , fontStyle, italic, oblique
     , fontWeight, bold, lighter, bolder
     , fontStretch, ultraCondensed, extraCondensed, condensed, semiCondensed, semiExpanded, expanded, extraExpanded, ultraExpanded
-    , fontFeatureSettings, fontFeatureSettingsList, featureTag, featureTag2
-    , fontVariationSettings, fontVariationSettingsList
-    , fontVariantCaps, smallCaps, allSmallCaps, petiteCaps, allPetiteCaps, unicase, titlingCaps
-    , fontVariantEastAsian, fontVariantEastAsian2, fontVariantEastAsian3, jis78, jis83, jis90, jis04, simplified, traditional, proportionalWidth
-    , fontVariantLigatures, commonLigatures, noCommonLigatures, discretionaryLigatures, noDiscretionaryLigatures, historicalLigatures, noHistoricalLigatures, contextual, noContextual
-    , fontVariantNumeric, fontVariantNumeric4, ordinal, slashedZero, liningNums, oldstyleNums, proportionalNums, tabularNums, diagonalFractions, stackedFractions
-    , fontKerning, fontLanguageOverride, fontSynthesis, fontSynthesis2, fontSynthesis3, fontOpticalSizing, fontVariantPosition, weight
     
-    -- ??
-    , wordSpacing
-    , tabSize
-    , fontDisplay, fallback, swap, optional
-    , writingMode, verticalLr, verticalRl, horizontalTb
-    , hyphens, quotes, quotes2, quotes4, textOverflow, textOverflow2, lineBreak, manual, ellipsis, loose
-    , hangingPunctuation, hangingPunctuation2, hangingPunctuation3, first, last, forceEnd, allowEnd
-    , lineClamp
+    -- font features and variants
+    , fontFeatureSettings, fontFeatureSettingsList, featureTag, featureTag2
+    , fontVariantCaps, smallCaps, allSmallCaps, petiteCaps, allPetiteCaps, unicase, titlingCaps
+    , fontVariantEastAsian, fontVariantEastAsian2, fontVariantEastAsian3
+    , jis78, jis83, jis90, jis04, simplified, traditional, proportionalWidth
+    , fontVariantLigatures
+    , commonLigatures, noCommonLigatures, discretionaryLigatures, noDiscretionaryLigatures, historicalLigatures, noHistoricalLigatures, contextual, noContextual
+    , fontVariantNumeric, fontVariantNumeric4
+    , ordinal, slashedZero, liningNums, oldstyleNums, proportionalNums, tabularNums, diagonalFractions, stackedFractions
+    , fontKerning, fontLanguageOverride, fontSynthesis, fontSynthesis2, fontSynthesis3, fontOpticalSizing, fontVariantPosition
+    , weight
+
+    -- variable fonts (not to be confused with variants)
+    , fontVariationSettings, fontVariationSettingsList
 
     -- cursors
     , CursorKeyword
@@ -205,7 +219,19 @@ module Css exposing
     , listStyle, listStyle2, listStyle3, listStylePosition, inside, outside, listStyleType, listStyleImage
     , arabicIndic, armenian, bengali, cambodian, cjkDecimal, cjkEarthlyBranch, cjkHeavenlyStem, cjkIdeographic, decimal, decimalLeadingZero, devanagari, disclosureClosed, disclosureOpen, disc, ethiopicNumeric, georgian, gujarati, gurmukhi, hebrew, hiragana, hiraganaIroha, japaneseFormal, japaneseInformal, kannada, katakana, katakanaIroha, khmer, koreanHangulFormal, koreanHanjaFormal, koreanHanjaInformal, lao, lowerAlpha, lowerArmenian, lowerGreek, lowerLatin, lowerRoman, malayalam, monogolian, myanmar, oriya, persian, simpChineseFormal, simpChineseInformal, tamil, telugu, thai, tibetan, tradChineseFormal, tradChineseInformal, upperAlpha, upperArmenian, upperLatin, upperRoman
 
+    -- text transform + decoration
+    , textTransform
+    , capitalize, uppercase, lowercase, fullSizeKana
+    , textDecoration, textDecoration2, textDecoration3, textDecorationLine, textDecorationLine2, textDecorationLine3, textDecorationStyle, textDecorationColor, textDecorationThickness, fromFont
+    , textDecorationSkip, textDecorationSkipInk, objects, spaces, ink, edges, boxDecoration
+    , wavy, underline, overline, lineThrough
 
+    -- ??
+    , textStroke, textStroke2, textStrokeColor, textStrokeWidth
+    , textIndent, textIndent2, textIndent3, hanging, eachLine
+    , textUnderlineOffset
+    , textEmphasis, textEmphasis2, textEmphasisStyle, textEmphasisStyle2, textEmphasisColor, textEmphasisPosition, textEmphasisPosition2, filled, open, dot, doubleCircle, triangle, sesame, over
+    
     -- ??
     , direction, ltr, rtl
     , justify, matchParent, textAlign, textJustify, interWord, interCharacter, textUnderlinePosition, textUnderlinePosition2
@@ -213,15 +239,17 @@ module Css exposing
     , mixed, sideways, sidewaysRight, upright, useGlyphOrientation
     , textRendering
     , geometricPrecision, optimizeLegibility, optimizeSpeed
-    , textTransform
-    , capitalize, uppercase, lowercase, fullSizeKana
-    , textDecoration, textDecoration2, textDecoration3, textDecorationLine, textDecorationLine2, textDecorationLine3, textDecorationStyle, textDecorationColor, textDecorationThickness, fromFont
-    , textDecorationSkip, textDecorationSkipInk, objects, spaces, ink, edges, boxDecoration
-    , wavy, underline, overline, lineThrough
-    , textStroke, textStroke2, textStrokeColor, textStrokeWidth
-    , textIndent, textIndent2, textIndent3, hanging, eachLine
-    , textUnderlineOffset
-    , textEmphasis, textEmphasis2, textEmphasisStyle, textEmphasisStyle2, textEmphasisColor, textEmphasisPosition, textEmphasisPosition2, filled, open, dot, doubleCircle, triangle, sesame, over
+
+    -- ??
+    , wordSpacing
+    , tabSize
+    , fontDisplay, fallback, swap, optional
+    , writingMode, verticalLr, verticalRl, horizontalTb
+    , hyphens, quotes, quotes2, quotes4, textOverflow, textOverflow2, lineBreak, manual, ellipsis, loose
+    , hangingPunctuation, hangingPunctuation2, hangingPunctuation3, first, last, forceEnd, allowEnd
+    , lineClamp
+
+    -- ??
     , borderCollapse
     , collapse, separate
     , borderSpacing, borderSpacing2
@@ -269,6 +297,14 @@ module Css exposing
     , opacity
     , zoom
 
+    -- break (page break)
+    , breakBefore, breakAfter, breakInside, avoid, avoidPage, avoidColumn, page
+    , pageBreakBefore, pageBreakAfter, pageBreakInside
+
+    -- pointer-events
+    , pointerEvents
+    , visiblePainted, visibleFill, visibleStroke, painted
+
     -- scrolling
     , scrollbarColor, scrollbarWidth
     , scrollBehavior, smooth, scrollSnapAlign, scrollSnapStop
@@ -291,8 +327,6 @@ module Css exposing
     , unicodeBidi, embed, bidiOverride, isolateOverride, plaintext
     , bleed
     , orphans, widows
-    , breakBefore, breakAfter, breakInside, avoid, avoidPage, avoidColumn, page
-    , pageBreakBefore, pageBreakAfter, pageBreakInside
     , mixBlendMode
     , imageRendering, crispEdges, pixelated
     , backfaceVisibility
@@ -305,8 +339,6 @@ module Css exposing
     , maskClip, maskClipList, maskComposite, maskMode, maskModeList, maskOrigin, maskOriginList, maskPosition, maskRepeat, maskRepeat2, maskSize, maskSize2, maskType
     , noClip, add, subtract, intersect, exclude, alpha, luminance, matchSource
     , caretColor
-    , pointerEvents
-    , visiblePainted, visibleFill, visibleStroke, painted
     , resize, horizontal, vertical
     , contain, contain2, contain3, contain4, size, layout, paint
     )
@@ -8406,6 +8438,23 @@ overflowWrap (Value val) =
     AppendProperty ("overflow-wrap:" ++ val)
 
 
+{-| Sets [`overflow-anchor`](https://css-tricks.com/almanac/properties/o/overflow-anchor/)
+
+    overflowAnchor auto
+
+    overflowAnchor none
+
+-}
+overflowAnchor :
+    BaseValue
+        { auto : Supported
+        , none : Supported
+        }
+    -> Style
+overflowAnchor (Value val) =
+    AppendProperty ("overflow-anchor:" ++ val)
+
+
 {-| The `break-word` value, which can be used with such properties as
 [`overflow-wrap`](https://css-tricks.com/almanac/properties/o/overflow-wrap/)
 and [`word-break`](https://css-tricks.com/almanac/properties/w/word-break/).
@@ -9998,1245 +10047,6 @@ columnGap (Value widthVal) =
 ------------------------------------------------------------------------
 ------------------------------------------------------------------------
 ------------------------------------------------------------------------
-------------------------------- FONT SIZE ------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-
-
-{-| Sets [`font-size`](https://css-tricks.com/almanac/properties/f/font-size/)
-
-    fontSize xxSmall
-
-    fontSize (px 12)
-
-Check out [fluid typography](https://css-tricks.com/snippets/css/fluid-typography/) for some cool stuff you can do with this.
-
--}
-fontSize :
-    BaseValue
-        (LengthSupported
-            { xxSmall : Supported
-            , xSmall : Supported
-            , small : Supported
-            , medium : Supported
-            , large : Supported
-            , xLarge : Supported
-            , xxLarge : Supported
-            , smaller : Supported
-            , larger : Supported
-            , pct : Supported
-            }
-        )
-    -> Style
-fontSize (Value val) =
-    AppendProperty ("font-size:" ++ val)
-
-
-{-| The `xx-small` [`font-size` value](https://developer.mozilla.org/en-US/docs/Web/CSS/font-size#Values).
-
-    fontSize xxSmall
-
--}
-xxSmall : Value { provides | xxSmall : Supported }
-xxSmall =
-    Value "xx-small"
-
-
-{-| The `x-small` [`font-size` value](https://developer.mozilla.org/en-US/docs/Web/CSS/font-size#Values).
-
-    fontSize xSmall
-
--}
-xSmall : Value { provides | xSmall : Supported }
-xSmall =
-    Value "x-small"
-
-
-{-| The `small` [`font-size` value](https://developer.mozilla.org/en-US/docs/Web/CSS/font-size#Values).
-
-    fontSize small
-
--}
-small : Value { provides | small : Supported }
-small =
-    Value "small"
-
-
-{-| The `medium` value used by properties such as [`fontSize`](#fontSize),
-[`borderWidth`](#borderWidth),
-[`columnRuleWidth`](#columnRuleWidth).
-
-    fontSize medium
-
-    borderWidth medium
-
-    columnRuleWidth medium
-
-The value is equivalent of 3px when using for `border-width`.
-
--}
-medium : Value { provides | medium : Supported }
-medium =
-    Value "medium"
-
-
-{-| The `large` [`font-size` value](https://developer.mozilla.org/en-US/docs/Web/CSS/font-size#Values).
-
-    fontSize large
-
--}
-large : Value { provides | large : Supported }
-large =
-    Value "large"
-
-
-{-| The `x-large` [`font-size` value](https://developer.mozilla.org/en-US/docs/Web/CSS/font-size#Values).
-
-    fontSize xLarge
-
--}
-xLarge : Value { provides | xLarge : Supported }
-xLarge =
-    Value "x-large"
-
-
-{-| The `xx-large` [`font-size` value](https://developer.mozilla.org/en-US/docs/Web/CSS/font-size#Values).
-
-    fontSize xxLarge
-
--}
-xxLarge : Value { provides | xxLarge : Supported }
-xxLarge =
-    Value "xx-large"
-
-
-{-| The `smaller` [`font-size` value](https://developer.mozilla.org/en-US/docs/Web/CSS/font-size#Values).
-
-    fontSize smaller
-
--}
-smaller : Value { provides | smaller : Supported }
-smaller =
-    Value "smaller"
-
-
-{-| The `larger` [`font-size` value](https://developer.mozilla.org/en-US/docs/Web/CSS/font-size#Values).
-
-    fontSize larger
-
--}
-larger : Value { provides | larger : Supported }
-larger =
-    Value "larger"
-
-
-
--- FONT FAMILY --
-
-
-{-| For when your font is one of the six [generic font family names](https://developer.mozilla.org/en-US/docs/Web/CSS/font-family#%3Cgeneric-name%3E) - [`serif`](#serif), [`sansSerif`](#sansSerif), [`monospace`](#monospace), [`cursive`](#cursive), [`fantasy`](#fantasy), or [`systemUi`](#systemUi).
-
-If you want to refer to a font by its name (like Helvetica or Arial), use [`fontFamilies`](#fontFamilies) instead.
-
--}
-fontFamily :
-    BaseValue
-        { serif : Supported
-        , sansSerif : Supported
-        , monospace : Supported
-        , cursive : Supported
-        , fantasy : Supported
-        , systemUi : Supported
-        }
-    -> Style
-fontFamily (Value genericFont) =
-    AppendProperty ("font-family:" ++ genericFont)
-
-
-{-| The `serif` [generic font family name](https://developer.mozilla.org/en-US/docs/Web/CSS/font-family#%3Cgeneric-name%3E).
-
-    fontFamily serif
-
-    fontFamilies [ "Gill Sans", "Helvetica" ] serif
-
-This can be used with [`fontFamily`](#fontFamily) and [`fontFamilies`](#fontFamilies).
-
--}
-serif : Value { provides | serif : Supported }
-serif =
-    Value "serif"
-
-
-{-| The `sans-serif` [generic font family name](https://developer.mozilla.org/en-US/docs/Web/CSS/font-family#%3Cgeneric-name%3E).
-
-    fontFamily sansSerif
-
-    fontFamilies [ "Georgia", "Times" ] sansSerif
-
-This can be used with [`fontFamily`](#fontFamily) and [`fontFamilies`](#fontFamilies).
-
--}
-sansSerif : Value { provides | sansSerif : Supported }
-sansSerif =
-    Value "sans-serif"
-
-
-{-| The `monospace` [generic font family name](https://developer.mozilla.org/en-US/docs/Web/CSS/font-family#3Cgeneric-name%3E).
-
-    fontFamily monospace
-
-    fontFamilies [ "Source Code Pro", "Lucida Console" ] monospace
-
-This can be used with [`fontFamily`](#fontFamily) and [`fontFamilies`](#fontFamilies).
-
--}
-monospace : Value { provides | monospace : Supported }
-monospace =
-    Value "monospace"
-
-
-{-| The `cursive` [generic font family name](https://developer.mozilla.org/en-US/docs/Web/CSS/font-family#3Cgeneric-name%3E).
-
-    fontFamily cursive
-
-    fontFamilies [ "Brush Sript Std", "Lucida Calligraphy" ] cursive
-
-This can be used with [`fontFamily`](#fontFamily) and [`fontFamilies`](#fontFamilies).
-
--}
-cursive : Value { provides | cursive : Supported }
-cursive =
-    Value "cursive"
-
-
-{-| The `fantasy` [generic font family name](https://developer.mozilla.org/en-US/docs/Web/CSS/font-family#3Cgeneric-name%3E).
-
-    fontFamily fantasy
-    fontFamilies [ "Herculanum", Harrington" ] fantasy
-
-This can be used with [`fontFamily`](#fontFamily) and [`fontFamilies`](#fontFamilies).
-
--}
-fantasy : Value { provides | fantasy : Supported }
-fantasy =
-    Value "fantasy"
-
-
-{-| The `system-ui` [generic font family name](https://developer.mozilla.org/en-US/docs/Web/CSS/font-family#3Cgeneric-name%3E).
-
-You may want to [read more about the system font stack](https://css-tricks.com/snippets/css/system-font-stack/) before using this one.
-
-    fontFamily systemUi
-
-    fontFamilies [ "", "Segoe UI" ] systemUi
-
-    fontFamilies [ "system-ui", "Segoe UI", "Roboto", "Helvetica", "Arial", "sans-serif", "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol" ] sansSerif
-
-This can be used with [`fontFamily`](#fontFamily) and [`fontFamilies`](#fontFamilies).
-
--}
-systemUi : Value { provides | systemUi : Supported }
-systemUi =
-    Value "system-ui"
-
-
-{-| Define multiple [font families](https://css-tricks.com/almanac/properties/f/font-family/).
-
-Per the CSS spec, a [generic name](https://developer.mozilla.org/en-US/docs/Web/CSS/font-family#%3Cgeneric-name%3E) must always be at the end of this list. (The generic names are [`serif`](#serif), [`sansSerif`](#sansSerif), [`monospace`](#monospace), [`cursive`](#cursive) or [`fantasy`](#fantasy).)
-
-    fontFamilies [ "Gill Sans Extrabold", "Helvetica", "Arial" ] sansSerif
-
-This function will automatically wrap each font family in quotation marks unless it is one of the six [generic names]((https://developer.mozilla.org/en-US/docs/Web/CSS/font-family#%3Cgeneric-name%3E)) (like `sans-serif`), which must never be quoted.
-
--}
-fontFamilies :
-    List String
-    ->
-        Value
-            { serif : Supported
-            , sansSerif : Supported
-            , monospace : Supported
-            , cursive : Supported
-            , fantasy : Supported
-            , systemUi : Supported
-            }
-    -> Style
-fontFamilies list (Value genericFont) =
-    case list of
-        [] ->
-            AppendProperty ("font-family:" ++ genericFont)
-
-        fonts ->
-            AppendProperty
-                ("font-family:"
-                    ++ String.join "," (List.map enquoteIfNotGeneric fonts)
-                    ++ ("," ++ genericFont)
-                )
-
-
-enquoteIfNotGeneric : String -> String
-enquoteIfNotGeneric fontName =
-    case fontName of
-        "serif" ->
-            fontName
-
-        "sans-serif" ->
-            fontName
-
-        "monospace" ->
-            fontName
-
-        "cursive" ->
-            fontName
-
-        "fantasy" ->
-            fontName
-
-        "system-ui" ->
-            fontName
-
-        _ ->
-            enquoteString fontName
-
-
-enquoteString : String -> String
-enquoteString str =
-    let
-        escapeChars char rest =
-            rest ++ escapeChar char
-
-        escapeChar char =
-            case char of
-                '\n' ->
-                    "\\A "
-
-                '"' ->
-                    "\\\""
-
-                '\\' ->
-                    "\\\\"
-
-                _ ->
-                    String.fromChar char
-    in
-    "\"" ++ String.foldl escapeChars "" str ++ "\""
-
-
-
--- FONT STYLES --
-
-
-{-| Sets [`font-style`](https://css-tricks.com/almanac/properties/f/font-style/)
-
-    fontStyle italic
-
--}
-fontStyle :
-    BaseValue
-        { normal : Supported
-        , italic : Supported
-        , oblique : Supported
-        }
-    -> Style
-fontStyle (Value val) =
-    AppendProperty ("font-style:" ++ val)
-
-
-{-| -}
-italic : Value { provides | italic : Supported }
-italic =
-    Value "italic"
-
-
-{-| -}
-oblique : Value { provides | oblique : Supported }
-oblique =
-    Value "oblique"
-
-
-
--- FONT FEATURE SETTINGS --
-
-
-{-| Sets [`font-feature-settings`](https://css-tricks.com/almanac/properties/f/font-feature-settings/)
-
-    fontFeatureSettings normal
-
-    fontFeatureSettings (featureTag "liga")
-
-    fontFeatureSettings (featureTag2 "swsh" 2)
-
--}
-fontFeatureSettings :
-    BaseValue
-        { featureTag : Supported
-        , normal : Supported
-        }
-    -> Style
-fontFeatureSettings (Value val) =
-    AppendProperty ("font-feature-settings:" ++ val)
-
-
-{-| Sets [`font-feature-settings`](https://css-tricks.com/almanac/properties/f/font-feature-settings/)
-in a way that lets you add a list of [`featureTag`](#featureTag)s.
-
-    fontFeatureSettingsList featureTag "liga" [ featureTag2 "swsh" 2 ]
-
--}
-fontFeatureSettingsList :
-    Value { featureTag : Supported }
-    -> List (Value { featureTag : Supported })
-    -> Style
-fontFeatureSettingsList head rest =
-    AppendProperty ("font-feature-settings:" ++ hashListToString head rest)
-
-
-{-| Creates a [feature-tag-value](https://developer.mozilla.org/en-US/docs/Web/CSS/font-feature-settings#feature-tag-value)
-for use with [`fontFeatureSettings`](#fontFeatureSettings)
-and [`fontFeatureSettingsList`](#fontFeatureSettingsList)
-
-    featureTag "smcp"
-
--}
-featureTag : String -> Value { provides | featureTag : Supported }
-featureTag =
-    Value << enquoteString
-
-
-{-| Creates a [feature-tag-value](https://developer.mozilla.org/en-US/docs/Web/CSS/font-feature-settings#feature-tag-value)
-with an specific value
-for use with [`fontFeatureSettings`](#fontFeatureSettings)
-and [`fontFeatureSettingsList`](#fontFeatureSettingsList)
-
-    featureTag2 "swsh" 2
-
--}
-featureTag2 : String -> Int -> Value { provides | featureTag : Supported }
-featureTag2 tag value =
-    Value (enquoteString tag ++ " " ++ String.fromInt value)
-
-
-
--- FONT WEIGHTS --
-
-
-{-| Sets [`font-weight`](https://css-tricks.com/almanac/properties/f/font-weight/)
-
-    fontWeight bold
-
-    fontWeight (int 300)
-
--}
-fontWeight :
-    BaseValue
-        { normal : Supported
-        , bold : Supported
-        , bolder : Supported
-        , lighter : Supported
-        , int : Supported
-        }
-    -> Style
-fontWeight (Value val) =
-    AppendProperty ("font-weight:" ++ val)
-
-
-{-| -}
-bold : Value { provides | bold : Supported }
-bold =
-    Value "bold"
-
-
-{-| -}
-lighter : Value { provides | lighter : Supported }
-lighter =
-    Value "lighter"
-
-
-{-| -}
-bolder : Value { provides | bolder : Supported }
-bolder =
-    Value "bolder"
-
-
-{-| The 1-argument variant of the [`font-variation-settings`](https://developer.mozilla.org/en-US/docs/Web/CSS/font-variation-settings)
-property.
-
-For controlling aspects of variable fonts.
-Use [`fontVariationSettingsList`](#fontVariationSettingsList) to work with variable font tags.
-
-    fontVariationSettings normal
-
-    fontVariationSettings inherit
-
-    fontVariationSettingsList [ ("XHGT", 0.7) ]
--}
-fontVariationSettings :
-    BaseValue
-        { normal : Supported
-        }
-    -> Style
-fontVariationSettings (Value val) =
-    AppendProperty ("font-variation-settings:" ++ val)
-
-
-{-| The multi-argument variant of the [`font-variation-settings`](https://developer.mozilla.org/en-US/docs/Web/CSS/font-variation-settings)
-property.
-
-For using single keywords with this property, use [`fontVariationSettings`](#fontVariationSettings).
-
-    fontVariationSettingsList [ ("XHGT", 0.7) ]
--}
-fontVariationSettingsList :
-    List
-        ( String
-        , Float
-        )
-    -> Style
-fontVariationSettingsList list =
-    AppendProperty <|
-        "font-variation-settings:"
-        ++
-        ( list
-        |> List.map
-            (\(tagVal, numberVal) -> (enquoteString tagVal) ++ " " ++ (String.fromFloat numberVal)
-            )
-        |> String.join ", "
-        )
-
-
--- FONT VARIANT CAPS --
-
-
-{-| Sets [`font-variant-caps`](https://developer.mozilla.org/en-US/docs/Web/CSS/font-variant-caps).
-
-    fontVariantCaps normal
-
-    fontVariantCaps smallCaps
-
-    fontVariantCaps allSmallCaps
-
-    fontVariantCaps petiteCaps
-
-    fontVariantCaps allPetiteCaps
-
-    fontVariantCaps unicase
-
-    fontVariantCaps titlingCaps
-
--}
-fontVariantCaps :
-    BaseValue
-        { normal : Supported
-        , smallCaps : Supported
-        , petiteCaps : Supported
-        , allPetiteCaps : Supported
-        , unicase : Supported
-        , titlingCaps : Supported
-        }
-    -> Style
-fontVariantCaps (Value str) =
-    AppendProperty ("font-variant-caps:" ++ str)
-
-
-{-| The `small-caps` value used in
-
-  - [`fontVariantCaps`](#fontVariantCaps)
-  - [`fontSynthesis`](#fontSynthesis)
-
-```
-fontVariantCaps smallCaps
-
-fontSynthesis2 smallCaps style
-```
-
--}
-smallCaps : Value { provides | smallCaps : Supported }
-smallCaps =
-    Value "small-caps"
-
-
-{-| The `all-small-caps` [`font-variant-caps` value](https://developer.mozilla.org/en-US/docs/Web/CSS/font-variant-caps#Values).
-
-    fontVariantCaps allSmallCaps
-
--}
-allSmallCaps : Value { provides | allSmallCaps : Supported }
-allSmallCaps =
-    Value "all-small-caps"
-
-
-{-| The `petite-caps` [`font-variant-caps` value](https://developer.mozilla.org/en-US/docs/Web/CSS/font-variant-caps#Values).
-
-    fontVariantCaps petiteCaps
-
--}
-petiteCaps : Value { provides | petiteCaps : Supported }
-petiteCaps =
-    Value "petite-caps"
-
-
-{-| The `all-petite-caps` [`font-variant-caps` value](https://developer.mozilla.org/en-US/docs/Web/CSS/font-variant-caps#Values).
-
-    fontVariantCaps allPetiteCaps
-
--}
-allPetiteCaps : Value { provides | allPetiteCaps : Supported }
-allPetiteCaps =
-    Value "all-petite-caps"
-
-
-{-| The `unicase` [`font-variant-caps` value](https://developer.mozilla.org/en-US/docs/Web/CSS/font-variant-caps#Values).
-
-    fontVariantCaps unicase
-
--}
-unicase : Value { provides | unicase : Supported }
-unicase =
-    Value "unicase"
-
-
-{-| The `titling-caps` [`font-variant-caps` value](https://developer.mozilla.org/en-US/docs/Web/CSS/font-variant-caps#Values).
-
-    fontVariantCaps titlingCaps
-
--}
-titlingCaps : Value { provides | titlingCaps : Supported }
-titlingCaps =
-    Value "titling-caps"
-
-
-
--- FONT VARIANT EAST ASIAN --
-
-
-{-| The [`font-variant-east-asian`](https://developer.mozilla.org/en-US/docs/Web/CSS/font-variant-east-asian#syntax) property.
-
-This property controls the use of alternative glyphs for East Asian scripts.
-
-    fontVariantEastAsian normal
-
-    fontVariantEastAsian2 ruby jis83
-
-    fontVariantEastAsian3 ruby jis90 fullWidth
-
--}
-fontVariantEastAsian :
-    BaseValue
-        { normal : Supported
-        , ruby : Supported
-
-        -- variant values
-        , jis78 : Supported
-        , jis83 : Supported
-        , jis90 : Supported
-        , jis04 : Supported
-        , simplified : Supported
-        , traditional : Supported
-
-        -- width values
-        , fullWidth : Supported
-        , proportionalWidth : Supported
-        }
-    -> Style
-fontVariantEastAsian (Value val) =
-    AppendProperty ("font-variant-east-asian:" ++ val)
-
-
-{-| The [`font-variant-east-asian`](https://developer.mozilla.org/en-US/docs/Web/CSS/font-variant-east-asian#syntax) property.
-
-This property controls the use of alternative glyphs for East Asian scripts.
-
-    fontVariantEastAsian2 ruby jis83
-
--}
-fontVariantEastAsian2 :
-    Value
-        { ruby : Supported
-        , jis78 : Supported
-        , jis83 : Supported
-        , jis90 : Supported
-        , jis04 : Supported
-        , simplified : Supported
-        , traditional : Supported
-        , fullWidth : Supported
-        , proportionalWidth : Supported
-        }
-    ->
-        Value
-            { ruby : Supported
-            , jis78 : Supported
-            , jis83 : Supported
-            , jis90 : Supported
-            , jis04 : Supported
-            , simplified : Supported
-            , traditional : Supported
-            , fullWidth : Supported
-            , proportionalWidth : Supported
-            }
-    -> Style
-fontVariantEastAsian2 (Value val1) (Value val2) =
-    AppendProperty ("font-variant-east-asian:" ++ val1 ++ " " ++ val2)
-
-
-{-| The [`font-variant-east-asian`](https://developer.mozilla.org/en-US/docs/Web/CSS/font-variant-east-asian#syntax) property.
-
-This property controls the use of alternative glyphs for East Asian scripts.
-
-    fontVariantEastAsian3 ruby jis90 fullWidth
-
--}
-fontVariantEastAsian3 :
-    Value
-        { ruby : Supported
-        }
-    ->
-        Value
-            { jis78 : Supported
-            , jis83 : Supported
-            , jis90 : Supported
-            , jis04 : Supported
-            , simplified : Supported
-            , traditional : Supported
-            }
-    ->
-        Value
-            { fullWidth : Supported
-            , proportionalWidth : Supported
-            }
-    -> Style
-fontVariantEastAsian3 (Value rubyVal) (Value variantVal) (Value widthVal) =
-    AppendProperty ("font-variant-east-asian:" ++ rubyVal ++ " " ++ variantVal ++ " " ++ widthVal)
-
-
-{-| Sets the [`jis78`](https://developer.mozilla.org/en-US/docs/Web/CSS/font-variant-east-asian#syntax) value for [`fontVariantEastAsian`](#fontVariantEastAsian).
-
-This specifies that the JIS X 0208:1978 standard for East Asian logographic glyphs
-should be used.
-
-    fontVariantEastAsian jis78
-
--}
-jis78 : Value { provides | jis78 : Supported }
-jis78 =
-    Value "jis78"
-
-
-{-| Sets the [`jis83`](https://developer.mozilla.org/en-US/docs/Web/CSS/font-variant-east-asian#syntax) value for [`fontVariantEastAsian`](#fontVariantEastAsian).
-
-This specifies that the JIS X 0208:1983 standard for East Asian logographic glyphs
-should be used.
-
-    fontVariantEastAsian jis83
-
--}
-jis83 : Value { provides | jis83 : Supported }
-jis83 =
-    Value "jis83"
-
-
-{-| Sets the [`jis90`](https://developer.mozilla.org/en-US/docs/Web/CSS/font-variant-east-asian#syntax) value for [`fontVariantEastAsian`](#fontVariantEastAsian).
-
-This specifies that the JIS X 0208:1990 standard for East Asian logographic glyphs
-should be used.
-
-    fontVariantEastAsian jis90
-
--}
-jis90 : Value { provides | jis90 : Supported }
-jis90 =
-    Value "jis90"
-
-
-{-| Sets the [`jis04`](https://developer.mozilla.org/en-US/docs/Web/CSS/font-variant-east-asian#syntax) value for [`fontVariantEastAsian`](#fontVariantEastAsian).
-
-This specifies that the JIS X 0208:2004 standard for East Asian logographic glyphs
-should be used.
-
-    fontVariantEastAsian jis04
-
--}
-jis04 : Value { provides | jis04 : Supported }
-jis04 =
-    Value "jis04"
-
-
-{-| Sets the [`simplified`](https://developer.mozilla.org/en-US/docs/Web/CSS/font-variant-east-asian#syntax) value for [`fontVariantEastAsian`](#fontVariantEastAsian).
-
-This specifies that no particular standard should be used for East Asian logographic glyphs
-apart from them being simplified Chinese glyphs.
-
-    fontVariantEastAsian simplified
-
--}
-simplified : Value { provides | simplified : Supported }
-simplified =
-    Value "simplified"
-
-
-{-| Sets the [`traditional`](https://developer.mozilla.org/en-US/docs/Web/CSS/font-variant-east-asian#syntax) value for [`fontVariantEastAsian`](#fontVariantEastAsian).
-
-This specifies that no particular standard should be used for East Asian logographic glyphs
-apart from them being traditional Chinese glyphs.
-
-    fontVariantEastAsian traditional
-
--}
-traditional : Value { provides | traditional : Supported }
-traditional =
-    Value "traditional"
-
-
-{-| Sets the [`proportional-width`](https://developer.mozilla.org/en-US/docs/Web/CSS/font-variant-east-asian#syntax) value for [`fontVariantEastAsian`](#fontVariantEastAsian).
-
-This activates the East Asian characters that vary in width.
-
-(As opposed to [`fullWidth`](#fullWidth), which specifies that they should roughly be the same width.)
-
-    fontVariantEastAsian proportionalWidth
-
--}
-proportionalWidth : Value { provides | proportionalWidth : Supported }
-proportionalWidth =
-    Value "proportional-width"
-
-
-
--- FONT VARIANT LIGATURES --
-
-
-{-| Sets [`font-variant-ligatures`](https://developer.mozilla.org/en-US/docs/Web/CSS/font-variant-ligatures).
-
-    fontVariantLigatures discretionaryLigatures
-
-    fontVariantLigatures none
-
--}
-fontVariantLigatures :
-    BaseValue
-        { normal : Supported
-        , none : Supported
-        , commonLigatures : Supported
-        , noCommonLigatures : Supported
-        , discretionaryLigatures : Supported
-        , noDiscretionaryLigatures : Supported
-        , historicalLigatures : Supported
-        , noHistoricalLigatures : Supported
-        , contextual : Supported
-        , noContextual : Supported
-        }
-    -> Style
-fontVariantLigatures (Value str) =
-    AppendProperty ("font-variant-ligatures:" ++ str)
-
-
-{-| The `common-ligatures` [`font-variant-ligatures` value](https://developer.mozilla.org/en-US/docs/Web/CSS/font-variant-ligatures#Values).
-
-    fontVariantLigatures commonLigatures
-
--}
-commonLigatures : Value { provides | commonLigatures : Supported }
-commonLigatures =
-    Value "common-ligatures"
-
-
-{-| The `no-common-ligatures` [`font-variant-ligatures` value](https://developer.mozilla.org/en-US/docs/Web/CSS/font-variant-ligatures#Values).
-
-    fontVariantLigatures noCommonLigatures
-
--}
-noCommonLigatures : Value { provides | noCommonLigatures : Supported }
-noCommonLigatures =
-    Value "no-common-ligatures"
-
-
-{-| The `discretionary-ligatures` [`font-variant-ligatures` value](https://developer.mozilla.org/en-US/docs/Web/CSS/font-variant-ligatures#Values).
-
-    fontVariantLigatures discretionaryLigatures
-
--}
-discretionaryLigatures : Value { provides | discretionaryLigatures : Supported }
-discretionaryLigatures =
-    Value "discretionary-ligatures"
-
-
-{-| The `no-discretionary-ligatures` [`font-variant-ligatures` value](https://developer.mozilla.org/en-US/docs/Web/CSS/font-variant-ligatures#Values).
-
-    fontVariantLigatures noDiscretionaryLigatures
-
--}
-noDiscretionaryLigatures : Value { provides | noDiscretionaryLigatures : Supported }
-noDiscretionaryLigatures =
-    Value "no-discretionary-ligatures"
-
-
-{-| The `historical-ligatures` [`font-variant-ligatures` value](https://developer.mozilla.org/en-US/docs/Web/CSS/font-variant-ligatures#Values).
-
-    fontVariantLigatures historicalLigatures
-
--}
-historicalLigatures : Value { provides | historicalLigatures : Supported }
-historicalLigatures =
-    Value "historical-ligatures"
-
-
-{-| The `no-historical-ligatures` [`font-variant-ligatures` value](https://developer.mozilla.org/en-US/docs/Web/CSS/font-variant-ligatures#Values).
-
-    fontVariantLigatures noHistoricalLigatures
-
--}
-noHistoricalLigatures : Value { provides | noHistoricalLigatures : Supported }
-noHistoricalLigatures =
-    Value "no-historical-ligatures"
-
-
-{-| The `contextual` [`font-variant-ligatures` value](https://developer.mozilla.org/en-US/docs/Web/CSS/font-variant-ligatures#Values).
-
-    fontVariantLigatures contextual
-
--}
-contextual : Value { provides | contextual : Supported }
-contextual =
-    Value "contextual"
-
-
-{-| The `no-contextual` [`font-variant-ligatures` value](https://developer.mozilla.org/en-US/docs/Web/CSS/font-variant-ligatures#Values).
-
-    fontVariantLigatures noContextual
-
--}
-noContextual : Value { provides | noContextual : Supported }
-noContextual =
-    Value "no-contextual"
-
-
-
--- FONT VARIANT NUMERIC --
-
-
-{-| Sets [`font-variant-numeric`](https://css-tricks.com/almanac/properties/f/font-variant-numeric/).
-
-    fontVariantNumeric ordinal
-
-See [`fontVariantNumeric4`](#fontVariantNumeric4) for a more advanced version.
-
--}
-fontVariantNumeric :
-    BaseValue
-        { normal : Supported
-        , ordinal : Supported
-        , slashedZero : Supported
-        , liningNums : Supported
-        , oldstyleNums : Supported
-        , proportionalNums : Supported
-        , tabularNums : Supported
-        , diagonalFractions : Supported
-        , stackedFractions : Supported
-        }
-    -> Style
-fontVariantNumeric (Value str) =
-    AppendProperty ("font-variant-numeric:" ++ str)
-
-
-{-| Sets [`font-variant-numeric`](https://css-tricks.com/almanac/properties/f/font-variant-numeric/).
-
-This one can be tricky to use because many of the options are mutually exclusive.
-For example, `normal` cannot be used with any of the others, so the only way
-to get it from this function is to pass `Nothing` for everything. The other
-arguments are chosen such that you can choose between the mutually exclusive
-values, or leave that value off.
-
-    fontVariantNumeric4 Nothing Nothing Nothing Nothing -- "normal"
-
-    fontVariantNumeric4
-        (Just ordinal)
-        Nothing
-        (Just tabularNums)
-        Nothing
-        -- "ordinal tabular-nums"
-
-See [`fontVariantNumeric`](#fontVariantNumeric) for a more concise version.
-
--}
-fontVariantNumeric4 :
-    Maybe (Value { ordinal : Supported, slashedZero : Supported })
-    -> Maybe (Value { liningNums : Supported, oldstyleNums : Supported })
-    -> Maybe (Value { proportionalNums : Supported, tabularNums : Supported })
-    -> Maybe (Value { diagonalFractions : Supported, stackedFractions : Supported })
-    -> Style
-fontVariantNumeric4 val1 val2 val3 val4 =
-    let
-        valueStr =
-            case
-                [ maybeValToString val1
-                , maybeValToString val2
-                , maybeValToString val3
-                , maybeValToString val4
-                ]
-                    |> List.filterMap identity
-            of
-                [] ->
-                    "normal"
-
-                strings ->
-                    String.join "," strings
-    in
-    AppendProperty ("font-variant-numeric:" ++ valueStr)
-
-
-maybeValToString : Maybe (Value a) -> Maybe String
-maybeValToString =
-    Maybe.map unpackValue
-
-
-{-| The `ordinal` [`font-variant-numeric` value](https://developer.mozilla.org/en-US/docs/Web/CSS/font-variant-numeric).
-
-    fontVariantNumeric ordinal
-
--}
-ordinal : Value { provides | ordinal : Supported }
-ordinal =
-    Value "ordinal"
-
-
-{-| The `slashed-zero` [`font-variant-numeric` value](https://developer.mozilla.org/en-US/docs/Web/CSS/font-variant-numeric).
-
-    fontVariantNumeric slashedZero
-
--}
-slashedZero : Value { provides | slashedZero : Supported }
-slashedZero =
-    Value "slashed-zero"
-
-
-{-| The `lining-nums` [`font-variant-numeric` value](https://developer.mozilla.org/en-US/docs/Web/CSS/font-variant-numeric).
-
-    fontVariantNumeric liningNums
-
--}
-liningNums : Value { provides | liningNums : Supported }
-liningNums =
-    Value "lining-nums"
-
-
-{-| The `oldstyle-nums` [`font-variant-numeric` value](https://developer.mozilla.org/en-US/docs/Web/CSS/font-variant-numeric).
-
-    fontVariantNumeric oldstyleNums
-
--}
-oldstyleNums : Value { provides | oldstyleNums : Supported }
-oldstyleNums =
-    Value "oldstyle-nums"
-
-
-{-| The `proportional-nums` [`font-variant-numeric` value](https://developer.mozilla.org/en-US/docs/Web/CSS/font-variant-numeric).
-
-    fontVariantNumeric proportionalNums
-
--}
-proportionalNums : Value { provides | proportionalNums : Supported }
-proportionalNums =
-    Value "proportional-nums"
-
-
-{-| The `tabular-nums` [`font-variant-numeric` value](https://developer.mozilla.org/en-US/docs/Web/CSS/font-variant-numeric).
-
-    fontVariantNumeric tabularNums
-
--}
-tabularNums : Value { provides | tabularNums : Supported }
-tabularNums =
-    Value "tabular-nums"
-
-
-{-| The `diagonal-fractions` [`font-variant-numeric` value](https://developer.mozilla.org/en-US/docs/Web/CSS/font-variant-numeric).
-
-    fontVariantNumeric diagonalFractions
-
--}
-diagonalFractions : Value { provides | diagonalFractions : Supported }
-diagonalFractions =
-    Value "diagonal-fractions"
-
-
-{-| The `stacked-fractions` [`font-variant-numeric` value](https://developer.mozilla.org/en-US/docs/Web/CSS/font-variant-numeric).
-
-    fontVariantNumeric stackedFractions
-
--}
-stackedFractions : Value { provides | stackedFractions : Supported }
-stackedFractions =
-    Value "stacked-fractions"
-
-
-
--- FONT OPTICAL SIZING --
-
-
-{-| The [`font-kerning`](https://developer.mozilla.org/en-US/docs/Web/CSS/font-kerning) property.
-
-    fontKerning none
-
--}
-fontKerning :
-    BaseValue
-        { none : Supported
-        , auto : Supported
-        , normal : Supported
-        }
-    -> Style
-fontKerning (Value val) =
-    AppendProperty ("font-kerning:" ++ val)
-
-
-{-| The [`font-language-override`](https://developer.mozilla.org/en-US/docs/Web/CSS/font-language-override) property.
-
-    fontLanguageOverride normal
-
-    fontLanguageOverride (string "ENG")
-
--}
-fontLanguageOverride :
-    BaseValue
-        { normal : Supported
-        , string : Supported
-        }
-    -> Style
-fontLanguageOverride (Value val) =
-    AppendProperty ("font-language-override:" ++ val)
-
-
-{-| The [`font-synthesis`](https://developer.mozilla.org/en-US/docs/Web/CSS/font-synthesis) property.
-
-    fontSynthesis none
-
-    fontSynthesis smallCaps
-
-    fontSynthesis2 smallCaps weight
-
-    fontSynthesis3 weight style smallCaps
-
--}
-fontSynthesis :
-    BaseValue
-        { none : Supported
-        , weight : Supported
-        , style : Supported
-        , smallCaps : Supported
-        }
-    -> Style
-fontSynthesis (Value val) =
-    AppendProperty ("font-synthesis:" ++ val)
-
-
-{-| The [`font-synthesis`](https://developer.mozilla.org/en-US/docs/Web/CSS/font-synthesis) property.
-
-This is the two-argument variant, in which you can indicate
-two different font properties to be synthesised by the browser.
-
-    fontSynthesis2 smallCaps weight
-
--}
-fontSynthesis2 :
-    Value
-        { weight : Supported
-        , style : Supported
-        , smallCaps : Supported
-        }
-    ->
-        Value
-            { weight : Supported
-            , style : Supported
-            , smallCaps : Supported
-            }
-    -> Style
-fontSynthesis2 (Value val1) (Value val2) =
-    AppendProperty ("font-synthesis:" ++ val1 ++ " " ++ val2)
-
-
-{-| The [`font-synthesis`](https://developer.mozilla.org/en-US/docs/Web/CSS/font-synthesis) property.
-
-This is the three-argument variant, in which you can indicate
-all three different font properties to be synthesised by the browser.
-
-    fontSynthesis3 weight style smallCaps
-
--}
-fontSynthesis3 :
-    Value
-        { weight : Supported
-        , style : Supported
-        , smallCaps : Supported
-        }
-    ->
-        Value
-            { weight : Supported
-            , style : Supported
-            , smallCaps : Supported
-            }
-    ->
-        Value
-            { weight : Supported
-            , style : Supported
-            , smallCaps : Supported
-            }
-    -> Style
-fontSynthesis3 (Value val1) (Value val2) (Value val3) =
-    AppendProperty ("font-synthesis:" ++ val1 ++ " " ++ val2 ++ " " ++ val3)
-
-
-{-| The `weight` value for the [`fontSynthesis`](#fontSynthesis) property.
-
-    fontSynthesis weight
-
--}
-weight : Value { provides | weight : Supported }
-weight =
-    Value "weight"
-
-
-{-| The [`font-optical-sizing`](https://developer.mozilla.org/en-US/docs/Web/CSS/font-optical-sizing) property.
-
-    fontOpticalSizing none
-
--}
-fontOpticalSizing :
-    BaseValue
-        { none : Supported
-        , auto : Supported
-        }
-    -> Style
-fontOpticalSizing (Value val) =
-    AppendProperty ("font-optical-sizing:" ++ val)
-
-
-{-| The [`font-variant-position`](https://developer.mozilla.org/en-US/docs/Web/CSS/font-variant-position) property.
-
-    fontVariantPosition sub
-
-    fontVariantPosition normal
-
--}
-fontVariantPosition :
-    BaseValue
-        { normal : Supported
-        , sub : Supported
-        , super : Supported
-        }
-    -> Style
-fontVariantPosition (Value val) =
-    AppendProperty ("font-variant-position:" ++ val)
-
-
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
-------------------------------------------------------------------------
 --------------------------------- COLOR --------------------------------
 ------------------------------------------------------------------------
 ------------------------------------------------------------------------
@@ -12063,6 +10873,1430 @@ backgroundSize2 :
     -> Style
 backgroundSize2 (Value widthVal) (Value heightVal) =
     AppendProperty ("background-size:" ++ widthVal ++ " " ++ heightVal)
+
+
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------- FONT SIZE ------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+
+
+{-| Sets [`font-size`](https://css-tricks.com/almanac/properties/f/font-size/)
+
+    fontSize xxSmall
+
+    fontSize (px 12)
+
+Check out [fluid typography](https://css-tricks.com/snippets/css/fluid-typography/) for some cool stuff you can do with this.
+
+-}
+fontSize :
+    BaseValue
+        (LengthSupported
+            { xxSmall : Supported
+            , xSmall : Supported
+            , small : Supported
+            , medium : Supported
+            , large : Supported
+            , xLarge : Supported
+            , xxLarge : Supported
+            , smaller : Supported
+            , larger : Supported
+            , pct : Supported
+            }
+        )
+    -> Style
+fontSize (Value val) =
+    AppendProperty ("font-size:" ++ val)
+
+
+{-| The `xx-small` [`font-size` value](https://developer.mozilla.org/en-US/docs/Web/CSS/font-size#Values).
+
+    fontSize xxSmall
+
+-}
+xxSmall : Value { provides | xxSmall : Supported }
+xxSmall =
+    Value "xx-small"
+
+
+{-| The `x-small` [`font-size` value](https://developer.mozilla.org/en-US/docs/Web/CSS/font-size#Values).
+
+    fontSize xSmall
+
+-}
+xSmall : Value { provides | xSmall : Supported }
+xSmall =
+    Value "x-small"
+
+
+{-| The `small` [`font-size` value](https://developer.mozilla.org/en-US/docs/Web/CSS/font-size#Values).
+
+    fontSize small
+
+-}
+small : Value { provides | small : Supported }
+small =
+    Value "small"
+
+
+{-| The `medium` value used by properties such as [`fontSize`](#fontSize),
+[`borderWidth`](#borderWidth),
+[`columnRuleWidth`](#columnRuleWidth).
+
+    fontSize medium
+
+    borderWidth medium
+
+    columnRuleWidth medium
+
+The value is equivalent of 3px when using for `border-width`.
+
+-}
+medium : Value { provides | medium : Supported }
+medium =
+    Value "medium"
+
+
+{-| The `large` [`font-size` value](https://developer.mozilla.org/en-US/docs/Web/CSS/font-size#Values).
+
+    fontSize large
+
+-}
+large : Value { provides | large : Supported }
+large =
+    Value "large"
+
+
+{-| The `x-large` [`font-size` value](https://developer.mozilla.org/en-US/docs/Web/CSS/font-size#Values).
+
+    fontSize xLarge
+
+-}
+xLarge : Value { provides | xLarge : Supported }
+xLarge =
+    Value "x-large"
+
+
+{-| The `xx-large` [`font-size` value](https://developer.mozilla.org/en-US/docs/Web/CSS/font-size#Values).
+
+    fontSize xxLarge
+
+-}
+xxLarge : Value { provides | xxLarge : Supported }
+xxLarge =
+    Value "xx-large"
+
+
+{-| The `smaller` [`font-size` value](https://developer.mozilla.org/en-US/docs/Web/CSS/font-size#Values).
+
+    fontSize smaller
+
+-}
+smaller : Value { provides | smaller : Supported }
+smaller =
+    Value "smaller"
+
+
+{-| The `larger` [`font-size` value](https://developer.mozilla.org/en-US/docs/Web/CSS/font-size#Values).
+
+    fontSize larger
+
+-}
+larger : Value { provides | larger : Supported }
+larger =
+    Value "larger"
+
+
+{-| Sets [`font-size-adjust`](https://css-tricks.com/almanac/properties/f/font-size-adjust/)
+
+    fontSizeAdjust zero
+
+    fontSizeAdjust none
+
+    fontSizeAdjust (num 0.5)
+
+-}
+fontSizeAdjust :
+    BaseValue
+        { none : Supported
+        , zero : Supported
+        , num : Supported
+        }
+    -> Style
+fontSizeAdjust (Value val) =
+    AppendProperty ("font-size-adjust:" ++ val)
+
+
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------ FONT FAMILY -----------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+
+
+{-| For when your font is one of the six [generic font family names](https://developer.mozilla.org/en-US/docs/Web/CSS/font-family#%3Cgeneric-name%3E) - [`serif`](#serif), [`sansSerif`](#sansSerif), [`monospace`](#monospace), [`cursive`](#cursive), [`fantasy`](#fantasy), or [`systemUi`](#systemUi).
+
+If you want to refer to a font by its name (like Helvetica or Arial), use [`fontFamilies`](#fontFamilies) instead.
+
+-}
+fontFamily :
+    BaseValue
+        { serif : Supported
+        , sansSerif : Supported
+        , monospace : Supported
+        , cursive : Supported
+        , fantasy : Supported
+        , systemUi : Supported
+        }
+    -> Style
+fontFamily (Value genericFont) =
+    AppendProperty ("font-family:" ++ genericFont)
+
+
+{-| The `serif` [generic font family name](https://developer.mozilla.org/en-US/docs/Web/CSS/font-family#%3Cgeneric-name%3E).
+
+    fontFamily serif
+
+    fontFamilies [ "Gill Sans", "Helvetica" ] serif
+
+This can be used with [`fontFamily`](#fontFamily) and [`fontFamilies`](#fontFamilies).
+
+-}
+serif : Value { provides | serif : Supported }
+serif =
+    Value "serif"
+
+
+{-| The `sans-serif` [generic font family name](https://developer.mozilla.org/en-US/docs/Web/CSS/font-family#%3Cgeneric-name%3E).
+
+    fontFamily sansSerif
+
+    fontFamilies [ "Georgia", "Times" ] sansSerif
+
+This can be used with [`fontFamily`](#fontFamily) and [`fontFamilies`](#fontFamilies).
+
+-}
+sansSerif : Value { provides | sansSerif : Supported }
+sansSerif =
+    Value "sans-serif"
+
+
+{-| The `monospace` [generic font family name](https://developer.mozilla.org/en-US/docs/Web/CSS/font-family#3Cgeneric-name%3E).
+
+    fontFamily monospace
+
+    fontFamilies [ "Source Code Pro", "Lucida Console" ] monospace
+
+This can be used with [`fontFamily`](#fontFamily) and [`fontFamilies`](#fontFamilies).
+
+-}
+monospace : Value { provides | monospace : Supported }
+monospace =
+    Value "monospace"
+
+
+{-| The `cursive` [generic font family name](https://developer.mozilla.org/en-US/docs/Web/CSS/font-family#3Cgeneric-name%3E).
+
+    fontFamily cursive
+
+    fontFamilies [ "Brush Sript Std", "Lucida Calligraphy" ] cursive
+
+This can be used with [`fontFamily`](#fontFamily) and [`fontFamilies`](#fontFamilies).
+
+-}
+cursive : Value { provides | cursive : Supported }
+cursive =
+    Value "cursive"
+
+
+{-| The `fantasy` [generic font family name](https://developer.mozilla.org/en-US/docs/Web/CSS/font-family#3Cgeneric-name%3E).
+
+    fontFamily fantasy
+    fontFamilies [ "Herculanum", Harrington" ] fantasy
+
+This can be used with [`fontFamily`](#fontFamily) and [`fontFamilies`](#fontFamilies).
+
+-}
+fantasy : Value { provides | fantasy : Supported }
+fantasy =
+    Value "fantasy"
+
+
+{-| The `system-ui` [generic font family name](https://developer.mozilla.org/en-US/docs/Web/CSS/font-family#3Cgeneric-name%3E).
+
+You may want to [read more about the system font stack](https://css-tricks.com/snippets/css/system-font-stack/) before using this one.
+
+    fontFamily systemUi
+
+    fontFamilies [ "", "Segoe UI" ] systemUi
+
+    fontFamilies [ "system-ui", "Segoe UI", "Roboto", "Helvetica", "Arial", "sans-serif", "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol" ] sansSerif
+
+This can be used with [`fontFamily`](#fontFamily) and [`fontFamilies`](#fontFamilies).
+
+-}
+systemUi : Value { provides | systemUi : Supported }
+systemUi =
+    Value "system-ui"
+
+
+{-| Define multiple [font families](https://css-tricks.com/almanac/properties/f/font-family/).
+
+Per the CSS spec, a [generic name](https://developer.mozilla.org/en-US/docs/Web/CSS/font-family#%3Cgeneric-name%3E) must always be at the end of this list. (The generic names are [`serif`](#serif), [`sansSerif`](#sansSerif), [`monospace`](#monospace), [`cursive`](#cursive) or [`fantasy`](#fantasy).)
+
+    fontFamilies [ "Gill Sans Extrabold", "Helvetica", "Arial" ] sansSerif
+
+This function will automatically wrap each font family in quotation marks unless it is one of the six [generic names]((https://developer.mozilla.org/en-US/docs/Web/CSS/font-family#%3Cgeneric-name%3E)) (like `sans-serif`), which must never be quoted.
+
+-}
+fontFamilies :
+    List String
+    ->
+        Value
+            { serif : Supported
+            , sansSerif : Supported
+            , monospace : Supported
+            , cursive : Supported
+            , fantasy : Supported
+            , systemUi : Supported
+            }
+    -> Style
+fontFamilies list (Value genericFont) =
+    case list of
+        [] ->
+            AppendProperty ("font-family:" ++ genericFont)
+
+        fonts ->
+            AppendProperty
+                ("font-family:"
+                    ++ String.join "," (List.map enquoteIfNotGeneric fonts)
+                    ++ ("," ++ genericFont)
+                )
+
+
+enquoteIfNotGeneric : String -> String
+enquoteIfNotGeneric fontName =
+    case fontName of
+        "serif" ->
+            fontName
+
+        "sans-serif" ->
+            fontName
+
+        "monospace" ->
+            fontName
+
+        "cursive" ->
+            fontName
+
+        "fantasy" ->
+            fontName
+
+        "system-ui" ->
+            fontName
+
+        _ ->
+            enquoteString fontName
+
+
+enquoteString : String -> String
+enquoteString str =
+    let
+        escapeChars char rest =
+            rest ++ escapeChar char
+
+        escapeChar char =
+            case char of
+                '\n' ->
+                    "\\A "
+
+                '"' ->
+                    "\\\""
+
+                '\\' ->
+                    "\\\\"
+
+                _ ->
+                    String.fromChar char
+    in
+    "\"" ++ String.foldl escapeChars "" str ++ "\""
+
+
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+-------------------------- FONT STYLE + WEIGHT -------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+
+
+{-| Sets [`font-style`](https://css-tricks.com/almanac/properties/f/font-style/)
+
+    fontStyle italic
+
+-}
+fontStyle :
+    BaseValue
+        { normal : Supported
+        , italic : Supported
+        , oblique : Supported
+        }
+    -> Style
+fontStyle (Value val) =
+    AppendProperty ("font-style:" ++ val)
+
+
+{-| -}
+italic : Value { provides | italic : Supported }
+italic =
+    Value "italic"
+
+
+{-| -}
+oblique : Value { provides | oblique : Supported }
+oblique =
+    Value "oblique"
+
+
+{-| Sets [`font-weight`](https://css-tricks.com/almanac/properties/f/font-weight/)
+
+    fontWeight bold
+
+    fontWeight (int 300)
+
+-}
+fontWeight :
+    BaseValue
+        { normal : Supported
+        , bold : Supported
+        , bolder : Supported
+        , lighter : Supported
+        , int : Supported
+        }
+    -> Style
+fontWeight (Value val) =
+    AppendProperty ("font-weight:" ++ val)
+
+
+{-| -}
+bold : Value { provides | bold : Supported }
+bold =
+    Value "bold"
+
+
+{-| -}
+lighter : Value { provides | lighter : Supported }
+lighter =
+    Value "lighter"
+
+
+{-| -}
+bolder : Value { provides | bolder : Supported }
+bolder =
+    Value "bolder"
+
+
+{-| Sets [`font-stretch`](https://css-tricks.com/almanac/properties/f/font-stretch/)
+
+    fontStretch ultraCondensed
+
+    fontStretch extraCondensed
+
+    fontStretch condensed
+
+    fontStretch semiCondensed
+
+    fontStretch normal
+
+    fontStretch semiExpanded
+
+    fontStretch expanded
+
+    fontStretch extraExpanded
+
+    fontStretch ultraExpanded
+
+-}
+fontStretch :
+    BaseValue
+        { ultraCondensed : Supported
+        , extraCondensed : Supported
+        , condensed : Supported
+        , semiCondensed : Supported
+        , normal : Supported
+        , semiExpanded : Supported
+        , expanded : Supported
+        , extraExpanded : Supported
+        , ultraExpanded : Supported
+        }
+    -> Style
+fontStretch (Value val) =
+    AppendProperty ("font-stretch:" ++ val)
+
+
+{-| Sets `ultra-condensed` value for usage with [`fontStretch`](#fontStretch).
+
+      fontDisplay ultraCondensed
+
+-}
+ultraCondensed : Value { provides | ultraCondensed : Supported }
+ultraCondensed =
+    Value "ultra-condensed"
+
+
+{-| Sets `extra-condensed` value for usage with [`fontStretch`](#fontStretch).
+
+      fontDisplay extraCondensed
+
+-}
+extraCondensed : Value { provides | extraCondensed : Supported }
+extraCondensed =
+    Value "extra-condensed"
+
+
+{-| Sets `condensed` value for usage with [`fontStretch`](#fontStretch).
+
+      fontDisplay Condensed
+
+-}
+condensed : Value { provides | condensed : Supported }
+condensed =
+    Value "condensed"
+
+
+{-| Sets `semi-condensed` value for usage with [`fontStretch`](#fontStretch).
+
+      fontDisplay semiCondensed
+
+-}
+semiCondensed : Value { provides | semiCondensed : Supported }
+semiCondensed =
+    Value "semi-condensed"
+
+
+{-| Sets `ultra-expanded` value for usage with [`fontStretch`](#fontStretch).
+
+      fontDisplay ultraExpanded
+
+-}
+ultraExpanded : Value { provides | ultraExpanded : Supported }
+ultraExpanded =
+    Value "ultra-expanded"
+
+
+{-| Sets `extra-expanded` value for usage with [`fontStretch`](#fontStretch).
+
+      fontDisplay extraExpanded
+
+-}
+extraExpanded : Value { provides | extraExpanded : Supported }
+extraExpanded =
+    Value "extra-expanded"
+
+
+{-| Sets `expanded` value for usage with [`fontStretch`](#fontStretch).
+
+      fontDisplay Expanded
+
+-}
+expanded : Value { provides | expanded : Supported }
+expanded =
+    Value "expanded"
+
+
+{-| Sets `semi-expanded` value for usage with [`fontStretch`](#fontStretch).
+
+      fontDisplay semiExpanded
+
+-}
+semiExpanded : Value { provides | semiExpanded : Supported }
+semiExpanded =
+    Value "semi-expanded"
+
+
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+----------------------- FONT FEATURES AND VARIANTS ---------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+
+
+{-| Sets [`font-feature-settings`](https://css-tricks.com/almanac/properties/f/font-feature-settings/)
+
+    fontFeatureSettings normal
+
+    fontFeatureSettings (featureTag "liga")
+
+    fontFeatureSettings (featureTag2 "swsh" 2)
+
+-}
+fontFeatureSettings :
+    BaseValue
+        { featureTag : Supported
+        , normal : Supported
+        }
+    -> Style
+fontFeatureSettings (Value val) =
+    AppendProperty ("font-feature-settings:" ++ val)
+
+
+{-| Sets [`font-feature-settings`](https://css-tricks.com/almanac/properties/f/font-feature-settings/)
+in a way that lets you add a list of [`featureTag`](#featureTag)s.
+
+    fontFeatureSettingsList featureTag "liga" [ featureTag2 "swsh" 2 ]
+
+-}
+fontFeatureSettingsList :
+    Value { featureTag : Supported }
+    -> List (Value { featureTag : Supported })
+    -> Style
+fontFeatureSettingsList head rest =
+    AppendProperty ("font-feature-settings:" ++ hashListToString head rest)
+
+
+{-| Creates a [feature-tag-value](https://developer.mozilla.org/en-US/docs/Web/CSS/font-feature-settings#feature-tag-value)
+for use with [`fontFeatureSettings`](#fontFeatureSettings)
+and [`fontFeatureSettingsList`](#fontFeatureSettingsList)
+
+    featureTag "smcp"
+
+-}
+featureTag : String -> Value { provides | featureTag : Supported }
+featureTag =
+    Value << enquoteString
+
+
+{-| Creates a [feature-tag-value](https://developer.mozilla.org/en-US/docs/Web/CSS/font-feature-settings#feature-tag-value)
+with an specific value
+for use with [`fontFeatureSettings`](#fontFeatureSettings)
+and [`fontFeatureSettingsList`](#fontFeatureSettingsList)
+
+    featureTag2 "swsh" 2
+
+-}
+featureTag2 : String -> Int -> Value { provides | featureTag : Supported }
+featureTag2 tag value =
+    Value (enquoteString tag ++ " " ++ String.fromInt value)
+
+
+-- FONT VARIANT CAPS --
+
+
+{-| Sets [`font-variant-caps`](https://developer.mozilla.org/en-US/docs/Web/CSS/font-variant-caps).
+
+    fontVariantCaps normal
+
+    fontVariantCaps smallCaps
+
+    fontVariantCaps allSmallCaps
+
+    fontVariantCaps petiteCaps
+
+    fontVariantCaps allPetiteCaps
+
+    fontVariantCaps unicase
+
+    fontVariantCaps titlingCaps
+
+-}
+fontVariantCaps :
+    BaseValue
+        { normal : Supported
+        , smallCaps : Supported
+        , petiteCaps : Supported
+        , allPetiteCaps : Supported
+        , unicase : Supported
+        , titlingCaps : Supported
+        }
+    -> Style
+fontVariantCaps (Value str) =
+    AppendProperty ("font-variant-caps:" ++ str)
+
+
+{-| The `small-caps` value used in
+
+  - [`fontVariantCaps`](#fontVariantCaps)
+  - [`fontSynthesis`](#fontSynthesis)
+
+```
+fontVariantCaps smallCaps
+
+fontSynthesis2 smallCaps style
+```
+
+-}
+smallCaps : Value { provides | smallCaps : Supported }
+smallCaps =
+    Value "small-caps"
+
+
+{-| The `all-small-caps` [`font-variant-caps` value](https://developer.mozilla.org/en-US/docs/Web/CSS/font-variant-caps#Values).
+
+    fontVariantCaps allSmallCaps
+
+-}
+allSmallCaps : Value { provides | allSmallCaps : Supported }
+allSmallCaps =
+    Value "all-small-caps"
+
+
+{-| The `petite-caps` [`font-variant-caps` value](https://developer.mozilla.org/en-US/docs/Web/CSS/font-variant-caps#Values).
+
+    fontVariantCaps petiteCaps
+
+-}
+petiteCaps : Value { provides | petiteCaps : Supported }
+petiteCaps =
+    Value "petite-caps"
+
+
+{-| The `all-petite-caps` [`font-variant-caps` value](https://developer.mozilla.org/en-US/docs/Web/CSS/font-variant-caps#Values).
+
+    fontVariantCaps allPetiteCaps
+
+-}
+allPetiteCaps : Value { provides | allPetiteCaps : Supported }
+allPetiteCaps =
+    Value "all-petite-caps"
+
+
+{-| The `unicase` [`font-variant-caps` value](https://developer.mozilla.org/en-US/docs/Web/CSS/font-variant-caps#Values).
+
+    fontVariantCaps unicase
+
+-}
+unicase : Value { provides | unicase : Supported }
+unicase =
+    Value "unicase"
+
+
+{-| The `titling-caps` [`font-variant-caps` value](https://developer.mozilla.org/en-US/docs/Web/CSS/font-variant-caps#Values).
+
+    fontVariantCaps titlingCaps
+
+-}
+titlingCaps : Value { provides | titlingCaps : Supported }
+titlingCaps =
+    Value "titling-caps"
+
+
+
+-- FONT VARIANT EAST ASIAN --
+
+
+{-| The [`font-variant-east-asian`](https://developer.mozilla.org/en-US/docs/Web/CSS/font-variant-east-asian#syntax) property.
+
+This property controls the use of alternative glyphs for East Asian scripts.
+
+    fontVariantEastAsian normal
+
+    fontVariantEastAsian2 ruby jis83
+
+    fontVariantEastAsian3 ruby jis90 fullWidth
+
+-}
+fontVariantEastAsian :
+    BaseValue
+        { normal : Supported
+        , ruby : Supported
+
+        -- variant values
+        , jis78 : Supported
+        , jis83 : Supported
+        , jis90 : Supported
+        , jis04 : Supported
+        , simplified : Supported
+        , traditional : Supported
+
+        -- width values
+        , fullWidth : Supported
+        , proportionalWidth : Supported
+        }
+    -> Style
+fontVariantEastAsian (Value val) =
+    AppendProperty ("font-variant-east-asian:" ++ val)
+
+
+{-| The [`font-variant-east-asian`](https://developer.mozilla.org/en-US/docs/Web/CSS/font-variant-east-asian#syntax) property.
+
+This property controls the use of alternative glyphs for East Asian scripts.
+
+    fontVariantEastAsian2 ruby jis83
+
+-}
+fontVariantEastAsian2 :
+    Value
+        { ruby : Supported
+        , jis78 : Supported
+        , jis83 : Supported
+        , jis90 : Supported
+        , jis04 : Supported
+        , simplified : Supported
+        , traditional : Supported
+        , fullWidth : Supported
+        , proportionalWidth : Supported
+        }
+    ->
+        Value
+            { ruby : Supported
+            , jis78 : Supported
+            , jis83 : Supported
+            , jis90 : Supported
+            , jis04 : Supported
+            , simplified : Supported
+            , traditional : Supported
+            , fullWidth : Supported
+            , proportionalWidth : Supported
+            }
+    -> Style
+fontVariantEastAsian2 (Value val1) (Value val2) =
+    AppendProperty ("font-variant-east-asian:" ++ val1 ++ " " ++ val2)
+
+
+{-| The [`font-variant-east-asian`](https://developer.mozilla.org/en-US/docs/Web/CSS/font-variant-east-asian#syntax) property.
+
+This property controls the use of alternative glyphs for East Asian scripts.
+
+    fontVariantEastAsian3 ruby jis90 fullWidth
+
+-}
+fontVariantEastAsian3 :
+    Value
+        { ruby : Supported
+        }
+    ->
+        Value
+            { jis78 : Supported
+            , jis83 : Supported
+            , jis90 : Supported
+            , jis04 : Supported
+            , simplified : Supported
+            , traditional : Supported
+            }
+    ->
+        Value
+            { fullWidth : Supported
+            , proportionalWidth : Supported
+            }
+    -> Style
+fontVariantEastAsian3 (Value rubyVal) (Value variantVal) (Value widthVal) =
+    AppendProperty ("font-variant-east-asian:" ++ rubyVal ++ " " ++ variantVal ++ " " ++ widthVal)
+
+
+{-| Sets the [`jis78`](https://developer.mozilla.org/en-US/docs/Web/CSS/font-variant-east-asian#syntax) value for [`fontVariantEastAsian`](#fontVariantEastAsian).
+
+This specifies that the JIS X 0208:1978 standard for East Asian logographic glyphs
+should be used.
+
+    fontVariantEastAsian jis78
+
+-}
+jis78 : Value { provides | jis78 : Supported }
+jis78 =
+    Value "jis78"
+
+
+{-| Sets the [`jis83`](https://developer.mozilla.org/en-US/docs/Web/CSS/font-variant-east-asian#syntax) value for [`fontVariantEastAsian`](#fontVariantEastAsian).
+
+This specifies that the JIS X 0208:1983 standard for East Asian logographic glyphs
+should be used.
+
+    fontVariantEastAsian jis83
+
+-}
+jis83 : Value { provides | jis83 : Supported }
+jis83 =
+    Value "jis83"
+
+
+{-| Sets the [`jis90`](https://developer.mozilla.org/en-US/docs/Web/CSS/font-variant-east-asian#syntax) value for [`fontVariantEastAsian`](#fontVariantEastAsian).
+
+This specifies that the JIS X 0208:1990 standard for East Asian logographic glyphs
+should be used.
+
+    fontVariantEastAsian jis90
+
+-}
+jis90 : Value { provides | jis90 : Supported }
+jis90 =
+    Value "jis90"
+
+
+{-| Sets the [`jis04`](https://developer.mozilla.org/en-US/docs/Web/CSS/font-variant-east-asian#syntax) value for [`fontVariantEastAsian`](#fontVariantEastAsian).
+
+This specifies that the JIS X 0208:2004 standard for East Asian logographic glyphs
+should be used.
+
+    fontVariantEastAsian jis04
+
+-}
+jis04 : Value { provides | jis04 : Supported }
+jis04 =
+    Value "jis04"
+
+
+{-| Sets the [`simplified`](https://developer.mozilla.org/en-US/docs/Web/CSS/font-variant-east-asian#syntax) value for [`fontVariantEastAsian`](#fontVariantEastAsian).
+
+This specifies that no particular standard should be used for East Asian logographic glyphs
+apart from them being simplified Chinese glyphs.
+
+    fontVariantEastAsian simplified
+
+-}
+simplified : Value { provides | simplified : Supported }
+simplified =
+    Value "simplified"
+
+
+{-| Sets the [`traditional`](https://developer.mozilla.org/en-US/docs/Web/CSS/font-variant-east-asian#syntax) value for [`fontVariantEastAsian`](#fontVariantEastAsian).
+
+This specifies that no particular standard should be used for East Asian logographic glyphs
+apart from them being traditional Chinese glyphs.
+
+    fontVariantEastAsian traditional
+
+-}
+traditional : Value { provides | traditional : Supported }
+traditional =
+    Value "traditional"
+
+
+{-| Sets the [`proportional-width`](https://developer.mozilla.org/en-US/docs/Web/CSS/font-variant-east-asian#syntax) value for [`fontVariantEastAsian`](#fontVariantEastAsian).
+
+This activates the East Asian characters that vary in width.
+
+(As opposed to [`fullWidth`](#fullWidth), which specifies that they should roughly be the same width.)
+
+    fontVariantEastAsian proportionalWidth
+
+-}
+proportionalWidth : Value { provides | proportionalWidth : Supported }
+proportionalWidth =
+    Value "proportional-width"
+
+
+
+-- FONT VARIANT LIGATURES --
+
+
+{-| Sets [`font-variant-ligatures`](https://developer.mozilla.org/en-US/docs/Web/CSS/font-variant-ligatures).
+
+    fontVariantLigatures discretionaryLigatures
+
+    fontVariantLigatures none
+
+-}
+fontVariantLigatures :
+    BaseValue
+        { normal : Supported
+        , none : Supported
+        , commonLigatures : Supported
+        , noCommonLigatures : Supported
+        , discretionaryLigatures : Supported
+        , noDiscretionaryLigatures : Supported
+        , historicalLigatures : Supported
+        , noHistoricalLigatures : Supported
+        , contextual : Supported
+        , noContextual : Supported
+        }
+    -> Style
+fontVariantLigatures (Value str) =
+    AppendProperty ("font-variant-ligatures:" ++ str)
+
+
+{-| The `common-ligatures` [`font-variant-ligatures` value](https://developer.mozilla.org/en-US/docs/Web/CSS/font-variant-ligatures#Values).
+
+    fontVariantLigatures commonLigatures
+
+-}
+commonLigatures : Value { provides | commonLigatures : Supported }
+commonLigatures =
+    Value "common-ligatures"
+
+
+{-| The `no-common-ligatures` [`font-variant-ligatures` value](https://developer.mozilla.org/en-US/docs/Web/CSS/font-variant-ligatures#Values).
+
+    fontVariantLigatures noCommonLigatures
+
+-}
+noCommonLigatures : Value { provides | noCommonLigatures : Supported }
+noCommonLigatures =
+    Value "no-common-ligatures"
+
+
+{-| The `discretionary-ligatures` [`font-variant-ligatures` value](https://developer.mozilla.org/en-US/docs/Web/CSS/font-variant-ligatures#Values).
+
+    fontVariantLigatures discretionaryLigatures
+
+-}
+discretionaryLigatures : Value { provides | discretionaryLigatures : Supported }
+discretionaryLigatures =
+    Value "discretionary-ligatures"
+
+
+{-| The `no-discretionary-ligatures` [`font-variant-ligatures` value](https://developer.mozilla.org/en-US/docs/Web/CSS/font-variant-ligatures#Values).
+
+    fontVariantLigatures noDiscretionaryLigatures
+
+-}
+noDiscretionaryLigatures : Value { provides | noDiscretionaryLigatures : Supported }
+noDiscretionaryLigatures =
+    Value "no-discretionary-ligatures"
+
+
+{-| The `historical-ligatures` [`font-variant-ligatures` value](https://developer.mozilla.org/en-US/docs/Web/CSS/font-variant-ligatures#Values).
+
+    fontVariantLigatures historicalLigatures
+
+-}
+historicalLigatures : Value { provides | historicalLigatures : Supported }
+historicalLigatures =
+    Value "historical-ligatures"
+
+
+{-| The `no-historical-ligatures` [`font-variant-ligatures` value](https://developer.mozilla.org/en-US/docs/Web/CSS/font-variant-ligatures#Values).
+
+    fontVariantLigatures noHistoricalLigatures
+
+-}
+noHistoricalLigatures : Value { provides | noHistoricalLigatures : Supported }
+noHistoricalLigatures =
+    Value "no-historical-ligatures"
+
+
+{-| The `contextual` [`font-variant-ligatures` value](https://developer.mozilla.org/en-US/docs/Web/CSS/font-variant-ligatures#Values).
+
+    fontVariantLigatures contextual
+
+-}
+contextual : Value { provides | contextual : Supported }
+contextual =
+    Value "contextual"
+
+
+{-| The `no-contextual` [`font-variant-ligatures` value](https://developer.mozilla.org/en-US/docs/Web/CSS/font-variant-ligatures#Values).
+
+    fontVariantLigatures noContextual
+
+-}
+noContextual : Value { provides | noContextual : Supported }
+noContextual =
+    Value "no-contextual"
+
+
+
+-- FONT VARIANT NUMERIC --
+
+
+{-| Sets [`font-variant-numeric`](https://css-tricks.com/almanac/properties/f/font-variant-numeric/).
+
+    fontVariantNumeric ordinal
+
+See [`fontVariantNumeric4`](#fontVariantNumeric4) for a more advanced version.
+
+-}
+fontVariantNumeric :
+    BaseValue
+        { normal : Supported
+        , ordinal : Supported
+        , slashedZero : Supported
+        , liningNums : Supported
+        , oldstyleNums : Supported
+        , proportionalNums : Supported
+        , tabularNums : Supported
+        , diagonalFractions : Supported
+        , stackedFractions : Supported
+        }
+    -> Style
+fontVariantNumeric (Value str) =
+    AppendProperty ("font-variant-numeric:" ++ str)
+
+
+{-| Sets [`font-variant-numeric`](https://css-tricks.com/almanac/properties/f/font-variant-numeric/).
+
+This one can be tricky to use because many of the options are mutually exclusive.
+For example, `normal` cannot be used with any of the others, so the only way
+to get it from this function is to pass `Nothing` for everything. The other
+arguments are chosen such that you can choose between the mutually exclusive
+values, or leave that value off.
+
+    fontVariantNumeric4 Nothing Nothing Nothing Nothing -- "normal"
+
+    fontVariantNumeric4
+        (Just ordinal)
+        Nothing
+        (Just tabularNums)
+        Nothing
+        -- "ordinal tabular-nums"
+
+See [`fontVariantNumeric`](#fontVariantNumeric) for a more concise version.
+
+-}
+fontVariantNumeric4 :
+    Maybe (Value { ordinal : Supported, slashedZero : Supported })
+    -> Maybe (Value { liningNums : Supported, oldstyleNums : Supported })
+    -> Maybe (Value { proportionalNums : Supported, tabularNums : Supported })
+    -> Maybe (Value { diagonalFractions : Supported, stackedFractions : Supported })
+    -> Style
+fontVariantNumeric4 val1 val2 val3 val4 =
+    let
+        valueStr =
+            case
+                [ maybeValToString val1
+                , maybeValToString val2
+                , maybeValToString val3
+                , maybeValToString val4
+                ]
+                    |> List.filterMap identity
+            of
+                [] ->
+                    "normal"
+
+                strings ->
+                    String.join "," strings
+    in
+    AppendProperty ("font-variant-numeric:" ++ valueStr)
+
+
+maybeValToString : Maybe (Value a) -> Maybe String
+maybeValToString =
+    Maybe.map unpackValue
+
+
+{-| The `ordinal` [`font-variant-numeric` value](https://developer.mozilla.org/en-US/docs/Web/CSS/font-variant-numeric).
+
+    fontVariantNumeric ordinal
+
+-}
+ordinal : Value { provides | ordinal : Supported }
+ordinal =
+    Value "ordinal"
+
+
+{-| The `slashed-zero` [`font-variant-numeric` value](https://developer.mozilla.org/en-US/docs/Web/CSS/font-variant-numeric).
+
+    fontVariantNumeric slashedZero
+
+-}
+slashedZero : Value { provides | slashedZero : Supported }
+slashedZero =
+    Value "slashed-zero"
+
+
+{-| The `lining-nums` [`font-variant-numeric` value](https://developer.mozilla.org/en-US/docs/Web/CSS/font-variant-numeric).
+
+    fontVariantNumeric liningNums
+
+-}
+liningNums : Value { provides | liningNums : Supported }
+liningNums =
+    Value "lining-nums"
+
+
+{-| The `oldstyle-nums` [`font-variant-numeric` value](https://developer.mozilla.org/en-US/docs/Web/CSS/font-variant-numeric).
+
+    fontVariantNumeric oldstyleNums
+
+-}
+oldstyleNums : Value { provides | oldstyleNums : Supported }
+oldstyleNums =
+    Value "oldstyle-nums"
+
+
+{-| The `proportional-nums` [`font-variant-numeric` value](https://developer.mozilla.org/en-US/docs/Web/CSS/font-variant-numeric).
+
+    fontVariantNumeric proportionalNums
+
+-}
+proportionalNums : Value { provides | proportionalNums : Supported }
+proportionalNums =
+    Value "proportional-nums"
+
+
+{-| The `tabular-nums` [`font-variant-numeric` value](https://developer.mozilla.org/en-US/docs/Web/CSS/font-variant-numeric).
+
+    fontVariantNumeric tabularNums
+
+-}
+tabularNums : Value { provides | tabularNums : Supported }
+tabularNums =
+    Value "tabular-nums"
+
+
+{-| The `diagonal-fractions` [`font-variant-numeric` value](https://developer.mozilla.org/en-US/docs/Web/CSS/font-variant-numeric).
+
+    fontVariantNumeric diagonalFractions
+
+-}
+diagonalFractions : Value { provides | diagonalFractions : Supported }
+diagonalFractions =
+    Value "diagonal-fractions"
+
+
+{-| The `stacked-fractions` [`font-variant-numeric` value](https://developer.mozilla.org/en-US/docs/Web/CSS/font-variant-numeric).
+
+    fontVariantNumeric stackedFractions
+
+-}
+stackedFractions : Value { provides | stackedFractions : Supported }
+stackedFractions =
+    Value "stacked-fractions"
+
+
+
+-- FONT OPTICAL SIZING --
+
+
+{-| The [`font-kerning`](https://developer.mozilla.org/en-US/docs/Web/CSS/font-kerning) property.
+
+    fontKerning none
+
+-}
+fontKerning :
+    BaseValue
+        { none : Supported
+        , auto : Supported
+        , normal : Supported
+        }
+    -> Style
+fontKerning (Value val) =
+    AppendProperty ("font-kerning:" ++ val)
+
+
+{-| The [`font-language-override`](https://developer.mozilla.org/en-US/docs/Web/CSS/font-language-override) property.
+
+    fontLanguageOverride normal
+
+    fontLanguageOverride (string "ENG")
+
+-}
+fontLanguageOverride :
+    BaseValue
+        { normal : Supported
+        , string : Supported
+        }
+    -> Style
+fontLanguageOverride (Value val) =
+    AppendProperty ("font-language-override:" ++ val)
+
+
+{-| The [`font-synthesis`](https://developer.mozilla.org/en-US/docs/Web/CSS/font-synthesis) property.
+
+    fontSynthesis none
+
+    fontSynthesis smallCaps
+
+    fontSynthesis2 smallCaps weight
+
+    fontSynthesis3 weight style smallCaps
+
+-}
+fontSynthesis :
+    BaseValue
+        { none : Supported
+        , weight : Supported
+        , style : Supported
+        , smallCaps : Supported
+        }
+    -> Style
+fontSynthesis (Value val) =
+    AppendProperty ("font-synthesis:" ++ val)
+
+
+{-| The [`font-synthesis`](https://developer.mozilla.org/en-US/docs/Web/CSS/font-synthesis) property.
+
+This is the two-argument variant, in which you can indicate
+two different font properties to be synthesised by the browser.
+
+    fontSynthesis2 smallCaps weight
+
+-}
+fontSynthesis2 :
+    Value
+        { weight : Supported
+        , style : Supported
+        , smallCaps : Supported
+        }
+    ->
+        Value
+            { weight : Supported
+            , style : Supported
+            , smallCaps : Supported
+            }
+    -> Style
+fontSynthesis2 (Value val1) (Value val2) =
+    AppendProperty ("font-synthesis:" ++ val1 ++ " " ++ val2)
+
+
+{-| The [`font-synthesis`](https://developer.mozilla.org/en-US/docs/Web/CSS/font-synthesis) property.
+
+This is the three-argument variant, in which you can indicate
+all three different font properties to be synthesised by the browser.
+
+    fontSynthesis3 weight style smallCaps
+
+-}
+fontSynthesis3 :
+    Value
+        { weight : Supported
+        , style : Supported
+        , smallCaps : Supported
+        }
+    ->
+        Value
+            { weight : Supported
+            , style : Supported
+            , smallCaps : Supported
+            }
+    ->
+        Value
+            { weight : Supported
+            , style : Supported
+            , smallCaps : Supported
+            }
+    -> Style
+fontSynthesis3 (Value val1) (Value val2) (Value val3) =
+    AppendProperty ("font-synthesis:" ++ val1 ++ " " ++ val2 ++ " " ++ val3)
+
+
+{-| The [`font-optical-sizing`](https://developer.mozilla.org/en-US/docs/Web/CSS/font-optical-sizing) property.
+
+    fontOpticalSizing none
+
+-}
+fontOpticalSizing :
+    BaseValue
+        { none : Supported
+        , auto : Supported
+        }
+    -> Style
+fontOpticalSizing (Value val) =
+    AppendProperty ("font-optical-sizing:" ++ val)
+
+
+{-| The [`font-variant-position`](https://developer.mozilla.org/en-US/docs/Web/CSS/font-variant-position) property.
+
+    fontVariantPosition sub
+
+    fontVariantPosition normal
+
+-}
+fontVariantPosition :
+    BaseValue
+        { normal : Supported
+        , sub : Supported
+        , super : Supported
+        }
+    -> Style
+fontVariantPosition (Value val) =
+    AppendProperty ("font-variant-position:" ++ val)
+
+
+{-| The `weight` value for the [`fontSynthesis`](#fontSynthesis) property.
+
+    fontSynthesis weight
+
+-}
+weight : Value { provides | weight : Supported }
+weight =
+    Value "weight"
+
+
+
+
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+----------------------------- VARIABLE FONTS ---------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+
+
+{-| The 1-argument variant of the [`font-variation-settings`](https://developer.mozilla.org/en-US/docs/Web/CSS/font-variation-settings)
+property.
+
+For controlling aspects of variable fonts.
+Use [`fontVariationSettingsList`](#fontVariationSettingsList) to work with variable font tags.
+
+    fontVariationSettings normal
+
+    fontVariationSettings inherit
+
+    fontVariationSettingsList [ ("XHGT", 0.7) ]
+-}
+fontVariationSettings :
+    BaseValue
+        { normal : Supported
+        }
+    -> Style
+fontVariationSettings (Value val) =
+    AppendProperty ("font-variation-settings:" ++ val)
+
+
+{-| The multi-argument variant of the [`font-variation-settings`](https://developer.mozilla.org/en-US/docs/Web/CSS/font-variation-settings)
+property.
+
+For using single keywords with this property, use [`fontVariationSettings`](#fontVariationSettings).
+
+    fontVariationSettingsList [ ("XHGT", 0.7) ]
+-}
+fontVariationSettingsList :
+    List
+        ( String
+        , Float
+        )
+    -> Style
+fontVariationSettingsList list =
+    AppendProperty <|
+        "font-variation-settings:"
+        ++
+        ( list
+        |> List.map
+            (\(tagVal, numberVal) -> (enquoteString tagVal) ++ " " ++ (String.fromFloat numberVal)
+            )
+        |> String.join ", "
+        )
+
 
 
 ------------------------------------------------------------------------
@@ -13879,7 +14113,7 @@ optimizeSpeed =
 ------------------------------------------------------------------------
 ------------------------------------------------------------------------
 ------------------------------------------------------------------------
----------------------------- TEXT-TRANSFORM ----------------------------
+--------------------- TEXT TRANSFORM + DECORATION ----------------------
 ------------------------------------------------------------------------
 ------------------------------------------------------------------------
 ------------------------------------------------------------------------
@@ -13947,10 +14181,6 @@ textTransform fullSizeKana
 fullSizeKana : Value { provedes | fullSizeKana : Supported }
 fullSizeKana =
     Value "full-size-kana"
-
-
-
--- TEXT DECORATION --
 
 
 {-| Sets [`text-decoration`][text-decoration] shorthand property.
@@ -14255,10 +14485,6 @@ boxDecoration =
     Value "box-decoration"
 
 
-
--- TEXT DECORATION --
-
-
 {-| The `wavy` [`text-decoration-style`][text-decoration-style] value.
 
     textDecorationStyle wavy
@@ -14308,8 +14534,24 @@ lineThrough =
 
 
 
--- TABLES --
--- BORDER COLLAPSE --
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 
 
 {-| Sets [`border-collapse`](https://css-tricks.com/almanac/properties/b/border-collapse/).
@@ -18361,144 +18603,6 @@ fontDisplay (Value val) =
     AppendProperty ("font-display:" ++ val)
 
 
-{-| Sets [`font-size-adjust`](https://css-tricks.com/almanac/properties/f/font-size-adjust/)
-
-    fontSizeAdjust zero
-
-    fontSizeAdjust none
-
-    fontSizeAdjust (num 0.5)
-
--}
-fontSizeAdjust :
-    BaseValue
-        { none : Supported
-        , zero : Supported
-        , num : Supported
-        }
-    -> Style
-fontSizeAdjust (Value val) =
-    AppendProperty ("font-size-adjust:" ++ val)
-
-
-{-| Sets `ultra-condensed` value for usage with [`fontStretch`](#fontStretch).
-
-      fontDisplay ultraCondensed
-
--}
-ultraCondensed : Value { provides | ultraCondensed : Supported }
-ultraCondensed =
-    Value "ultra-condensed"
-
-
-{-| Sets `extra-condensed` value for usage with [`fontStretch`](#fontStretch).
-
-      fontDisplay extraCondensed
-
--}
-extraCondensed : Value { provides | extraCondensed : Supported }
-extraCondensed =
-    Value "extra-condensed"
-
-
-{-| Sets `condensed` value for usage with [`fontStretch`](#fontStretch).
-
-      fontDisplay Condensed
-
--}
-condensed : Value { provides | condensed : Supported }
-condensed =
-    Value "condensed"
-
-
-{-| Sets `semi-condensed` value for usage with [`fontStretch`](#fontStretch).
-
-      fontDisplay semiCondensed
-
--}
-semiCondensed : Value { provides | semiCondensed : Supported }
-semiCondensed =
-    Value "semi-condensed"
-
-
-{-| Sets `ultra-expanded` value for usage with [`fontStretch`](#fontStretch).
-
-      fontDisplay ultraExpanded
-
--}
-ultraExpanded : Value { provides | ultraExpanded : Supported }
-ultraExpanded =
-    Value "ultra-expanded"
-
-
-{-| Sets `extra-expanded` value for usage with [`fontStretch`](#fontStretch).
-
-      fontDisplay extraExpanded
-
--}
-extraExpanded : Value { provides | extraExpanded : Supported }
-extraExpanded =
-    Value "extra-expanded"
-
-
-{-| Sets `expanded` value for usage with [`fontStretch`](#fontStretch).
-
-      fontDisplay Expanded
-
--}
-expanded : Value { provides | expanded : Supported }
-expanded =
-    Value "expanded"
-
-
-{-| Sets `semi-expanded` value for usage with [`fontStretch`](#fontStretch).
-
-      fontDisplay semiExpanded
-
--}
-semiExpanded : Value { provides | semiExpanded : Supported }
-semiExpanded =
-    Value "semi-expanded"
-
-
-{-| Sets [`font-stretch`](https://css-tricks.com/almanac/properties/f/font-stretch/)
-
-    fontStretch ultraCondensed
-
-    fontStretch extraCondensed
-
-    fontStretch condensed
-
-    fontStretch semiCondensed
-
-    fontStretch normal
-
-    fontStretch semiExpanded
-
-    fontStretch expanded
-
-    fontStretch extraExpanded
-
-    fontStretch ultraExpanded
-
--}
-fontStretch :
-    BaseValue
-        { ultraCondensed : Supported
-        , extraCondensed : Supported
-        , condensed : Supported
-        , semiCondensed : Supported
-        , normal : Supported
-        , semiExpanded : Supported
-        , expanded : Supported
-        , extraExpanded : Supported
-        , ultraExpanded : Supported
-        }
-    -> Style
-fontStretch (Value val) =
-    AppendProperty ("font-stretch:" ++ val)
-
-
 {-| Sets `first` value for usage with [`hangingPunctuation`](#hangingPunctuation).
 
       hangingPunctuation first
@@ -18830,212 +18934,6 @@ loose =
     Value "loose"
 
 
-{-| Sets `pixelated` value for usage with [`imageRendering`](#imageRendering).
-
-    imageRendering pixelated
-
--}
-pixelated : Value { provides | pixelated : Supported }
-pixelated =
-    Value "pixelated"
-
-
-{-| Sets `crisp-edges` value for usage with [`imageRendering`](#imageRendering).
-
-    imageRendering crispEdges
-
--}
-crispEdges : Value { provides | crispEdges : Supported }
-crispEdges =
-    Value "crisp-edges"
-
-
-{-| Sets [`image-rendering`](https://css-tricks.com/almanac/properties/i/image-rendering/)
-
-    imageRendering auto
-
-    imageRendering crispEdges
-
-    imageRendering pixelated
-
--}
-imageRendering :
-    BaseValue
-        { auto : Supported
-        , crispEdges : Supported
-        , pixelated : Supported
-        }
-    -> Style
-imageRendering (Value val) =
-    AppendProperty ("image-rendering:" ++ val)
-
-
-{-| Sets `isolate` value for usage with [`isolation`](#isolation), and
-[`unicodeBidi`](#unicodeBidi).
-
-    isolation isolate
-
-    unicodeBidi isolate
-
--}
-isolate : Value { provides | isolate : Supported }
-isolate =
-    Value "isolate"
-
-
-{-| Sets [`isolation`](https://css-tricks.com/almanac/properties/i/isolation/)
-
-    isolation auto
-
-    isolation isolate
-
--}
-isolation :
-    BaseValue
-        { auto : Supported
-        , isolate : Supported
-        }
-    -> Style
-isolation (Value val) =
-    AppendProperty ("isolation:" ++ val)
-
-
-{-| Sets [`lineClamp`](https://css-tricks.com/almanac/properties/l/line-clamp/)
-
-    lineClamp none
-
-    lineClamp zero
-
-    lineClamp (int 3)
-
--}
-lineClamp :
-    BaseValue
-        { none : Supported
-        , zero : Supported
-        , int : Supported
-        }
-    -> Style
-lineClamp (Value val) =
-    AppendProperty ("line-clamp:" ++ val)
-
-
-{-| The 1-argument variant of the
-[`clip-path`](https://css-tricks.com/almanac/properties/c/clip-path/) property.
-
-    clipPath marginBox
-
-    clipPath inherit
-
-    clipPath (circle (pct 2))
-
-    clipPath2 marginBox (circleAt2 farthestSide left top)
--}
-clipPath :
-    BaseValue
-        (BasicShapeSupported
-            { marginBox : Supported
-            , borderBox : Supported
-            , paddingBox : Supported
-            , contentBox : Supported
-            , fillBox : Supported
-            , strokeBox : Supported
-            , viewBox : Supported
-            }
-        )
-    -> Style
-clipPath (Value val) =
-    AppendProperty ("clip-path:" ++ val)
-
-
-{-| The 2-argument variant of the
-[`clip-path`](https://css-tricks.com/almanac/properties/c/clip-path/) property.
-
-    clipPath2 marginBox (circleAt2 farthestSide left top)
--}
-clipPath2 :
-    Value
-        { marginBox : Supported
-        , borderBox : Supported
-        , paddingBox : Supported
-        , contentBox : Supported
-        , fillBox : Supported
-        , strokeBox : Supported
-        , viewBox : Supported
-        }
-    -> Value (BasicShapeSupported a)
-    -> Style
-clipPath2 (Value val1) (Value val2) =
-    AppendProperty ("clip-path:" ++ val1 ++ " " ++ val2)
-
-
-{-| Sets [`mix-blend-mode`](https://css-tricks.com/almanac/properties/m/mix-blend-mode/)
-
-    mixBlendMode multiply
-
-    mixBlendMode saturation
-
--}
-mixBlendMode :
-    BaseValue
-        { normal : Supported
-        , multiply : Supported
-        , screen : Supported
-        , overlay : Supported
-        , darken : Supported
-        , lighten : Supported
-        , colorDodge : Supported
-        , colorBurn : Supported
-        , hardLight : Supported
-        , softLight : Supported
-        , difference : Supported
-        , exclusion : Supported
-        , hue : Supported
-        , saturation : Supported
-        , color_ : Supported
-        , luminosity : Supported
-        }
-    -> Style
-mixBlendMode (Value val) =
-    AppendProperty ("mix-blend-mode:" ++ val)
-
-
-{-| Sets `scale-down` value for usage with [`objectFit`](#objectFit).
-
-    objectFit scaleDown
-
--}
-scaleDown : Value { provides | scaleDown : Supported }
-scaleDown =
-    Value "scale-down"
-
-
-{-| Sets [`object-fit`](https://css-tricks.com/almanac/properties/o/object-fit/)
-
-    objectFit fill_
-
-    objectFit contain_
-
-    objectFit cover
-
-    objectFit scaleDown
-
-    objectFit none
-
--}
-objectFit :
-    BaseValue
-        { fill_ : Supported
-        , contain_ : Supported
-        , cover : Supported
-        , none : Supported
-        , scaleDown : Supported
-        }
-    -> Style
-objectFit (Value val) =
-    AppendProperty ("object-fit:" ++ val)
-
-
 {-| Sets [`object-position`](https://css-tricks.com/almanac/properties/o/object-position/).
 
     objectPosition left_
@@ -19156,41 +19054,19 @@ objectPosition4 (Value horiz) (Value horizAmount) (Value vert) (Value vertAmount
             ++ vertAmount
         )
 
-
-{-| Sets [`orphans`](https://css-tricks.com/almanac/properties/o/orphans/)
-**Note:** This function accepts only positive integers.
-
-    orphans (int 2)
-
--}
-orphans :
-    BaseValue
-        { int : Supported
-        }
-    -> Style
-orphans (Value val) =
-    AppendProperty ("orphans:" ++ val)
-
-
-{-| Sets [`overflow-anchor`](https://css-tricks.com/almanac/properties/o/overflow-anchor/)
-
-    overflowAnchor auto
-
-    overflowAnchor none
-
--}
-overflowAnchor :
-    BaseValue
-        { auto : Supported
-        , none : Supported
-        }
-    -> Style
-overflowAnchor (Value val) =
-    AppendProperty ("overflow-anchor:" ++ val)
-
-
-
--- Page break
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+-------------------------- BREAK (PAGE BREAK) --------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
 
 
 {-| Sets [`break-before`](https://css-tricks.com/almanac/properties/b/break-before/).
@@ -19319,6 +19195,7 @@ page : Value { provides | page : Supported }
 page =
     Value "page"
 
+
 {-| Sets [`page-break-before`](https://css-tricks.com/almanac/properties/p/page-break/)
 
 **This property has been depreciated and replaced with
@@ -19396,6 +19273,19 @@ pageBreakInside (Value val) =
     AppendProperty ("page-break-inside:" ++ val)
 
 
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+---------------------------- POINTER-EVENTS-----------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
 
 
 {-| Sets [`pointer-events`](https://css-tricks.com/almanac/properties/b/pointer-events/)
@@ -19463,8 +19353,19 @@ painted =
     Value "painted"
 
 
-
---- Scroll ---
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------ SCROLLING ------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
+------------------------------------------------------------------------
 
 
 {-| Sets `smooth` value for usage with [`scrollBehavior`](#scrollBehavior).
@@ -21354,3 +21255,226 @@ by the browser if the containing box is offscreen.
 paint : Value { provides | paint : Supported }
 paint =
     Value "paint"
+
+
+{-| Sets [`orphans`](https://css-tricks.com/almanac/properties/o/orphans/)
+**Note:** This function accepts only positive integers.
+
+    orphans (int 2)
+
+-}
+orphans :
+    BaseValue
+        { int : Supported
+        }
+    -> Style
+orphans (Value val) =
+    AppendProperty ("orphans:" ++ val)
+
+
+
+{-| Sets [`image-rendering`](https://css-tricks.com/almanac/properties/i/image-rendering/)
+
+    imageRendering auto
+
+    imageRendering crispEdges
+
+    imageRendering pixelated
+
+-}
+imageRendering :
+    BaseValue
+        { auto : Supported
+        , crispEdges : Supported
+        , pixelated : Supported
+        }
+    -> Style
+imageRendering (Value val) =
+    AppendProperty ("image-rendering:" ++ val)
+
+
+{-| Sets `pixelated` value for usage with [`imageRendering`](#imageRendering).
+
+    imageRendering pixelated
+
+-}
+pixelated : Value { provides | pixelated : Supported }
+pixelated =
+    Value "pixelated"
+
+
+{-| Sets `crisp-edges` value for usage with [`imageRendering`](#imageRendering).
+
+    imageRendering crispEdges
+
+-}
+crispEdges : Value { provides | crispEdges : Supported }
+crispEdges =
+    Value "crisp-edges"
+
+
+{-| Sets `isolate` value for usage with [`isolation`](#isolation), and
+[`unicodeBidi`](#unicodeBidi).
+
+    isolation isolate
+
+    unicodeBidi isolate
+
+-}
+isolate : Value { provides | isolate : Supported }
+isolate =
+    Value "isolate"
+
+
+{-| Sets [`isolation`](https://css-tricks.com/almanac/properties/i/isolation/)
+
+    isolation auto
+
+    isolation isolate
+
+-}
+isolation :
+    BaseValue
+        { auto : Supported
+        , isolate : Supported
+        }
+    -> Style
+isolation (Value val) =
+    AppendProperty ("isolation:" ++ val)
+
+
+{-| Sets [`lineClamp`](https://css-tricks.com/almanac/properties/l/line-clamp/)
+
+    lineClamp none
+
+    lineClamp zero
+
+    lineClamp (int 3)
+
+-}
+lineClamp :
+    BaseValue
+        { none : Supported
+        , zero : Supported
+        , int : Supported
+        }
+    -> Style
+lineClamp (Value val) =
+    AppendProperty ("line-clamp:" ++ val)
+
+
+{-| The 1-argument variant of the
+[`clip-path`](https://css-tricks.com/almanac/properties/c/clip-path/) property.
+
+    clipPath marginBox
+
+    clipPath inherit
+
+    clipPath (circle (pct 2))
+
+    clipPath2 marginBox (circleAt2 farthestSide left top)
+-}
+clipPath :
+    BaseValue
+        (BasicShapeSupported
+            { marginBox : Supported
+            , borderBox : Supported
+            , paddingBox : Supported
+            , contentBox : Supported
+            , fillBox : Supported
+            , strokeBox : Supported
+            , viewBox : Supported
+            }
+        )
+    -> Style
+clipPath (Value val) =
+    AppendProperty ("clip-path:" ++ val)
+
+
+{-| The 2-argument variant of the
+[`clip-path`](https://css-tricks.com/almanac/properties/c/clip-path/) property.
+
+    clipPath2 marginBox (circleAt2 farthestSide left top)
+-}
+clipPath2 :
+    Value
+        { marginBox : Supported
+        , borderBox : Supported
+        , paddingBox : Supported
+        , contentBox : Supported
+        , fillBox : Supported
+        , strokeBox : Supported
+        , viewBox : Supported
+        }
+    -> Value (BasicShapeSupported a)
+    -> Style
+clipPath2 (Value val1) (Value val2) =
+    AppendProperty ("clip-path:" ++ val1 ++ " " ++ val2)
+
+
+{-| Sets [`mix-blend-mode`](https://css-tricks.com/almanac/properties/m/mix-blend-mode/)
+
+    mixBlendMode multiply
+
+    mixBlendMode saturation
+
+-}
+mixBlendMode :
+    BaseValue
+        { normal : Supported
+        , multiply : Supported
+        , screen : Supported
+        , overlay : Supported
+        , darken : Supported
+        , lighten : Supported
+        , colorDodge : Supported
+        , colorBurn : Supported
+        , hardLight : Supported
+        , softLight : Supported
+        , difference : Supported
+        , exclusion : Supported
+        , hue : Supported
+        , saturation : Supported
+        , color_ : Supported
+        , luminosity : Supported
+        }
+    -> Style
+mixBlendMode (Value val) =
+    AppendProperty ("mix-blend-mode:" ++ val)
+
+
+{-| Sets `scale-down` value for usage with [`objectFit`](#objectFit).
+
+    objectFit scaleDown
+
+-}
+scaleDown : Value { provides | scaleDown : Supported }
+scaleDown =
+    Value "scale-down"
+
+
+{-| Sets [`object-fit`](https://css-tricks.com/almanac/properties/o/object-fit/)
+
+    objectFit fill_
+
+    objectFit contain_
+
+    objectFit cover
+
+    objectFit scaleDown
+
+    objectFit none
+
+-}
+objectFit :
+    BaseValue
+        { fill_ : Supported
+        , contain_ : Supported
+        , cover : Supported
+        , none : Supported
+        , scaleDown : Supported
+        }
+    -> Style
+objectFit (Value val) =
+    AppendProperty ("object-fit:" ++ val)
+

--- a/src/Css.elm
+++ b/src/Css.elm
@@ -30,6 +30,8 @@ module Css exposing
     , borderRight, borderRight2, borderRight3
     , borderBottom, borderBottom2, borderBottom3
     , borderLeft, borderLeft2, borderLeft3
+    , borderBlock, borderBlock2, borderBlock3
+    , borderInline, borderInline2, borderInline3
     , borderWidth, borderWidth2, borderWidth3, borderWidth4, borderTopWidth, borderRightWidth, borderBottomWidth, borderLeftWidth
     , thin, thick
     , borderStyle, borderStyle2, borderStyle3, borderStyle4, borderTopStyle, borderRightStyle, borderBottomStyle, borderLeftStyle
@@ -285,6 +287,13 @@ All CSS properties can have the values `unset`, `initial`, and `inherit`
 @docs borderBottom, borderBottom2, borderBottom3
 
 @docs borderLeft, borderLeft2, borderLeft3
+
+
+## Logical Borders
+
+@docs borderBlock, borderBlock2, borderBlock3
+
+@docs borderInline, borderInline2, borderInline3
 
 
 ## Border Width
@@ -7398,6 +7407,95 @@ borderLeft2 (Value widthVal) (Value style) =
 borderLeft3 : Value LineWidth -> Value LineStyle -> Value Color -> Style
 borderLeft3 (Value widthVal) (Value style) (Value colorVal) =
     AppendProperty ("border-left:" ++ widthVal ++ " " ++ style ++ " " ++ colorVal)
+
+
+
+{-| Sets [`border-block`](https://css-tricks.com/almanac/properties/b/border-block/) property.
+
+    borderBlock (px 1)
+
+    borderBlock2 (px 1) solid
+
+    borderBlock3 (px 1) solid (hex "#f00")
+
+-}
+borderBlock : BaseValue LineWidth -> Style
+borderBlock (Value widthVal) =
+    AppendProperty ("border-block:" ++ widthVal)
+
+
+{-| Sets [`border-block`](https://css-tricks.com/almanac/properties/b/border-block/) property.
+
+    borderBlock (px 1)
+
+    borderBlock2 (px 1) solid
+
+    borderBlock3 (px 1) solid (hex "#f00")
+
+-}
+borderBlock2 : Value LineWidth -> Value LineStyle -> Style
+borderBlock2 (Value widthVal) (Value style) =
+    AppendProperty ("border-block:" ++ widthVal ++ " " ++ style)
+
+
+{-| Sets [`border-block`](https://css-tricks.com/almanac/properties/b/border-block/) property.
+
+    borderBlock (px 1)
+
+    borderBlock2 (px 1) solid
+
+    borderBlock3 (px 1) solid (hex "#f00")
+
+-}
+borderBlock3 : Value LineWidth -> Value LineStyle -> Value Color -> Style
+borderBlock3 (Value widthVal) (Value style) (Value colorVal) =
+    AppendProperty ("border-block:" ++ widthVal ++ " " ++ style ++ " " ++ colorVal)
+
+
+{-| Sets [`border-inline`](https://css-tricks.com/almanac/properties/b/border-inline/) property.
+
+    borderInline (px 1)
+
+    borderInline2 (px 1) solid
+
+    borderInline3 (px 1) solid (hex "#f00")
+
+-}
+borderInline : BaseValue LineWidth -> Style
+borderInline (Value widthVal) =
+    AppendProperty ("border-inline:" ++ widthVal)
+
+
+{-| Sets [`border-inline`](https://css-tricks.com/almanac/properties/b/border-inline/) property.
+
+    borderInline (px 1)
+
+    borderInline2 (px 1) solid
+
+    borderInline3 (px 1) solid (hex "#f00")
+
+-}
+borderInline2 : Value LineWidth -> Value LineStyle -> Style
+borderInline2 (Value widthVal) (Value style) =
+    AppendProperty ("border-inline:" ++ widthVal ++ " " ++ style)
+
+
+{-| Sets [`border-inline`](https://css-tricks.com/almanac/properties/b/border-inline/) property.
+
+    borderInline (px 1)
+
+    borderInline2 (px 1) solid
+
+    borderInline3 (px 1) solid (hex "#f00")
+
+-}
+borderInline3 : Value LineWidth -> Value LineStyle -> Value Color -> Style
+borderInline3 (Value widthVal) (Value style) (Value colorVal) =
+    AppendProperty ("border-inline:" ++ widthVal ++ " " ++ style ++ " " ++ colorVal)
+
+
+
+
 
 
 {-| Sets [`border-width`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-width) property.

--- a/src/Css.elm
+++ b/src/Css.elm
@@ -12,12 +12,13 @@ module Css exposing
     , Time, TimeSupported, s, ms
     , deg, grad, rad, turn
     , url
-    , auto, none, normal
+    , auto, none, normal, strict, all_, both, always
     , hidden, visible
     , contentBox, borderBox, paddingBox
     , left_, right_, top_, bottom_, block, inline, start, end
+    , x, y
     , baseline, clip, ruby
-    , stretch, center, content, text
+    , stretch, center, content, fill_, stroke, text, style
     , cover, contain_, fullWidth
     , sub, super
     , pseudoClass, active, checked, disabled, empty, enabled
@@ -76,7 +77,7 @@ module Css exposing
     , tabSize
     , fontDisplay, fallback, swap, optional
     , writingMode, verticalLr, verticalRl, horizontalTb
-    , hyphens, quotes, quotes2, quotes4, textOverflow, textOverflow2, lineBreak, manual, ellipsis, strict, loose
+    , hyphens, quotes, quotes2, quotes4, textOverflow, textOverflow2, lineBreak, manual, ellipsis, loose
     , hangingPunctuation, hangingPunctuation2, hangingPunctuation3, first, last, forceEnd, allowEnd
     , lineClamp
     , fontSize, xxSmall, xSmall, small, medium, large, xLarge, xxLarge, smaller, larger, lineHeight, letterSpacing
@@ -132,7 +133,7 @@ module Css exposing
     , wordBreak
     , breakAll, keepAll
     , float
-    , clear, both, inlineStart, inlineEnd
+    , clear, inlineStart, inlineEnd
     , visibility
     , fill
     , strokeDasharray, strokeDashoffset, strokeWidth, strokeAlign, strokeColor, strokeImage, strokeMiterlimit, strokeOpacity, strokePosition, strokePosition2, strokePosition4, strokeRepeat, strokeRepeat2, strokeSize, strokeSize2, strokeDashCorner
@@ -144,7 +145,7 @@ module Css exposing
     , paintOrder, paintOrder2, paintOrder3, markers
     , columns, columns2, columnWidth, columnCount, columnRuleWidth, columnRuleStyle, columnRuleColor, columnRule, columnRule2, columnRule3
     , columnFill, balance, balanceAll
-    , columnSpan, all_
+    , columnSpan
     , transform, transforms, transformOrigin, transformOrigin2
     , TransformFunction, TransformFunctionSupported
     , matrix, matrix3d
@@ -158,8 +159,8 @@ module Css exposing
     , EasingFunction, EasingFunctionSupported, linear, ease, easeIn, easeOut, easeInOut, cubicBezier, stepStart, stepEnd, steps, steps2, jumpStart, jumpEnd, jumpNone, jumpBoth, infinite, reverse, alternate, alternateReverse, running, paused, forwards, backwards
     , opacity
     , zoom
-    , scrollBehavior, smooth, scrollSnapAlign, always, scrollSnapStop
-    , scrollSnapType, scrollSnapType2, x, y, mandatory, proximity
+    , scrollBehavior, smooth, scrollSnapAlign, scrollSnapStop
+    , scrollSnapType, scrollSnapType2, mandatory, proximity
     , scrollMargin, scrollMargin2, scrollMargin3, scrollMargin4, scrollMarginTop, scrollMarginLeft, scrollMarginRight, scrollMarginBottom
     , scrollMarginBlock, scrollMarginBlock2, scrollMarginInline, scrollMarginInline2
     , scrollMarginBlockStart, scrollMarginBlockEnd, scrollMarginInlineStart, scrollMarginInlineEnd
@@ -177,15 +178,15 @@ module Css exposing
     , mixBlendMode
     , imageRendering, crispEdges, pixelated
     , backfaceVisibility
-    , objectFit, fill_, scaleDown
+    , objectFit, scaleDown
     , objectPosition, objectPosition2, objectPosition4
     , boxDecorationBreak
     , isolation, isolate
     , caretColor
     , pointerEvents
-    , visiblePainted, visibleFill, visibleStroke, painted, stroke
+    , visiblePainted, visibleFill, visibleStroke, painted
     , resize, horizontal, vertical
-    , contain, contain2, contain3, contain4, size, layout, style, paint
+    , contain, contain2, contain3, contain4, size, layout, paint
     )
 
 {-| If you need something that `elm-css` does not support right now, the
@@ -259,14 +260,16 @@ All CSS properties can have the values `unset`, `initial`, and `inherit`.
 
 Many different kinds of CSS properties use these values.
 
-@docs auto, none, normal
+@docs auto, none, normal, strict, all_, both, always
 @docs hidden, visible
 @docs contentBox, borderBox, paddingBox
 @docs left_, right_, top_, bottom_, block, inline, start, end
+@docs x, y
 @docs baseline, clip, ruby
-@docs stretch, center, content, text
+@docs stretch, center, content, fill_, stroke, text, style
 @docs cover, contain_, fullWidth
 @docs sub, super
+
 
 # Pseudo-Classes
 
@@ -498,7 +501,7 @@ Other values you can use for flex item alignment:
 
 @docs fontDisplay, fallback, swap, optional
 @docs writingMode, verticalLr, verticalRl, horizontalTb
-@docs hyphens, quotes, quotes2, quotes4, textOverflow, textOverflow2, lineBreak, manual, ellipsis, strict, loose
+@docs hyphens, quotes, quotes2, quotes4, textOverflow, textOverflow2, lineBreak, manual, ellipsis, loose
 @docs hangingPunctuation, hangingPunctuation2, hangingPunctuation3, first, last, forceEnd, allowEnd
 @docs lineClamp
 
@@ -688,7 +691,7 @@ Other values you can use for flex item alignment:
 ## Float
 
 @docs float
-@docs clear, both, inlineStart, inlineEnd
+@docs clear, inlineStart, inlineEnd
 
 
 # Visibility
@@ -723,7 +726,7 @@ Other values you can use for flex item alignment:
 
 @docs columns, columns2, columnWidth, columnCount, columnRuleWidth, columnRuleStyle, columnRuleColor, columnRule, columnRule2, columnRule3
 @docs columnFill, balance, balanceAll
-@docs columnSpan, all_
+@docs columnSpan
 
 
 # Transformation
@@ -781,8 +784,8 @@ Other values you can use for flex item alignment:
 
 # Scroll
 
-@docs scrollBehavior, smooth, scrollSnapAlign, always, scrollSnapStop
-@docs scrollSnapType, scrollSnapType2, x, y, mandatory, proximity
+@docs scrollBehavior, smooth, scrollSnapAlign, scrollSnapStop
+@docs scrollSnapType, scrollSnapType2, mandatory, proximity
 @docs scrollMargin, scrollMargin2, scrollMargin3, scrollMargin4, scrollMarginTop, scrollMarginLeft, scrollMarginRight, scrollMarginBottom
 @docs scrollMarginBlock, scrollMarginBlock2, scrollMarginInline, scrollMarginInline2
 @docs scrollMarginBlockStart, scrollMarginBlockEnd, scrollMarginInlineStart, scrollMarginInlineEnd
@@ -812,7 +815,7 @@ Other values you can use for flex item alignment:
 @docs mixBlendMode
 @docs imageRendering, crispEdges, pixelated
 @docs backfaceVisibility
-@docs objectFit, fill_, scaleDown
+@docs objectFit, scaleDown
 @docs objectPosition, objectPosition2, objectPosition4
 @docs boxDecorationBreak
 @docs isolation, isolate
@@ -822,9 +825,9 @@ Other values you can use for flex item alignment:
 
 @docs caretColor
 @docs pointerEvents
-@docs visiblePainted, visibleFill, visibleStroke, painted, stroke
+@docs visiblePainted, visibleFill, visibleStroke, painted
 @docs resize, horizontal, vertical
-@docs contain, contain2, contain3, contain4, size, layout, style, paint
+@docs contain, contain2, contain3, contain4, size, layout, paint
 
 -}
 
@@ -1317,6 +1320,57 @@ normal =
     Value "normal"
 
 
+{-| Sets `strict` value for usage with [`lineBreak`](#lineBreak) and [`contain`](#contain).
+
+    contain strict
+
+    lineBreak strict
+
+-}
+strict : Value { provides | strict : Supported }
+strict =
+    Value "strict"
+
+
+{-| The `all` value used in properties such as [`columnSpan`](#columnSpan)
+and [`pointerEvents`](#pointerEvents).
+
+    columnSpan all_
+
+    pointerEvents all_
+
+-}
+all_ : Value { provides | all_ : Supported }
+all_ =
+    Value "all"
+
+
+{-| Sets `both` value for usage with [`clear`](#clear) and [`resize`](#resize).
+
+      clear both
+
+      resize both
+
+-}
+both : Value { provides | both : Supported }
+both =
+    Value "both"
+
+
+{-| Sets `always` value for usage with [`scrollSnapStop`](#scrollSnapStop), [`pageBreakBefore`](#pageBreakBefore), and [`pageBreakAfter`](#pageBreakAfter).
+
+    scrollSnapStop always
+
+    pageBreakBefore always
+
+    pageBreakAfter always
+
+-}
+always : Value { provides | always : Supported }
+always =
+    Value "always"
+
+
 {-| The `hidden` value used for properties such as [`visibility`](https://css-tricks.com/almanac/properties/v/visibility/), [`overflow`](https://css-tricks.com/almanac/properties/o/overflow/) and [`border style`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-style).
 
     visibility hidden
@@ -1625,6 +1679,32 @@ end =
     Value "end"
 
 
+{-| Sets `x` value for usage with [`scrollSnapType2`](#scrollSnapType2)
+and [`rotate2`](#rotate2).
+
+    scrollSnapType2 x mandatory
+
+    rotate x (deg 10)
+
+-}
+x : Value { provides | x : Supported }
+x =
+    Value "x"
+
+
+{-| Sets `y` value for usage with [`scrollSnapType2`](#scrollSnapType2)
+and [`rotate2`](#rotate2).
+
+    scrollSnapType2 y mandatory
+
+    rotate y (deg 50)
+
+-}
+y : Value { provides | y : Supported }
+y =
+    Value "y"
+
+
 {-| The `baseline` value, used in the following properties:
 
   - [`alignContent`](#alignContent)
@@ -1735,6 +1815,33 @@ content =
     Value "content"
 
 
+{-| The `fill` value used in properties such as [`objectFit`](#objectFit),
+[`pointerEvents`](#pointerEvents) and [`paintOrder`](#paintOrder).
+
+    objectFit fill_
+
+    pointerEvents fill_
+
+    paintOrder2 fill markers
+
+-}
+fill_ : Value { provides | fill_ : Supported }
+fill_ =
+    Value "fill"
+
+
+{-| The `stroke` value used by [`pointerEvents`](#pointerEvents) and [`paintOrder`](#paintOrder).
+
+    pointerEvents stroke
+
+    paintOrder2 stroke markers
+
+-}
+stroke : Value { provides | stroke : Supported }
+stroke =
+    Value "stroke"
+
+
 {-| The `text` value for the [`cursor`](#cursor),
 [`backgroundClip`](#backgroundClip),
 and [`user-select`](#userSelect) properties.
@@ -1749,6 +1856,23 @@ and [`user-select`](#userSelect) properties.
 text : Value { provides | text : Supported }
 text =
     Value "text"
+
+
+{-| Sets the `style` value for:
+
+  - [`contain`](#contain). **(This value is considered at-risk from being depreciated for this property.)**
+  - [`fontSynthesis`](#fontSynthesis)
+
+```
+    contain style
+
+    fontSynthesis style
+```
+
+-}
+style : Value { provides | style : Supported }
+style =
+    Value "style"
 
 
 {-| Sets `contain` for the following properties:
@@ -1817,13 +1941,14 @@ fullWidth =
 
 {-| A `sub` value for the following properties:
 
-    - [`fontVariantPosition](#fontVariantPosition)
-    - [`verticalAlign`](#verticalAlign)
+  - [`fontVariantPosition`](#fontVariantPosition)
+  - [`verticalAlign`](#verticalAlign)
 
-
+```
     fontVariantPosition sub
 
     verticalAlign sub
+```
 
 -}
 sub : Value { provides | sub : Supported }
@@ -1833,18 +1958,20 @@ sub =
 
 {-| A `super` value for the following properties:
 
-    - [`fontVariantPosition](#fontVariantPosition)
-    - [`verticalAlign`](#verticalAlign)
+  - [`fontVariantPosition`](#fontVariantPosition)
+  - [`verticalAlign`](#verticalAlign)
 
-
+```
     fontVariantPosition super
 
     verticalAlign super
+```
 
 -}
 super : Value { provides | super : Supported }
 super =
     Value "super"
+
 
 
 -- OVERFLOW --
@@ -11177,6 +11304,7 @@ under =
     Value "under"
 
 
+
 -- WHITE-SPACE --
 
 
@@ -11518,19 +11646,6 @@ columnSpan (Value span) =
     AppendProperty ("column-span:" ++ span)
 
 
-{-| The `all` value used in properties such as [`columnSpan`](#columnSpan)
-and [`pointerEvents`](#pointerEvents).
-
-    columnSpan all_
-
-    pointerEvents all_
-
--}
-all_ : Value { provides | all_ : Supported }
-all_ =
-    Value "all"
-
-
 {-| Sets [`column-rule-width`](https://www.w3.org/TR/css-multicol-1/#propdef-column-rule-width)
 
     columnRuleWidth thin
@@ -11835,9 +11950,11 @@ boundingBox =
     Value "bounding-box"
 
 
-{-| A `slice` value for the [`strokeBreak`](#strokeBreak) property.
+{-| A `slice` value for the [`strokeBreak`](#strokeBreak) and [`boxDecorationBreak`](#boxDecorationBreak) properties.
 
       strokeBreak slice
+
+      boxDecorationbreak clone
 
 -}
 slice : Value { provides | slice : Supported }
@@ -11845,9 +11962,11 @@ slice =
     Value "slice"
 
 
-{-| A `clone` value for the [`strokeBreak`](#strokeBreak) property.
+{-| A `clone` value for the [`strokeBreak`](#strokeBreak) and [`boxDecorationBreak`](#boxDecorationBreak) properties.
 
       strokeBreak clone
+
+      boxDecorationBreak clone
 
 -}
 clone : Value { provides | clone : Supported }
@@ -13838,18 +13957,6 @@ clear (Value val) =
     AppendProperty ("clear:" ++ val)
 
 
-{-| Sets `both` value for usage with [`clear`](#clear) and [`resize`](#resize).
-
-      clear both
-
-      resize both
-
--}
-both : Value { provides | both : Supported }
-both =
-    Value "both"
-
-
 {-| Sets `inline-start` value for usage with [`clear`](#clear).
 
       clear inlineStart
@@ -14923,18 +15030,6 @@ ellipsis =
     Value "ellipsis"
 
 
-{-| Sets `strict` value for usage with [`lineBreak`](#lineBreak) and [`contain`](#contain).
-
-    contain strict
-
-    lineBreak strict
-
--}
-strict : Value { provides | strict : Supported }
-strict =
-    Value "strict"
-
-
 {-| Sets `loose` value for usage with [`lineBreak`](#lineBreak).
 
     lineBreak loose
@@ -15064,21 +15159,6 @@ mixBlendMode :
     -> Style
 mixBlendMode (Value val) =
     AppendProperty ("mix-blend-mode:" ++ val)
-
-
-{-| The `fill` value used in properties such as [`objectFit`](#objectFit),
-[`pointerEvents`](#pointerEvents) and [`paintOrder`](#paintOrder)
-
-    objectFit fill_
-
-    pointerEvents fill_
-
-    paintOrder2 fill markers
-
--}
-fill_ : Value { provides | fill_ : Supported }
-fill_ =
-    Value "fill"
 
 
 {-| Sets `scale-down` value for usage with [`objectFit`](#objectFit).
@@ -15406,18 +15486,6 @@ visibleStroke =
 painted : Value { provides | painted : Supported }
 painted =
     Value "painted"
-
-
-{-| The `stroke` value used by [`pointerEvents`](#pointerEvents) and [`paintOrder`](#paintOrder).
-
-    pointerEvents stroke
-
-    paintOrder2 stroke markers
-
--}
-stroke : Value { provides | stroke : Supported }
-stroke =
-    Value "stroke"
 
 
 
@@ -16268,20 +16336,6 @@ scrollSnapAlign (Value val) =
     AppendProperty ("scroll-snap-align:" ++ val)
 
 
-{-| Sets `always` value for usage with [`scrollSnapStop`](#scrollSnapStop), [`pageBreakBefore`](#pageBreakBefore), and [`pageBreakAfter`](#pageBreakAfter).
-
-    scrollSnapStop always
-
-    pageBreakBefore always
-
-    pageBreakAfter always
-
--}
-always : Value { provides | always : Supported }
-always =
-    Value "always"
-
-
 {-| Sets [`scroll-snap-stop`](https://css-tricks.com/almanac/properties/s/scroll-snap-stop/)
 
     scrollSnapStop normal
@@ -16316,32 +16370,6 @@ scrollSnapType :
     -> Style
 scrollSnapType (Value val) =
     AppendProperty ("scroll-snap-type:" ++ val)
-
-
-{-| Sets `x` value for usage with [`scrollSnapType2`](#scrollSnapType2)
-and [`rotate2`](#rotate2).
-
-    scrollSnapType2 x mandatory
-
-    rotate x (deg 10)
-
--}
-x : Value { provides | x : Supported }
-x =
-    Value "x"
-
-
-{-| Sets `y` value for usage with [`scrollSnapType2`](#scrollSnapType2)
-and [`rotate2`](#rotate2).
-
-    scrollSnapType2 y mandatory
-
-    rotate y (deg 50)
-
--}
-y : Value { provides | y : Supported }
-y =
-    Value "y"
 
 
 {-| Sets `mandatory` value for usage with [`scrollSnapType2`](#scrollSnapType2).
@@ -17012,21 +17040,6 @@ may affect its internal layout and vice versa.
 layout : Value { provides | layout : Supported }
 layout =
     Value "layout"
-
-
-{-| Sets the `style` value for:
-
-    - [`contain`](#contain). **(This value is considered at-risk from being depreciated for this property.)**
-    - [`fontSynthesis`](#fontSynthesis)
-
-    contain style
-
-    fontSynthesis style
-
--}
-style : Value { provides | style : Supported }
-style =
-    Value "style"
 
 
 {-| Sets the `paint` value for [`contain`](#contain).

--- a/src/Css.elm
+++ b/src/Css.elm
@@ -10,6 +10,15 @@ module Css exposing
     , calc, CalcOperation, minus, plus, times, dividedBy
     , Color, ColorSupported, color, backgroundColor, hex, rgb, rgba, hsl, hsla, currentcolor
     , Time, TimeSupported, s, ms
+    , deg, grad, rad, turn
+    , url
+    , auto, none, normal
+    , hidden, visible
+    , contentBox, borderBox, paddingBox
+    , left_, right_, top_, bottom_, block, inline, start, end
+    , baseline, clip, ruby
+    , stretch, center, content, text
+    , cover, contain_
     , pseudoClass, active, checked, disabled, empty, enabled
     , firstChild, firstOfType, focus, fullscreen, hover, inRange
     , indeterminate, invalid, lastChild, lastOfType, link, onlyChild
@@ -55,6 +64,8 @@ module Css exposing
     , gap, gap2, rowGap, columnGap
     , boxSizing
     , alignContent, alignContent2, alignItems, alignItems2, alignSelf, alignSelf2, justifyContent, justifyContent2, justifyItems, justifyItems2, justifySelf, justifySelf2
+    , flexStart, flexEnd, selfStart, selfEnd, spaceBetween, spaceAround, spaceEvenly
+    , firstBaseline, lastBaseline, safe, unsafe, legacy, legacyLeft, legacyRight, legacyCenter
     , flexDirection, row, rowReverse, column, columnReverse
     , order
     , flexGrow, flexShrink, flexBasis
@@ -79,10 +90,9 @@ module Css exposing
     , fontVariantLigatures, commonLigatures, noCommonLigatures, discretionaryLigatures, noDiscretionaryLigatures, historicalLigatures, noHistoricalLigatures, contextual, noContextual
     , fontVariantNumeric, fontVariantNumeric4, ordinal, slashedZero, liningNums, oldstyleNums, proportionalNums, tabularNums, diagonalFractions, stackedFractions
     , fontKerning, fontLanguageOverride, fontSynthesis, fontSynthesis2, fontSynthesis3, fontOpticalSizing, fontVariantPosition
-    , flexStart, flexEnd, selfStart, selfEnd, spaceBetween, spaceAround, spaceEvenly, firstBaseline, lastBaseline, safe, unsafe, legacy, legacyLeft, legacyRight, legacyCenter
-    , url
     , CursorKeyword
-    , cursor, cursor2, cursor4, pointer, default, contextMenu, help, progress, wait, cell
+    , cursor, cursor2, cursor4
+    , pointer, default, contextMenu, help, progress, wait, cell
     , crosshair, verticalText, alias, copy, move, noDrop
     , notAllowed, allScroll, colResize, rowResize, nResize, eResize, sResize
     , wResize, neResize, nwResize, seResize, swResize, ewResize, nsResize
@@ -90,18 +100,10 @@ module Css exposing
     , ListStyleType, ListStyleTypeSupported
     , listStyle, listStyle2, listStyle3, listStylePosition, inside, outside, listStyleType, string, customIdent, listStyleImage
     , arabicIndic, armenian, bengali, cambodian, circle, cjkDecimal, cjkEarthlyBranch, cjkHeavenlyStem, cjkIdeographic, decimal, decimalLeadingZero, devanagari, disclosureClosed, disclosureOpen, disc, ethiopicNumeric, georgian, gujarati, gurmukhi, hebrew, hiragana, hiraganaIroha, japaneseFormal, japaneseInformal, kannada, katakana, katakanaIroha, khmer, koreanHangulFormal, koreanHanjaFormal, koreanHanjaInformal, lao, lowerAlpha, lowerArmenian, lowerGreek, lowerLatin, lowerRoman, malayalam, monogolian, myanmar, oriya, persian, simpChineseFormal, simpChineseInformal, tamil, telugu, thai, tibetan, tradChineseFormal, tradChineseInformal, upperAlpha, upperArmenian, upperLatin, upperRoman
-    , auto, none, normal
-    , hidden, visible
-    , contentBox, borderBox, paddingBox
-    , left_, right_, top_, bottom_, block, inline, start, end
-    , baseline, clip, ruby
-    , stretch, center, content, text
-    , cover, contain_
     , overflow, overflowX, overflowY, overflowBlock, overflowInline
     , overflowAnchor
     , overflowWrap
     , breakWord, anywhere
-    , deg, grad, rad, turn
     , direction, ltr, rtl
     , justify, matchParent, textAlign, textJustify, interWord, interCharacter, textUnderlinePosition, textUnderlinePosition2, under
     , textOrientation
@@ -213,7 +215,7 @@ functions let you define custom properties and selectors, respectively.
 
 # General Values
 
-All CSS properties can have the values `unset`, `initial`, and `inherit`
+All CSS properties can have the values `unset`, `initial`, and `inherit`.
 
 @docs unset, initial, inherit
 
@@ -242,7 +244,30 @@ All CSS properties can have the values `unset`, `initial`, and `inherit`
 @docs Time, TimeSupported, s, ms
 
 
-## Pseudo-Classes
+## Angles
+
+@docs deg, grad, rad, turn
+
+
+## URLs
+
+@docs url
+
+
+# Shared Values
+
+Many different kinds of CSS properties use these values.
+
+@docs auto, none, normal
+@docs hidden, visible
+@docs contentBox, borderBox, paddingBox
+@docs left_, right_, top_, bottom_, block, inline, start, end
+@docs baseline, clip, ruby
+@docs stretch, center, content, text
+@docs cover, contain_
+
+
+# Pseudo-Classes
 
 @docs pseudoClass, active, checked, disabled, empty, enabled
 @docs firstChild, firstOfType, focus, fullscreen, hover, inRange
@@ -251,16 +276,19 @@ All CSS properties can have the values `unset`, `initial`, and `inherit`
 @docs root, scope, target, valid, visited
 
 
-## Pseudo-Elements
+# Pseudo-Elements
 
 @docs pseudoElement, before, after, backdrop, cue, marker, placeholder, selection
 
 
-## Sizing
+# Sizing
 
 @docs width, minWidth, maxWidth, height, minHeight, maxHeight
 @docs blockSize, minBlockSize, maxBlockSize, inlineSize, minInlineSize, maxInlineSize
 @docs minContent, maxContent, fitContent
+
+
+# Backgrounds
 
 
 ## Background Attachment
@@ -288,6 +316,9 @@ All CSS properties can have the values `unset`, `initial`, and `inherit`
 @docs repeat, noRepeat, repeatX, repeatY, space, round
 
 
+# Shadows
+
+
 ## Box Shadow
 
 @docs BoxShadowConfig, boxShadow, boxShadows, defaultBoxShadow
@@ -298,7 +329,7 @@ All CSS properties can have the values `unset`, `initial`, and `inherit`
 @docs TextShadowConfig, textShadow, defaultTextShadow
 
 
-## Border
+# Borders
 
 @docs LineWidth, LineWidthSupported, LineStyle, LineStyleSupported
 
@@ -346,61 +377,84 @@ All CSS properties can have the values `unset`, `initial`, and `inherit`
 @docs borderImageWidth, borderImageWidth2, borderImageWidth3, borderImageWidth4
 
 
-## Outline
+# Outline
 
 @docs outline, outline3, outlineWidth, outlineColor, invert, outlineStyle, outlineOffset
 
 
-## Display
+# Display
 
 @docs display, display2, displayListItem2, displayListItem3
+
+
+## Display values
+
+You can also use [`block`](#block), [`inline`](#inline) and [`ruby`](#ruby) as values.
 
 @docs flex_, flow, flowRoot, grid, contents, listItem, inlineBlock, inlineFlex, inlineTable, inlineGrid, rubyBase, rubyBaseContainer, rubyText, rubyTextContainer, runIn, table, tableCaption, tableCell, tableColumn, tableColumnGroup, tableFooterGroup, tableHeaderGroup, tableRow, tableRowGroup
 
 
-## Positions
+# Positions
 
 @docs position, zIndex
 
 @docs absolute, fixed, relative, static, sticky
 
 
-## Inset
+# Inset
 
 @docs inset, inset2, inset3, inset4, top, right, bottom, left
 
 @docs insetBlock, insetBlock2, insetInline, insetInline2, insetBlockStart, insetBlockEnd, insetInlineStart, insetInlineEnd
 
 
-## Paddings
+# Paddings
 
 @docs padding, padding2, padding3, padding4, paddingTop, paddingRight, paddingBottom, paddingLeft
 
 
-## Margins
+# Margins
 
 @docs margin, margin2, margin3, margin4, marginTop, marginRight, marginBottom, marginLeft
 
 
-## Gap
+# Gaps
 
 @docs gap, gap2, rowGap, columnGap
 
 
-## Box Sizing
+# Box Sizing
 
 @docs boxSizing
 
 
-## Flexbox
+# Flexbox
 
 The CSS Flexible Box Layout Module.
 See this [complete guide](https://css-tricks.com/snippets/css/a-guide-to-flexbox/).
 
 
-### Flexbox Alignment
+## Flexbox Alignment
 
 @docs alignContent, alignContent2, alignItems, alignItems2, alignSelf, alignSelf2, justifyContent, justifyContent2, justifyItems, justifyItems2, justifySelf, justifySelf2
+
+
+### Align Items
+
+Other values you can use for flex item alignment:
+
+  - [`left_`](#left_)
+  - [`right_`](#right_)
+  - [`top_`](#top_)
+  - [`bottom_`](#bottom_)
+  - [`start`](#start)
+  - [`end`](#end)
+  - [`center`](#center)
+  - [`stretch`](#stretch)
+  - [`baseline`](#baseline)
+
+@docs flexStart, flexEnd, selfStart, selfEnd, spaceBetween, spaceAround, spaceEvenly
+@docs firstBaseline, lastBaseline, safe, unsafe, legacy, legacyLeft, legacyRight, legacyCenter
 
 
 ### Flexbox Direction
@@ -507,41 +561,24 @@ See this [complete guide](https://css-tricks.com/snippets/css/a-guide-to-flexbox
 @docs fontKerning, fontLanguageOverride, fontSynthesis, fontSynthesis2, fontSynthesis3, fontOpticalSizing, fontVariantPosition
 
 
-# Align Items
-
-Other values you can use for alignment than the ones listed in this section:
-
-  - [`left_`](#left_)
-  - [`right_`](#right_)
-  - [`top_`](#top_)
-  - [`bottom_`](#bottom_)
-  - [`start`](#start)
-  - [`end`](#end)
-  - [`center`](#center)
-  - [`stretch`](#stretch)
-  - [`baseline`](#baseline)
-
-@docs flexStart, flexEnd, selfStart, selfEnd, spaceBetween, spaceAround, spaceEvenly, firstBaseline, lastBaseline, safe, unsafe, legacy, legacyLeft, legacyRight, legacyCenter
-
-
-# Url
-
-@docs url
-
-
-## Cursors
-
-[`text`](#text) is also a supported value.
+# Cursors
 
 @docs CursorKeyword
-@docs cursor, cursor2, cursor4, pointer, default, contextMenu, help, progress, wait, cell
+@docs cursor, cursor2, cursor4
+
+
+## Cursor values
+
+[`text`](#text) is also a supported value for `cursor`.
+
+@docs pointer, default, contextMenu, help, progress, wait, cell
 @docs crosshair, verticalText, alias, copy, move, noDrop
 @docs notAllowed, allScroll, colResize, rowResize, nResize, eResize, sResize
 @docs wResize, neResize, nwResize, seResize, swResize, ewResize, nsResize
 @docs neswResize, nwseResize, zoomIn, zoomOut, grab, grabbing
 
 
-## List Style
+# List Style
 
 @docs ListStyleType, ListStyleTypeSupported
 @docs listStyle, listStyle2, listStyle3, listStylePosition, inside, outside, listStyleType, string, customIdent, listStyleImage
@@ -550,19 +587,7 @@ Other values you can use for alignment than the ones listed in this section:
 [`square`](#square) is also a supported value for [`listStyle`](#listStyle) and [`listStyleType`](#listStyleType).
 
 
-## Shared Values
-
-Multiple CSS properties use these values.
-
-@docs auto, none, normal
-@docs hidden, visible
-@docs contentBox, borderBox, paddingBox
-@docs left_, right_, top_, bottom_, block, inline, start, end
-@docs baseline, clip, ruby
-@docs stretch, center, content, text
-@docs cover, contain_
-
-## Overflow
+# Overflow
 
 @docs overflow, overflowX, overflowY, overflowBlock, overflowInline
 @docs overflowAnchor
@@ -571,40 +596,35 @@ Multiple CSS properties use these values.
 @docs breakWord, anywhere
 
 
-## Angles
-
-@docs deg, grad, rad, turn
-
-
-## Direction
+# Direction
 
 @docs direction, ltr, rtl
 
 
-## Text Align
+# Text Align
 
 @docs justify, matchParent, textAlign, textJustify, interWord, interCharacter, textUnderlinePosition, textUnderlinePosition2, under
 
 
-## Text Orientation
+# Text Orientation
 
 @docs textOrientation
 @docs mixed, sideways, upright
 
 
-## Text Rendering
+# Text Rendering
 
 @docs textRendering
 @docs geometricPrecision, optimizeLegibility, optimizeSpeed
 
 
-## Text Transform
+# Text Transform
 
 @docs textTransform
 @docs capitalize, uppercase, lowercase, fullWidth, fullSizeKana
 
 
-## Text Decoration
+# Text Decoration
 
 @docs textDecoration, textDecoration2, textDecoration3, textDecorationLine, textDecorationLine2, textDecorationLine3, textDecorationStyle, textDecorationColor
 @docs textDecorationSkip, objects, spaces, ink, edges, boxDecoration
@@ -1221,6 +1241,10 @@ url str =
     Value ("url(" ++ str ++ ")")
 
 
+
+-- SHARED VALUES --
+
+
 {-| The `auto` value used in many properties such as [`width`](#width),
 [`zoom`](#zoom),
 [`outlineStyle`](#outlineStyle),
@@ -1738,7 +1762,7 @@ text =
 ```
 backgroundSize contain_
 
-overscrollBehavior contain
+overscrollBehavior contain_
 ```
 
 The value is called `contain_` instead of `contain` because [`contain`](#contain) is already a function.
@@ -1751,20 +1775,22 @@ contain_ =
 
 {-| Sets `cover` for the following properties:
 
-- [`backgroundSize`](#backgroundSize)
-- [`objectFit`](#objectFit)
-- [`strokeDashCorner`](#strokeDashCorner)
-- [`strokeSize`](#strokeSize)
+  - [`backgroundSize`](#backgroundSize)
+  - [`objectFit`](#objectFit)
+  - [`strokeDashCorner`](#strokeDashCorner)
+  - [`strokeSize`](#strokeSize)
 
+```
+backgroundSize cover
 
-    backgroundSize cover
-
-    strokeSize cover
+strokeSize cover
+```
 
 -}
 cover : Value { provides | cover : Supported }
 cover =
     Value "cover"
+
 
 
 -- OVERFLOW --
@@ -5791,12 +5817,15 @@ fontVariantCaps (Value str) =
 
 
 {-| The `small-caps` value used in
-- [`fontVariantCaps`](#fontVariantCaps)
-- [`fontSynthesis`](#fontSynthesis)
 
-    fontVariantCaps smallCaps
+  - [`fontVariantCaps`](#fontVariantCaps)
+  - [`fontSynthesis`](#fontSynthesis)
 
-    fontSynthesis2 smallCaps style
+```
+fontVariantCaps smallCaps
+
+fontSynthesis2 smallCaps style
+```
 
 -}
 smallCaps : Value { provides | smallCaps : Supported }
@@ -7588,6 +7617,7 @@ backgroundSize2 :
     -> Style
 backgroundSize2 (Value widthVal) (Value heightVal) =
     AppendProperty ("background-size:" ++ widthVal ++ " " ++ heightVal)
+
 
 
 {- GRADIENTS -}
@@ -14833,8 +14863,8 @@ textOverflow (Value value) =
 
 `text-overflow` describes how text that gets cut off is signalled to users.
 
-This version specifies how the text cut-off is displayed in start
-(left in LTR) and the end (right in LTR) of the text..
+This version specifies how the text cut-off is displayed at the start
+(left in LTR) and at the end (right in LTR) of the text.
 
     textOverflow2 ellipsis ellipsis
 

--- a/src/Css.elm
+++ b/src/Css.elm
@@ -6,10 +6,11 @@ module Css exposing
     , unset, initial, inherit
     , all, revert
     , Angle, AngleSupported, Width, WidthSupported
-    , BasicShapeSupported, circle, circleAt, circleAt2, ellipse, ellipseAt, ellipseAt2, closestSide, farthestSide, polygon, path
+    , BasicShape, BasicShapeSupported, circle, circleAt, circleAt2, ellipse, ellipseAt, ellipseAt2, closestSide, farthestSide, polygon, path
     , Length, LengthSupported, zero, px, em, ex, ch, rem, vh, vw, vmin, vmax, mm, cm, q, inches, pt, pc, pct, num, int
     , calc, CalcOperation, minus, plus, times, dividedBy
     , Color, ColorSupported, color, backgroundColor, hex, rgb, rgba, hsl, hsla, currentcolor
+    , Resolution, ResolutionSupported, dpi, dpcm, dppx
     , Time, TimeSupported, s, ms
     , deg, grad, rad, turn
     , url
@@ -275,7 +276,11 @@ All CSS properties can have the values `unset`, `initial`, `inherit` and `revert
 
 ## Shapes
 
-@docs BasicShapeSupported, circle, circleAt, circleAt2, ellipse, ellipseAt, ellipseAt2, closestSide, farthestSide, polygon, path
+@docs BasicShape, BasicShapeSupported, circle, circleAt, circleAt2, ellipse, ellipseAt, ellipseAt2, closestSide, farthestSide, polygon, path
+
+## Resolution
+
+@docs Resolution, ResolutionSupported, dpi, dpcm, dppx
 
 ## URLs
 
@@ -1152,6 +1157,8 @@ type alias Angle =
     AngleSupported {}
 
 
+
+
 {-| A type alias used to accept an [image](https://developer.mozilla.org/en-US/docs/Web/CSS/image)
 among other values.
 -}
@@ -1164,7 +1171,15 @@ type alias ImageSupported supported =
         , repeatingRadialGradient : Supported
     }
 
-{-| A type alias used to accept a [basic shape](https://developer.mozilla.org/en-US/docs/Web/CSS/basic-shape).
+
+{-| A type alias used to accept an [image](https://developer.mozilla.org/en-US/docs/Web/CSS/image).
+-}
+type alias Image =
+    ImageSupported {}
+
+
+{-| A type alias used to accept a [basic shape](https://developer.mozilla.org/en-US/docs/Web/CSS/basic-shape)
+among other values.
 -}
 type alias BasicShapeSupported supported =
     { supported
@@ -1180,10 +1195,27 @@ type alias BasicShapeSupported supported =
     }
 
 
-{-| A type alias used to accept an [image](https://developer.mozilla.org/en-US/docs/Web/CSS/image).
+{-| A type alias used to accept a [basic shape](https://developer.mozilla.org/en-US/docs/Web/CSS/basic-shape).
 -}
-type alias Image =
-    ImageSupported {}
+type alias BasicShape =
+    BasicShapeSupported {}
+
+
+{-| A type alias used to accept a [resolution](https://developer.mozilla.org/en-US/docs/Web/CSS/resolution)
+among other values.
+-}
+type alias ResolutionSupported supported =
+    { supported
+        | dpi : Supported
+        , dpcm : Supported
+        , dppx : Supported
+    }
+
+
+{-| A type alias used to accept a [resolution](https://developer.mozilla.org/en-US/docs/Web/CSS/resolution).
+-}
+type alias Resolution =
+    ResolutionSupported {}
 
 
 {-| A type alias used to accept an [time](https://developer.mozilla.org/en-US/docs/Web/CSS/time)
@@ -1674,6 +1706,31 @@ and [`backgroundImage`](#backgroundImage) properties.
 url : String -> Value { provides | url : Supported }
 url str =
     Value ("url(" ++ str ++ ")")
+
+
+
+
+-- RESOLUTION --
+
+{-| [`dpi`](https://developer.mozilla.org/en-US/docs/Web/CSS/resolution) resolution units.
+-}
+dpi : Float -> Value { provides | dpi : Supported }
+dpi val =
+    Value <| String.fromFloat val ++ "dpi"
+
+
+{-| [`dpcm`](https://developer.mozilla.org/en-US/docs/Web/CSS/resolution) resolution units.
+-}
+dpcm : Float -> Value { provides | dpcm : Supported }
+dpcm val =
+    Value <| String.fromFloat val ++ "dpcm"
+
+
+{-| [`dppx`](https://developer.mozilla.org/en-US/docs/Web/CSS/resolution) resolution units.
+-}
+dppx : Float -> Value { provides | dppx : Supported }
+dppx val =
+    Value <| String.fromFloat val ++ "dppx"
 
 
 
@@ -18443,7 +18500,7 @@ textEmphasis2 :
         }
     ->
         BaseValue
-            (ColorSupported a)
+            (Color)
     -> Style
 textEmphasis2 (Value value1) (Value value2) =
     AppendProperty
@@ -18514,8 +18571,7 @@ textEmphasisStyle2 (Value val1) (Value val2) =
     textemphasisColor (hex "0000ff")
 -}
 textEmphasisColor :
-    BaseValue
-        (ColorSupported a)
+    BaseValue (Color)
     -> Style
 textEmphasisColor (Value value) =
     AppendProperty ("text-emphasis-color:" ++ value)


### PR DESCRIPTION
These were either not on the checklists or self-assigned by someone else as far as I could see so I figured it would be okay to make a PR request for them ^^ (Reading some more I think someone removed the padding ones because they used to be tagged as experimental, they are no longer considered experimental.)

Adds implementations for:
- `padding-block` (including 1 and 2-argument variants)
- `padding-block-start`
- `padding-block-end`
- `padding-inline` (including 1 and 2-argument variants)
- `padding-inline-start`
- `padding-inline-end`
- `margin-block` (including 1 and 2-argument variants)
- `margin-block-start`
- `margin-block-end`
- `margin-inline` (including 1 and 2-argument variants)
- `margin-inline-start`
- `margin-inline-end`