### PR TITLE
Fixed Styled.elm docstring issue

### DIFF
--- a/src/Html/Styled.elm
+++ b/src/Html/Styled.elm
@@ -152,21 +152,21 @@ type alias Attribute msg =
 
 
 {-| Takes a function that creates an element, and pre-applies styles to it.
-bigButton : List (Attribute msg) -> List (Html msg) -> Html msg
-bigButton =
-styled button
-[ padding (px 30)
-, fontWeight bold
-]
-view : Model -> Html msg
-view model =
-[ text "These two buttons are identical:"
-, bigButton [][ text "Hi!" ]
-, button [ css [ padding (px 30), fontWeight bold ] ][ text "Hi!" ]
-][ text "These two buttons are identical:"
-, bigButton [] [ text "Hi!" ]
-, button [ css [ padding (px 30), fontWeight bold ] ] [] [ text "Hi!" ]
-]
+
+    bigButton : List (Attribute msg) -> List (Html msg) -> Html msg
+    bigButton =
+        styled button
+            [ padding (px 30)
+            , fontWeight bold
+            ]
+    
+    view : Model -> Html msg
+    view model =
+        [ text "These two buttons are identical:"
+        , bigButton [] [ text "Hi!" ]
+        , button [ css [ padding (px 30), fontWeight bold ] ] [] [ text "Hi!" ]
+        ]
+
 Here, the `bigButton` function we've defined using `styled button` is
 identical to the normal `button` function, except that it has pre-applied
 the attribute of `css [ padding (px 30), fontWeight bold ]`.


### PR DESCRIPTION
Broken text is on https://package.elm-lang.org/packages/rtfeldman/elm-css/latest/Html-Styled - top of the page. I'm guessing it's an indentation issue.

