### PR TITLE
Phantom types: Logical borders

### DIFF
--- a/src/Css.elm
+++ b/src/Css.elm
@@ -33,7 +33,7 @@ module Css exposing
     , borderBlock, borderBlock2, borderBlock3
     , borderInline, borderInline2, borderInline3
     , borderWidth, borderWidth2, borderWidth3, borderWidth4, borderTopWidth, borderRightWidth, borderBottomWidth, borderLeftWidth
-    , borderBlockWidth, borderInlineWidth
+    , borderBlockWidth, borderBlockStartWidth, borderBlockEndWidth, borderInlineWidth, borderInlineStartWidth, borderInlineEndWidth
     , thin, thick
     , borderStyle, borderStyle2, borderStyle3, borderStyle4, borderTopStyle, borderRightStyle, borderBottomStyle, borderLeftStyle
     , borderBlockStyle, borderBlockStartStyle, borderBlockEndStyle, borderInlineStyle, borderInlineStartStyle, borderInlineEndStyle
@@ -300,7 +300,7 @@ All CSS properties can have the values `unset`, `initial`, and `inherit`
 
 @docs borderWidth, borderWidth2, borderWidth3, borderWidth4, borderTopWidth, borderRightWidth, borderBottomWidth, borderLeftWidth
 
-@docs borderBlockWidth, borderInlineWidth
+@docs borderBlockWidth, borderBlockStartWidth, borderBlockEndWidth, borderInlineWidth, borderInlineStartWidth, borderInlineEndWidth
 
 @docs thin, thick
 
@@ -7613,6 +7613,26 @@ borderBlockWidth (Value widthVal) =
     AppendProperty ("border-block-width:" ++ widthVal)
 
 
