### PR TITLE
Phantom types: Some more properties + a few fixes

### DIFF
--- a/src/Css.elm
+++ b/src/Css.elm
@@ -36,6 +36,7 @@ module Css exposing
     , dotted, dashed, solid, double, groove, ridge, inset, outset
     , borderColor, borderColor2, borderColor3, borderColor4, borderTopColor, borderRightColor, borderBottomColor, borderLeftColor
     , borderRadius, borderRadius2, borderRadius3, borderRadius4, borderTopLeftRadius, borderTopLeftRadius2, borderTopRightRadius, borderTopRightRadius2, borderBottomRightRadius, borderBottomRightRadius2, borderBottomLeftRadius, borderBottomLeftRadius2
+    , borderStartStartRadius, borderStartStartRadius2, borderStartEndRadius, borderStartEndRadius2, borderEndStartRadius, borderEndStartRadius2, borderEndEndRadius, borderEndEndRadius2
     , borderImageOutset, borderImageOutset2, borderImageOutset3, borderImageOutset4
     , borderImageWidth, borderImageWidth2, borderImageWidth3, borderImageWidth4
     , outline, outline3, outlineWidth, outlineColor, invert, outlineStyle, outlineOffset
@@ -309,6 +310,8 @@ All CSS properties can have the values `unset`, `initial`, and `inherit`
 ## Border Radius
 
 @docs borderRadius, borderRadius2, borderRadius3, borderRadius4, borderTopLeftRadius, borderTopLeftRadius2, borderTopRightRadius, borderTopRightRadius2, borderBottomRightRadius, borderBottomRightRadius2, borderBottomLeftRadius, borderBottomLeftRadius2
+
+@docs borderStartStartRadius, borderStartStartRadius2, borderStartEndRadius, borderStartEndRadius2, borderEndStartRadius, borderEndStartRadius2, borderEndEndRadius, borderEndEndRadius2
 
 
 ## Border Image
@@ -8168,6 +8171,174 @@ borderBottomLeftRadius2 :
     -> Style
 borderBottomLeftRadius2 (Value horizontal) (Value vertical) =
     AppendProperty ("border-bottom-left-radius:" ++ horizontal ++ " " ++ vertical)
