### PR TITLE
Replace fnv with murmur3

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -5,13 +5,6 @@
     "license": "BSD-3-Clause",
     "version": "17.0.1",
     "exposed-modules": {
-        "Styling": [
-            "Css",
-            "Css.Animations",
-            "Css.Transitions",
-            "Css.Media",
-            "Css.Global"
-        ],
         "Elements": [
             "Html.Styled",
             "Html.Styled.Attributes",
@@ -23,6 +16,13 @@
             "Svg.Styled.Events",
             "Svg.Styled.Keyed",
             "Svg.Styled.Lazy"
+        ],
+        "Styling": [
+            "Css",
+            "Css.Animations",
+            "Css.Transitions",
+            "Css.Media",
+            "Css.Global"
         ]
     },
     "elm-version": "0.19.0 <= v < 0.20.0",
@@ -30,7 +30,7 @@
         "elm/core": "1.0.0 <= v < 2.0.0",
         "elm/json": "1.0.0 <= v < 2.0.0",
         "elm/virtual-dom": "1.0.0 <= v < 2.0.0",
-        "robinheghan/fnv1a": "1.0.0 <= v < 2.0.0",
+        "robinheghan/murmur3": "1.0.0 <= v < 2.0.0",
         "rtfeldman/elm-hex": "1.0.0 <= v < 2.0.0"
     },
     "test-dependencies": {

--- a/src/Hash.elm
+++ b/src/Hash.elm
@@ -1,11 +1,17 @@
-module Hash exposing (fromString)
+module Hash exposing (fromString, initialSeed)
 
-import FNV1a
 import Hex
+import Murmur3
 
 
 fromString : String -> String
 fromString str =
-    FNV1a.hash str
+    str
+        |> Murmur3.hashString initialSeed
         |> Hex.toString
         |> String.cons '_'
+
+
+initialSeed : Int
+initialSeed =
+    15739

--- a/tests/Keyframes.elm
+++ b/tests/Keyframes.elm
@@ -35,7 +35,7 @@ suite =
 
             output =
                 """
-            @keyframes _f8c0e7dc {
+            @keyframes _a56b5063 {
                 0% {background-color:#00FF00;background-size:2px;}
 
                 50% {opacity:0;}
@@ -54,12 +54,12 @@ suite =
             p {
                 color:#FF0000;
                 display:inline;
-                animation-name:_f8c0e7dc;
+                animation-name:_a56b5063;
                 background-color:rgb(11, 11, 11);
             }
 
             i {
-                animation-name:_f8c0e7dc;
+                animation-name:_a56b5063;
             }
             """
           in
@@ -97,11 +97,11 @@ suite =
 
             output =
                 """
-            @keyframes _70a5b6a0 {
+            @keyframes _23526425 {
                 10% {transform:translate(100px);}
             }
 
-            @keyframes _f8c0e7dc {
+            @keyframes _a56b5063 {
                 0% {background-color:#00FF00;background-size:2px;}
 
                 50% {opacity:0;}
@@ -115,14 +115,14 @@ suite =
 
             button {
                 margin:auto;
-                animation-name:_70a5b6a0;
+                animation-name:_23526425;
                 background-color:#0F0F0F;
             }
 
             p {
                 color:#FF0000;
                 display:inline;
-                animation-name:_f8c0e7dc;
+                animation-name:_a56b5063;
                 background-color:rgb(11, 11, 11);
             }
             """

--- a/tests/Styled.elm
+++ b/tests/Styled.elm
@@ -99,28 +99,28 @@ all =
             (\_ ->
                 Query.fromHtml (toUnstyled <| view "BUY TICKETS")
                     |> Query.has
-                        [ Selector.text """._2e879635 {
+                        [ Selector.text """._3de4d102 {
     background-color:#333333;
     padding:20px;
 }"""
-                        , Selector.text """._322e2311 {
+                        , Selector.text """._e9904f07 {
     margin:12px;
     color:rgb(255, 255, 255);
 }"""
-                        , Selector.text """._c6e22f50 {
+                        , Selector.text """._3ac819d0 {
     display:inline-block;
     padding-bottom:12px;
 }"""
-                        , Selector.text """._9c310192 {
+                        , Selector.text """._c9b3bf47 {
     display:inline-block;
     margin-left:150px;
     margin-right:80px;
     vertical-align:middle;
 }"""
-                        , Selector.text """._5daeac28 {
+                        , Selector.text """._b9f3f75d {
     background-color:#222222;
 }"""
-                        , Selector.text """._36e932ea {
+                        , Selector.text """._33ecd3f8 {
     padding:16px;
     padding-left:24px;
     padding-right:24px;


### PR DESCRIPTION
After talking to Richard, we agreed to hold back the hash-function change. FNV is a slightly worse hash than Murmur3, and elm-css doesn't have a way to handle hash collisions. It's safer to stick with Murmur3, for now.