+{-| Sets [`border-block-start-width`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-block-start-width) property.
+
+    borderBlockStartWidth (px 1)
+
+-}
+borderBlockStartWidth : BaseValue LineWidth -> Style
+borderBlockStartWidth (Value widthVal) =
+    AppendProperty ("border-block-start-width:" ++ widthVal)
+
+
+{-| Sets [`border-block-end-width`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-block-end-width) property.
+
+    borderBlockEndWidth (px 1)
+
+-}
+borderBlockEndWidth : BaseValue LineWidth -> Style
+borderBlockEndWidth (Value widthVal) =
+    AppendProperty ("border-block-end-width:" ++ widthVal)
+
+
 {-| Sets [`border-inline-width`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-inline-width) property.
 
     borderTopWidth (px 1)
@@ -7621,6 +7641,26 @@ borderBlockWidth (Value widthVal) =
 borderInlineWidth : BaseValue LineWidth -> Style
 borderInlineWidth (Value widthVal) =
     AppendProperty ("border-inline-width:" ++ widthVal)
+
+
+{-| Sets [`border-inline-start-width`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-inline-start-width) property.
+
+    borderInlineStartWidth (px 1)
+
+-}
+borderInlineStartWidth : BaseValue LineWidth -> Style
+borderInlineStartWidth (Value widthVal) =
+    AppendProperty ("border-inline-start-width:" ++ widthVal)
+
+
+{-| Sets [`border-inline-end-width`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-inline-end-width) property.
+
+    borderInlineEndWidth (px 1)
+
+-}
+borderInlineEndWidth : BaseValue LineWidth -> Style
+borderInlineEndWidth (Value widthVal) =
+    AppendProperty ("border-inline-end-width:" ++ widthVal)
 
 
 {-| Sets [`border-style`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-style) property.

--- a/src/Css.elm
+++ b/src/Css.elm
@@ -36,7 +36,7 @@ module Css exposing
     , thin, thick
     , borderStyle, borderStyle2, borderStyle3, borderStyle4, borderTopStyle, borderRightStyle, borderBottomStyle, borderLeftStyle
     , dotted, dashed, solid, double, groove, ridge, inset, outset
-    , borderColor, borderColor2, borderColor3, borderColor4, borderTopColor, borderRightColor, borderBottomColor, borderLeftColor, borderBlockColor, borderInlineColor
+    , borderColor, borderColor2, borderColor3, borderColor4, borderTopColor, borderRightColor, borderBottomColor, borderLeftColor, borderBlockColor, borderBlockStartColor, borderBlockEndColor, borderInlineColor, borderInlineStartColor, borderInlineEndColor
     , borderRadius, borderRadius2, borderRadius3, borderRadius4, borderTopLeftRadius, borderTopLeftRadius2, borderTopRightRadius, borderTopRightRadius2, borderBottomRightRadius, borderBottomRightRadius2, borderBottomLeftRadius, borderBottomLeftRadius2
     , borderImageOutset, borderImageOutset2, borderImageOutset3, borderImageOutset4
     , borderImageWidth, borderImageWidth2, borderImageWidth3, borderImageWidth4
@@ -314,7 +314,7 @@ All CSS properties can have the values `unset`, `initial`, and `inherit`
 
 @docs borderColor, borderColor2, borderColor3, borderColor4, borderTopColor, borderRightColor, borderBottomColor, borderLeftColor
 
-@docs borderBlockColor, borderInlineColor
+@docs borderBlockColor, borderBlockStartColor, borderBlockEndColor, borderInlineColor, borderInlineStartColor, borderInlineEndColor
 
 
 ## Border Radius
@@ -7804,6 +7804,26 @@ borderBlockColor (Value colorVal) =
     AppendProperty ("border-block-color:" ++ colorVal)
 
 
+{-| Sets [`border-block-start-color`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-block-start-color) property.
+
+    borderBlockStartColor (rgb 0 0 0)
+
+-}
+borderBlockStartColor : BaseValue Color -> Style
+borderBlockStartColor (Value colorVal) =
+    AppendProperty ("border-block-start-color:" ++ colorVal)
+
+
+{-| Sets [`border-block-end-color`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-block-end-color) property.
+
+    borderBlockEndColor (rgb 0 0 0)
+
+-}
+borderBlockEndColor : BaseValue Color -> Style
+borderBlockEndColor (Value colorVal) =
+    AppendProperty ("border-block-end-color:" ++ colorVal)
+
+
 {-| Sets [`border-inline-color`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-inline-color) property.
 
     borderInlineColor (rgb 0 0 0)
@@ -7812,6 +7832,26 @@ borderBlockColor (Value colorVal) =
 borderInlineColor : BaseValue Color -> Style
 borderInlineColor (Value colorVal) =
     AppendProperty ("border-inline-color:" ++ colorVal)
+
+
+{-| Sets [`border-inline-start-color`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-inline-start-color) property.
+
+    borderInlineStartColor (rgb 0 0 0)
+
+-}
+borderInlineStartColor : BaseValue Color -> Style
+borderInlineStartColor (Value colorVal) =
+    AppendProperty ("border-inline-start-color:" ++ colorVal)
+
+
+{-| Sets [`border-inline-end-color`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-inline-end-color) property.
+
+    borderInlineEndColor (rgb 0 0 0)
+
+-}
+borderInlineEndColor : BaseValue Color -> Style
+borderInlineEndColor (Value colorVal) =
+    AppendProperty ("border-inline-end-color:" ++ colorVal)
 
 
 -- BORDER WIDTH --

--- a/src/Css.elm
+++ b/src/Css.elm
@@ -36,7 +36,7 @@ module Css exposing
     , thin, thick
     , borderStyle, borderStyle2, borderStyle3, borderStyle4, borderTopStyle, borderRightStyle, borderBottomStyle, borderLeftStyle
     , dotted, dashed, solid, double, groove, ridge, inset, outset
-    , borderColor, borderColor2, borderColor3, borderColor4, borderTopColor, borderRightColor, borderBottomColor, borderLeftColor
+    , borderColor, borderColor2, borderColor3, borderColor4, borderTopColor, borderRightColor, borderBottomColor, borderLeftColor, borderBlockColor, borderInlineColor
     , borderRadius, borderRadius2, borderRadius3, borderRadius4, borderTopLeftRadius, borderTopLeftRadius2, borderTopRightRadius, borderTopRightRadius2, borderBottomRightRadius, borderBottomRightRadius2, borderBottomLeftRadius, borderBottomLeftRadius2
     , borderImageOutset, borderImageOutset2, borderImageOutset3, borderImageOutset4
     , borderImageWidth, borderImageWidth2, borderImageWidth3, borderImageWidth4
@@ -313,6 +313,8 @@ All CSS properties can have the values `unset`, `initial`, and `inherit`
 ## Border Color
 
 @docs borderColor, borderColor2, borderColor3, borderColor4, borderTopColor, borderRightColor, borderBottomColor, borderLeftColor
+
+@docs borderBlockColor, borderInlineColor
 
 
 ## Border Radius
@@ -7791,6 +7793,25 @@ borderLeftColor : BaseValue Color -> Style
 borderLeftColor (Value colorVal) =
     AppendProperty ("border-left-color:" ++ colorVal)
 
+
+{-| Sets [`border-block-color`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-block-color) property.
+
+    borderBlockColor (rgb 0 0 0)
+
+-}
+borderBlockColor : BaseValue Color -> Style
+borderBlockColor (Value colorVal) =
+    AppendProperty ("border-block-color:" ++ colorVal)
+
+
+{-| Sets [`border-inline-color`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-inline-color) property.
+
+    borderInlineColor (rgb 0 0 0)
+
+-}
+borderInlineColor : BaseValue Color -> Style
+borderInlineColor (Value colorVal) =
+    AppendProperty ("border-inline-color:" ++ colorVal)
 
 
 -- BORDER WIDTH --

--- a/src/Css.elm
+++ b/src/Css.elm
@@ -35,7 +35,7 @@ module Css exposing
     , borderWidth, borderWidth2, borderWidth3, borderWidth4, borderTopWidth, borderRightWidth, borderBottomWidth, borderLeftWidth
     , thin, thick
     , borderStyle, borderStyle2, borderStyle3, borderStyle4, borderTopStyle, borderRightStyle, borderBottomStyle, borderLeftStyle
-    , borderBlockStyle, borderInlineStyle
+    , borderBlockStyle, borderBlockStartStyle, borderBlockEndStyle, borderInlineStyle, borderInlineStartStyle, borderInlineEndStyle
     , dotted, dashed, solid, double, groove, ridge, inset, outset
     , borderColor, borderColor2, borderColor3, borderColor4, borderTopColor, borderRightColor, borderBottomColor, borderLeftColor
     , borderBlockColor, borderBlockStartColor, borderBlockEndColor, borderInlineColor, borderInlineStartColor, borderInlineEndColor
@@ -309,7 +309,7 @@ All CSS properties can have the values `unset`, `initial`, and `inherit`
 
 @docs borderStyle, borderStyle2, borderStyle3, borderStyle4, borderTopStyle, borderRightStyle, borderBottomStyle, borderLeftStyle
 
-@docs borderBlockStyle, borderInlineStyle
+@docs borderBlockStyle, borderBlockStartStyle, borderBlockEndStyle, borderInlineStyle, borderInlineStartStyle, borderInlineEndStyle
 
 @docs dotted, dashed, solid, double, groove, ridge, inset, outset
 
@@ -7699,6 +7699,26 @@ borderBlockStyle (Value style) =
     AppendProperty ("border-block-style:" ++ style)
 
 
+{-| Sets [`border-block-start-style`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-block-start-style) property.
+
+    borderBlockStartStyle solid
+
+-}
+borderBlockStartStyle : BaseValue LineStyle -> Style
+borderBlockStartStyle (Value style) =
+    AppendProperty ("border-block-start-style:" ++ style)
+
+
+{-| Sets [`border-block-end-style`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-block-end-style) property.
+
+    borderBlockEndStyle solid
+
+-}
+borderBlockEndStyle : BaseValue LineStyle -> Style
+borderBlockEndStyle (Value style) =
+    AppendProperty ("border-block-end-style:" ++ style)
+
+
 {-| Sets [`border-inline-style`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-inline-style) property.
 
     borderInlineStyle solid
@@ -7707,6 +7727,26 @@ borderBlockStyle (Value style) =
 borderInlineStyle : BaseValue LineStyle -> Style
 borderInlineStyle (Value style) =
     AppendProperty ("border-inline-style:" ++ style)
+
+
+{-| Sets [`border-inline-start-style`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-inline-start-style) property.
+
+    borderInlineStartStyle solid
+
+-}
+borderInlineStartStyle : BaseValue LineStyle -> Style
+borderInlineStartStyle (Value style) =
+    AppendProperty ("border-inline-start-style:" ++ style)
+
+
+{-| Sets [`border-inline-end-style`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-inline-end-style) property.
+
+    borderInlineEndStyle solid
+
+-}
+borderInlineEndStyle : BaseValue LineStyle -> Style
+borderInlineEndStyle (Value style) =
+    AppendProperty ("border-inline-end-style:" ++ style)
 
 
 {-| Sets [`border-color`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-color) property.

--- a/src/Css.elm
+++ b/src/Css.elm
@@ -33,6 +33,7 @@ module Css exposing
     , borderBlock, borderBlock2, borderBlock3
     , borderInline, borderInline2, borderInline3
     , borderWidth, borderWidth2, borderWidth3, borderWidth4, borderTopWidth, borderRightWidth, borderBottomWidth, borderLeftWidth
+    , borderBlockWidth, borderInlineWidth
     , thin, thick
     , borderStyle, borderStyle2, borderStyle3, borderStyle4, borderTopStyle, borderRightStyle, borderBottomStyle, borderLeftStyle
     , borderBlockStyle, borderBlockStartStyle, borderBlockEndStyle, borderInlineStyle, borderInlineStartStyle, borderInlineEndStyle
@@ -290,9 +291,6 @@ All CSS properties can have the values `unset`, `initial`, and `inherit`
 
 @docs borderLeft, borderLeft2, borderLeft3
 
-
-## Logical Borders
-
 @docs borderBlock, borderBlock2, borderBlock3
 
 @docs borderInline, borderInline2, borderInline3
@@ -301,6 +299,8 @@ All CSS properties can have the values `unset`, `initial`, and `inherit`
 ## Border Width
 
 @docs borderWidth, borderWidth2, borderWidth3, borderWidth4, borderTopWidth, borderRightWidth, borderBottomWidth, borderLeftWidth
+
+@docs borderBlockWidth, borderInlineWidth
 
 @docs thin, thick
 
@@ -7601,6 +7601,26 @@ borderBottomWidth (Value widthVal) =
 borderLeftWidth : BaseValue LineWidth -> Style
 borderLeftWidth (Value widthVal) =
     AppendProperty ("border-left-width:" ++ widthVal)
+
+
+{-| Sets [`border-block-width`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-block-width) property.
+
+    borderBlockWidth (px 1)
+
+-}
+borderBlockWidth : BaseValue LineWidth -> Style
+borderBlockWidth (Value widthVal) =
+    AppendProperty ("border-block-width:" ++ widthVal)
+
+
+{-| Sets [`border-inline-width`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-inline-width) property.
+
+    borderTopWidth (px 1)
+
+-}
+borderInlineWidth : BaseValue LineWidth -> Style
+borderInlineWidth (Value widthVal) =
+    AppendProperty ("border-inline-width:" ++ widthVal)
 
 
 {-| Sets [`border-style`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-style) property.

--- a/src/Css.elm
+++ b/src/Css.elm
@@ -31,7 +31,11 @@ module Css exposing
     , borderBottom, borderBottom2, borderBottom3
     , borderLeft, borderLeft2, borderLeft3
     , borderBlock, borderBlock2, borderBlock3
+    , borderBlockStart, borderBlockStart2, borderBlockStart3
+    , borderBlockEnd, borderBlockEnd2, borderBlockEnd3
     , borderInline, borderInline2, borderInline3
+    , borderInlineStart, borderInlineStart2, borderInlineStart3
+    , borderInlineEnd, borderInlineEnd2, borderInlineEnd3
     , borderWidth, borderWidth2, borderWidth3, borderWidth4, borderTopWidth, borderRightWidth, borderBottomWidth, borderLeftWidth
     , borderBlockWidth, borderBlockStartWidth, borderBlockEndWidth, borderInlineWidth, borderInlineStartWidth, borderInlineEndWidth
     , thin, thick
@@ -293,7 +297,15 @@ All CSS properties can have the values `unset`, `initial`, and `inherit`
 
 @docs borderBlock, borderBlock2, borderBlock3
 
+@docs borderBlockStart, borderBlockStart2, borderBlockStart3
+
+@docs borderBlockEnd, borderBlockEnd2, borderBlockEnd3
+
 @docs borderInline, borderInline2, borderInline3
+
+@docs borderInlineStart, borderInlineStart2, borderInlineStart3
+
+@docs borderInlineEnd, borderInlineEnd2, borderInlineEnd3
 
 
 ## Border Width
@@ -7457,6 +7469,90 @@ borderBlock3 (Value widthVal) (Value style) (Value colorVal) =
     AppendProperty ("border-block:" ++ widthVal ++ " " ++ style ++ " " ++ colorVal)
 
 
+{-| Sets [`border-block-start`](https://css-tricks.com/almanac/properties/b/border-block-start/) property.
+
+    borderBlockStart (px 1)
+
+    borderBlockStart2 (px 1) solid
+
+    borderBlockStart3 (px 1) solid (hex "#f00")
+
+-}
+borderBlockStart : BaseValue LineWidth -> Style
+borderBlockStart (Value widthVal) =
+    AppendProperty ("border-block-start:" ++ widthVal)
+
+
+{-| Sets [`border-block-start`](https://css-tricks.com/almanac/properties/b/border-block-start/) property.
+
+    borderBlockStart (px 1)
+
+    borderBlockStart2 (px 1) solid
+
+    borderBlockStart3 (px 1) solid (hex "#f00")
+
+-}
+borderBlockStart2 : Value LineWidth -> Value LineStyle -> Style
+borderBlockStart2 (Value widthVal) (Value style) =
+    AppendProperty ("border-block-start:" ++ widthVal ++ " " ++ style)
+
+
+{-| Sets [`border-block-start`](https://css-tricks.com/almanac/properties/b/border-block-start/) property.
+
+    borderBlockStart (px 1)
+
+    borderBlockStart2 (px 1) solid
+
+    borderBlockStart3 (px 1) solid (hex "#f00")
+
+-}
+borderBlockStart3 : Value LineWidth -> Value LineStyle -> Value Color -> Style
+borderBlockStart3 (Value widthVal) (Value style) (Value colorVal) =
+    AppendProperty ("border-block-start:" ++ widthVal ++ " " ++ style ++ " " ++ colorVal)
+
+
+{-| Sets [`border-block-end`](https://css-tricks.com/almanac/properties/b/border-block-end/) property.
+
+    borderBlockEnd (px 1)
+
+    borderBlockEnd2 (px 1) solid
+
+    borderBlockEnd3 (px 1) solid (hex "#f00")
+
+-}
+borderBlockEnd : BaseValue LineWidth -> Style
+borderBlockEnd (Value widthVal) =
+    AppendProperty ("border-block-end:" ++ widthVal)
+
+
+{-| Sets [`border-block-end`](https://css-tricks.com/almanac/properties/b/border-block-end/) property.
+
+    borderBlockEnd (px 1)
+
+    borderBlockEnd2 (px 1) solid
+
+    borderBlockEnd3 (px 1) solid (hex "#f00")
+
+-}
+borderBlockEnd2 : Value LineWidth -> Value LineStyle -> Style
+borderBlockEnd2 (Value widthVal) (Value style) =
+    AppendProperty ("border-block-end:" ++ widthVal ++ " " ++ style)
+
+
+{-| Sets [`border-block-end`](https://css-tricks.com/almanac/properties/b/border-block-end/) property.
+
+    borderBlockEnd (px 1)
+
+    borderBlockEnd2 (px 1) solid
+
+    borderBlockEnd3 (px 1) solid (hex "#f00")
+
+-}
+borderBlockEnd3 : Value LineWidth -> Value LineStyle -> Value Color -> Style
+borderBlockEnd3 (Value widthVal) (Value style) (Value colorVal) =
+    AppendProperty ("border-block-end:" ++ widthVal ++ " " ++ style ++ " " ++ colorVal)
+
+
 {-| Sets [`border-inline`](https://css-tricks.com/almanac/properties/b/border-inline/) property.
 
     borderInline (px 1)
@@ -7497,6 +7593,90 @@ borderInline2 (Value widthVal) (Value style) =
 borderInline3 : Value LineWidth -> Value LineStyle -> Value Color -> Style
 borderInline3 (Value widthVal) (Value style) (Value colorVal) =
     AppendProperty ("border-inline:" ++ widthVal ++ " " ++ style ++ " " ++ colorVal)
+
+
+{-| Sets [`border-inline-start`](https://css-tricks.com/almanac/properties/b/border-inline-start/) property.
+
+    borderInlineStart (px 1)
+
+    borderInlineStart2 (px 1) solid
+
+    borderInlineStart3 (px 1) solid (hex "#f00")
+
+-}
+borderInlineStart : BaseValue LineWidth -> Style
+borderInlineStart (Value widthVal) =
+    AppendProperty ("border-inline-start:" ++ widthVal)
+
+
+{-| Sets [`border-inline-start`](https://css-tricks.com/almanac/properties/b/border-inline-start/) property.
+
+    borderInlineStart (px 1)
+
+    borderInlineStart2 (px 1) solid
+
+    borderInlineStart3 (px 1) solid (hex "#f00")
+
+-}
+borderInlineStart2 : Value LineWidth -> Value LineStyle -> Style
+borderInlineStart2 (Value widthVal) (Value style) =
+    AppendProperty ("border-inline-start:" ++ widthVal ++ " " ++ style)
+
+
+{-| Sets [`border-inline-start`](https://css-tricks.com/almanac/properties/b/border-inline-start/) property.
+
+    borderInlineStart (px 1)
+
+    borderInlineStart2 (px 1) solid
+
+    borderInlineStart3 (px 1) solid (hex "#f00")
+
+-}
+borderInlineStart3 : Value LineWidth -> Value LineStyle -> Value Color -> Style
+borderInlineStart3 (Value widthVal) (Value style) (Value colorVal) =
+    AppendProperty ("border-inline-start:" ++ widthVal ++ " " ++ style ++ " " ++ colorVal)
+
+
+{-| Sets [`border-inline-end`](https://css-tricks.com/almanac/properties/b/border-inline-end/) property.
+
+    borderInlineEnd (px 1)
+
+    borderInlineEnd2 (px 1) solid
+
+    borderInlineEnd3 (px 1) solid (hex "#f00")
+
+-}
+borderInlineEnd : BaseValue LineWidth -> Style
+borderInlineEnd (Value widthVal) =
+    AppendProperty ("border-inline-end:" ++ widthVal)
+
+
+{-| Sets [`border-inline-end`](https://css-tricks.com/almanac/properties/b/border-inline-end/) property.
+
+    borderInlineEnd (px 1)
+
+    borderInlineEnd2 (px 1) solid
+
+    borderInlineEnd3 (px 1) solid (hex "#f00")
+
+-}
+borderInlineEnd2 : Value LineWidth -> Value LineStyle -> Style
+borderInlineEnd2 (Value widthVal) (Value style) =
+    AppendProperty ("border-inline-end:" ++ widthVal ++ " " ++ style)
+
+
+{-| Sets [`border-inline-end`](https://css-tricks.com/almanac/properties/b/border-inline-end/) property.
+
+    borderInlineEnd (px 1)
+
+    borderInlineEnd2 (px 1) solid
+
+    borderInlineEnd3 (px 1) solid (hex "#f00")
+
+-}
+borderInlineEnd3 : Value LineWidth -> Value LineStyle -> Value Color -> Style
+borderInlineEnd3 (Value widthVal) (Value style) (Value colorVal) =
+    AppendProperty ("border-inline-end:" ++ widthVal ++ " " ++ style ++ " " ++ colorVal)
 
 
 {-| Sets [`border-width`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-width) property.

--- a/src/Css.elm
+++ b/src/Css.elm
@@ -35,8 +35,10 @@ module Css exposing
     , borderWidth, borderWidth2, borderWidth3, borderWidth4, borderTopWidth, borderRightWidth, borderBottomWidth, borderLeftWidth
     , thin, thick
     , borderStyle, borderStyle2, borderStyle3, borderStyle4, borderTopStyle, borderRightStyle, borderBottomStyle, borderLeftStyle
+    , borderBlockStyle, borderInlineStyle
     , dotted, dashed, solid, double, groove, ridge, inset, outset
-    , borderColor, borderColor2, borderColor3, borderColor4, borderTopColor, borderRightColor, borderBottomColor, borderLeftColor, borderBlockColor, borderBlockStartColor, borderBlockEndColor, borderInlineColor, borderInlineStartColor, borderInlineEndColor
+    , borderColor, borderColor2, borderColor3, borderColor4, borderTopColor, borderRightColor, borderBottomColor, borderLeftColor
+    , borderBlockColor, borderBlockStartColor, borderBlockEndColor, borderInlineColor, borderInlineStartColor, borderInlineEndColor
     , borderRadius, borderRadius2, borderRadius3, borderRadius4, borderTopLeftRadius, borderTopLeftRadius2, borderTopRightRadius, borderTopRightRadius2, borderBottomRightRadius, borderBottomRightRadius2, borderBottomLeftRadius, borderBottomLeftRadius2
     , borderImageOutset, borderImageOutset2, borderImageOutset3, borderImageOutset4
     , borderImageWidth, borderImageWidth2, borderImageWidth3, borderImageWidth4
@@ -306,6 +308,8 @@ All CSS properties can have the values `unset`, `initial`, and `inherit`
 ## Border Style
 
 @docs borderStyle, borderStyle2, borderStyle3, borderStyle4, borderTopStyle, borderRightStyle, borderBottomStyle, borderLeftStyle
+
+@docs borderBlockStyle, borderInlineStyle
 
 @docs dotted, dashed, solid, double, groove, ridge, inset, outset
 
@@ -7411,7 +7415,6 @@ borderLeft3 (Value widthVal) (Value style) (Value colorVal) =
     AppendProperty ("border-left:" ++ widthVal ++ " " ++ style ++ " " ++ colorVal)
 
 
-
 {-| Sets [`border-block`](https://css-tricks.com/almanac/properties/b/border-block/) property.
 
     borderBlock (px 1)
@@ -7494,10 +7497,6 @@ borderInline2 (Value widthVal) (Value style) =
 borderInline3 : Value LineWidth -> Value LineStyle -> Value Color -> Style
 borderInline3 (Value widthVal) (Value style) (Value colorVal) =
     AppendProperty ("border-inline:" ++ widthVal ++ " " ++ style ++ " " ++ colorVal)
-
-
-
-
 
 
 {-| Sets [`border-width`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-width) property.
@@ -7690,6 +7689,26 @@ borderLeftStyle (Value style) =
     AppendProperty ("border-left-style:" ++ style)
 
 
+{-| Sets [`border-block-style`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-block-style) property.
+
+    borderBlockStyle solid
+
+-}
+borderBlockStyle : BaseValue LineStyle -> Style
+borderBlockStyle (Value style) =
+    AppendProperty ("border-block-style:" ++ style)
+
+
+{-| Sets [`border-inline-style`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-inline-style) property.
+
+    borderInlineStyle solid
+
+-}
+borderInlineStyle : BaseValue LineStyle -> Style
+borderInlineStyle (Value style) =
+    AppendProperty ("border-inline-style:" ++ style)
+
+
 {-| Sets [`border-color`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-color) property.
 
     borderColor (rgb 0 0 0)
@@ -7852,6 +7871,7 @@ borderInlineStartColor (Value colorVal) =
 borderInlineEndColor : BaseValue Color -> Style
 borderInlineEndColor (Value colorVal) =
     AppendProperty ("border-inline-end-color:" ++ colorVal)
+
 
 
 -- BORDER WIDTH --

--- a/src/Css.elm
+++ b/src/Css.elm
@@ -30,6 +30,8 @@ module Css exposing
     , borderRight, borderRight2, borderRight3
     , borderBottom, borderBottom2, borderBottom3
     , borderLeft, borderLeft2, borderLeft3
+    , borderBlock, borderBlock2, borderBlock3
+    , borderInline, borderInline2, borderInline3
     , borderWidth, borderWidth2, borderWidth3, borderWidth4, borderTopWidth, borderRightWidth, borderBottomWidth, borderLeftWidth
     , thin, thick
     , borderStyle, borderStyle2, borderStyle3, borderStyle4, borderTopStyle, borderRightStyle, borderBottomStyle, borderLeftStyle
@@ -285,6 +287,13 @@ All CSS properties can have the values `unset`, `initial`, and `inherit`
 @docs borderBottom, borderBottom2, borderBottom3
 
 @docs borderLeft, borderLeft2, borderLeft3
+
+
+## Logical Borders
+
+@docs borderBlock, borderBlock2, borderBlock3
+
+@docs borderInline, borderInline2, borderInline3
 
 
 ## Border Width
@@ -7398,6 +7407,95 @@ borderLeft2 (Value widthVal) (Value style) =
 borderLeft3 : Value LineWidth -> Value LineStyle -> Value Color -> Style
 borderLeft3 (Value widthVal) (Value style) (Value colorVal) =
     AppendProperty ("border-left:" ++ widthVal ++ " " ++ style ++ " " ++ colorVal)
+
+
+
+{-| Sets [`border-block`](https://css-tricks.com/almanac/properties/b/border-block/) property.
+
+    borderBlock (px 1)
+
+    borderBlock2 (px 1) solid
+
+    borderBlock3 (px 1) solid (hex "#f00")
+
+-}
+borderBlock : BaseValue LineWidth -> Style
+borderBlock (Value widthVal) =
+    AppendProperty ("border-block:" ++ widthVal)
+
+
+{-| Sets [`border-block`](https://css-tricks.com/almanac/properties/b/border-block/) property.
+
+    borderBlock (px 1)
+
+    borderBlock2 (px 1) solid
+
+    borderBlock3 (px 1) solid (hex "#f00")
+
+-}
+borderBlock2 : Value LineWidth -> Value LineStyle -> Style
+borderBlock2 (Value widthVal) (Value style) =
+    AppendProperty ("border-block:" ++ widthVal ++ " " ++ style)
+
+
+{-| Sets [`border-block`](https://css-tricks.com/almanac/properties/b/border-block/) property.
+
+    borderBlock (px 1)
+
+    borderBlock2 (px 1) solid
+
+    borderBlock3 (px 1) solid (hex "#f00")
+
+-}
+borderBlock3 : Value LineWidth -> Value LineStyle -> Value Color -> Style
+borderBlock3 (Value widthVal) (Value style) (Value colorVal) =
+    AppendProperty ("border-block:" ++ widthVal ++ " " ++ style ++ " " ++ colorVal)
+
+
+{-| Sets [`border-inline`](https://css-tricks.com/almanac/properties/b/border-inline/) property.
+
+    borderInline (px 1)
+
+    borderInline2 (px 1) solid
+
+    borderInline3 (px 1) solid (hex "#f00")
+
+-}
+borderInline : BaseValue LineWidth -> Style
+borderInline (Value widthVal) =
+    AppendProperty ("border-inline:" ++ widthVal)
+
+
+{-| Sets [`border-inline`](https://css-tricks.com/almanac/properties/b/border-inline/) property.
+
+    borderInline (px 1)
+
+    borderInline2 (px 1) solid
+
+    borderInline3 (px 1) solid (hex "#f00")
+
+-}
+borderInline2 : Value LineWidth -> Value LineStyle -> Style
+borderInline2 (Value widthVal) (Value style) =
+    AppendProperty ("border-inline:" ++ widthVal ++ " " ++ style)
+
+
+{-| Sets [`border-inline`](https://css-tricks.com/almanac/properties/b/border-inline/) property.
+
+    borderInline (px 1)
+
+    borderInline2 (px 1) solid
+
+    borderInline3 (px 1) solid (hex "#f00")
+
+-}
+borderInline3 : Value LineWidth -> Value LineStyle -> Value Color -> Style
+borderInline3 (Value widthVal) (Value style) (Value colorVal) =
+    AppendProperty ("border-inline:" ++ widthVal ++ " " ++ style ++ " " ++ colorVal)
+
+
+
+
 
 
 {-| Sets [`border-width`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-width) property.


### PR DESCRIPTION
Adds functions covering the following properties for the `phantom-types` branch:

- [`border-block`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-block)
- [`border-block-color`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-block-color) 
- [`border-block-end`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-block-end)
- [`border-block-end-color`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-block-end-color)
- [`border-block-end-style`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-block-end-style)
- [`border-block-end-width`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-block-end-width) 
- [`border-block-start`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-block-start)
- [`border-block-start-color`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-block-start-color)
- [`border-block-start-style`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-block-start-style)
- [`border-block-start-width`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-block-start-width)
- [`border-block-style`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-block-style) 
- [`border-block-width`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-block-width)
- [`border-inline`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-inline)
- [`border-inline-color`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-inline-color)
- [`border-inline-end`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-inline-end)
- [`border-inline-end-color`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-inline-end-color)
- [`border-inline-end-style`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-inline-end-style)
- [`border-inline-end-width`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-inline-end-width) 
- [`border-inline-start`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-inline-start)
- [`border-inline-start-color`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-inline-start-color)
- [`border-inline-start-style`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-inline-start-style)
- [`border-inline-start-width`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-inline-start-width) 
- [`border-inline-style`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-inline-style) 
- [`border-inline-width`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-inline-width) 

Implementing them basically just involved a lot of repetition because they share identical arguments with similar border properties.