### PR TITLE
Remove unused code

### DIFF
--- a/src/Css/Structure.elm
+++ b/src/Css/Structure.elm
@@ -66,7 +66,7 @@ type Declaration
     | MediaRule (List MediaQuery) (List StyleBlock)
     | SupportsRule String (List Declaration)
     | DocumentRule String String String String StyleBlock
-    | PageRule String (List Property)
+    | PageRule (List Property)
     | FontFace (List Property)
     | Keyframes { name : String, declaration : String }
     | Viewport (List Property)
@@ -341,7 +341,7 @@ concatMapLastStyleBlock update declarations =
             update styleBlock
                 |> List.map (DocumentRule str1 str2 str3 str4)
 
-        (PageRule _ _) :: [] ->
+        (PageRule _) :: [] ->
             declarations
 
         (FontFace _) :: [] ->
@@ -480,7 +480,7 @@ compactHelp declaration ( keyframesByName, declarations ) =
         DocumentRule _ _ _ _ _ ->
             ( keyframesByName, declaration :: declarations )
 
-        PageRule _ properties ->
+        PageRule properties ->
             if List.isEmpty properties then
                 ( keyframesByName, declarations )
 


### PR DESCRIPTION
I noticed that this argument was unused and could therefore be removed. I have no clue what the argument was meant for in the first place :shrug: 

There is a lot of dead code in this project (even excluding the deprecated folder). Would you care for a clean up PR?