### PR TITLE
Set display: none and add elm-css-style-wrapper class

### DIFF
--- a/src/Css/Global.elm
+++ b/src/Css/Global.elm
@@ -106,7 +106,10 @@ global snippets =
         |> VirtualDom.node "style" []
         -- wrap the style node in a div to prevent `Dark Reader` from blowin up the dom.
         |> List.singleton
-        |> VirtualDom.node "span" []
+        |> VirtualDom.node "span"
+            [ VirtualDom.attribute "style" "display: none;"
+            , VirtualDom.attribute "class" "elm-css-style-wrapper"
+            ]
         |> VirtualDom.Styled.unstyledNode
 
 

--- a/src/VirtualDom/Styled.elm
+++ b/src/VirtualDom/Styled.elm
@@ -439,7 +439,9 @@ toStyleNode : Dict Classname (List Style) -> VirtualDom.Node msg
 toStyleNode styles =
     -- wrap the style node in a div to prevent `Dark Reader` from blowin up the dom.
     VirtualDom.node "span"
-        []
+        [ VirtualDom.attribute "style" "display: none;"
+        , VirtualDom.attribute "class" "elm-css-style-wrapper"
+        ]
         [ -- this <style> node will be the first child of the requested one
           toDeclaration styles
             |> VirtualDom.text


### PR DESCRIPTION
Fixes #557

Using `display: none;` seems like a good default and still fixes #542.

I think it might be worth adding a class like `elm-css-style-wrapper` in case the display: none is not good or if someone needs to override the style as @ymtszw needed.

If that's the case using the following will allow to override even the inline `display: none;` [^1]

```css
.elm-css-style-wrapper[style] { 
   /* your style */
}
```

I based this change on 17.0.1 in case a 17.0.2 is wanted.

[^1]: [Override Inline Styles with CSS](https://css-tricks.com/override-inline-styles-with-css/)