### PR TITLE
Make Css.Structure.Property a custom type

### DIFF
--- a/src/Css.elm
+++ b/src/Css.elm
@@ -1162,12 +1162,12 @@ important =
 
 
 makeImportant : Property -> Property
-makeImportant str =
+makeImportant (Property str) =
     if String.endsWith " !important" (String.toLower str) then
-        str
+        Property str
 
     else
-        str ++ " !important"
+        Property (str ++ " !important")
 
 
 {-| A [`ColorValue`](#ColorValue) that does not have `red`, `green`, or `blue`
@@ -7239,6 +7239,7 @@ batch =
 property : String -> String -> Style
 property key value =
     (key ++ ":" ++ value)
+        |> Property
         |> Preprocess.AppendProperty
 
 

--- a/src/Css/Internal.elm
+++ b/src/Css/Internal.elm
@@ -2,7 +2,7 @@ module Css.Internal exposing (AnimationProperty(..), ColorValue, ExplicitLength,
 
 import Css.Preprocess as Preprocess exposing (Style)
 import Css.String
-import Css.Structure exposing (Compatible(..))
+import Css.Structure as Structure exposing (Compatible(..))
 
 
 type IncompatibleUnits
@@ -106,7 +106,7 @@ Other notes:
 getOverloadedProperty : String -> String -> Style -> Style
 getOverloadedProperty functionName desiredKey style =
     case style of
-        Preprocess.AppendProperty str ->
+        Preprocess.AppendProperty (Structure.Property str) ->
             let
                 key =
                     String.split ":" str
@@ -153,6 +153,7 @@ getOverloadedProperty functionName desiredKey style =
 property : String -> String -> Style
 property key value =
     (key ++ ":" ++ value)
+        |> Structure.Property
         |> Preprocess.AppendProperty
 
 

--- a/src/Css/Preprocess.elm
+++ b/src/Css/Preprocess.elm
@@ -176,7 +176,7 @@ toPropertyStrings styles =
         [] ->
             []
 
-        (AppendProperty str) :: rest ->
+        (AppendProperty (Structure.Property str)) :: rest ->
             str :: toPropertyStrings rest
 
         (ApplyStyles otherStyles) :: rest ->

--- a/src/Css/Preprocess/Resolve.elm
+++ b/src/Css/Preprocess/Resolve.elm
@@ -223,8 +223,9 @@ applyStyles styles declarations =
                 name =
                     Hash.fromString str
 
+                newProperty : Property
                 newProperty =
-                    "animation-name:" ++ name
+                    Structure.Property ("animation-name:" ++ name)
 
                 newDeclarations =
                     declarations

--- a/src/Css/Structure.elm
+++ b/src/Css/Structure.elm
@@ -1,4 +1,4 @@
-module Css.Structure exposing (Compatible(..), Declaration(..), KeyframeProperty, MediaExpression, MediaQuery(..), MediaType(..), Number, Property, PseudoElement(..), RepeatableSimpleSelector(..), Selector(..), SelectorCombinator(..), SimpleSelectorSequence(..), StyleBlock(..), Stylesheet, TypeSelector(..), appendProperty, appendPseudoElementToLastSelector, appendRepeatable, appendRepeatableSelector, appendRepeatableToLastSelector, appendRepeatableWithCombinator, appendToLastSelector, applyPseudoElement, compactDeclarations, compactHelp, compactStylesheet, concatMapLast, concatMapLastStyleBlock, extendLastSelector, mapLast, styleBlockToMediaRule, withKeyframeDeclarations, withPropertyAppended)
+module Css.Structure exposing (Compatible(..), Declaration(..), KeyframeProperty, MediaExpression, MediaQuery(..), MediaType(..), Number, Property(..), PseudoElement(..), RepeatableSimpleSelector(..), Selector(..), SelectorCombinator(..), SimpleSelectorSequence(..), StyleBlock(..), Stylesheet, TypeSelector(..), appendProperty, appendPseudoElementToLastSelector, appendRepeatable, appendRepeatableSelector, appendRepeatableToLastSelector, appendRepeatableWithCombinator, appendToLastSelector, applyPseudoElement, compactDeclarations, compactHelp, compactStylesheet, concatMapLast, concatMapLastStyleBlock, extendLastSelector, mapLast, styleBlockToMediaRule, withKeyframeDeclarations, withPropertyAppended)
 
 {-| A representation of the structure of a stylesheet. This module is concerned
 solely with representing valid stylesheets; it is not concerned with the
@@ -19,14 +19,9 @@ type alias Number compatible =
 
 
 {-| A property consisting of a key:value string.
-
-Ideally, this would be `type Property = Property String` - but in order to
-reduce allocations, we're doing it as a `type alias` until union types with
-one constructor get unboxed automatically.
-
 -}
-type alias Property =
-    String
+type Property
+    = Property String
 
 
 {-| A stylesheet. Since they follow such specific rules, the following at-rules

--- a/src/Css/Structure/Output.elm
+++ b/src/Css/Structure/Output.elm
@@ -223,4 +223,4 @@ combinatorToString combinator =
 
 emitProperties : List Property -> String
 emitProperties properties =
-    Css.String.mapJoin (\prop -> prop ++ ";") "" properties
+    Css.String.mapJoin (\(Property prop) -> prop ++ ";") "" properties


### PR DESCRIPTION
> Ideally, this would be `type Property = Property String` - but in order to reduce allocations, we're doing it as a `type alias` until union types with one constructor get unboxed automatically.

Trying to realize your years-old wish. Feel free to ignore, I just couldn't help myself :sweat_smile: 