### PR TITLE
Update README, examples/MyCss for elm 0.19

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Here's an example of how to define some `elm-css` styles:
 ```elm
 module MyCss exposing (main)
 
+import Browser
 import Css exposing (..)
 import Html
 import Html.Styled exposing (..)
@@ -91,12 +92,12 @@ view model =
         ]
 
 
-main : Program Never Model Msg
+main : Program () Model Msg
 main =
-    Html.beginnerProgram
-        { view = view >> toUnstyled
+    Browser.sandbox
+        { init = initialModel
+        , view = view >> toUnstyled
         , update = update
-        , model = initialModel
         }
 ```
 

--- a/examples/readme/src/MyCss.elm
+++ b/examples/readme/src/MyCss.elm
@@ -1,5 +1,6 @@
 module MyCss exposing (main)
 
+import Browser
 import Css exposing (..)
 import Html
 import Html.Styled exposing (..)
@@ -83,12 +84,12 @@ view model =
         ]
 
 
-main : Program Never Model Msg
+main : Program () Model Msg
 main =
-    Html.beginnerProgram
+    Browser.sandbox
         { view = view >> toUnstyled
         , update = update
-        , model = initialModel
+        , init = initialModel
         }
 
 


### PR DESCRIPTION
I believe the example used in the readme were still using elm 0.18, based on seeing `Html.beginnerProgram` and `Never`. 

## Changes
- update examples/readme/src/MyCss.elm and README to run on elm 0.19
   - import `Browser`
   - replace `Html.beginnerProgram` with `Browser.sandbox`
   - replace `Never` with Unit