### PR TITLE
fix: Set attribute value to class

### DIFF
--- a/src/VirtualDom/Styled.elm
+++ b/src/VirtualDom/Styled.elm
@@ -492,10 +492,10 @@ extractUnstyledAttribute styles (Attribute val isCssStyles cssTemplate) =
     if isCssStyles then
         case Dict.get cssTemplate styles of
             Just classname ->
-                VirtualDom.attribute "className" classname
+                VirtualDom.attribute "class" classname
 
             Nothing ->
-                VirtualDom.attribute "className" "_unstyled"
+                VirtualDom.attribute "class" "_unstyled"
 
     else
         val


### PR DESCRIPTION
fixes #563 

# Context
Using attribute does set the css class correctly however the attribute
name needs to be class instead of className.

Using className will set classes as `classname` in dom nodes and
`className` in svg nodes which is incorrect.

Here we can see the incorrect attribute name. On the left we should be seeing a handsome `elm-select`. No styles are applied.
![classnames](https://user-images.githubusercontent.com/25443812/148689323-8067f7c8-e5fa-4b46-b359-a5c4c88bde4c.png)

And with correct class.
![classnamefixed](https://user-images.githubusercontent.com/25443812/148689589-8a659b66-ee80-4c15-8eb8-266368f9fb7d.png)


