### PR TITLE
fix: Runtime exception when using css in SVG elements

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -25,7 +25,7 @@
             "Css.Global"
         ]
     },
-    "elm-version": "0.19.1 <= v < 0.20.0",
+    "elm-version": "0.19.0 <= v < 0.20.0",
     "dependencies": {
         "elm/core": "1.0.0 <= v < 2.0.0",
         "elm/json": "1.0.0 <= v < 2.0.0",

--- a/elm.json
+++ b/elm.json
@@ -25,7 +25,7 @@
             "Css.Global"
         ]
     },
-    "elm-version": "0.19.0 <= v < 0.20.0",
+    "elm-version": "0.19.1 <= v < 0.20.0",
     "dependencies": {
         "elm/core": "1.0.0 <= v < 2.0.0",
         "elm/json": "1.0.0 <= v < 2.0.0",

--- a/examples/html-styled/Main.elm
+++ b/examples/html-styled/Main.elm
@@ -6,6 +6,8 @@ import Html
 import Html.Styled exposing (..)
 import Html.Styled.Attributes exposing (css, href, src)
 import Html.Styled.Events exposing (onClick)
+import Svg.Styled as StyledSvg
+import Svg.Styled.Attributes as SvgAttribs
 
 
 {-| A logo image, with inline styles that change on hover.
@@ -82,6 +84,7 @@ view model =
     nav []
         [ img [ src "assets/backdrop.jpg", css [ width (pct 100) ] ] []
         , btn [ onClick DoSomething ] [ text "Click me!" ]
+        , StyledSvg.svg [ SvgAttribs.css [], SvgAttribs.width "100", SvgAttribs.height "100" ] [ StyledSvg.circle [ SvgAttribs.cx "50", SvgAttribs.cy "50", SvgAttribs.r "40" ] [] ]
         ]
 
 

--- a/examples/html-styled/elm.json
+++ b/examples/html-styled/elm.json
@@ -4,7 +4,7 @@
         ".",
         "../../src"
     ],
-    "elm-version": "0.19.1",
+    "elm-version": "0.19.0",
     "dependencies": {
         "direct": {
             "elm/browser": "1.0.0",

--- a/examples/html-styled/elm.json
+++ b/examples/html-styled/elm.json
@@ -4,22 +4,21 @@
         ".",
         "../../src"
     ],
-    "elm-version": "0.19.0",
+    "elm-version": "0.19.1",
     "dependencies": {
         "direct": {
-            "Skinney/murmur3": "2.0.7",
             "elm/browser": "1.0.0",
             "elm/core": "1.0.0",
             "elm/html": "1.0.0",
             "elm/json": "1.0.0",
-            "rtfeldman/elm-hex": "1.0.0",
             "elm/virtual-dom": "1.0.0",
-            "elm-explorations/markdown": "1.0.0"
+            "elm-explorations/markdown": "1.0.0",
+            "robinheghan/murmur3": "1.0.0",
+            "rtfeldman/elm-hex": "1.0.0"
         },
         "indirect": {
             "elm/time": "1.0.0",
-            "elm/url": "1.0.0",
-            "elm/parser": "1.0.0"
+            "elm/url": "1.0.0"
         }
     },
     "test-dependencies": {
@@ -27,6 +26,7 @@
             "elm-explorations/test": "1.0.0"
         },
         "indirect": {
+            "elm/parser": "1.0.0",
             "elm/random": "1.0.0"
         }
     }

--- a/package.json
+++ b/package.json
@@ -44,9 +44,9 @@
     "tmp": "0.0.28"
   },
   "devDependencies": {
-    "elm-test": "0.18.13-beta",
+    "chai": "3.4.1",
     "elm-format": "0.8.0",
-    "chai": "3.4.1"
+    "elm-test": "^0.19.1-revision7"
   },
   "engineStrict": true,
   "engines": {

--- a/src/VirtualDom/Styled.elm
+++ b/src/VirtualDom/Styled.elm
@@ -492,10 +492,10 @@ extractUnstyledAttribute styles (Attribute val isCssStyles cssTemplate) =
     if isCssStyles then
         case Dict.get cssTemplate styles of
             Just classname ->
-                VirtualDom.property "className" (Json.Encode.string classname)
+                VirtualDom.attribute "className" classname
 
             Nothing ->
-                VirtualDom.property "className" (Json.Encode.string "_unstyled")
+                VirtualDom.attribute "className" "_unstyled"
 
     else
         val


### PR DESCRIPTION
fixes #543 
# Context
When `unStyling` nodes elm-css internally was using `VirtualDom.property "className" ...` which was causing runtime exceptions for svg elements. The property "className" is deprecated for svg elements and was the reason for the exception.

This meant that anytime you would set css inside of any svg element, an exception would be thrown and cause the page to not render correctly. 

![virtualdomerror](https://user-images.githubusercontent.com/25443812/148686577-5a888a2a-7da5-4c37-a2e4-3a9cd6b02167.png)

# Fix
Using `VirtualDom.attribute "className" ...` properly sets the value and stops the exception from happening.

# Extra
- Updated elm examples
- Replaced dead package
- Updated elm-test