+
+
+{-| Sets [`border-start-start-radius`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-start-start-radius) property.
+
+    borderStartStartRadius (em 4)
+
+    borderStartStartRadius2 (em 4) (px 2)
+
+-}
+borderStartStartRadius :
+    BaseValue
+        (LengthSupported
+            { pct : Supported
+            }
+        )
+    -> Style
+borderStartStartRadius (Value radius) =
+    AppendProperty ("border-start-start-radius:" ++ radius)
+
+
+{-| Sets [`border-start-start-radius`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-start-start-radius) property.
+
+    borderStartStartRadius (em 4)
+
+    borderStartStartRadius2 (em 4) (px 2)
+
+-}
+borderStartStartRadius2 :
+    Value
+        (LengthSupported
+            { pct : Supported
+            }
+        )
+    ->
+        Value
+            (LengthSupported
+                { pct : Supported
+                }
+            )
+    -> Style
+borderStartStartRadius2 (Value horizontal) (Value vertical) =
+    AppendProperty ("border-start-start-radius:" ++ horizontal ++ " " ++ vertical)
+
+
+{-| Sets [`border-start-end-radius`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-start-end-radius) property.
+
+    borderStartEndRadius (em 4)
+
+    borderStartEndRadius2 (em 4) (px 2)
+
+-}
+borderStartEndRadius :
+    BaseValue
+        (LengthSupported
+            { pct : Supported
+            }
+        )
+    -> Style
+borderStartEndRadius (Value radius) =
+    AppendProperty ("border-start-end-radius:" ++ radius)
+
+
+{-| Sets [`border-start-end-radius`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-start-end-radius) property.
+
+    borderStartEndRadius (em 4)
+
+    borderStartEndRadius2 (em 4) (px 2)
+
+-}
+borderStartEndRadius2 :
+    Value
+        (LengthSupported
+            { pct : Supported
+            }
+        )
+    ->
+        Value
+            (LengthSupported
+                { pct : Supported
+                }
+            )
+    -> Style
+borderStartEndRadius2 (Value horizontal) (Value vertical) =
+    AppendProperty ("border-start-end-radius:" ++ horizontal ++ " " ++ vertical)
+
+
+{-| Sets [`border-end-start-radius`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-end-start-radius) property.
+
+    borderEndStartRadius (em 4)
+
+    borderEndStartRadius2 (em 4) (px 2)
+
+-}
+borderEndStartRadius :
+    BaseValue
+        (LengthSupported
+            { pct : Supported
+            }
+        )
+    -> Style
+borderEndStartRadius (Value radius) =
+    AppendProperty ("border-end-start-radius:" ++ radius)
+
+
+{-| Sets [`border-end-start-radius`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-end-start-radius) property.
+
+    borderEndStartRadius (em 4)
+
+    borderEndStartRadius2 (em 4) (px 2)
+
+-}
+borderEndStartRadius2 :
+    Value
+        (LengthSupported
+            { pct : Supported
+            }
+        )
+    ->
+        Value
+            (LengthSupported
+                { pct : Supported
+                }
+            )
+    -> Style
+borderEndStartRadius2 (Value horizontal) (Value vertical) =
+    AppendProperty ("border-end-start-radius:" ++ horizontal ++ " " ++ vertical)
+
+
+{-| Sets [`border-end-end-radius`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-end-end-radius) property.
+
+    borderEndEndRadius (em 4)
+
+    borderEndEndRadius2 (em 4) (px 2)
+
+-}
+borderEndEndRadius :
+    BaseValue
+        (LengthSupported
+            { pct : Supported
+            }
+        )
+    -> Style
+borderEndEndRadius (Value radius) =
+    AppendProperty ("border-end-end-radius:" ++ radius)
+
+
+{-| Sets [`border-end-end-radius`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-end-end-radius) property.
+
+    borderEndEndRadius (em 4)
+
+    borderEndEndRadius2 (em 4) (px 2)
+
+-}
+borderEndEndRadius2 :
+    Value
+        (LengthSupported
+            { pct : Supported
+            }
+        )
+    ->
+        Value
+            (LengthSupported
+                { pct : Supported
+                }
+            )
+    -> Style
+borderEndEndRadius2 (Value horizontal) (Value vertical) =
+    AppendProperty ("border-end-end-radius:" ++ horizontal ++ " " ++ vertical)
 
 
 {-| Sets [`border-image-outset`](https://css-tricks.com/almanac/properties/b/border-image/) property.

--- a/src/Css.elm
+++ b/src/Css.elm
@@ -1541,7 +1541,7 @@ position (Value val) =
 
 -}
 inset :
-    Value
+    BaseValue
         (LengthSupported
             { pct : Supported
             , auto : Supported
@@ -1783,7 +1783,7 @@ right (Value val) =
 
 -}
 insetBlock :
-    Value
+    BaseValue
         (LengthSupported
             { pct : Supported
             , auto : Supported
@@ -1832,7 +1832,7 @@ insetBlock2 (Value valStart) (Value valEnd) =
 
 -}
 insetInline :
-    Value
+    BaseValue
         (LengthSupported
             { pct : Supported
             , auto : Supported


### PR DESCRIPTION
Another batch of mostly-logical properties :)

### New properties
This PR implements the following:

#### Logical border radius
- [`border-end-end-radius`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-end-end-radius)
- [`border-end-start-radius`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-end-start-radius)
- [`border-start-end-radius`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-start-end-radius)
- [`border-start-start-radius`](https://developer.mozilla.org/en-US/docs/Web/CSS/border-start-start-radius)

#### Logical snap scrolling metrics
- [`scroll-margin-block`](https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-margin-block)
- [`scroll-margin-block-end`](https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-margin-block-end)
- [`scroll-margin-block-start`](https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-margin-block-start)
- [`scroll-margin-inline`](https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-margin-inline)
- [`scroll-margin-inline-end`](https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-margin-inline-end)
- [`scroll-margin-inline-start`](https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-margin-inline-start)
- [`scroll-padding-block`](https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-padding-block)
- [`scroll-padding-block-end`](https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-padding-block-end)
- [`scroll-padding-block-start`](https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-padding-block-start)
- [`scroll-padding-inline`](https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-padding-inline)
- [`scroll-padding-inline-end`](https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-padding-inline-end)
- [`scroll-padding-inline-start`](https://developer.mozilla.org/en-US/docs/Web/CSS/scroll-padding-inline-start)

#### Inset and logical insets
- [`inset`](https://developer.mozilla.org/en-US/docs/Web/CSS/inset)
- [`inset-block`](https://developer.mozilla.org/en-US/docs/Web/CSS/inset-block)
- [`inset-block-end`](https://developer.mozilla.org/en-US/docs/Web/CSS/inset-block-end)
- [`inset-block-start`](https://developer.mozilla.org/en-US/docs/Web/CSS/inset-block-start)
- [`inset-inline`](https://developer.mozilla.org/en-US/docs/Web/CSS/inset-inline)
- [`inset-inline-end`](https://developer.mozilla.org/en-US/docs/Web/CSS/inset-inline-end)
- [`inset-inline-start`](https://developer.mozilla.org/en-US/docs/Web/CSS/inset-inline-start)

### Changes to existing code
- I renamed the `inset` value to `inset_` to make room for the `inset` property since that seems to be the convention when there's a naming clash in this project.
- Fixed some typos in the documentation for pre-existing `scroll-padding` functions.
- According to MDN, `scroll-margin` properties should only take `Length`s, not `LengthSupported {auto : Supported}`, so I changed the code for all the pre-existing ones to make that the case.
- I rearranged `left`, `right`, `top` , `bottom` properties to be grouped with `inset` as they are part of the same family of properties.

I hope this is all okay! Sorry for doing 3 separate PRs for adding all these, this was kind of impromptu and I wasn't sure how many I was gonna do ^^' (I'm pretty new to doing PRs)